### PR TITLE
class properties with an undefined value are now correctly writable

### DIFF
--- a/src/babel/transformation/transformers/es6/classes.js
+++ b/src/babel/transformation/transformers/es6/classes.js
@@ -552,6 +552,11 @@ class ClassTransformer {
         this.instancePropBody.push(t.expressionStatement(
           t.assignmentExpression("=", t.memberExpression(t.thisExpression(), node.key), node.value)
         ));
+
+        node.value = null;
+      }
+
+      if (!node.value) {
         node.value = t.identifier("undefined");
       }
 

--- a/test/core/fixtures/transformation/es7.class-properties/instance-undefined/actual.js
+++ b/test/core/fixtures/transformation/es7.class-properties/instance-undefined/actual.js
@@ -1,0 +1,3 @@
+class Foo {
+  bar;
+}

--- a/test/core/fixtures/transformation/es7.class-properties/instance-undefined/expected.js
+++ b/test/core/fixtures/transformation/es7.class-properties/instance-undefined/expected.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var Foo = (function () {
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "bar",
+    value: undefined,
+    enumerable: true
+  }]);
+  return Foo;
+})();

--- a/test/core/fixtures/transformation/es7.class-properties/static-undefined/actual.js
+++ b/test/core/fixtures/transformation/es7.class-properties/static-undefined/actual.js
@@ -1,0 +1,3 @@
+class Foo {
+  static bar;
+}

--- a/test/core/fixtures/transformation/es7.class-properties/static-undefined/exec.js
+++ b/test/core/fixtures/transformation/es7.class-properties/static-undefined/exec.js
@@ -1,0 +1,6 @@
+class Foo {
+  static num;
+}
+
+assert.equal("num" in Foo, true);
+assert.equal(Foo.num, undefined);

--- a/test/core/fixtures/transformation/es7.class-properties/static-undefined/expected.js
+++ b/test/core/fixtures/transformation/es7.class-properties/static-undefined/expected.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var Foo = (function () {
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+  }
+
+  babelHelpers.createClass(Foo, null, [{
+    key: "bar",
+    value: undefined,
+    enumerable: true
+  }]);
+  return Foo;
+})();


### PR DESCRIPTION
The `_createClass` internal `defineProperties` has `if ("value" in descriptor) descriptor.writable = true`, but currently class properties (instance/static) that aren't provided an initialization value are not transformed with `value: undefined`, so they fail that test and are not marked as writable.

[DEMO](https://babeljs.io/repl/#?experimental=true&evaluate=true&loose=false&spec=false&playground=true&code=class%20Foo%20%7B%0A%20%20bar%3B%0A%7D%0A%0Avar%20foo%20%3D%20new%20Foo()%3B%0Afoo.bar%20%3D%20123%3B%0A%2F%2F%20Cannot%20assign%20to%20read%20only%20property%20'bar'%20of%20%5Bobject%20Object%5D&stage=0)