### PR TITLE
Ignore vendor/regenerator in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ packages/babel-runtime/core-js
 packages/babel-runtime/helpers/*.js
 packages/babel-runtime/regenerator/*.js
 lib
+vendor/regenerator


### PR DESCRIPTION
`vendor/regenerator` submodule should either be checked in or ignored.