### PR TITLE
Fix resolve rc loading options twice

### DIFF
--- a/src/babel/tools/resolve-rc.js
+++ b/src/babel/tools/resolve-rc.js
@@ -17,8 +17,16 @@ function exists(filename) {
 export default function (loc, opts = {}) {
   var rel = ".babelrc";
 
+  if (!opts.babelrc) {
+    opts.babelrc = [];
+  }
+
   function find(start, rel) {
     var file = path.join(start, rel);
+
+    if (opts.babelrc.indexOf(file) >= 0) {
+      return;
+    }
 
     if (exists(file)) {
       var content = fs.readFileSync(file, "utf8");
@@ -31,10 +39,18 @@ export default function (loc, opts = {}) {
         throw err;
       }
 
+      opts.babelrc.push(file);
+
       if (json.breakConfig) return;
       merge(opts, json, function(a, b) {
         if (Array.isArray(a)) {
-          return a.concat(b);
+          var c = a.slice(0);
+          for (var v of b) {
+            if (a.indexOf(v) < 0) {
+              c.push(v); 
+            }
+          }
+          return c;
         }
       });
     }
@@ -45,7 +61,7 @@ export default function (loc, opts = {}) {
     }
   }
 
-  if (opts.breakConfig !== true) {
+  if (opts.babelrc.indexOf(loc) < 0 && opts.breakConfig !== true) {
     find(loc, rel);
   }
 

--- a/src/babel/transformation/file/options.json
+++ b/src/babel/transformation/file/options.json
@@ -206,6 +206,11 @@
     "default": false,
     "hidden": true,
     "description": "stop trying to load .babelrc files"
+  },
+
+  "babelrc": {
+    "hidden": true,
+    "description": "do not load the same .babelrc file twice"
   }
 
 }


### PR DESCRIPTION
Two different changes here:

1 - Replaces a.concat(b) with something that only adds an option if it doesn't already exist. I looked over the options and there don't seem to be any that would need the same value twice.

2 - Added an internal `babelrc` option to the options object to track which `.babelrc` files have been already loaded to prevent the same file from being loaded twice. I think it's different than breakConfig because line 44, `if (json.breakConfig) return;`, prevents the loaded `.babelrc` from being merged.

Both solve different issues. The first prevents plugins from being loaded twice. The second allows you to call resolveRc as many times as you wish without consequence. It will prevent future bugs from occurring where resolveRc is called 2 or more times on the same file w/ the same options object. No need to inject a `breakConfig` into babel/register.