### PR TITLE
add tests for babel-external-helpers

### DIFF
--- a/test/fixtures/bin/babel-external-helpers/--output-type global/options.json
+++ b/test/fixtures/bin/babel-external-helpers/--output-type global/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--whitelist", "nonexistent"]
+}

--- a/test/fixtures/bin/babel-external-helpers/--output-type global/stdout.txt
+++ b/test/fixtures/bin/babel-external-helpers/--output-type global/stdout.txt
@@ -1,0 +1,3 @@
+(function (global) {
+  var babelHelpers = global.babelHelpers = {};
+})(typeof global === "undefined" ? self : global);

--- a/test/fixtures/bin/babel-external-helpers/--output-type umd/options.json
+++ b/test/fixtures/bin/babel-external-helpers/--output-type umd/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--whitelist", "nonexistent", "--output-type", "umd"]
+}

--- a/test/fixtures/bin/babel-external-helpers/--output-type umd/stdout.txt
+++ b/test/fixtures/bin/babel-external-helpers/--output-type umd/stdout.txt
@@ -1,0 +1,11 @@
+(function (root, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports"], factory);
+  } else if (typeof exports === "object") {
+    factory(exports);
+  } else {
+    factory(root.babelHelpers = {});
+  }
+})(this, function (global) {
+  var babelHelpers = global;
+})

--- a/test/fixtures/bin/babel-external-helpers/--output-type var/options.json
+++ b/test/fixtures/bin/babel-external-helpers/--output-type var/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--whitelist", "nenexistent", "--output-type", "var"]
+}

--- a/test/fixtures/bin/babel-external-helpers/--output-type var/stdout.txt
+++ b/test/fixtures/bin/babel-external-helpers/--output-type var/stdout.txt
@@ -1,0 +1,1 @@
+var babelHelpers = {};

--- a/test/fixtures/bin/babel-external-helpers/--whitelist/options.json
+++ b/test/fixtures/bin/babel-external-helpers/--whitelist/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--whitelist", "slice,has-own"]
+}

--- a/test/fixtures/bin/babel-external-helpers/--whitelist/stdout.txt
+++ b/test/fixtures/bin/babel-external-helpers/--whitelist/stdout.txt
@@ -1,0 +1,5 @@
+(function (global) {
+  var babelHelpers = global.babelHelpers = {};
+  babelHelpers.hasOwn = Object.prototype.hasOwnProperty;
+  babelHelpers.slice = Array.prototype.slice;
+})(typeof global === "undefined" ? self : global);


### PR DESCRIPTION
Whitelist is used in *outputType* tests to make tests less fragile. Test for whitelist itself is prone to breakage from helper changes but there is no other way.