### PR TITLE
modularize `user-home`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "source-map-support": "^0.2.9",
     "strip-json-comments": "^1.0.2",
     "to-fast-properties": "^1.0.0",
-    "trim-right": "^1.0.0"
+    "trim-right": "^1.0.0",
+    "user-home": "^1.1.1"
   },
   "devDependencies": {
     "babel": "4.7.13",

--- a/src/babel/api/register/cache.js
+++ b/src/babel/api/register/cache.js
@@ -1,12 +1,9 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
+import userHome from "user-home";
 
-function getUserHome() {
-  return process.env.HOME || process.env.USERPROFILE;
-}
-
-const FILENAME = process.env.BABEL_CACHE_PATH || path.join(getUserHome() || os.tmpdir(), ".babel.json");
+const FILENAME = process.env.BABEL_CACHE_PATH || path.join(userHome || os.tmpdir(), ".babel.json");
 var data = {};
 
 export function save() {


### PR DESCRIPTION
No reason Babel should have to care about the intricacies of this.

This module is already used by `bower`, `eslint`, `yo`, etc.

https://github.com/sindresorhus/user-home