### PR TITLE
Fix for spread on computed context

### DIFF
--- a/lib/6to5/transformers/spread.js
+++ b/lib/6to5/transformers/spread.js
@@ -56,7 +56,14 @@ exports.CallExpression = function (node, parent, file) {
 
   if (callee.type === "MemberExpression") {
     contextLiteral = callee.object;
-    callee.property = b.memberExpression(callee.property, b.identifier("apply"), false);
+
+    if (callee.computed) {
+      callee.object = b.memberExpression(callee.object, callee.property, true);
+      callee.property = b.identifier("apply");
+      callee.computed = false;
+    } else {
+      callee.property = b.memberExpression(callee.property, b.identifier("apply"), false);
+    }
   } else {
     node.callee = b.memberExpression(node.callee, b.identifier("apply"), false);
   }

--- a/test/fixtures/syntax/spread/contexted-computed-method-call-multiple-args/actual.js
+++ b/test/fixtures/syntax/spread/contexted-computed-method-call-multiple-args/actual.js
@@ -1,0 +1,1 @@
+obj[method](foo, bar, ...args);

--- a/test/fixtures/syntax/spread/contexted-computed-method-call-multiple-args/expected.js
+++ b/test/fixtures/syntax/spread/contexted-computed-method-call-multiple-args/expected.js
@@ -1,0 +1,3 @@
+"use strict";
+var _slice = Array.prototype.slice;
+obj[method].apply(obj, [foo, bar].concat(_slice.call(args)));

--- a/test/fixtures/syntax/spread/contexted-computed-method-call-single-arg/actual.js
+++ b/test/fixtures/syntax/spread/contexted-computed-method-call-single-arg/actual.js
@@ -1,0 +1,1 @@
+obj[method](...args);

--- a/test/fixtures/syntax/spread/contexted-computed-method-call-single-arg/expected.js
+++ b/test/fixtures/syntax/spread/contexted-computed-method-call-single-arg/expected.js
@@ -1,0 +1,3 @@
+"use strict";
+var _slice = Array.prototype.slice;
+obj[method].apply(obj, _slice.call(args));


### PR DESCRIPTION
Right now:

``` js
obj[method](...args);
```

will result in:

``` js
"use strict";
var _slice = Array.prototype.slice;
obj[method.apply](_slice.call(args));
```

instead of:

``` js
"use strict";
var _slice = Array.prototype.slice;
obj[method].apply(_slice.call(args));
```

This fixes that.
