### PR TITLE
Add failing test for printing comments with retainLines option

### DIFF
--- a/test/core/fixtures/generation/comments/comment-statement-with-retainlines-option/actual.js
+++ b/test/core/fixtures/generation/comments/comment-statement-with-retainlines-option/actual.js
@@ -1,0 +1,2 @@
+// comment
+print("hello");

--- a/test/core/fixtures/generation/comments/comment-statement-with-retainlines-option/expected.js
+++ b/test/core/fixtures/generation/comments/comment-statement-with-retainlines-option/expected.js
@@ -1,0 +1,2 @@
+// comment
+print("hello");

--- a/test/core/fixtures/generation/comments/comment-statement-with-retainlines-option/options.json
+++ b/test/core/fixtures/generation/comments/comment-statement-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}

--- a/test/core/generation.js
+++ b/test/core/generation.js
@@ -37,7 +37,7 @@ _.each(helper.get("generation"), function (testSuite) {
             "es7.exportExtensions": true
           }
         }, actual.code);
-        var actualCode = generate(actualAst, null, actual.code).code;
+        var actualCode = generate(actualAst, task.options, actual.code).code;
 
         chai.expect(actualCode).to.equal(expect.code, actual.loc + " !== " + expect.loc);
       });


### PR DESCRIPTION
Expected:
```js
// comment
print("hello")
```

Actual:
```js
// commentprint("hello")
```