### PR TITLE
Clear bindings immediately inside the TCO loop.

### DIFF
--- a/src/babel/transformation/transformers/es6/tail-call.js
+++ b/src/babel/transformation/transformers/es6/tail-call.js
@@ -179,10 +179,12 @@ class TailCallTransformer {
       var declarations = flatten(map(this.vars, function (decl) {
         return decl.declarations;
       }, this));
-      var statement = reduceRight(declarations, function (expr, decl) {
+      var assignment = reduceRight(declarations, function (expr, decl) {
         return t.assignmentExpression("=", decl.id, expr);
       }, t.identifier("undefined"));
-      body.unshift(t.expressionStatement(statement));
+      var statement = t.expressionStatement(assignment);
+      statement._blockHoist = Infinity;
+      body.unshift(statement);
     }
 
     var paramDecls = this.paramDecls;

--- a/test/fixtures/transformation/es6-tail-call/default-parameters/actual.js
+++ b/test/fixtures/transformation/es6-tail-call/default-parameters/actual.js
@@ -1,0 +1,6 @@
+function sum(a=1, b=2) {
+  if (b > 0) {
+    return sum(a + 1, b - 1);
+  }
+  return a;
+}

--- a/test/fixtures/transformation/es6-tail-call/default-parameters/expected.js
+++ b/test/fixtures/transformation/es6-tail-call/default-parameters/expected.js
@@ -1,0 +1,20 @@
+"use strict";
+
+function sum() {
+  var _arguments = arguments;
+  var _again = true;
+
+  _function: while (_again) {
+    a = b = undefined;
+    var a = _arguments[0] === undefined ? 1 : _arguments[0];
+    _again = false;
+    var b = _arguments[1] === undefined ? 2 : _arguments[1];
+
+    if (b > 0) {
+      _arguments = [a + 1, b - 1];
+      _again = true;
+      continue _function;
+    }
+    return a;
+  }
+}

--- a/test/fixtures/transformation/es6-tail-call/factorial/expected.js
+++ b/test/fixtures/transformation/es6-tail-call/factorial/expected.js
@@ -5,9 +5,9 @@ function fact(_x2) {
   var _again = true;
 
   _function: while (_again) {
+    acc = undefined;
     _again = false;
     var n = _x2;
-    acc = undefined;
     var acc = _arguments[1] === undefined ? 1 : _arguments[1];
     if (n > 1) {
       _arguments = [_x2 = n - 1, acc * n];

--- a/test/fixtures/transformation/es6-tail-call/recursion/expected.js
+++ b/test/fixtures/transformation/es6-tail-call/recursion/expected.js
@@ -5,11 +5,12 @@
   var _again = true;
 
   _function: while (_again) {
+    m = local1 = local2 = local3 = undefined;
+
     var g = function g() {};
 
     _again = false;
     var n = _x2;
-    m = local1 = local2 = local3 = undefined;
     var m = _arguments[1] === undefined ? getDefaultValue() : _arguments[1];
 
     // `m` should be `getDefaultValue()` after first pass


### PR DESCRIPTION
We have to ensure that this happens before any potentially-hoisted declarations from default parameters.

Closes #1080.