### PR TITLE
.travis.yml: Fix Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.11
+  - "0.10"
+  - "0.11"
 
 before_script: "npm install -g codeclimate-test-reporter"
 script: "make test-travis"


### PR DESCRIPTION
`0.10` becomes `0.1` unless strings are used.
