### PR TITLE
fix createClass helper when native Symbols are used as properties

### DIFF
--- a/src/babel/transformation/templates/create-class.js
+++ b/src/babel/transformation/templates/create-class.js
@@ -1,7 +1,8 @@
 (function() {
   function defineProperties(target, props) {
-    for (var key in props) {
-      var prop = props[key];
+    var keys = Object.getOwnPropertyNames(props).concat(Object.getOwnPropertySymbols(props));
+    for (var i = 0, count = keys.length; i < count; ++i) {
+      var prop = props[keys[i]];
       prop.configurable = true;
       if (prop.value) prop.writable = true;
     }

--- a/src/babel/transformation/templates/create-class.js
+++ b/src/babel/transformation/templates/create-class.js
@@ -1,6 +1,7 @@
 (function() {
   function defineProperties(target, props) {
-    var keys = Object.getOwnPropertyNames(props).concat(Object.getOwnPropertySymbols(props));
+    var keys = Object.getOwnPropertyNames(props);
+    if (Object.getOwnPropertySymbols !== undefined) keys = keys.concat(Object.getOwnPropertySymbols(props));
     for (var i = 0, count = keys.length; i < count; ++i) {
       var prop = props[keys[i]];
       prop.configurable = true;

--- a/test/fixtures/transformation/bluebird-coroutines/class/expected.js
+++ b/test/fixtures/transformation/bluebird-coroutines/class/expected.js
@@ -2,7 +2,7 @@
 
 var _bluebird = require("bluebird");
 
-var _createClass = (function () { function defineProperties(target, props) { var keys = Object.getOwnPropertyNames(props).concat(Object.getOwnPropertySymbols(props)); for (var i = 0, count = keys.length; i < count; ++i) { var prop = props[keys[i]]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = (function () { function defineProperties(target, props) { var keys = Object.getOwnPropertyNames(props); if (Object.getOwnPropertySymbols !== undefined) keys = keys.concat(Object.getOwnPropertySymbols(props)); for (var i = 0, count = keys.length; i < count; ++i) { var prop = props[keys[i]]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 

--- a/test/fixtures/transformation/bluebird-coroutines/class/expected.js
+++ b/test/fixtures/transformation/bluebird-coroutines/class/expected.js
@@ -2,7 +2,7 @@
 
 var _bluebird = require("bluebird");
 
-var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = (function () { function defineProperties(target, props) { var keys = Object.getOwnPropertyNames(props).concat(Object.getOwnPropertySymbols(props)); for (var i = 0, count = keys.length; i < count; ++i) { var prop = props[keys[i]]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
@@ -21,3 +21,4 @@ var Foo = (function () {
 
   return Foo;
 })();
+

--- a/test/fixtures/transformation/source-maps/class/expected.js
+++ b/test/fixtures/transformation/source-maps/class/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _createClass = (function () { function defineProperties(target, props) { var keys = Object.getOwnPropertyNames(props).concat(Object.getOwnPropertySymbols(props)); for (var i = 0, count = keys.length; i < count; ++i) { var prop = props[keys[i]]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = (function () { function defineProperties(target, props) { var keys = Object.getOwnPropertyNames(props); if (Object.getOwnPropertySymbols !== undefined) keys = keys.concat(Object.getOwnPropertySymbols(props)); for (var i = 0, count = keys.length; i < count; ++i) { var prop = props[keys[i]]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 

--- a/test/fixtures/transformation/source-maps/class/expected.js
+++ b/test/fixtures/transformation/source-maps/class/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = (function () { function defineProperties(target, props) { var keys = Object.getOwnPropertyNames(props).concat(Object.getOwnPropertySymbols(props)); for (var i = 0, count = keys.length; i < count; ++i) { var prop = props[keys[i]]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
@@ -22,3 +22,4 @@ var Test = (function () {
 
 var test = new Test();
 test.bar;
+


### PR DESCRIPTION
Fixes https://github.com/babel/babel/issues/984
No newly introduced issues I am aware of (now).
