### PR TITLE
Fix broken dead-code-removal case.

### DIFF
--- a/src/babel/transformation/transformers/utility/dead-code-elimination.js
+++ b/src/babel/transformation/transformers/utility/dead-code-elimination.js
@@ -34,6 +34,7 @@ export var IfStatement = {
   exit(node, parent, scope) {
     var consequent = node.consequent;
     var alternate  = node.alternate;
+    var test = node.test;
 
     var evaluateTest = this.get("test").evaluateTruthy();
 


### PR DESCRIPTION
The "test" local variable was removed with path work. The last dead-code-removal check used this var. By reintroducing the local var, the unknown variable reference is fixed.