### PR TITLE
Parenthesize statement argument when on a different line

### DIFF
--- a/test/core/fixtures/generation/edgecase/return-with-retainlines-option/actual.js
+++ b/test/core/fixtures/generation/edgecase/return-with-retainlines-option/actual.js
@@ -1,0 +1,5 @@
+function foo(l) {
+  return (
+    l
+  );
+}

--- a/test/core/fixtures/generation/edgecase/return-with-retainlines-option/expected.js
+++ b/test/core/fixtures/generation/edgecase/return-with-retainlines-option/expected.js
@@ -1,0 +1,2 @@
+function foo(l) {
+  return l;}

--- a/test/core/fixtures/generation/edgecase/return-with-retainlines-option/expected.js
+++ b/test/core/fixtures/generation/edgecase/return-with-retainlines-option/expected.js
@@ -1,2 +1,3 @@
 function foo(l) {
-  return l;}
+  return (
+  l);}

--- a/test/core/fixtures/generation/edgecase/return-with-retainlines-option/options.json
+++ b/test/core/fixtures/generation/edgecase/return-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}


### PR DESCRIPTION
Note that this is not a parenthesis issue but this was the easiest way
to reproduce it. I ran into it when testing generators with `retainLines`
and the generated `return` statement (replacing yeild) was printed on
the line preceding the expression being yielded.

expected:
```js
function foo(l) {
  return (
    l
  );
}
```

actual:
```js
function foo(l) {
  return
  l;}
```