### PR TITLE
Add failing tests that document ES 6 generators bug

### DIFF
--- a/test/core/fixtures/transformation/regenerator/destructuring/exec.js
+++ b/test/core/fixtures/transformation/regenerator/destructuring/exec.js
@@ -11,3 +11,41 @@ function* foo2({ bar = 0 }) {
 
 assert.equal(foo2({ bar: undefined }).next().value, 0);
 assert.equal(foo2({ bar: 3 }).next().value, 3);
+
+function* foo3() {
+  loop:
+    while(true) {
+      // Changing "let" to "var" makes the tests pass.
+      let { what, value } = yield "iteration";
+
+      switch(what) {
+        case "one":
+          // Removing these 5 lines makes the tests pass.
+          if(value === 1) {
+            break;
+          } else if(value === 2) {
+            break;
+          }
+
+        case "two":
+          // Removing these 3 lines makes the tests pass.
+          ["a", "b"].map(function(v) {
+            return value + v;
+          });
+
+          break;
+
+        case "three":
+          break loop;
+      }
+    }
+}
+
+var gen3 = foo3();
+
+assert.equal(gen3.next().value, "iteration");
+assert.equal(gen3.next({what: "one", value: 3}).done, false);
+assert.equal(gen3.next({what: "one", value: 2}).done, false);
+assert.equal(gen3.next({what: "one", value: 1}).done, false);
+assert.equal(gen3.next({what: "two", value: "sometext"}).done, false);
+assert.equal(gen3.next({what: "three"}).done, true);


### PR DESCRIPTION
I keep bumping into this weird bug with ES 6 generators. The real cause of the bug must be ES 6 feature like `let` used in the test, ie. once babel kicks in (not regenerator, without ES 6 in it it actually works).

*I think PR with failing tests is better than creating an issue.*

I added the tests to `regenerator/destructuring` because there is no suitable category there right now.

## What makes the tests *pass*

Either of these:

1. Using `var` instead of `let`  on line `19`.
2. Removing the `if` and `else if` on lines `24-28`.
3. Removing the `map` with anonymous fn that has ref to `value` on lines `32-34`. **This actually makes the output pretty long since it creates an inner delegate generator.**