### PR TITLE
test on `iojs` and the upcoming node `0.13` but allow failures from it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ sudo: false
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
   - "0.12"
+  - "0.13"
+  - "iojs"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.13"
 
 branches:
   except:


### PR DESCRIPTION
also removed `0.11` as it's totally moot to test on it now that `0.12` is out.