### PR TITLE
JSX Transformer: Add 'jsxPragma' option

### DIFF
--- a/src/babel/transformation/file/options.json
+++ b/src/babel/transformation/file/options.json
@@ -83,6 +83,13 @@
     "shorthand": "L"
   },
 
+  "jsxPragma": {
+    "type": "string",
+    "description": "Custom pragma to use with JSX (same functionality as @jsx comments)",
+    "default": "React.createElement",
+    "shorthand": "P"
+  },
+
   "ignore": {
     "type": "list"
   },

--- a/src/babel/transformation/transformers/other/react.js
+++ b/src/babel/transformation/transformers/other/react.js
@@ -4,7 +4,7 @@ import * as t from "../../../types";
 var JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
 
 export function Program(node, parent, scope, file) {
-  var id = "React.createElement";
+  var id = file.opts.jsxPragma;
 
   for (var i = 0; i < file.ast.comments.length; i++) {
     var comment = file.ast.comments[i];

--- a/test/core/fixtures/transformation/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/actual.js
+++ b/test/core/fixtures/transformation/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/actual.js
@@ -1,0 +1,8 @@
+/** @jsx dom */
+
+<Foo></Foo>;
+
+var profile = <div>
+  <img src="avatar.png" className="profile" />
+  <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+</div>;

--- a/test/core/fixtures/transformation/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/expected.js
+++ b/test/core/fixtures/transformation/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/expected.js
@@ -1,0 +1,14 @@
+/** @jsx dom */
+
+dom(Foo, null);
+
+var profile = dom(
+  "div",
+  null,
+  dom("img", { src: "avatar.png", className: "profile" }),
+  dom(
+    "h3",
+    null,
+    [user.firstName, user.lastName].join(" ")
+  )
+);

--- a/test/core/fixtures/transformation/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/options.json
+++ b/test/core/fixtures/transformation/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/options.json
@@ -1,0 +1,3 @@
+{
+  "jsxPragma": "foo.bar"
+}

--- a/test/core/fixtures/transformation/react/honor-custom-jsx-pragma-option/actual.js
+++ b/test/core/fixtures/transformation/react/honor-custom-jsx-pragma-option/actual.js
@@ -1,0 +1,6 @@
+<Foo></Foo>;
+
+var profile = <div>
+  <img src="avatar.png" className="profile" />
+  <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+</div>;

--- a/test/core/fixtures/transformation/react/honor-custom-jsx-pragma-option/expected.js
+++ b/test/core/fixtures/transformation/react/honor-custom-jsx-pragma-option/expected.js
@@ -1,0 +1,12 @@
+dom(Foo, null);
+
+var profile = dom(
+  "div",
+  null,
+  dom("img", { src: "avatar.png", className: "profile" }),
+  dom(
+    "h3",
+    null,
+    [user.firstName, user.lastName].join(" ")
+  )
+);

--- a/test/core/fixtures/transformation/react/honor-custom-jsx-pragma-option/options.json
+++ b/test/core/fixtures/transformation/react/honor-custom-jsx-pragma-option/options.json
@@ -1,0 +1,3 @@
+{
+  "jsxPragma": "dom"
+}


### PR DESCRIPTION
Like #1107 but based off of `experimental` instead

For a project I've been tinkering on, I'd like to be able to use a custom pragma with JSX without needing to use the `/** @jsx [name] */` comment at the top of every JSX file; this PR adds the ability to set the pragma via Babel's options.

Examples:

Programatically:

```javascript
babel.transform('<tag>Hello, world! <Component /></tag>', { jsxPragma: 'dom' });
```

CLI:

```shell
echo "<tag>Hello, world! <Component /></tag>" | babel --jsx-pragma=dom
```

Will output:

```javascript
"use strict";

dom(
  "tag",
  null,
  "Hello, world! ",
  dom(Component, null)
);
```

This option will be overridden in a file if a `@jsx` pragma comment is present.