### PR TITLE
Links the babel logo in the readme to the home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center">
-  <img alt="babel" src="https://raw.githubusercontent.com/babel/logo/master/logo.png" width="546">
+  <a href="https://babeljs.io/">
+    <img alt="babel" src="https://raw.githubusercontent.com/babel/logo/master/logo.png" width="546">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The large “BABEL” logo is tempting, but if you click it you are taken to the image in its own tab. This wraps the image in a link to the home page for anyone who visits the repo and clicks on the logo.