### PR TITLE
Copy statics from foreign exports objects when doing an ES6 import

### DIFF
--- a/src/babel/transformation/templates/helper-interop-require-wildcard.js
+++ b/src/babel/transformation/templates/helper-interop-require-wildcard.js
@@ -1,3 +1,16 @@
 (function (obj) {
-  return obj && obj.__esModule ? obj : { default: obj };
+  if (obj && obj.__esModule) {
+    return obj;
+  } else {
+    var hop = Object.prototype.hasOwnProperty;
+    var es_obj = { "default": obj };
+    if (typeof obj === "object" && obj !== null) {
+      for (var key in obj) {
+        if (key !== "default" && hop.call(obj, key)) {
+          es_obj[key] = obj[key];
+        }
+      }
+    }
+    return es_obj;
+  }
 })

--- a/test/core/fixtures/transformation/es6.modules-amd/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/exports-from/expected.js
@@ -1,7 +1,7 @@
 define(["exports", "foo"], function (exports, _foo) {
   "use strict";
 
-  var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+  var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
   var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 

--- a/test/core/fixtures/transformation/es6.modules-common/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/exports-from/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
 var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 

--- a/test/core/fixtures/transformation/es6.modules-common/imports-default/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/imports-default/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
 var _foo = require("foo");
 

--- a/test/core/fixtures/transformation/es6.modules-common/imports-glob/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/imports-glob/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
 var _import = require("foo");
 

--- a/test/core/fixtures/transformation/es6.modules-common/imports-mixing/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/imports-mixing/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
 var _foo$xyz = require("foo");
 

--- a/test/core/fixtures/transformation/es6.modules-common/overview/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/overview/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/test/core/fixtures/transformation/es6.modules-umd/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/exports-from/expected.js
@@ -13,7 +13,7 @@
 })(this, function (exports, _foo) {
   "use strict";
 
-  var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+  var _interopRequireWildcard = function (obj) { if (obj && obj.__esModule) { return obj; } else { var hop = Object.prototype.hasOwnProperty; var es_obj = { "default": obj }; if (typeof obj === "object" && obj !== null) { for (var key in obj) { if (key !== "default" && hop.call(obj, key)) { es_obj[key] = obj[key]; } } } return es_obj; } };
 
   var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 


### PR DESCRIPTION
This makes a best-effort copy of any static properties that existed on a "foreign" (i.e. CommonJS `exports`) object when importing it into an ES6 module. This skips any foreign keys named "default" so as to guarantee that the "default" property in these cases is always a direct reference back to the original export object.

I went with standard property init (rather than `defineProperty`) just for simplicity/code size -- but I'm happy to switch to `defineProperty` if that seems more important.