### PR TITLE
Ensure destruct hoisting is always 1. Fixes #1095.

### DIFF
--- a/src/babel/transformation/transformers/es6/destructuring.js
+++ b/src/babel/transformation/transformers/es6/destructuring.js
@@ -65,7 +65,7 @@ exports.Function = function (node, parent, scope, file) {
     var ref = scope.generateUidIdentifier("ref");
 
     var destructuring = new DestructuringTransformer({
-      blockHoist: node.params.length - i,
+      blockHoist: 1,
       nodes:      nodes,
       scope:      scope,
       file:       file,

--- a/test/core/fixtures/transformation/es6.destructuring/parameters-recursion/actual.js
+++ b/test/core/fixtures/transformation/es6.destructuring/parameters-recursion/actual.js
@@ -1,0 +1,4 @@
+function resolve({a, b}, c) {
+  c += 1;
+  return resolve();
+}

--- a/test/core/fixtures/transformation/es6.destructuring/parameters-recursion/expected.js
+++ b/test/core/fixtures/transformation/es6.destructuring/parameters-recursion/expected.js
@@ -1,0 +1,18 @@
+"use strict";
+
+function resolve(_x, _x2) {
+  var _again = true;
+
+  _function: while (_again) {
+    a = b = undefined;
+    _again = false;
+    var _ref = _x,
+        c = _x2;
+    var a = _ref.a;
+    var b = _ref.b;
+
+    c += 1;
+    _again = true;
+    continue _function;
+  }
+}


### PR DESCRIPTION
I'm not sure why this was dependent on the length of the params, but fixing it to `1`, solves the issue encountered in #1095.