### PR TITLE
Prefer module provided `global` rather than `window` reference

### DIFF
--- a/lib/6to5/browser.js
+++ b/lib/6to5/browser.js
@@ -75,6 +75,6 @@ var runScripts = function () {
 
 if (global.addEventListener) {
   global.addEventListener("DOMContentLoaded", runScripts, false);
-} else {
+} else if (global.attachEvent) {
   global.attachEvent("onload", runScripts);
 }


### PR DESCRIPTION
I love the `dist/6to5.js` build, but it does make a hard assumption that the host environment browser document context. It'd be great if just checked the module provided `global` local instead of hard coding window. Then the script would work in Web Workers or in standalone CLI environments besides node (I know node would prefer to use the lib/ files anyway).
- Use `global` instead of `window`
- Check before trying to call `attachEvent` to install loading hooks

Thanks!
