### PR TITLE
Generate moduleNames for AMD/UMD

### DIFF
--- a/lib/6to5/transformation/modules/amd.js
+++ b/lib/6to5/transformation/modules/amd.js
@@ -29,10 +29,37 @@ AMDFormatter.prototype.transform = function (ast) {
   var params = _.values(this.ids);
   params.unshift(t.identifier("exports"));
 
+  var moduleName = this.getModuleName(this.file);
+
   var container = t.functionExpression(null, params, t.blockStatement(body));
-  var call = t.callExpression(t.identifier("define"), [names, container]);
+  var call = t.callExpression(t.identifier("define"), [t.literal(moduleName), names, container]);
 
   program.body = [t.expressionStatement(call)];
+};
+
+AMDFormatter.prototype.getModuleName = function (file) {
+  var opts = file.opts,
+      filenameRelative = opts.filenameRelative,
+      sourceRootRegEx,
+      moduleName;
+
+  if (opts.moduleRoot) {
+    moduleName = opts.moduleRoot + '/';
+  }
+
+  if (!opts.filenameRelative) {
+    return moduleName + opts.filename.replace(/^\//, '');
+  }
+
+  if (opts.sourceRoot) {
+    sourceRootRegEx = new RegExp('^' + opts.sourceRoot + '\/?');
+    filenameRelative = filenameRelative.replace(sourceRootRegEx, '');
+  }
+
+  filenameRelative = filenameRelative.replace(/\.js$/, '');
+  moduleName += filenameRelative;
+
+  return moduleName;
 };
 
 AMDFormatter.prototype._push = function (node) {

--- a/lib/6to5/transformation/modules/umd.js
+++ b/lib/6to5/transformation/modules/umd.js
@@ -32,8 +32,10 @@ UMDFormatter.prototype.transform = function (ast) {
 
   // runner
 
+  var moduleName = this.getModuleName(this.file);
+
   var runner = util.template("umd-runner-body", {
-    AMD_ARGUMENTS: t.arrayExpression([t.literal("exports")].concat(names)),
+    AMD_ARGUMENTS: [t.literal(moduleName), t.arrayExpression([t.literal("exports")].concat(names))],
 
     COMMON_ARGUMENTS: names.map(function (name) {
       return t.callExpression(t.identifier("require"), [name]);


### PR DESCRIPTION
references #158, references #44

This PR allows for generating user-defined module names for AMD and UMD.

Users can define a root prefix for each module, which allows for more flexible application routing (e.g. `js-client/moduleA`), and can strip the source file's directory root so that module names can be relative (e.g. module name is `moduleA` rather than `/home/user/myApp/es6/moduleA`).

This meant a couple of new user-defined opts, which for now I've named:
- `sourceRoot` - the JS source directory to be stripped from the path
- `moduleRoot` - an optional prefix for each module. I've got a couple of lines for `gulp-6to5` for this part that I will submit a PR for if these changes look good to go. For `gulp-6to5` the changeset would be something like this:

``` js
try {
  var fileOpts = objectAssign({}, opts, {
    filename: file.path,
+    filenameRelative: file.relative,
    sourceMap: !!file.sourceMap
  });
```

With `sourceRoot: __dirname + '/js'` in `gulpfile.js` and `moduleRoot: 'client'`, you'll see something like this:
## Modules

``` js
// /root/js/moduleA
import moduleB from 'client/moduleB';

export default function () {
    console.log('moduleA! ' + moduleB());
}
```

``` js
// /root/js/moduleB
import moduleC from 'client/subdir/moduleC';

export default function () {
    return 'moduleB! ' + moduleC();
}
```

``` js
// /root/js/subdir/moduleC
export default function () {
    return 'moduleC!';
}
```
## Output

``` js
define("client/moduleA", ["exports", "client/moduleB"], function (exports, _clientModuleB) {
  "use strict";

  var moduleB = _clientModuleB["default"];
  exports["default"] = function () {
    console.log("moduleA! " + moduleB());
  };
});
define("client/moduleB", ["exports", "client/subdir/moduleC"], function (exports, _clientSubdirModuleC) {
  "use strict";

  var moduleC = _clientSubdirModuleC["default"];
  exports["default"] = function () {
    return "moduleB! " + moduleC();
  };
});
define("client/subdir/moduleC", ["exports"], function (exports) {
  "use strict";

  exports["default"] = function () {
    return "moduleC!";
  };
});
```
## `index.html`

``` html
<script>require('client/moduleA').default()</script> // 'moduleA! moduleB! moduleC!'
```

I'm not totally sure how sourcemaps work here so I haven't done anything on that front yet.

Let me know what you think! :wink: 
