### PR TITLE
Ignore assignment to Error#stack if it is readonly property

### DIFF
--- a/src/babel/helpers/parse.js
+++ b/src/babel/helpers/parse.js
@@ -40,7 +40,13 @@ export default function (opts, code, callback) {
         message += frame;
       }
 
-      if (err.stack) err.stack = err.stack.replace(err.message, message);
+      if (err.stack) {
+        var newStack = err.stack.replace(err.message, message);
+        try {
+          err.stack = newStack;
+        } catch (e) { /* `err.stack` may be a readonly property in some environments. */ }
+      }
+
       err.message = message;
     }
 


### PR DESCRIPTION
`Error#stack` may be an readonly property in some environments such as PhantomJS 1.9.2 and Safari 7.0.

There are issues against other repository by the same cause:
* https://github.com/google/traceur-compiler/issues/1611
* https://github.com/angular/angular.js/pull/5047