### PR TITLE
JSX Transformer: Add 'jsxPragma' option

### DIFF
--- a/bin/babel/index.js
+++ b/bin/babel/index.js
@@ -26,6 +26,7 @@ commander.option("-d, --out-dir [out]", "Compile an input directory of modules i
 commander.option("-c, --remove-comments", "Remove comments from the compiled code", false);
 commander.option("-M, --module-ids", "Insert module id in modules", false);
 commander.option("-R, --react-compat", "Makes the react transformer produce pre-v0.12 code");
+commander.option("-P, --jsx-pragma [name]", "Makes the react transformer use a custom pragma");
 commander.option("--keep-module-id-extensions", "Keep extensions when generating module ids", false);
 commander.option("-a, --auxiliary-comment [comment]", "Comment text to prepend to all auxiliary code");
 commander.option("-D, --copy-files", "When compiling a directory copy over non-compilable files");
@@ -112,6 +113,7 @@ exports.opts = {
   blacklist:              commander.blacklist,
   whitelist:              commander.whitelist,
   sourceMap:              commander.sourceMaps || commander.sourceMapsInline,
+  jsxPragma:              commander.jsxPragma,
   optional:               commander.optional,
   comments:               !commander.removeComments,
   modules:                commander.modules,

--- a/src/babel/transformation/file.js
+++ b/src/babel/transformation/file.js
@@ -113,6 +113,8 @@ export default class File {
     "sourceRoot",
     "moduleRoot",
 
+    "jsxPragma",
+
     // legacy
     "format",
     "reactCompat",
@@ -147,6 +149,7 @@ export default class File {
       blacklist:              [],
       whitelist:              [],
       sourceMap:              false,
+      jsxPragma:              null,
       optional:               [],
       comments:               true,
       filename:               "unknown",

--- a/src/babel/transformation/transformers/other/react.js
+++ b/src/babel/transformation/transformers/other/react.js
@@ -4,7 +4,11 @@ import * as t from "../../../types";
 var JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
 
 export function Program(node, parent, scope, file) {
-  var id = "React.createElement";
+  if (file.opts.jsxPragma) {
+    var id = file.opts.jsxPragma;
+  } else {
+    var id = "React.createElement";
+  }
 
   for (var i = 0; i < file.ast.comments.length; i++) {
     var comment = file.ast.comments[i];


### PR DESCRIPTION
For a project I've been tinkering on, I'd like to be able to use a custom pragma with JSX without needing to use the `/** @jsx [name] */` comment at the top of every JSX file; this PR adds the ability to set the pragma via Babel's options.

Examples:

Programatically:

```javascript
babel.transform('<tag>Hello, world! <Component /></tag>', { jsxPragma: 'dom' });
```

CLI:

```shell
echo "<tag>Hello, world! <Component /></tag>" | babel --jsx-pragma=dom
```

Will output:

```javascript
"use strict";

dom(
  "tag",
  null,
  "Hello, world! ",
  dom(Component, null)
);
```

This option will be overridden in a file if a `@jsx` pragma comment is present.