### PR TITLE
Don't hoist generators in System output

### DIFF
--- a/test/core/fixtures/transformation/es6-modules-system/exports-generator/expected.js
+++ b/test/core/fixtures/transformation/es6-modules-system/exports-generator/expected.js
@@ -1,17 +1,5 @@
 System.register([], function (_export) {
-  var generator = regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$1$0) {
-      while (1) switch (context$1$0.prev = context$1$0.next) {
-        case 0:
-          context$1$0.next = 2;
-          return 1;
-
-        case 2:
-        case "end":
-          return context$1$0.stop();
-      }
-    }, generator, this);
-  });
+  var generator;
 
   _export("generator", generator);
 
@@ -19,6 +7,20 @@ System.register([], function (_export) {
     setters: [],
     execute: function () {
       "use strict";
+
+      generator = regeneratorRuntime.mark(function generator() {
+        return regeneratorRuntime.wrap(function generator$(context$1$0) {
+          while (1) switch (context$1$0.prev = context$1$0.next) {
+            case 0:
+              context$1$0.next = 2;
+              return 1;
+
+            case 2:
+            case "end":
+              return context$1$0.stop();
+          }
+        }, generator, this);
+      });
     }
   };
 });


### PR DESCRIPTION
When trying out the _runtime_ transformer with generator exports using the System transformer, the generator code runs before the regenerator export has been populated.

As a result exported generators throw.

I think the best option is just to disable the hoisting of generators? Alternatively we could just disable the hoisting in the case of the runtime transformer.