### PR TITLE
Strip out comments before parsing babelrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "slash": "^1.0.0",
     "source-map": "^0.4.0",
     "source-map-support": "^0.2.9",
+    "strip-json-comments": "^1.0.2",
     "to-fast-properties": "^1.0.0",
     "trim-right": "^1.0.0"
   },

--- a/src/babel/tools/resolve-rc.js
+++ b/src/babel/tools/resolve-rc.js
@@ -1,3 +1,4 @@
+import stripJsonComments from "strip-json-comments";
 import merge from "lodash/object/merge";
 import path from "path";
 import fs from "fs";
@@ -24,7 +25,7 @@ export default function (loc, opts = {}) {
       var json;
 
       try {
-        json = jsons[content] ||= JSON.parse(content);
+        json = jsons[content] ||= JSON.parse(stripJsonComments(content));
       } catch (err) {
         err.message = `${file}: ${err.message}`;
         throw err;


### PR DESCRIPTION
`.babelrc` much like `.eslintrc` is just one of those files that you want to annotate.