### PR TITLE
Allow module transformers to be directly passed into opts.

### DIFF
--- a/lib/6to5/file.js
+++ b/lib/6to5/file.js
@@ -59,7 +59,7 @@ File.normaliseOptions = function (opts) {
 };
 
 File.prototype.getModuleFormatter = function (type) {
-  var ModuleFormatter = transform.moduleFormatters[type];
+  var ModuleFormatter = _.isFunction(type) ? type : transform.moduleFormatters[type];
 
   if (!ModuleFormatter) {
     var loc = util.resolve(type);


### PR DESCRIPTION
This patch allows a module transformer to be passed directly through the options instead of relying on it being require()able.
