### PR TITLE
Simplify chokidar event handler

### DIFF
--- a/bin/6to5/file.js
+++ b/bin/6to5/file.js
@@ -117,8 +117,10 @@ module.exports = function (commander, filenames) {
         persistent: true,
         ignoreInitial: true
       }).on("all", function (type, filename) {
-        console.log(type, filename);
-        walk();
+        if (type === "add" || type === "change" || type === "unlink" ) {
+          console.log(type, filename);
+          walk();
+        }
       });
     }
   };


### PR DESCRIPTION
Chokidar provides an `all` event, making it possible to bind just one handler instead of iterating to bind several that are all doing the same thing.
