### PR TITLE
Fixes bug where position was never set

### DIFF
--- a/src/babel/transformation/file/index.js
+++ b/src/babel/transformation/file/index.js
@@ -243,7 +243,7 @@ export default class File {
     if (name) {
       if (typeof name === "object" && name.transformer) {
         plugin = name.transformer;
-        position ||= name.position;
+        position = name.position || position;
       } else if (typeof name === "string") {
         // this is a plugin in the form of "foobar" or "foobar:after"
         // where the optional colon is the delimiter for plugin position in the transformer stack


### PR DESCRIPTION
The mallet operator was compiling to `if (!position) position = name.position`. Since position is set earlier the conditional was always true and position was never updated from the plugin object.

I couldn't run the tests, because the build setup just doesn't play nicely with Windows (make, an *nix specific shell idioms). But it probably doesn't matter in this case since its such a small change. let me know if you need anything else for this.

Many thanks