### PR TITLE
Add 'color' option to CLI and API

### DIFF
--- a/bin/_babel-node
+++ b/bin/_babel-node
@@ -21,6 +21,7 @@ program.option("-g, --playground", "Enable playground support");
 program.option("-w, --whitelist [whitelist]", "Whitelist of transformers to ONLY use", util.list);
 program.option("-b, --blacklist [blacklist]", "Blacklist of transformers to NOT use", util.list);
 program.option("-o, --optional [optional]", "List of optional transformers to enable", util.list);
+program.option("--color [when]", "Use color in output (never, always or auto) [auto]", "auto");
 
 var pkg = require("../package.json");
 program.version(pkg.version);
@@ -36,7 +37,8 @@ babel.register({
   blacklist:    program.blacklist,
   whitelist:    program.whitelist,
   optional:     program.optional,
-  ignore:       program.ignore
+  ignore:       program.ignore,
+  color:        program.color,
 });
 
 //
@@ -48,7 +50,8 @@ var _eval = function (code, filename) {
     whitelist: program.whitelist,
     optional: program.optional,
     experimental: program.experimental,
-    playground: program.playground
+    playground: program.playground,
+    color: program.color
   }).code;
 
   return vm.runInThisContext(code, {

--- a/bin/_babel-node
+++ b/bin/_babel-node
@@ -21,7 +21,7 @@ program.option("-g, --playground", "Enable playground support");
 program.option("-w, --whitelist [whitelist]", "Whitelist of transformers to ONLY use", util.list);
 program.option("-b, --blacklist [blacklist]", "Blacklist of transformers to NOT use", util.list);
 program.option("-o, --optional [optional]", "List of optional transformers to enable", util.list);
-program.option("--color [when]", "Use color in output (never, always or auto) [auto]", "auto");
+program.option("--highlight [when]", "Use color in output (never, always or auto) [auto]", "auto");
 
 var pkg = require("../package.json");
 program.version(pkg.version);
@@ -38,7 +38,7 @@ babel.register({
   whitelist:    program.whitelist,
   optional:     program.optional,
   ignore:       program.ignore,
-  color:        program.color,
+  highlight:    program.highlight,
 });
 
 //
@@ -51,7 +51,7 @@ var _eval = function (code, filename) {
     optional: program.optional,
     experimental: program.experimental,
     playground: program.playground,
-    color: program.color
+    highlight: program.highlight
   }).code;
 
   return vm.runInThisContext(code, {

--- a/bin/babel/index.js
+++ b/bin/babel/index.js
@@ -29,7 +29,7 @@ commander.option("-R, --react-compat", "Makes the react transformer produce pre-
 commander.option("--keep-module-id-extensions", "Keep extensions when generating module ids", false);
 commander.option("-a, --auxiliary-comment [comment]", "Comment text to prepend to all auxiliary code");
 commander.option("-D, --copy-files", "When compiling a directory copy over non-compilable files");
-commander.option("--color [when]", "Use color in output (never, always or auto) [auto]", 'auto');
+commander.option("--highlight [when]", "Use color in output (never, always or auto) [auto]", 'auto');
 
 commander.on("--help", function () {
   var outKeys = function (title, obj) {
@@ -118,7 +118,7 @@ exports.opts = {
   modules:                commander.modules,
   compact:                commander.compact,
   loose:                  commander.loose,
-  color:                  commander.color,
+  highlight:              commander.highlight,
 };
 
 var fn;

--- a/bin/babel/index.js
+++ b/bin/babel/index.js
@@ -29,6 +29,7 @@ commander.option("-R, --react-compat", "Makes the react transformer produce pre-
 commander.option("--keep-module-id-extensions", "Keep extensions when generating module ids", false);
 commander.option("-a, --auxiliary-comment [comment]", "Comment text to prepend to all auxiliary code");
 commander.option("-D, --copy-files", "When compiling a directory copy over non-compilable files");
+commander.option("--color [when]", "Use color in output (never, always or auto) [auto]", 'auto');
 
 commander.on("--help", function () {
   var outKeys = function (title, obj) {
@@ -116,7 +117,8 @@ exports.opts = {
   comments:               !commander.removeComments,
   modules:                commander.modules,
   compact:                commander.compact,
-  loose:                  commander.loose
+  loose:                  commander.loose,
+  color:                  commander.color,
 };
 
 var fn;

--- a/src/babel/helpers/code-frame.js
+++ b/src/babel/helpers/code-frame.js
@@ -55,10 +55,14 @@ var highlight = function (text) {
   });
 };
 
-module.exports = function (lines, lineNumber, colNumber) {
+module.exports = function (lines, lineNumber, colNumber, opts) {
   colNumber = Math.max(colNumber, 0);
 
-  if (chalk.supportsColor) {
+  var useColor = !opts || opts.color === 'auto' ?
+    chalk.supportsColor :
+    opts.color === 'always';
+
+  if (useColor) {
     lines = highlight(lines);
   }
 

--- a/src/babel/helpers/code-frame.js
+++ b/src/babel/helpers/code-frame.js
@@ -5,6 +5,10 @@ import esutils from "esutils";
 import chalk from "chalk";
 import ary from "lodash/function/ary";
 
+// By default, chalk is disabled if it doesn't support colors. As we want to
+// override this with the "highlight" option, let's make it always enabled.
+chalk.enabled = true;
+
 var defs = {
   string:     chalk.red,
   punctuator: chalk.white.bold,

--- a/src/babel/helpers/code-frame.js
+++ b/src/babel/helpers/code-frame.js
@@ -58,9 +58,9 @@ var highlight = function (text) {
 module.exports = function (lines, lineNumber, colNumber, opts) {
   colNumber = Math.max(colNumber, 0);
 
-  var useColor = !opts || opts.color === 'auto' ?
+  var useColor = !opts || opts.highlight === 'auto' ?
     chalk.supportsColor :
-    opts.color === 'always';
+    opts.highlight === 'always';
 
   if (useColor) {
     lines = highlight(lines);

--- a/src/babel/helpers/parse.js
+++ b/src/babel/helpers/parse.js
@@ -36,7 +36,7 @@ module.exports = function (opts, code, callback) {
 
       var loc = err.loc;
       if (loc) {
-        var frame = codeFrame(code, loc.line, loc.column + 1);
+        var frame = codeFrame(code, loc.line, loc.column + 1, opts);
         message += frame;
       }
 

--- a/src/babel/transformation/file.js
+++ b/src/babel/transformation/file.js
@@ -103,6 +103,8 @@ export default class File {
     "resolveModuleSource",
     "moduleId",
 
+    "color",
+
     // legacy
     "format",
 
@@ -140,6 +142,7 @@ export default class File {
       filename:               "unknown",
       modules:                "common",
       compact:                "auto",
+      color:                  "auto",
       loose:                  [],
       code:                   true,
       ast:                    true

--- a/src/babel/transformation/file.js
+++ b/src/babel/transformation/file.js
@@ -103,7 +103,7 @@ export default class File {
     "resolveModuleSource",
     "moduleId",
 
-    "color",
+    "highlight",
 
     // legacy
     "format",
@@ -137,12 +137,12 @@ export default class File {
       blacklist:              [],
       whitelist:              [],
       sourceMap:              false,
+      highlight:              "auto",
       optional:               [],
       comments:               true,
       filename:               "unknown",
       modules:                "common",
       compact:                "auto",
-      color:                  "auto",
       loose:                  [],
       code:                   true,
       ast:                    true


### PR DESCRIPTION
Code highlighting is great, but I have two use cases where I find it annoying:

* I use babel in a toy IRC bot, to have a command evaluating some code snippets
* I use babel in an atom-shell with hot reload, the compile errors are printed in the chromium console

Both IRC messages and chromium console doesn't support ANSI escape codes for color, so a lot of unexpected characters are printed when the code doesn't compile.

This pull request adds the `--color` option to the CLI and the `"color"` option to the API, both defaulting to `"auto"` (the previous behavior, based on `chalk.supportsColor`). `"never"` and `"always"` will respectively never and always use code highlighting. Those options are inspired by GNU grep. I didn't use the short `-c` option because there is already two of those (`--compact` and `--remove-comments` are sharing the same short option).

Let me know if I missed something.

EDIT: for various reasons, the `color` option is now called `highlight`, see below.