### PR TITLE
Add choice of output format to babel-external-helpers

### DIFF
--- a/bin/babel-external-helpers
+++ b/bin/babel-external-helpers
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
 
+var commander = require("commander");
+var util      = require("../lib/babel/util");
 var runtime = require("../lib/babel/build-external-helpers");
-console.log(runtime());
+
+commander.option("-l, --whitelist [whitelist]", "Whitelist of helpers to ONLY include", util.list);
+commander.option("-t, --output-type [type]", "Type of output (global|umd|var)", "global");
+
+commander.usage("[options]");
+commander.parse(process.argv);
+
+console.log(runtime(commander.whitelist, commander.outputType));

--- a/src/babel/build-external-helpers.js
+++ b/src/babel/build-external-helpers.js
@@ -6,18 +6,28 @@ import t from "./types";
 export default function (whitelist) {
   var namespace = t.identifier("babelHelpers");
 
-  var body      = [];
-  var container = t.functionExpression(null, [t.identifier("global")], t.blockStatement(body));
-  var tree      = t.program([t.expressionStatement(t.callExpression(container, [util.template("self-global")]))]);
-
+  var body = [];
   body.push(t.variableDeclaration("var", [
-    t.variableDeclarator(
-      namespace,
-      t.assignmentExpression("=", t.memberExpression(t.identifier("global"), namespace), t.objectExpression([]))
-    )
+    t.variableDeclarator(namespace, t.identifier("global"))
   ]));
 
   buildHelpers(body, namespace, whitelist);
+
+  var globalHelpersDeclar = t.variableDeclaration("var", [
+    t.variableDeclarator(
+      namespace,
+      t.objectExpression({})
+    )
+  ]);
+  var container = util.template("umd-commonjs-strict", {
+    AMD_ARGUMENTS:      t.arrayExpression([t.literal("exports")]),
+    COMMON_ARGUMENTS:   t.identifier("exports"),
+    BROWSER_ARGUMENTS:  t.identifier("root"),
+    UMD_ROOT:           namespace,
+    FACTORY_PARAMETERS: t.identifier("global"),
+    FACTORY_BODY:       body
+  });
+  var tree = t.program([globalHelpersDeclar, container]);
 
   return generator(tree).code;
 };

--- a/src/babel/build-external-helpers.js
+++ b/src/babel/build-external-helpers.js
@@ -29,12 +29,12 @@ function buildUmd(namespace, builder) {
   builder(body);
 
   var container = util.template("umd-commonjs-strict", {
-    AMD_ARGUMENTS:      t.arrayExpression([t.literal("exports")]),
-    COMMON_ARGUMENTS:   t.identifier("exports"),
-    BROWSER_ARGUMENTS:  t.assignmentExpression("=", t.memberExpression(t.identifier("root"), namespace), t.objectExpression({})),
-    UMD_ROOT:           t.identifier("this"),
     FACTORY_PARAMETERS: t.identifier("global"),
-    FACTORY_BODY:       body
+    BROWSER_ARGUMENTS:  t.assignmentExpression("=", t.memberExpression(t.identifier("root"), namespace), t.objectExpression({})),
+    COMMON_ARGUMENTS:   t.identifier("exports"),
+    AMD_ARGUMENTS:      t.arrayExpression([t.literal("exports")]),
+    FACTORY_BODY:       body,
+    UMD_ROOT:           t.identifier("this")
   });
   return t.program([container]);
 }

--- a/src/babel/build-external-helpers.js
+++ b/src/babel/build-external-helpers.js
@@ -55,17 +55,13 @@ export default function (whitelist, outputType = "global") {
   };
 
   var tree;
-  switch (outputType) {
-  case "global":
+  if (outputType === "global") {
     tree = buildGlobal(namespace, builder);
-    break;
-  case "umd":
+  } else if (outputType === "umd") {
     tree = buildUmd(namespace, builder);
-    break;
-  case "var":
+  } else if (outputType === "var") {
     tree = buildVar(namespace, builder);
-    break;
-  default:
+  } else {
     throw new Error("Unsupported output type");
   }
 

--- a/src/babel/build-external-helpers.js
+++ b/src/babel/build-external-helpers.js
@@ -13,21 +13,15 @@ export default function (whitelist) {
 
   buildHelpers(body, namespace, whitelist);
 
-  var globalHelpersDeclar = t.variableDeclaration("var", [
-    t.variableDeclarator(
-      namespace,
-      t.objectExpression({})
-    )
-  ]);
   var container = util.template("umd-commonjs-strict", {
     AMD_ARGUMENTS:      t.arrayExpression([t.literal("exports")]),
     COMMON_ARGUMENTS:   t.identifier("exports"),
-    BROWSER_ARGUMENTS:  t.identifier("root"),
-    UMD_ROOT:           namespace,
+    BROWSER_ARGUMENTS:  t.assignmentExpression("=", t.memberExpression(t.identifier("root"), namespace), t.objectExpression({})),
+    UMD_ROOT:           t.identifier("this"),
     FACTORY_PARAMETERS: t.identifier("global"),
     FACTORY_BODY:       body
   });
-  var tree = t.program([globalHelpersDeclar, container]);
+  var tree = t.program([container]);
 
   return generator(tree).code;
 };

--- a/src/babel/build-external-helpers.js
+++ b/src/babel/build-external-helpers.js
@@ -1,5 +1,6 @@
 import buildHelpers from "./build-helpers";
 import generator from "./generation";
+import * as messages from "./messages";
 import * as util from  "./util";
 import t from "./types";
 
@@ -62,7 +63,7 @@ export default function (whitelist, outputType = "global") {
   } else if (outputType === "var") {
     tree = buildVar(namespace, builder);
   } else {
-    throw new Error("Unsupported output type");
+    throw new Error(messages.get("unsupportedOutputType", outputType));
   }
 
   return generator(tree).code;

--- a/src/babel/messages.js
+++ b/src/babel/messages.js
@@ -20,7 +20,8 @@ export var messages = {
   didYouMean: "Did you mean $1?",
   evalInStrictMode: "eval is not allowed in strict mode",
   codeGeneratorDeopt: "Note: The code generator has deoptimised the styling of $1 as it exceeds the max of $2.",
-  missingTemplatesDirectory: "no templates directory - this is most likely the result of a broken `npm publish`. Please report to https://github.com/babel/babel/issues"
+  missingTemplatesDirectory: "no templates directory - this is most likely the result of a broken `npm publish`. Please report to https://github.com/babel/babel/issues",
+  unsupportedOutputType: "Unsupported output type $1"
 };
 
 export function get(key) {

--- a/src/babel/transformation/templates/umd-commonjs-strict.js
+++ b/src/babel/transformation/templates/umd-commonjs-strict.js
@@ -1,0 +1,11 @@
+(function (root, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(AMD_ARGUMENTS, factory);
+  } else if (typeof exports === 'object') {
+    factory(COMMON_ARGUMENTS);
+  } else {
+    factory(BROWSER_ARGUMENTS);
+  }
+})(UMD_ROOT, function (FACTORY_PARAMETERS) {
+  FACTORY_BODY
+});


### PR DESCRIPTION
This PR adds selectable output format of babel-external-helpers for different use cases, while keeping backward compatibility (of both runner script and API).

Based on discussion in https://github.com/babel/babel/issues/903 . Details are available in https://github.com/babel/babel/issues/903#issuecomment-77107765 .

Fixes https://github.com/babel/babel/issues/903

If this is accepted (and even if not), my thanks go to @jquense and @scottgonzalez for their ideas, review and whole discussion that shaped this PR.

And of crouse, I am waiting for final review and comments.