### PR TITLE
add variable to Makefile to allow `make test TEST=test_name`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-clean:
 	rm -rf test/tmp
 
 test: test-parser
-	node $(MOCHA_CMD) test/core
+	node $(MOCHA_CMD) test/core/$(TEST)
 	make test-clean
 
 test-all:


### PR DESCRIPTION
I couldn't find a way to run specific tests without doing:

`node_modules/mocha/bin/_mocha test/core/<TEST>`

Which gets :weary: after a while, so I added a variable `$(TEST)` to the `Makefile` that you can set when running `make test` like this:

```sh
> make test TEST=util
```

Cheers.