### PR TITLE
Speed up constructor spreads.

### DIFF
--- a/lib/6to5/templates/apply-constructor.js
+++ b/lib/6to5/templates/apply-constructor.js
@@ -1,5 +1,5 @@
 (function (Constructor, args) {
-  var bindArgs = [null].concat(args);
-  var Factory = Constructor.bind.apply(Constructor, bindArgs);
-  return new Factory;
+  var instance = Object.create(Constructor);
+  Constructor.apply(instance, args);
+  return instance;
 });


### PR DESCRIPTION
Replace slow .bind with manual .create+.apply.
Gives up to 19x speed up depending on browser.

http://jsperf.com/apply-constructor
