### PR TITLE
Fix bugs in `replaceWithSourceString`

### DIFF
--- a/src/babel/traversal/path/index.js
+++ b/src/babel/traversal/path/index.js
@@ -481,7 +481,7 @@ export default class TraversalPath {
   replaceWithSourceString(replacement) {
     try {
       replacement = `(${replacement})`;
-      replacement = parse(code);
+      replacement = parse(replacement);
     } catch (err) {
       var loc = err.loc;
       if (loc) {
@@ -491,7 +491,7 @@ export default class TraversalPath {
       throw err;
     }
 
-    replacement = replacement.body[0].expression;
+    replacement = replacement.program.body[0].expression;
     traverse.removeProperties(replacement);
     return this.replaceWith(replacement);
   }


### PR DESCRIPTION
I think I found 2 bugs in `replaceWithSourceString`, added in 0fc02f2cf09e0b1fe8738646c815b869921863b9:

- `code` is undefined as it should be `replacement`
- the expression of the parsed replacement hasn't been accessed correctly

---

I want to add tests for this but I'm struggling with where to start (mainly because this is my first contribution to babel). Can you point out where I should put a test and if there is already a similar one which I can use for inspiration? I thought of something along the following lines, where I would need help on what the correct call for `generateAST` would be:

``` js
test("replaceWithSourceString", function() {
  var ast = generateAST("function() { console.log('hello'); }");

  var transformed = transform(ast, {
    CallExpression: function(node) {
      if (this.get("callee").matchesPattern("console", true)) {
        return "console.debug()";
      }
    }
  });

  assert.deepEqual(transformed, generateAST("function() { console.debug(); }"));
});
```