### PR TITLE
Changed error message for required class instance setter parameter

### DIFF
--- a/lib/6to5/transformation/transformers/validation/setters.js
+++ b/lib/6to5/transformation/transformers/validation/setters.js
@@ -3,6 +3,6 @@
 exports.MethodDefinition =
 exports.Property = function (node, parent, scope, context, file) {
   if (node.kind === "set" && node.value.params.length !== 1) {
-    throw file.errorWithNode(node.value, "Setters must have only one parameter");
+    throw file.errorWithNode(node.value, "Setters must have exactly one parameter");
   }
 };


### PR DESCRIPTION
Minor change..

Changed the compile-time error message for class instance setters requiring a single parameter. When it said "only" one parameter, it implies that you have greater than one, even if you have zero parameters.

![image](https://cloud.githubusercontent.com/assets/762949/6218275/7fe5a9f6-b5d1-11e4-872c-bfbf93d59118.png)

[REPL](https://babeljs.io/repl/#?experimental=true&playground=true&evaluate=true&loose=false&spec=false&code=class%20Foo%20%7B%0A%20%20set%20kickDog()%20%7B%7D%0A%7D)

Side note: is there currently a way to test for compile-time exceptions the test suite? If so, I can add this one to confirm it throws under the correct cases. (I can't seem to find any existing tests doing so)