### PR TITLE
Add rest parameters optimization

### DIFF
--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -50,7 +50,7 @@ var hasRest = function (node) {
   return t.isRestElement(node.params[node.params.length - 1]);
 };
 
-exports.Function = function (node, parent, scope, file) {
+exports.Function = function (node, parent, scope) {
   if (!hasRest(node)) return;
 
   var rest = node.params.pop().argument;

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -93,7 +93,8 @@ exports.Function = function (node, parent, scope, file) {
   scope.traverse(node, memberExpressionVisitor, state);
 
   if (state.isOptimizable) {
-    for (let candidate of state.candidates) {
+    for (let i = 0, count = state.candidates.length; i < count; ++i) {
+      let candidate = state.candidates[i];
       optimizeMemberExpression(candidate.node, candidate.parent, node.params.length, state.strictMode);
     }
     return;

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -18,8 +18,7 @@ var memberExpressionVisitor = {
 
     if (t.isMemberExpression(parent)) {
       var prop = parent.property;
-      if (state.strictMode ||
-          typeof prop.value === "number" ||
+      if (typeof prop.value === "number" ||
           t.isUnaryExpression(prop) ||
           t.isBinaryExpression(prop)) {
         state.candidates.push({ node, parent });
@@ -32,7 +31,7 @@ var memberExpressionVisitor = {
   }
 };
 
-function optimizeMemberExpression(node, parent, offset, strictMode) {
+function optimizeMemberExpression(node, parent, offset) {
   var newExpr;
   var prop = parent.property;
 
@@ -40,19 +39,10 @@ function optimizeMemberExpression(node, parent, offset, strictMode) {
     node.name = "arguments";
     prop.value += offset;
     prop.raw = String(prop.value);
-  } else if (t.isUnaryExpression(prop)) {
+  } else {
     node.name = "arguments";
     newExpr = t.binaryExpression("+", prop, t.literal(offset));
     parent.property = newExpr;
-  } else if (t.isBinaryExpression(prop)) {
-    node.name = "arguments";
-    newExpr = t.binaryExpression("+", prop, t.literal(offset));
-    parent.property = newExpr;
-  }
-
-  if (strictMode && node.name !== "arguments") {
-    node.name = "arguments";
-    parent.property = t.binaryExpression("+", prop, t.literal(offset));
   }
 }
 
@@ -87,8 +77,7 @@ exports.Function = function (node, parent, scope, file) {
     name: rest.name,
     outerDeclar: restOuterDeclar,
     isOptimizable: true,
-    candidates: [],
-    strictMode: file.transformers.useStrict.canRun()
+    candidates: []
   };
   scope.traverse(node, memberExpressionVisitor, state);
 

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -5,13 +5,13 @@ exports.check = t.isRestElement;
 
 var memberExpressionVisitor = {
   enter: function (node, parent, scope, state) {
-    var localDeclar = scope.getBindingIdentifier(state.name);
-    if (localDeclar !== state.outerDeclar) return;
+    if (t.isScope(node, parent) && !scope.bindingIdentifierEquals(state.name, state.outerDeclar)) {
+      return this.skip();
+    }
 
     if (t.isFunctionDeclaration(node) || t.isFunctionExpression(node)) {
       state.isOptimizable = false;
-      this.skip();
-      return;
+      return this.skip();
     }
 
     if (!t.isReferencedIdentifier(node, parent, { name: state.name })) return;

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -50,9 +50,6 @@ function optimizeMemberExpression(node, parent, offset) {
   }
 }
 
-function optimizeCandidates(candidates) {
-}
-
 var hasRest = function (node) {
   return t.isRestElement(node.params[node.params.length - 1]);
 };

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -52,6 +52,10 @@ function optimizeMemberExpression(node, parent, offset) {
 }
 
 function optimizeMemberExpressionStrict(node, parent, offset) {
+  // handle basic expressions specially (especially literals)
+  optimizeMemberExpression(node, parent, offset);
+  if (node.name === 'arguments') return;
+
   var prop = parent.property;
   node.name = 'arguments';
   parent.property = t.binaryExpression('+', prop, t.literal(offset));

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -4,7 +4,7 @@ var t    = require("../../../types");
 exports.check = t.isRestElement;
 
 var memberExpressionVisitor = {
-  enter: function (node, parent, scope, state) {
+  enter(node, parent, scope, state) {
     if (t.isScope(node, parent) && !scope.bindingIdentifierEquals(state.name, state.outerDeclar)) {
       return this.skip();
     }
@@ -22,7 +22,7 @@ var memberExpressionVisitor = {
           typeof prop.value === "number" ||
           t.isUnaryExpression(prop) ||
           t.isBinaryExpression(prop)) {
-        state.candidates.push({ node: node, parent: parent });
+        state.candidates.push({ node, parent });
         return;
       }
     }
@@ -93,8 +93,7 @@ exports.Function = function (node, parent, scope, file) {
   scope.traverse(node, memberExpressionVisitor, state);
 
   if (state.isOptimizable) {
-    for (var i = 0, count = state.candidates.length; i < count; ++i) {
-      var candidate = state.candidates[i];
+    for (let candidate of state.candidates) {
       optimizeMemberExpression(candidate.node, candidate.parent, node.params.length, state.strictMode);
     }
     return;

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -65,7 +65,7 @@ exports.Function = function (node, parent, scope) {
     var pattern = rest;
     rest = scope.generateUidIdentifier("ref");
     var declar = t.variableDeclaration("var", pattern.elements.map(function (elem, index) {
-      var accessExpr = t.memberExpression(rest, t.literal(index));
+      var accessExpr = t.memberExpression(rest, t.literal(index), true);
       return t.variableDeclarator(elem, accessExpr);
     }));
     node.body.body.unshift(declar);

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -19,7 +19,7 @@ var memberExpressionVisitor = {
     if (t.isMemberExpression(parent)) {
       var prop = parent.property;
       if (state.strictMode ||
-          typeof prop.value === 'number' ||
+          typeof prop.value === "number" ||
           t.isUnaryExpression(prop) ||
           t.isBinaryExpression(prop)) {
         state.candidates.push({ node: node, parent: parent });
@@ -37,22 +37,22 @@ function optimizeMemberExpression(node, parent, offset, strictMode) {
   var prop = parent.property;
 
   if (t.isLiteral(prop)) {
-    node.name = 'arguments';
+    node.name = "arguments";
     prop.value += offset;
     prop.raw = String(prop.value);
   } else if (t.isUnaryExpression(prop)) {
-    node.name = 'arguments';
-    newExpr = t.binaryExpression('+', prop, t.literal(offset));
+    node.name = "arguments";
+    newExpr = t.binaryExpression("+", prop, t.literal(offset));
     parent.property = newExpr;
   } else if (t.isBinaryExpression(prop)) {
-    node.name = 'arguments';
-    newExpr = t.binaryExpression('+', prop, t.literal(offset));
+    node.name = "arguments";
+    newExpr = t.binaryExpression("+", prop, t.literal(offset));
     parent.property = newExpr;
   }
 
-  if (strictMode && node.name !== 'arguments') {
-    node.name = 'arguments';
-    parent.property = t.binaryExpression('+', prop, t.literal(offset));
+  if (strictMode && node.name !== "arguments") {
+    node.name = "arguments";
+    parent.property = t.binaryExpression("+", prop, t.literal(offset));
   }
 }
 

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -16,11 +16,11 @@ var memberExpressionVisitor = {
 
     if (!t.isReferencedIdentifier(node, parent, { name: state.name })) return;
 
-    if (parent.type === 'MemberExpression') {
+    if (t.isMemberExpression(parent)) {
       var prop = parent.property;
       if (typeof prop.value === 'number' ||
-          prop.type === 'UnaryExpression' ||
-          prop.type === 'BinaryExpression') {
+          t.isUnaryExpression(prop) ||
+          t.isBinaryExpression(prop)) {
         state.candidates.push({ node: node, parent: parent });
         return;
       }
@@ -35,26 +35,18 @@ function optimizeMemberExpression(node, parent, offset) {
   var newExpr;
 
   var prop = parent.property;
-  switch (prop.type) {
-  case 'Literal':
+  if (t.isLiteral(prop)) {
     node.name = 'arguments';
     prop.value += offset;
     prop.raw = String(prop.value);
-    break;
-  case 'UnaryExpression': {
+  } else if (t.isUnaryExpression(prop)) {
     node.name = 'arguments';
     newExpr = t.binaryExpression('+', prop, t.literal(offset));
     parent.property = newExpr;
-    break;
-  }
-  case 'BinaryExpression': {
+  } else if (t.isBinaryExpression(prop)) {
     node.name = 'arguments';
     newExpr = t.binaryExpression('+', prop, t.literal(offset));
     parent.property = newExpr;
-    break;
-  }
-  default:
-    throw new Error('Unsupported property type');
   }
 }
 

--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -11,7 +11,7 @@ var memberExpressionVisitor = {
 
     if (t.isFunctionDeclaration(node) || t.isFunctionExpression(node)) {
       state.isOptimizable = false;
-      return this.skip();
+      return this.stop();
     }
 
     if (!t.isReferencedIdentifier(node, parent, { name: state.name })) return;

--- a/test/fixtures/transformation/es6-parameters.rest/arrow-functions/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/arrow-functions/actual.js
@@ -1,3 +1,4 @@
 var concat = (...arrs) => {
-
+    var x = arrs[0];
+    var y = arrs[1];
 };

--- a/test/fixtures/transformation/es6-parameters.rest/arrow-functions/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/arrow-functions/expected.js
@@ -1,7 +1,8 @@
 "use strict";
 
+var _arguments = arguments;
 var concat = function () {
-  for (var _len = arguments.length, arrs = Array(_len), _key = 0; _key < _len; _key++) {
-    arrs[_key] = arguments[_key];
-  }
+    var x = _arguments[0];
+    var y = _arguments[1];
 };
+

--- a/test/fixtures/transformation/es6-parameters.rest/deopt/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/deopt/actual.js
@@ -1,0 +1,15 @@
+var x = function (foo, ...bar) {
+  console.log(bar);
+};
+
+var y = function (foo, ...bar) {
+  var x = function z(bar) {
+    bar[1] = 5;
+  };
+};
+
+var z = function (foo, ...bar) {
+    var x = function () {
+        bar[1] = 5;
+    };
+};

--- a/test/fixtures/transformation/es6-parameters.rest/deopt/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/deopt/actual.js
@@ -13,3 +13,12 @@ var z = function (foo, ...bar) {
         bar[1] = 5;
     };
 };
+
+var a = function (foo, ...bar) {
+    return bar.join(',');
+};
+
+var b = function (foo, ...bar) {
+    var join = "join";
+    return bar[join];
+};

--- a/test/fixtures/transformation/es6-parameters.rest/deopt/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/deopt/expected.js
@@ -1,26 +1,43 @@
 "use strict";
 
 var x = function x(foo) {
-  for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    bar[_key - 1] = arguments[_key];
-  }
+    for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        bar[_key - 1] = arguments[_key];
+    }
 
-  console.log(bar);
+    console.log(bar);
 };
 
 var y = function y(foo) {
-  var x = function z(bar) {
-    bar[1] = 5;
-  };
+    var x = function z(bar) {
+        bar[1] = 5;
+    };
 };
 
 var z = function z(foo) {
-  for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    bar[_key - 1] = arguments[_key];
-  }
+    for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        bar[_key - 1] = arguments[_key];
+    }
 
-  var x = function x() {
-    bar[1] = 5;
-  };
+    var x = function x() {
+        bar[1] = 5;
+    };
+};
+
+var a = function a(foo) {
+    for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        bar[_key - 1] = arguments[_key];
+    }
+
+    return bar.join(",");
+};
+
+var b = function b(foo) {
+    for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        bar[_key - 1] = arguments[_key];
+    }
+
+    var join = "join";
+    return bar[join];
 };
 

--- a/test/fixtures/transformation/es6-parameters.rest/deopt/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/deopt/expected.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var x = function x(foo) {
+  for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    bar[_key - 1] = arguments[_key];
+  }
+
+  console.log(bar);
+};
+
+var y = function y(foo) {
+  var x = function z(bar) {
+    bar[1] = 5;
+  };
+};
+
+var z = function z(foo) {
+  for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    bar[_key - 1] = arguments[_key];
+  }
+
+  var x = function x() {
+    bar[1] = 5;
+  };
+};
+

--- a/test/fixtures/transformation/es6-parameters.rest/multiple/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/multiple/actual.js
@@ -1,7 +1,11 @@
 var t = function (f, ...items) {
-
+    var x = f;
+    x = items[0];
+    x = items[1];
 };
 
 function t(f, ...items) {
-
+    var x = f;
+    x = items[0];
+    x = items[1];
 }

--- a/test/fixtures/transformation/es6-parameters.rest/multiple/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/multiple/expected.js
@@ -1,13 +1,14 @@
 "use strict";
 
 var t = function t(f) {
-  for (var _len = arguments.length, items = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    items[_key - 1] = arguments[_key];
-  }
+    var x = f;
+    x = arguments[1];
+    x = arguments[2];
 };
 
 function t(f) {
-  for (var _len = arguments.length, items = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    items[_key - 1] = arguments[_key];
-  }
+    var x = f;
+    x = arguments[1];
+    x = arguments[2];
 }
+

--- a/test/fixtures/transformation/es6-parameters.rest/pattern/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/pattern/actual.js
@@ -1,3 +1,2 @@
 var foo = function (...[a, b]) {
-
 };

--- a/test/fixtures/transformation/es6-parameters.rest/pattern/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/pattern/expected.js
@@ -1,10 +1,7 @@
 "use strict";
 
 var foo = function foo() {
-  for (var _len = arguments.length, _ref = Array(_len), _key = 0; _key < _len; _key++) {
-    _ref[_key] = arguments[_key];
-  }
-
-  var a = _ref[0];
-  var b = _ref[1];
+  var a = arguments[0],
+      b = arguments[1];
 };
+

--- a/test/fixtures/transformation/es6-parameters.rest/single/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/single/actual.js
@@ -1,7 +1,9 @@
 var t = function (...items) {
-
+    var x = items[0];
+    var y = items[1];
 }
 
 function t(...items) {
-
+    var x = items[0];
+    var y = items[1];
 }

--- a/test/fixtures/transformation/es6-parameters.rest/single/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/single/expected.js
@@ -1,13 +1,12 @@
 "use strict";
 
 var t = function t() {
-  for (var _len = arguments.length, items = Array(_len), _key = 0; _key < _len; _key++) {
-    items[_key] = arguments[_key];
-  }
+    var x = arguments[0];
+    var y = arguments[1];
 };
 
 function t() {
-  for (var _len = arguments.length, items = Array(_len), _key = 0; _key < _len; _key++) {
-    items[_key] = arguments[_key];
-  }
+    var x = arguments[0];
+    var y = arguments[1];
 }
+


### PR DESCRIPTION
Purpose
=======

This pull request introduces optimization of function rest parameters (example in https://babeljs.io/docs/learn-es6/#default-rest-spread).

This PRs should fix issue https://github.com/babel/babel/issues/886.

Problem
=======

Usage of rest parameters currently creates copy of arguments as show int following example:

    function f(foo, ...bar) {
      var x = bar[0];
    }

Generated code looks like this

    function f(foo) {
      for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        bar[_key - 1] = arguments[_key];
      }

      var x = bar[0];
    }

Proposal
=======

Generated code could be simplifies in some cases. This pull request adds some optimizations. These are show in following blocks. Cases that are not optimized are added to show safety and/or limitations of current implementation.

    function f(foo, ...bar) {
      console.log(bar[0]);
      console.log(bar[1]);
    }

    function g(foo, ...bar) {
      console.log(bar);
    }

    function h(foo, ...bar) {
      return bar[0];
    }

    function m(foo, ...bar) {
      var x = bar[1+1];
      var y = bar[x+5];
    }

    function o(foo, ...bar) {
      var x = bar[+1];
      var y = bar[+x];
    }

    function k(foo, ...bar) {
      var z = bar[x || y];
    }

    function l(foo, ...bar) {
      var x = bar[foo];
      var y = bar[foo.something];
    }

    function i(foo, ...bar) {
    }

    function j(foo, ...bar) {
      var x = function z(bar) {
        bar[1] = 5;
      };
    }

    function n(foo, ...bar) {
        var x = function () {
            bar[1] = 5;
        };
    }

    function p(foo, ...[a, b]) {
        console.log(a);
        console.log(b);
    };

is now transpiled into

    function f(foo) {
      console.log(arguments[1]);
      console.log(arguments[2]);
    }

    function g(foo) {
      for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        bar[_key - 1] = arguments[_key];
      }

      console.log(bar);
    }

    function h(foo) {
      return arguments[1];
    }

    function m(foo) {
      var x = arguments[1 + 1 + 1];
      var y = arguments[x + 5 + 1];
    }

    function o(foo) {
      var x = arguments[+1 + 1];
      var y = arguments[+x + 1];
    }

    function k(foo) {
      for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        bar[_key - 1] = arguments[_key];
      }

      var z = bar[x || y];
    }

    function l(foo) {
      for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        bar[_key - 1] = arguments[_key];
      }

      var x = bar[foo];
      var y = bar[foo.something];
    }

    function i(foo) {}

    function j(foo) {
      var x = function z(bar) {
        bar[1] = 5;
      };
    }

    function n(foo) {
      for (var _len = arguments.length, bar = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        bar[_key - 1] = arguments[_key];
      }

      var x = function x() {
        bar[1] = 5;
      };
    }

    function p(foo) {
      var a = arguments[1],
          b = arguments[2];

      console.log(a);
      console.log(b);
    };

    var q = function q() {
      var a = arguments[0],
          b = arguments[1];
    };

    function r(joinStr) {
      for (var _len = arguments.length, items = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        items[_key - 1] = arguments[_key];
      }

      return items.join(joinStr);
    };

Known issues
==============

None.

Further improvements
==================

**removed; impossible** Separate strict mode assumptions about numeric indices as described by @sebmck in https://github.com/babel/babel/issues/886#issuecomment-75878863. This will be done before this is [eventually] merged (unless rejected for wharever reason during review).

Destructuring should be handled by destructuring transformer, however it copies whole arguments array which is opposite of this optimizations goal.

**done** Oh, and tests would not hurt.