### PR TITLE
Add option to allow ignoring .babelrc file

### DIFF
--- a/src/babel/tools/resolve-rc.js
+++ b/src/babel/tools/resolve-rc.js
@@ -43,8 +43,10 @@ export default function (loc, opts = {}) {
       find(up, rel);
     }
   }
-
-  find(loc, rel);
+  
+  if (opts.ignoreBabelrc !== true) {
+    find(loc, rel);
+  }
 
   return opts;
 };


### PR DESCRIPTION
Use case: I blacklist regenerator when my code runs in iojs, but enable it when webpack compiles it.