### PR TITLE
Update to regexpu v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mkdirp": "0.5.0",
     "es6-shim": "0.18.0",
     "es6-symbol": "0.1.1",
-    "regexpu": "0.2.2",
+    "regexpu": "0.3.0",
     "recast": "0.8.0",
     "source-map": "0.1.40"
   },


### PR DESCRIPTION
https://github.com/mathiasbynens/regexpu

This fixes a bug with the output for `/\s/u` and `/\S/u`. See https://github.com/mathiasbynens/regexpu/issues/7.
