### PR TITLE
breakpoint support for node-inspector using inline source maps fixes #481

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -1,5 +1,6 @@
 import "../../polyfill";
 import sourceMapSupport from "source-map-support";
+import convertSourceMap from "convert-source-map";
 import * as registerCache from "./cache";
 import resolveRc from "./resolve-rc";
 import extend from "lodash/object/extend";
@@ -60,6 +61,7 @@ var compile = function (filename) {
       sourceMap: true,
       ast:       false
     }));
+    result.code += "\n" + convertSourceMap.fromObject(result.map).toComment();
   }
 
   if (cache) {


### PR DESCRIPTION
currently it is not possible to debug node apps with `node-inspector` when `require("babel/register")` is used because `node-inspector` requires inline source maps which are not present. this commit will add inline source maps. using breakpoints is possible after this change, also stack traces are working as expected (they are also working without this change)