### PR TITLE
Added ability to register 6to5 with a blacklist

### DIFF
--- a/lib/6to5/register.js
+++ b/lib/6to5/register.js
@@ -41,10 +41,6 @@ var loader = function (m, filename) {
   m._compile(result.code, filename);
 };
 
-var addToBlacklist = function (array) {
-  blacklist = _.union(blacklist, array)
-}
-
 var hookExtensions = function (_exts) {
   _.each(exts, function (old, ext) {
     require.extensions[ext] = old;
@@ -70,5 +66,5 @@ module.exports = function (opts) {
 
   if (opts.extensions) hookExtensions(opts.extensions);
 
-  if (opts.blacklist) addToBlacklist(opts.blacklist);
+  if (opts.blacklist) blacklist = opts.blacklist;
 };


### PR DESCRIPTION
Currently, to achieve this, I have to use this workaround:

``` js
var to5 = require('6to5')
delete to5.transform.transformers.generators
require('6to5/register')
```

After this simple change, I can make it much nicer:

``` js
require('6to5/register')({
    blacklist: ['generators']
})
```

Cheers!
