### PR TITLE
Fix ignore/only on Windows

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -8,6 +8,8 @@ import each from "lodash/collection/each";
 import * as util from  "../../util";
 import fs from "fs";
 
+var isWindows = process.platform === 'win32';
+
 sourceMapSupport.install({
   handleUncaughtExceptions: false,
   retrieveSourceMap(source) {
@@ -76,6 +78,9 @@ var compile = function (filename) {
 };
 
 var shouldIgnore = function (filename) {
+  if (isWindows) {
+    filename = filename.split("\\").join("/");
+  }
   return (ignoreRegex && ignoreRegex.test(filename)) || (onlyRegex && !onlyRegex.test(filename));
 };
 

--- a/src/babel/util.js
+++ b/src/babel/util.js
@@ -19,6 +19,8 @@ import has from "lodash/object/has";
 import fs from "fs";
 import * as t from "./types";
 
+var isWindows = process.platform === 'win32';
+
 export { inherits, inspect } from "util";
 
 export var debug = buildDebug("babel");
@@ -94,6 +96,9 @@ export function booleanify(val: any): boolean {
 }
 
 export function shouldIgnore(filename, ignore, only) {
+  if (isWindows) {
+    filename = filename.split("\\").join("/");
+  }
   if (only.length) {
     for (var i = 0; i < only.length; i++) {
       if (only[i].test(filename)) return false;

--- a/test/core/bin.js
+++ b/test/core/bin.js
@@ -111,6 +111,7 @@ var buildTest = function (binName, testName, opts) {
 };
 
 var clear = function () {
+  process.chdir(__dirname);
   if (fs.existsSync(tmpLoc)) rimraf.sync(tmpLoc);
   fs.mkdirSync(tmpLoc);
   process.chdir(tmpLoc);


### PR DESCRIPTION
The regexp tests were failing because of minimatch always exporting a forward slash delimiter regexp. Used the same fix it uses https://github.com/isaacs/minimatch/blob/master/minimatch.js#L654-L656
Using this and the [other pull](https://github.com/babel/babel/pull/1333), all tests pass now on my system (Windows 7 SP1). Of course this includes the other stuff because otherwise all bin tests fail because of the no temp cleanup.