### PR TITLE
Update SO link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  For questions and support please visit the <a href="https://gitter.im/babel/babel">gitter room</a> or <a href="stackoverflow.com">StackOverflow</a>. The Babel issue tracker is <strong>exclusively</strong> for bug reports and future requests.
+  For questions and support please visit the <a href="https://gitter.im/babel/babel">gitter room</a> or <a href="http://stackoverflow.com/questions/tagged/babeljs">StackOverflow</a>. The Babel issue tracker is <strong>exclusively</strong> for bug reports and future requests.
 </p>
 
 <p align="center">


### PR DESCRIPTION
The SO link currently points to https://github.com/babel/babel/blob/master/stackoverflow.com, which is incorrect. After this change it points to the list of babeljs questions.