### PR TITLE
Use vanilla regenerator when building runtime

### DIFF
--- a/packages/build-runtime.js
+++ b/packages/build-runtime.js
@@ -70,8 +70,8 @@ each(File.helpers, function (helperName) {
   writeFile("helpers/" + helperName + ".js", buildHelper(helperName));
 });
 
-writeFile("regenerator/index.js", readFile("regenerator-babel/runtime-module", true));
-writeFile("regenerator/runtime.js", selfContainify(readFile("regenerator-babel/runtime")));
+writeFile("regenerator/index.js", readFile("regenerator/runtime-module", true));
+writeFile("regenerator/runtime.js", selfContainify(readFile("regenerator/runtime")));
 
 //
 


### PR DESCRIPTION
While Babel has switched to the vanilla `regenerator` (replacing the `regenerator-babel` fork), it appears that the standalone runtime was still building against the old fork. This switches the runtime to build with the locally installed `regenerator`.

See #1015 for background. Let me know if I missed something here, but this seemed to be the issue!