### PR TITLE
Explicitly sort instead of relying on key ordering.

### DIFF
--- a/src/babel/transformation/transformers/internal/block-hoist.js
+++ b/src/babel/transformation/transformers/internal/block-hoist.js
@@ -1,6 +1,4 @@
-import groupBy from "lodash/collection/groupBy";
-import flatten from "lodash/array/flatten";
-import values from "lodash/object/values";
+import sortBy from "lodash/collection/sortBy";
 
 // Priority:
 //
@@ -18,14 +16,14 @@ export var BlockStatement = {
     }
     if (!hasChange) return;
 
-    var nodePriorities = groupBy(node.body, function (bodyNode) {
+    node.body = sortBy(node.body, function(bodyNode){
       var priority = bodyNode && bodyNode._blockHoist;
       if (priority == null) priority = 1;
       if (priority === true) priority = 2;
-      return priority;
-    });
 
-    node.body = flatten(values(nodePriorities).reverse());
+      // Higher priorities should move toward the top.
+      return -1 * priority;
+    });
   }
 };
 


### PR DESCRIPTION
For example:

    console.log(Object.keys({'2': 'two', '1': 'one', '3': 'three'}));

In Chrome:

    ['1', '2', '3']

In Phantom 1.9:

    ['2', '1', '3']

The old Lodash `values` call relied on the fact that after the groupBy, things would be read in numeric order, which is not the case in Phantom.