### PR TITLE
Load regenerator runtime only for polyfill

### DIFF
--- a/lib/6to5/polyfill.js
+++ b/lib/6to5/polyfill.js
@@ -1,3 +1,3 @@
 require("es6-symbol/implement");
 require("es6-shim");
-require("regenerator").runtime();
+require("regenerator/runtime");


### PR DESCRIPTION
Currently the polyfill loads regenerator's `main.js`, containing everything required to transform source, when all is needed is the runtime itself.
