### PR TITLE
Unify ignore(Regex)/only options into a function

### DIFF
--- a/lib/6to5/register.js
+++ b/lib/6to5/register.js
@@ -57,17 +57,21 @@ blacklistTest("unicodeRegex", function () { new RegExp("foo", "u"); });
 
 //
 
-var transformOpts = {};
-var filter        = function(m, fileaame) { return !/node_modules/.test(filename); }
+var scopedOptsList = [];
 var whitelist     = [];
-var exts          = {};
 var maps          = {};
 var old           = require.extensions[".js"];
 
 var loader = function (m, filename) {
-  if (!filter(m, filename)) {
+  var filter, transformOpts;
+
+  filter = _.find(scopedOptsList, function(filter) {
+    return _.some(filter.exts, function(ext) { return filename.endsWith(ext); }) && filter.test(m, filename)
+  });
+  if (!filter) {
     return old.apply(this, arguments);
   }
+  transformOpts = filter.transformOpts;
 
   var result = to5.transformFileSync(filename, _.extend({
     whitelist: whitelist,
@@ -81,23 +85,19 @@ var loader = function (m, filename) {
   m._compile(result.code, filename);
 };
 
-var hookExtensions = function (_exts) {
-  _.each(exts, function (old, ext) {
-    require.extensions[ext] = old;
-  });
+var hookExtensions = function (scopedOpts) {
+  scopedOptsList.push(scopedOpts);
 
-  exts = {};
-
-  _.each(_exts, function (ext) {
-    exts[ext] = require.extensions[ext];
-    require.extensions[ext] = loader;
+  _.each(scopedOpts.exts, function (ext) {
+    var extLoader = require.extensions[ext];
+    if (extLoader !== loader) {
+      require.extensions[ext] = loader; // TODO: Should wrap existing one instead of replacing?
+    }
   });
 };
 
-hookExtensions([".es6", ".js"]);
-
 module.exports = function (opts) {
-  var ignoreRegex, onlyRegex, ignoreFunc, onlyFunc;
+  var ignoreRegex, onlyRegex, ignoreFunc, onlyFunc, test, exts, scopedOpts;
 
   onlyFunc = function() { return true; };
   ignoreFunc = function() { return false; };
@@ -112,9 +112,7 @@ module.exports = function (opts) {
       onlyFunc = function(m, filename) { return opts.only.call(opts, m, filename); };
     } else {
       onlyRegex = util.regexify(opts.only);
-      onlyFunc = function(m, filename) {
-        return onlyRegex.test(filename);
-      };
+      onlyFunc = function(m, filename) { return onlyRegex.test(filename); };
     }
   }
   if (opts.ignore != null) {
@@ -122,22 +120,19 @@ module.exports = function (opts) {
       ignoreFunc = function(m, filename) { return opts.ignore.call(opts, m, filename); };
     } else {
       ignoreRegex = util.regexify(opts.ignore);
-      ignoreFunc = function(m, filename) {
-        return ignoreRegex.test(filename);
-      };
+      ignoreFunc = function(m, filename) { return ignoreRegex.test(filename); };
     }
   }
 
-  if (onlyFunc || ignoreFunc) {
-    filter = function(m, filename) {
-      return !ignoreFunc(m, filename) && onlyFunc(m, filename);
-    }
-  }
-  if (/* Might be better not to add this option */opts.filter) {
-    filter = opts.filter;
-  }
+  if (onlyFunc || ignoreFunc)
+    test = function(m, filename) { return !ignoreFunc(m, filename) && onlyFunc(m, filename); };
 
-  if (opts.extensions) hookExtensions(util.arrayify(opts.extensions));
+  exts = util.arrayify(opts.extensions || ['.es6', '.js']);
+  scopedOpts = {
+    exts: exts,
+    test: test,
+    transformOpts: opts
+  };
 
-  _.extend(transformOpts, opts);
+  hookExtensions(scopedOpts);
 };


### PR DESCRIPTION
As a proposal, introduce a predicate function which finally unifies `ignore`, `ignoreRegex` and `only` options.

example: Assuming the file is at `(Some other projects)/node_modules/(This project)/index.js`

```
const path = require('path');
const projDir = path.resolve(module.filename, '..') + '/'';
const projNodeModulesDir = path.resolve(projDir, 'node_modules') + '/';

require('6to5/polyfill');
require('6to5/register')({
    filter: function(m, filename) {
        return filename.startsWith(projDir) && !filename.startsWith(projNodeModulesDir);
    }
    // Otherwise
    // ignore: '^' + ESCAPE_REGEX(projNodeModulesDir),
    // only  : '^' + ESCAPE_REGEX(projDir)
});
```

NOTE: I have not tested any compatibility, but it may work if I coded correctly.
