### PR TITLE
Fix --output-dir to use the correct path.

### DIFF
--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -9,6 +9,9 @@ module.exports = function (commander, filenames, opts) {
   var write = function (src, relative) {
     // remove extension and then append back on .js
     relative = relative.replace(/\.(\w*?)$/, "") + ".js";
+    
+    // remove original path if exists
+    relative = relative.replace(/(.*[\/\\]).+/, "");
 
     var dest = path.join(commander.outDir, relative);
 


### PR DESCRIPTION
This commit fixes an issue where specifying an --output-dir would append the input path to the output dir. Bug this addresses is described below.

Expected Behavior:

```
$ babel project_dir/static/es6/*.es --out-dir project_dir/static/js/
=> project_dir/static/es6/example.es -> project_dir\static\js\example.js
```

Actual Behavior:

```
$ babel project_dir/static/es6/*.es --out-dir project_dir/static/js/
=> project_dir/static/es6/example.es -> project_dir\static\js\project_dir\static\es6\example.js
```