### PR TITLE
fix inputSourceMap option

### DIFF
--- a/src/babel/transformation/file.js
+++ b/src/babel/transformation/file.js
@@ -280,7 +280,7 @@ export default class File {
   parseInputSourceMap(code: string) {
     var opts = this.opts;
 
-    if (opts.inputSourceMap === false) {
+    if (opts.inputSourceMap !== false) {
       var inputMap = convertSourceMap.fromSource(code);
       if (inputMap) {
         opts.inputSourceMap = inputMap.toObject();


### PR DESCRIPTION
See #827 - it looks like `opts.inputSourceMap` is the wrong way round, babel should only use an input sourcemap if the `inputSourceMap` option is *not* `false`