### PR TITLE
Add interop require support for AMD and UMD

### DIFF
--- a/lib/6to5/transformation/modules/amd.js
+++ b/lib/6to5/transformation/modules/amd.js
@@ -80,6 +80,10 @@ AMDFormatter.prototype.importSpecifier = function (specifier, node, nodes) {
   } else {
     // import foo from "foo";
     ref = t.memberExpression(this._push(node), id, false);
+
+    if (specifier.default) {
+      ref = t.callExpression(this.file.addDeclaration("interop-require"), [ref]);
+    }
   }
 
   nodes.push(t.variableDeclaration("var", [

--- a/test/fixtures/transformation/es6-modules-amd/imports-default/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/imports-default/expected.js
@@ -1,6 +1,11 @@
 define(["exports", "foo"], function (exports, _foo) {
   "use strict";
 
-  var foo = _foo["default"];
+  var _interopRequire = function (obj) {
+    return obj && (obj["default"] || obj);
+  };
+
+  var foo = _interopRequire(_foo["default"]);
+
   var foo = _foo["default"];
 });

--- a/test/fixtures/transformation/es6-modules-amd/imports-mixing/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/imports-mixing/expected.js
@@ -1,6 +1,11 @@
 define(["exports", "foo"], function (exports, _foo) {
   "use strict";
 
-  var foo = _foo["default"];
+  var _interopRequire = function (obj) {
+    return obj && (obj["default"] || obj);
+  };
+
+  var foo = _interopRequire(_foo["default"]);
+
   var xyz = _foo.baz;
 });

--- a/test/fixtures/transformation/es6-modules-amd/overview/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/overview/expected.js
@@ -1,7 +1,12 @@
 define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (exports, _foo, _fooBar, _directoryFooBar) {
   "use strict";
 
-  var foo = _foo["default"];
+  var _interopRequire = function (obj) {
+    return obj && (obj["default"] || obj);
+  };
+
+  var foo = _interopRequire(_foo["default"]);
+
   var foo = _foo;
   var bar = _foo.bar;
   var bar = _foo.foo;

--- a/test/fixtures/transformation/es6-modules-umd/imports-default/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/imports-default/expected.js
@@ -7,6 +7,11 @@
 })(function (exports, _foo) {
   "use strict";
 
-  var foo = _foo["default"];
+  var _interopRequire = function (obj) {
+    return obj && (obj["default"] || obj);
+  };
+
+  var foo = _interopRequire(_foo["default"]);
+
   var foo = _foo["default"];
 });

--- a/test/fixtures/transformation/es6-modules-umd/imports-mixing/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/imports-mixing/expected.js
@@ -7,6 +7,11 @@
 })(function (exports, _foo) {
   "use strict";
 
-  var foo = _foo["default"];
+  var _interopRequire = function (obj) {
+    return obj && (obj["default"] || obj);
+  };
+
+  var foo = _interopRequire(_foo["default"]);
+
   var xyz = _foo.baz;
 });

--- a/test/fixtures/transformation/es6-modules-umd/overview/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/overview/expected.js
@@ -7,7 +7,12 @@
 })(function (exports, _foo, _fooBar, _directoryFooBar) {
   "use strict";
 
-  var foo = _foo["default"];
+  var _interopRequire = function (obj) {
+    return obj && (obj["default"] || obj);
+  };
+
+  var foo = _interopRequire(_foo["default"]);
+
   var foo = _foo;
   var bar = _foo.bar;
   var bar = _foo.foo;


### PR DESCRIPTION
This is the AMD/UMD equivalent of #191. It allows non-ES6 modules to be imported in the AMD/UMD format.
