### PR TITLE
Incorrect package path

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -158,7 +158,7 @@ export default function (opts = {}) {
 
 try {
   var runtimePackage = require("babel-runtime/package");
-  var version = require("../../package").version;
+  var version = require("../../../../package").version;
   if (runtimePackage.version !== version) {
     throw new ReferenceError(`The verison of babel-runtime of ${runtimePackage.runtime} that you have installed does not match the babel verison of ${version}`);
   }


### PR DESCRIPTION
I'm pretty sure that this is a mistake, since the path doesn't exist relative to this file. Is it supposed to point to the babel-core package.json like this?