### PR TITLE
Add JSXHint in the plugins list.

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -10,6 +10,7 @@
  - [Grunt](https://github.com/sindresorhus/grunt-6to5)
  - [Jade](https://github.com/Apoxx/jade-6to5)
  - [Jest](https://github.com/6to5/6to5-jest)
+ - [JSXHint](https://github.com/STRML/JSXHint) (A wrapper around JSHint to allow linting of JSX files)
  - [Karma](https://github.com/shuhei/karma-6to5-preprocessor)
  - [Mocha](https://github.com/6to5/6to5-mocha)
  - [Rails](https://github.com/josh/sprockets-es6) or via [browserify-rails](https://github.com/6to5/6to5-rails)


### PR DESCRIPTION
Thanks for this awesome module. Its such a pleasure to finally have a sweet React + ES6 workflow. I recently add 6to5 to the JSXHint linter. So I thought I should add it to the plugins list.
