### PR TITLE
[BUGFIX] Check whether `value` key is in descriptor instead of checking truthy value

### DIFF
--- a/src/babel/transformation/templates/helper-create-class.js
+++ b/src/babel/transformation/templates/helper-create-class.js
@@ -4,7 +4,7 @@
       var descriptor = props[i];
       descriptor.enumerable = descriptor.enumerable || false;
       descriptor.configurable = true;
-      if (descriptor.value) descriptor.writable = true;
+      if ("value" in descriptor) descriptor.writable = true;
       Object.defineProperty(target, descriptor.key, descriptor);
     }
   }


### PR DESCRIPTION
[REPL Example](https://babeljs.io/repl/#?experimental=true&evaluate=true&loose=false&spec=false&playground=true&code=class%20Foo%20%7B%0A%20%20static%20bar%20%3D%200%3B%0A%7D%0A%0AFoo.bar%2B%2B%3B)
```js
class Foo {
  static bar = 0;
}

Foo.bar++;
// Cannot assign to read only property 'bar' of function
```