### PR TITLE
remove old references to jshint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ BROWSERIFY_CMD = node_modules/browserify/bin/cmd.js
 ISTANBUL_CMD = node_modules/istanbul/lib/cli.js cover
 UGLIFY_CMD = node_modules/uglify-js/bin/uglifyjs
 #UGLIFY_CMD = node_modules/uglify-js/bin/uglifyjs --mangle sort
-JSHINT_CMD = node_modules/jshint/bin/jshint
 MOCHA_CMD = node_modules/mocha/bin/_mocha
 BABEL_CMD = node_modules/babel/bin/babel
 

--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -87,7 +87,7 @@ var shouldIgnore = function (filename) {
 
 var istanbulMonkey = {};
 
-if (process.env.running_under_istanbul) { // jshint ignore:line
+if (process.env.running_under_istanbul) {
   // we need to monkey patch fs.readFileSync so we can hook into
   // what istanbul gets, it's extremely dirty but it's the only way
   var _readFileSync = fs.readFileSync;
@@ -117,7 +117,7 @@ var registerExtension = function (ext) {
   var old = oldHandlers[ext] || oldHandlers[".js"];
 
   var loader = normalLoader;
-  if (process.env.running_under_istanbul) loader = istanbulLoader; // jshint ignore:line
+  if (process.env.running_under_istanbul) loader = istanbulLoader;
 
   require.extensions[ext] = function (m, filename) {
     if (shouldIgnore(filename)) {


### PR DESCRIPTION
Since it was removed in https://github.com/babel/babel/commit/845f1ce65e9d91944bc7fec4a63fdc751d752694.