### PR TITLE
Fix comment regression

### DIFF
--- a/lib/6to5/generation/generator.js
+++ b/lib/6to5/generation/generator.js
@@ -35,12 +35,10 @@ _.each(Buffer.prototype, function (fn, key) {
 });
 
 CodeGenerator.normaliseOptions = function (opts) {
-  opts = opts.format || {};
-
   opts = _.merge({
     parentheses: true,
     semicolons: true,
-    comments: opts.comments,
+    comments: true,
     compact: false,
     indent: {
       adjustMultilineComment: true,


### PR DESCRIPTION
It looks like the quick change in 8a9a20512203ed39753af9933c045348110bdd58 broke the comments flag added in #179.

Though, I'm not sure whats going on with this `format` option.

I definitely think comments should be preserved by default. `cat already-es3.js | 6to5 == cat already-es3.js`
