### PR TITLE
Expose Module Imports

### DIFF
--- a/src/babel/transformation/file/index.js
+++ b/src/babel/transformation/file/index.js
@@ -415,6 +415,7 @@ export default class File {
     var modFormatter = this.moduleFormatter = this.getModuleFormatter(this.opts.modules);
     if (modFormatter.init && this.transformers["es6.modules"].canRun()) {
       modFormatter.init();
+      this.moduleImports = Object.keys(modFormatter.localImportOccurences);
     }
 
     this.checkNode(ast);
@@ -518,6 +519,8 @@ export default class File {
     if (opts.sourceMap === "inline") {
       result.map = null;
     }
+
+    result.moduleImports = this.moduleImports;
 
     return result;
   }


### PR DESCRIPTION
*This is more a feature request / idea. The implementation is mostly illustrative and not intended for shipping.*

It'd be great any of the file's module import ids were exposed in the returned data structure from `transform`. This data is interesting to build tools that might want to concatenate these imported dependencies.

``` js
babel.transform('import "foo";')
// { code: '"use strict";\n\nrequire("foo");',
//   moduleImports: [ 'foo' ] }
```

I did look at the returned `ast` here, but its the ast of the transformed code and doesn't reflect the original import nodes.

@sebmck do you think this is a good idea? Is it in scope of the things that could be returned in the returned result object here? Any guidance on how to implement this correctly?

Thanks!