### PR TITLE
Take 2: Fix class decorator scoping.

### DIFF
--- a/src/babel/transformation/transformers/es6/classes.js
+++ b/src/babel/transformation/transformers/es6/classes.js
@@ -30,7 +30,7 @@ var collectPropertyReferencesVisitor = {
       }
 
       if (this.isReferenced() && scope.getBinding(node.name) === state.scope.getBinding(node.name)) {
-        state.references[node.name] = true;;
+        state.references[node.name] = true;
       }
     }
   }
@@ -140,7 +140,7 @@ class ClassTransformer {
     var constructorBody = this.constructorBody = t.blockStatement([]);
     var constructor;
 
-    if (this.className) {
+    if (this.className && !this.node.decorators) {
       constructor = t.functionDeclaration(this.className, [], constructorBody);
       body.push(constructor);
     } else {
@@ -189,6 +189,14 @@ class ClassTransformer {
     }
 
     if (this.className) {
+      if (decorators) {
+        constructor = t.functionExpression(this.className, constructor.params, constructorBody);
+
+        body.unshift(t.variableDeclaration("var", [
+          t.variableDeclarator(classRef, constructor)
+        ]));
+      }
+
       // named class with only a constructor
       if (body.length === 1) return t.toExpression(body[0]);
     } else {

--- a/test/core/fixtures/transformation/es7.decorators/class/actual.js
+++ b/test/core/fixtures/transformation/es7.decorators/class/actual.js
@@ -12,3 +12,10 @@ var Foo2 = @bar class Foo {
 var Bar2 = @foo @bar class Bar {
 
 };
+
+@foo
+class Baz{
+  constructor(baz) {
+    this.baz = baz;
+  }
+}

--- a/test/core/fixtures/transformation/es7.decorators/class/expected.js
+++ b/test/core/fixtures/transformation/es7.decorators/class/expected.js
@@ -1,50 +1,55 @@
 "use strict";
 
 var Foo = (function () {
-  var Foo = function Foo() {
-    babelHelpers.classCallCheck(this, Foo);
-  };
+  function Foo() {
+    babelHelpers.classCallCheck(this, _Foo);
+  }
 
+  var _Foo = Foo;
   Foo = foo(Foo) || Foo;
   return Foo;
 })();
 
 var Bar = (function () {
-  var Bar = function Bar() {
-    babelHelpers.classCallCheck(this, Bar);
-  };
+  function Bar() {
+    babelHelpers.classCallCheck(this, _Bar);
+  }
 
+  var _Bar = Bar;
   Bar = foo(Bar) || Bar;
   Bar = bar(Bar) || Bar;
   return Bar;
 })();
 
 var Foo2 = (function () {
-  var Foo = function Foo() {
-    babelHelpers.classCallCheck(this, Foo);
-  };
+  function Foo() {
+    babelHelpers.classCallCheck(this, _Foo2);
+  }
 
+  var _Foo2 = Foo;
   Foo = bar(Foo) || Foo;
   return Foo;
 })();
 
 var Bar2 = (function () {
-  var Bar = function Bar() {
-    babelHelpers.classCallCheck(this, Bar);
-  };
+  function Bar() {
+    babelHelpers.classCallCheck(this, _Bar2);
+  }
 
+  var _Bar2 = Bar;
   Bar = foo(Bar) || Bar;
   Bar = bar(Bar) || Bar;
   return Bar;
 })();
 
 var Baz = (function () {
-  var Baz = function Baz(baz) {
-    babelHelpers.classCallCheck(this, Baz);
+  function Baz(baz) {
+    babelHelpers.classCallCheck(this, _Baz);
 
     this.baz = baz;
-  };
+  }
 
+  var _Baz = Baz;
   Baz = foo(Baz) || Baz;
   return Baz;
 })();

--- a/test/core/fixtures/transformation/es7.decorators/class/expected.js
+++ b/test/core/fixtures/transformation/es7.decorators/class/expected.js
@@ -1,18 +1,18 @@
 "use strict";
 
 var Foo = (function () {
-  function Foo() {
+  var Foo = function Foo() {
     babelHelpers.classCallCheck(this, Foo);
-  }
+  };
 
   Foo = foo(Foo) || Foo;
   return Foo;
 })();
 
 var Bar = (function () {
-  function Bar() {
+  var Bar = function Bar() {
     babelHelpers.classCallCheck(this, Bar);
-  }
+  };
 
   Bar = foo(Bar) || Bar;
   Bar = bar(Bar) || Bar;
@@ -20,20 +20,31 @@ var Bar = (function () {
 })();
 
 var Foo2 = (function () {
-  function Foo() {
+  var Foo = function Foo() {
     babelHelpers.classCallCheck(this, Foo);
-  }
+  };
 
   Foo = bar(Foo) || Foo;
   return Foo;
 })();
 
 var Bar2 = (function () {
-  function Bar() {
+  var Bar = function Bar() {
     babelHelpers.classCallCheck(this, Bar);
-  }
+  };
 
   Bar = foo(Bar) || Bar;
   Bar = bar(Bar) || Bar;
   return Bar;
+})();
+
+var Baz = (function () {
+  var Baz = function Baz(baz) {
+    babelHelpers.classCallCheck(this, Baz);
+
+    this.baz = baz;
+  };
+
+  Baz = foo(Baz) || Baz;
+  return Baz;
 })();


### PR DESCRIPTION
This now generates a local reference for the `classCallCheck`, so that the scope of the class inside the class stays the same as before. See discussion in #1184 