### PR TITLE
Fix test temporary dir cleanup

### DIFF
--- a/test/core/bin.js
+++ b/test/core/bin.js
@@ -111,6 +111,7 @@ var buildTest = function (binName, testName, opts) {
 };
 
 var clear = function () {
+  process.chdir(__dirname);
   if (fs.existsSync(tmpLoc)) rimraf.sync(tmpLoc);
   fs.mkdirSync(tmpLoc);
   process.chdir(tmpLoc);


### PR DESCRIPTION
Temporary dir wasn't being deleted because we were inside it so a few tests were failing on Windows. This fixes it by switching back to `__dirname` prior to `rimraf`.