### PR TITLE
Avoid searching .babelrc if breakConfig is set

### DIFF
--- a/src/babel/tools/resolve-rc.js
+++ b/src/babel/tools/resolve-rc.js
@@ -43,8 +43,11 @@ export default function (loc, opts = {}) {
       find(up, rel);
     }
   }
-
-  find(loc, rel);
+  
+  if (opts.breakConfig !== true) {
+    find(loc, rel);
+  }
+  
 
   return opts;
 };


### PR DESCRIPTION
It turns out I was mistaken :(, I had actually commented out the blacklist option in my `.babelrc` file. 

All I want is to ignore babelrc files when using webpack, this should do the trick.