### PR TITLE
Remove --no-timeouts flag.

### DIFF
--- a/bin/6to5-node
+++ b/bin/6to5-node
@@ -14,13 +14,11 @@ process.argv.slice(2).forEach(function(arg){
   switch (flag) {
     case "-d":
       args.unshift("--debug");
-      args.push("--no-timeouts");
       break;
     case "debug":
     case "--debug":
     case "--debug-brk":
       args.unshift(arg);
-      args.push("--no-timeouts");
       break;
     case "-gc":
     case "--expose-gc":


### PR DESCRIPTION
Not a valid flag, causes errors when trying to use debug modes.

No tests fail. Debugging is functional.
