### PR TITLE
Correct relative pathnames in source maps.

### DIFF
--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -27,9 +27,14 @@ module.exports = function (commander, filenames, opts) {
 
       if (result.map) {
         var consumer = new sourceMap.SourceMapConsumer(result.map);
+        var sourceFilename = filename;
 
-        map._sources.add(filename);
-        map.setSourceContent(filename, result.actual);
+        if (commander.outFile) {
+          sourceFilename = path.relative(path.dirname(commander.outFile), sourceFilename);
+        }
+
+        map._sources.add(sourceFilename);
+        map.setSourceContent(sourceFilename, result.actual);
 
         consumer.eachMapping(function (mapping) {
           map._mappings.add({
@@ -37,7 +42,7 @@ module.exports = function (commander, filenames, opts) {
             generatedColumn: mapping.generatedColumn,
             originalLine: mapping.originalLine,
             originalColumn: mapping.originalColumn,
-            source: filename
+            source: sourceFilename
           });
         });
 


### PR DESCRIPTION
Say you have a file called `src/thing.js` and you run

    $ babel src/thing.js --out-file lib/thing.js --source-maps true

This generates a source map at `lib/thing.js.map` that contains
"src/thing.js" in its `sources` array. This is incorrect; since browsers
resolve all relative URLs relative to the directory containing the file
that refers to the URL, this resolves to `lib/src/thing.js`.

To make the source map refer to the source files correctly, the
`sources` array should contain "../src/thing.js".