### PR TITLE
let Travis cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+cache:
+  directories:
+    - node_modules
 node_js:
   - "0.12"
   - "iojs"


### PR DESCRIPTION
http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/

> Travis CI can persist directories between builds. This is especially useful for dependencies that need to be downloaded and/or compiled from source.