### PR TITLE
Add breakConfig to options.json

### DIFF
--- a/src/babel/transformation/file/options.json
+++ b/src/babel/transformation/file/options.json
@@ -199,6 +199,7 @@
   "breakConfig": {
     "type": "boolean",
     "default": false,
+    "hidden": true,
     "description": "stop trying to load .babelrc files"
   }
 

--- a/src/babel/transformation/file/options.json
+++ b/src/babel/transformation/file/options.json
@@ -194,5 +194,12 @@
   "moduleRoot": {
     "type": "string",
     "description": "optional prefix for the AMD module formatter that will be prepend to the filename on module definitions"
+  },
+
+  "breakConfig": {
+    "type": "boolean",
+    "default": false,
+    "description": "stop trying to load .babelrc files"
   }
+
 }


### PR DESCRIPTION
Won't work if it's not in `options.json`.

Maybe it should also check breakConfig before it calls find?
Otherwise it has to crawl the whole path, but it's not a big deal.