### PR TITLE
[Proposal] Use parent node's name for computed property reference argument

### DIFF
--- a/lib/6to5/transformers/computed-property-names.js
+++ b/lib/6to5/transformers/computed-property-names.js
@@ -25,7 +25,7 @@ exports.ObjectExpression = function (node, parent, file) {
   var templateName = "function-return-obj";
   if (hasThis) templateName += "-this";
 
-  var objId = b.identifier(file.generateUid("ref"));
+  var objId = b.identifier(parent.id.name);
 
   var container = util.template(templateName, {
     KEY: objId,

--- a/test/fixtures/syntax/computed-property-names/method/expected.js
+++ b/test/fixtures/syntax/computed-property-names/method/expected.js
@@ -1,6 +1,6 @@
-var obj = function (_ref) {
-  _ref[foobar] = function () {
+var obj = function (obj) {
+  obj[foobar] = function () {
     return "foobar";
   };
-  return _ref;
+  return obj;
 }({});

--- a/test/fixtures/syntax/computed-property-names/mixed/expected.js
+++ b/test/fixtures/syntax/computed-property-names/mixed/expected.js
@@ -1,7 +1,7 @@
-var obj = function (_ref) {
-  _ref["x" + foo] = "heh";
-  _ref["y" + bar] = "noo";
-  return _ref;
+var obj = function (obj) {
+  obj["x" + foo] = "heh";
+  obj["y" + bar] = "noo";
+  return obj;
 }({
   foo: "foo",
   bar: "bar"

--- a/test/fixtures/syntax/computed-property-names/multiple/expected.js
+++ b/test/fixtures/syntax/computed-property-names/multiple/expected.js
@@ -1,5 +1,5 @@
-var obj = function (_ref) {
-  _ref["x" + foo] = "heh";
-  _ref["y" + bar] = "noo";
-  return _ref;
+var obj = function (obj) {
+  obj["x" + foo] = "heh";
+  obj["y" + bar] = "noo";
+  return obj;
 }({});

--- a/test/fixtures/syntax/computed-property-names/single/expected.js
+++ b/test/fixtures/syntax/computed-property-names/single/expected.js
@@ -1,4 +1,4 @@
-var obj = function (_ref) {
-  _ref["x" + foo] = "heh";
-  return _ref;
+var obj = function (obj) {
+  obj["x" + foo] = "heh";
+  return obj;
 }({});

--- a/test/fixtures/syntax/computed-property-names/this/expected.js
+++ b/test/fixtures/syntax/computed-property-names/this/expected.js
@@ -1,4 +1,4 @@
-var obj = function (_ref) {
-  _ref["x" + this.foo] = "heh";
-  return _ref;
+var obj = function (obj) {
+  obj["x" + this.foo] = "heh";
+  return obj;
 }.call(this, {});


### PR DESCRIPTION
Currently computed properties generates a self-executing anonymous function with the argument `_ref` (`file.generateUid('ref')`). Instead of this, I think it would be much more readable if you used the parent node's name.

``` js
var obj = {
  ["x" + foo]: "heh"
};
```

Generating:

``` js
// currently:
var obj = function (_ref) {
  _ref["x" + foo] = "heh";
  return _ref;
}({});

// proposed:
var obj = function (obj) {
  obj["x" + foo] = "heh";
  return obj;
}({});
```

> You can see something similar in [coffeescript](http://coffeescript.org/#try:class%20Foo%0A) and [typescript](http://www.typescriptlang.org/Playground#src=module%20Foo%20%7B%0A%20%20%20%20export%20class%20Bar%20%7B%7D%0A%7D).

I'm not sure if there are any edge cases I haven't thought of, but I'd be interested in hearing them.

If there is something that would prevent this. I think it would still be good to use `file.generateUid(parent.id.name)` so you could use `_obj` instead of `_ref`.

Thoughts?
