### PR TITLE
fix rest optimization in arrow functions

### DIFF
--- a/src/babel/transformation/transformers/es6/parameters.rest.js
+++ b/src/babel/transformation/transformers/es6/parameters.rest.js
@@ -28,7 +28,8 @@ var memberExpressionOptimisationVisitor = {
       // optimise it
       var prop = parent.property;
       if (isNumber(prop.value) || t.isUnaryExpression(prop) || t.isBinaryExpression(prop)) {
-        optimizeMemberExpression(node, parent, state.method.params.length);
+        this.node = state.argsId;
+        optimizeMemberExpression(parent, state.method.params.length);
         state.hasShorthand = true;
         return;
       }
@@ -38,16 +39,14 @@ var memberExpressionOptimisationVisitor = {
   }
 };
 
-function optimizeMemberExpression(node, parent, offset) {
+function optimizeMemberExpression(parent, offset) {
   var newExpr;
   var prop = parent.property;
 
   if (t.isLiteral(prop)) {
-    node.name = "arguments";
     prop.value += offset;
     prop.raw = String(prop.value);
   } else { // // UnaryExpression, BinaryExpression
-    node.name = "arguments";
     newExpr = t.binaryExpression("+", prop, t.literal(offset));
     parent.property = newExpr;
   }
@@ -86,6 +85,7 @@ exports.Function = function (node, parent, scope) {
     longForm:     false,
     method:       node,
     name:         rest.name,
+    argsId:       argsId
   };
 
   scope.traverse(node, memberExpressionOptimisationVisitor, state);

--- a/test/fixtures/transformation/es6-parameters.rest/arrow-functions/actual.js
+++ b/test/fixtures/transformation/es6-parameters.rest/arrow-functions/actual.js
@@ -2,3 +2,18 @@ var concat = (...arrs) => {
     var x = arrs[0];
     var y = arrs[1];
 };
+
+var somefun = function () {
+    let get2ndArg = (a, b, ...args1) => {
+        var _b = args1[0];
+        let somef = (x, y, z, ...args2) => {
+            var _a = args2[0];
+        };
+        let somefg = (c, d, e, f, ...args3) => {
+            var _a = args3[0];
+        };
+        var _c = arguments[1];
+        var _d = args1[1];
+    };
+    let get1stArg = (...args) => args[0];
+}

--- a/test/fixtures/transformation/es6-parameters.rest/arrow-functions/expected.js
+++ b/test/fixtures/transformation/es6-parameters.rest/arrow-functions/expected.js
@@ -1,8 +1,26 @@
 "use strict";
 
-var _arguments = arguments;
 var concat = function () {
-    var x = _arguments[0];
-    var y = _arguments[1];
+    var x = arguments[0];
+    var y = arguments[1];
+};
+
+var somefun = function somefun() {
+    var _arguments = arguments;
+
+    var get2ndArg = function (a, b) {
+        var _b = arguments[2];
+        var somef = function (x, y, z) {
+            var _a = arguments[3];
+        };
+        var somefg = function (c, d, e, f) {
+            var _a = arguments[4];
+        };
+        var _c = _arguments[1];
+        var _d = arguments[3];
+    };
+    var get1stArg = function () {
+        return arguments[0];
+    };
 };
 


### PR DESCRIPTION
fixes https://github.com/babel/babel/issues/917

When I was updating tests, I have missed underscore in _arguments.
Keep this open for a while. I am trying more arrow functions to check if there are no other problems.