### PR TITLE
Fix runtime injection in Web Worker.

### DIFF
--- a/lib/6to5/runtime.js
+++ b/lib/6to5/runtime.js
@@ -8,15 +8,13 @@ module.exports = function (namespace) {
   namespace = t.identifier(t.toIdentifier(namespace || "to5Runtime"));
 
   var body      = [];
-  var container = t.functionExpression(null, [], t.blockStatement(body));
-  var tree      = t.program([t.expressionStatement(t.callExpression(container, []))]);
-
-  body.push(util.template("self-global", true));
+  var container = t.functionExpression(null, [t.identifier("global")], t.blockStatement(body));
+  var tree      = t.program([t.expressionStatement(t.callExpression(container, [util.template("self-global")]))]);
 
   body.push(t.variableDeclaration("var", [
     t.variableDeclarator(
       namespace,
-      t.assignmentExpression("=", t.memberExpression(t.identifier("self"), namespace), t.objectExpression([]))
+      t.assignmentExpression("=", t.memberExpression(t.identifier("global"), namespace), t.objectExpression([]))
     )
   ]));
 

--- a/lib/6to5/templates/self-global.js
+++ b/lib/6to5/templates/self-global.js
@@ -1,1 +1,1 @@
-var self = typeof global === "undefined" ? window : global;
+typeof global === "undefined" ? self : global


### PR DESCRIPTION
Web Workers don't have `window` object but they have `self` (which is available in regular windows as well).
