### PR TITLE
Don't clobber js extension handler when using register helper

### DIFF
--- a/bin/6to5-node
+++ b/bin/6to5-node
@@ -28,7 +28,9 @@ if (commander.ignore) {
 }
 
 if (commander.extensions && commander.extensions.length) {
-  registerOpts.extensions = commander.extensions
+  registerOpts.extensions = commander.extensions;
+} else {
+  registerOpts.extensions = [ ".js", ".es6" ];
 }
 
 to5.register(registerOpts);

--- a/lib/6to5/register.js
+++ b/lib/6to5/register.js
@@ -51,8 +51,6 @@ var hookExtensions = function (_exts) {
   });
 };
 
-hookExtensions([".es6", ".js"]);
-
 module.exports = function (opts) {
   opts = opts || {};
   if (_.isRegExp(opts)) opts = { ignoreRegex: opts };


### PR DESCRIPTION
We want to ease into adopting es6 gently and opt-in for on a per file basis.  Initially we're trying it out in our test files and so I figured the lowest friction way to do this would be to use a test bootstrap file that uses the register helper to only register 6to5 as the extension handler for .es6 files. Unfortunately `hookExtensions` always gets called in register.  Does this PR represent a sensible approach to disabling that behaviour? (It doesn't break any tests, but I'm very new to the codebase) Or is there a better approach you would suggest?
