### PR TITLE
process glob matching in babel-cli (windows compat)

### DIFF
--- a/packages/babel-cli/bin/babel/index.js
+++ b/packages/babel-cli/bin/babel/index.js
@@ -8,7 +8,7 @@ var util      = require("babel-core").util;
 var each      = require("lodash/collection/each");
 var keys      = require("lodash/object/keys");
 var fs        = require("fs");
-var glob = require('glob');
+var glob      = require("glob");
 
 each(options, function (option, key) {
   if (option.hidden) return;

--- a/packages/babel-cli/bin/babel/index.js
+++ b/packages/babel-cli/bin/babel/index.js
@@ -8,6 +8,7 @@ var util      = require("babel-core").util;
 var each      = require("lodash/collection/each");
 var keys      = require("lodash/object/keys");
 var fs        = require("fs");
+var glob = require('glob');
 
 each(options, function (option, key) {
   if (option.hidden) return;
@@ -69,7 +70,9 @@ commander.parse(process.argv);
 
 var errors = [];
 
-var filenames = commander.args;
+var filenames = commander.args.reduce(function (globbed, input) {
+  return globbed.concat(glob.sync(input));
+}, []);
 
 each(filenames, function (filename) {
   if (!fs.existsSync(filename)) {

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -10,12 +10,13 @@
     "babel-core": "^5.1.13",
     "chokidar": "^1.0.0",
     "commander": "^2.6.0",
-    "fs-readdir-recursive": "^0.1.0",
-    "output-file-sync": "^1.1.0",
-    "lodash": "^3.2.0",
     "convert-source-map": "^1.1.0",
-    "source-map": "^0.4.0",
-    "path-is-absolute": "^1.0.0"
+    "fs-readdir-recursive": "^0.1.0",
+    "glob": "^5.0.5",
+    "lodash": "^3.2.0",
+    "output-file-sync": "^1.1.0",
+    "path-is-absolute": "^1.0.0",
+    "source-map": "^0.4.0"
   },
   "bin": {
     "babel": "./bin/babel/index.js",


### PR DESCRIPTION
Unlike bash, Windows cmd shell does not expand glob patters (e.g. `*.js`) on its own - instead, commands have to implement that internally. You can simulate this in bash by using a string literal: `babel "*.js"`.

This patch uses the `glob` module (used by npm, et al) to add this capability to babel-cli, enabling better cross platform support.

Previously: 
```
> babel "*.js"
*.js doesn't exist
```

With patch:
```
> babel "*.js"
"use strict";

module.exports = require("babel-core");
"use strict";

module.exports = require("babel-core/polyfill");
"use strict";

module.exports = require("babel-core/register");
```

Tested and working on Windows 8 x64.