### PR TITLE
Sort comparison table by most es6 support and split into two groups

### DIFF
--- a/doc/differences.md
+++ b/doc/differences.md
@@ -56,31 +56,42 @@ better suited if you'd like a full ES6 environment with polyfills and all.
 
 ## Comparison to other transpilers
 
-|                              | 6to5 | Traceur | esnext | es6now | es6-transpiler | jstransform |
-| ---------------------------- | ---- | ------- | ------ | ------ | -------------- | ----------- |
-| No runtime                   | ✓    |         |        |        | ✓              | ✓           |
-| Source maps                  | ✓    | ✓       | ✓      |        | ✓              | ✓           |
-| No compiler global pollution | ✓    |         | ✓      |        | ✓              | ✓           |
-| Browser support              | ✓    | ✓       | ✓      |        |                |             |
-| Array comprehension          | ✓    | ✓       |        |        | ✓              |             |
-| Arrow functions              | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| Async functions              | ✓    | ✓       | ✓      |        |                |             |
-| Classes                      | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| Computed property names      | ✓    | ✓       | ✓      | ✓      | ✓              |             |
-| Constants                    | ✓    | ✓       |        |        | ✓              |             |
-| Default parameters           | ✓    | ✓       | ✓      | ✓      | ✓              |             |
-| Destructuring                | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| For-of                       | ✓    | ✓       | ✓      | ✓      | ✓              |             |
-| Generators                   | ✓    | ✓       | ✓      |        |                |             |
-| Generator comprehension      | ✓    | ✓       |        |        |                |             |
-| Let scoping                  | ✓    | ✓       |        |        | ✓              |             |
-| Modules                      | ✓    | ✓       |        | ✓      |                |             |
-| Property method assignment   | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| Property name shorthand      | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| Rest parameters              | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| Spread                       | ✓    | ✓       | ✓      | ✓      | ✓              |             |
-| Template literals            | ✓    | ✓       | ✓      | ✓      | ✓              | ✓           |
-| Unicode regex                | ✓    | ✓       |        |        | ✓              |             |
+### Features
+
+|                              | 6to5 | Traceur | es6-transpiler | esnext | es6now | jstransform |
+| ---------------------------- | ---- | ------- | -------------- | ------ | ------ | ----------- |
+| Source maps                  | ✓    | ✓       | ✓              | ✓      |        | ✓           |
+| No compiler global pollution | ✓    |         | ✓              | ✓      |        | ✓           |
+| No runtime                   | ✓    |         | ✓              |        |        | ✓           |
+| Browser support              | ✓    | ✓       |                | ✓      |        |             |
+
+### Language Support
+
+|                              | 6to5  | Traceur | es6-transpiler | esnext | es6now | jstransform |
+| ---------------------------- | ----- | ------- | -------------- | ------ | ------ | ----------- |
+| Array comprehension          | ✓     | ✓       | ✓              |        |        |             |
+| Arrow functions              | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| Async functions              | ✓     | ✓       |                | ✓      |        |             |
+| Classes                      | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| Computed property names      | ✓     | ✓       | ✓              | ✓      | ✓      |             |
+| Constants                    | ✓     | ✓       | ✓              |        |        |             |
+| Default parameters           | ✓     | ✓       | ✓              | ✓      | ✓      |             |
+| Destructuring                | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| For-of                       | ✓     | ✓       | ✓              | ✓      | ✓      |             |
+| Generators                   | ✓     | ✓       |                | ✓      |        |             |
+| Generator comprehension      | ✓     | ✓       |                |        |        |             |
+| Let scoping                  | ✓     | ✓       | ✓              |        |        |             |
+| Modules                      | ✓     | ✓       |                |        | ✓      |             |
+| Property method assignment   | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| Property name shorthand      | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| Rest parameters              | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| Spread                       | ✓     | ✓       | ✓              | ✓      | ✓      |             |
+| Template literals            | ✓     | ✓       | ✓              | ✓      | ✓      | ✓           |
+| Unicode regex                | ✓     | ✓       | ✓              |        |        |             |
+
+
+
+
 
 ### [Traceur](https://github.com/google/traceur-compiler)
 


### PR DESCRIPTION
es6-transpiler has more es6 support than esnext or es6now so I figured they should be recognized for that.

I also split the table apart because it really is two separate categories.
