### PR TITLE
Add failing test for printing block line comments with retainLines option

### DIFF
--- a/test/core/fixtures/generation/comments/block-line-comment-with-retainlines-option/actual.js
+++ b/test/core/fixtures/generation/comments/block-line-comment-with-retainlines-option/actual.js
@@ -1,0 +1,4 @@
+{
+  print("hello");
+  // comment
+}

--- a/test/core/fixtures/generation/comments/block-line-comment-with-retainlines-option/expected.js
+++ b/test/core/fixtures/generation/comments/block-line-comment-with-retainlines-option/expected.js
@@ -1,0 +1,4 @@
+{
+  print("hello");
+  // comment
+}

--- a/test/core/fixtures/generation/comments/block-line-comment-with-retainlines-option/options.json
+++ b/test/core/fixtures/generation/comments/block-line-comment-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}


### PR DESCRIPTION
Not that urgent, since `comments: false` works but flagging for correctness.

expected:
```js
{
  print("hello");
  // comment
}
```

actual:
```js
{
  print("hello");
  // comment}

```