### PR TITLE
Allow customizing registered file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,17 @@ require("6to5/register");
 override this by passing an ignore regex via:
 
 ```javascript
-require("6to5/register")(/regex/)
+require("6to5/register")({ 
+  ignoreRegex: /node_modules/
+})
+```
+
+Customize registered file extensions with `extensions`.  Default values:
+
+```javascript
+require("6to5/register")({ 
+  extensions: ['.js', '.es6']
+})
 ```
 
 ### Browser

--- a/lib/6to5/register.js
+++ b/lib/6to5/register.js
@@ -20,9 +20,9 @@ sourceMapSupport.install({
 var ignoreRegex = /node_modules/;
 var maps        = {};
 var old         = require.extensions[".js"];
+var extensions = [".js", ".es6"]
 
-require.extensions[".js"] =
-require.extensions[".es6"] = function (m, filename) {
+function loader (m, filename) {
   if (ignoreRegex && ignoreRegex.test(filename)) {
     return old.apply(this, arguments);
   }
@@ -36,6 +36,16 @@ require.extensions[".es6"] = function (m, filename) {
   m._compile(result.code, filename);
 };
 
-module.exports = function (_ignoreRegex) {
-  ignoreRegex = _ignoreRegex;
+module.exports = function (options) {
+  if (options.ignoreRegex) {
+    ignoreRegex = options.ignoreRegex;
+  }
+
+  if(options.extensions) {
+    extensions = options.extensions;
+  }
+
+  for (var e in extensions) {
+    require.extensions[extensions[e]] = loader;
+  }
 };


### PR DESCRIPTION
This allows you to customize the extensions used. (I'd like to use `.es6.js` for simplicity, but others might prefer the plain `.es6`).
