### PR TITLE
Better variable renaming for let scopes.

### DIFF
--- a/lib/6to5/transformation/transformers/let-scoping.js
+++ b/lib/6to5/transformation/transformers/let-scoping.js
@@ -51,6 +51,7 @@ exports.For = function (node, parent, file, scope) {
 exports.BlockStatement = function (block, parent, file, scope) {
   if (!t.isFor(parent)) {
     var letScoping = new LetScoping(false, block, parent, file, scope);
+    block._letscope = letScoping;
     letScoping.run();
   }
 };
@@ -183,6 +184,7 @@ LetScoping.prototype.getInfo = function () {
   var block = this.block;
   var scope = this.scope;
   var file  = this.file;
+  var parent = this.parent;
 
   var opts = {
     // array of `Identifier` names of let variables that appear lexically out of
@@ -211,6 +213,13 @@ LetScoping.prototype.getInfo = function () {
       opts.duplicates[key] = id.name = file.generateUid(key, scope);
     }
   };
+  
+  var remapParentVars = function (replacement, key) {
+    if (opts.duplicates[key]) {
+      // remap
+      opts.duplicates[replacement] = opts.duplicates[key];
+    }
+  };
 
   _.each(opts.declarators, function (declar) {
     opts.declarators.push(declar);
@@ -231,7 +240,14 @@ LetScoping.prototype.getInfo = function () {
       opts.keys.push(key);
     });
   });
-
+  
+  while (parent) {
+    if (parent._letscope) {
+      _.each(parent._letscope.info.duplicates, remapParentVars);
+    }
+    parent = parent._parent;
+  }
+  
   return opts;
 };
 

--- a/test/fixtures/transformation/let-scoping/exec-block-scoped/exec.js
+++ b/test/fixtures/transformation/let-scoping/exec-block-scoped/exec.js
@@ -2,5 +2,9 @@ let x = 1;
 {
   let x = 2;
   assert.equal(x, 2);
+  {
+    let x = 3;
+    assert.equal(x, 3);
+  }
 }
 assert.equal(x, 1);


### PR DESCRIPTION
I've done some playing with the let renaming so that it also uses remapping from parent scopes. It fixes cases like:

``` javascript
let x = 1;
{
  let x = 2;
  {
    let x = 3;
    console.log(x); // should print 3
  }
}
```
