### PR TITLE
Add README.md to babel-cli

### DIFF
--- a/packages/babel-cli/README.md
+++ b/packages/babel-cli/README.md
@@ -1,0 +1,5 @@
+# babel-cli
+
+Babel CLI
+
+For more information please look at [babel](https://github.com/babel/babel).


### PR DESCRIPTION
I think this should fix the npm warning: 

```sh
npm WARN package.json babel@5.0.2 No README data
```