### PR TITLE
Fixed regenerator runtime require

### DIFF
--- a/lib/6to5/polyfill.js
+++ b/lib/6to5/polyfill.js
@@ -1,3 +1,3 @@
 require("es6-symbol/implement");
 require("es6-shim");
-global.regeneratorRuntime = require("regenerator/runtime");
+require("regenerator").runtime();


### PR DESCRIPTION
When storing the require value to global.regeneratorRuntime it overwrites itself with an empty object when it is required multiple times.
