### PR TITLE
Fix comment test directory names

### DIFF
--- a/test/fixtures/syntax/comments/preserve-multi-line/actual.js
+++ b/test/fixtures/syntax/comments/preserve-multi-line/actual.js
@@ -1,3 +1,5 @@
 wow;
-// um yeah lol
+/*
+ um yeah lol
+*/
 test.wow();

--- a/test/fixtures/syntax/comments/preserve-multi-line/expected.js
+++ b/test/fixtures/syntax/comments/preserve-multi-line/expected.js
@@ -1,3 +1,5 @@
 wow;
-// um yeah lol
+/*
+ um yeah lol
+*/
 test.wow();

--- a/test/fixtures/syntax/comments/preserve-single-line/actual.js
+++ b/test/fixtures/syntax/comments/preserve-single-line/actual.js
@@ -1,5 +1,3 @@
 wow;
-/*
- um yeah lol
-*/
+// um yeah lol
 test.wow();

--- a/test/fixtures/syntax/comments/preserve-single-line/expected.js
+++ b/test/fixtures/syntax/comments/preserve-single-line/expected.js
@@ -1,5 +1,3 @@
 wow;
-/*
- um yeah lol
-*/
+// um yeah lol
 test.wow();


### PR DESCRIPTION
`test/fixtures/syntax/comments/preserve-multi-line/` is testing single line comments.
`test/fixtures/syntax/comments/preserve-single-line/` is testing multi line comments.

This fixes the names :smile:
