### PR TITLE
build: ensure bootstrap works on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,5 +119,5 @@ publish-core:
 bootstrap:
 	npm install
 	git submodule update --init
-	cd vendor/regenerator; npm install
-	cd vendor/compat-table; npm install object-assign
+	cd vendor/regenerator && npm install
+	cd vendor/compat-table && npm install object-assign


### PR DESCRIPTION
Noticed Windows fails on bootstrap with ```The system cannot find the path specified.```.

I assume it just doesn't comprehend the semicolon correctly, switched to ```&&``` and tested on Windows and Mac and seems universally happy.