### PR TITLE
feat(6to5/register) don't override uncaughtException handler

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -10,6 +10,7 @@ var util             = require("../../util");
 var fs               = require("fs");
 
 sourceMapSupport.install({
+  handleUncaughtExceptions: false,
   retrieveSourceMap(source) {
     var map = maps && maps[source];
     if (map) {


### PR DESCRIPTION
Maybe we could do this by default or even make it configurable?

The weird thing is that https://github.com/evanw/node-source-map-support already overrides `error.stack` so that it shows all the right stuff, so I'm not super sure why it also overrides `process.on('uncaughtException')`

See also: https://github.com/evanw/node-source-map-support/issues/40