### PR TITLE
enable file add and remove to watched locations when using --watch option

### DIFF
--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -1,6 +1,6 @@
 var outputFileSync = require("output-file-sync");
 var chokidar       = require("chokidar");
-var globparent     = require('glob-parent');
+var globparent     = require("glob-parent");
 var path           = require("path");
 var util           = require("./util");
 var fs             = require("fs");
@@ -12,7 +12,7 @@ module.exports = function (commander, filenames, opts) {
     // remove extension and then append back on .js
     relative = relative.replace(/\.(\w*?)$/, "") + ".js";
     return path.join(commander.outDir, relative);
-  }
+  };
 
   var write = function (src, relative) {
     var dest = destFilePath(relative);
@@ -75,14 +75,14 @@ module.exports = function (commander, filenames, opts) {
         watcher.on(type, function (filename, stats) {
           var relative = path.relative(globroot, filename) || filename;
 
-          if (type === 'unlink') {
+          if (type === "unlink") {
             cache[filename] = undefined;
             var dest = destFilePath(relative);
-            console.log('unlink %s', dest);
-            if (fs.existsSync(dest)) 
+            console.log("unlink %s", dest);
+            if (fs.existsSync(dest))
               fs.unlink(dest);
-            if (fs.existsSync(dest + '.map'))
-              fs.unlink(dest + '.map');
+            if (fs.existsSync(dest + ".map"))
+              fs.unlink(dest + ".map");
           } else {
             var statsMtime;
             if (stats) statsMtime = stats.mtime.getTime();

--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -1,16 +1,21 @@
 var outputFileSync = require("output-file-sync");
 var chokidar       = require("chokidar");
+var globparent     = require('glob-parent');
 var path           = require("path");
 var util           = require("./util");
 var fs             = require("fs");
 var _              = require("lodash");
 
 module.exports = function (commander, filenames, opts) {
-  var write = function (src, relative) {
+
+  var destFilePath = function(relative) {
     // remove extension and then append back on .js
     relative = relative.replace(/\.(\w*?)$/, "") + ".js";
+    return path.join(commander.outDir, relative);
+  }
 
-    var dest = path.join(commander.outDir, relative);
+  var write = function (src, relative) {
+    var dest = destFilePath(relative);
 
     var data = util.compile(src, {
       sourceFileName: path.relative(dest + "/..", src)
@@ -57,19 +62,37 @@ module.exports = function (commander, filenames, opts) {
   _.each(filenames, handle);
 
   if (commander.watch) {
-    _.each(filenames, function (dirname) {
-      var watcher = chokidar.watch(dirname, {
+    var cache = {};
+
+    _.each(commander.args, function (glob) {
+      var watcher = chokidar.watch(glob, {
         persistent: true,
         ignoreInitial: true
       });
 
-      _.each(["add", "change"], function (type) {
-        watcher.on(type, function (filename) {
-          var relative = path.relative(dirname, filename) || filename;
-          try {
-            handleFile(filename, relative);
-          } catch (err) {
-            console.error(err.stack);
+      var globroot = globparent(glob);
+      _.each(["add", "change", "unlink"], function (type) {
+        watcher.on(type, function (filename, stats) {
+          var relative = path.relative(globroot, filename) || filename;
+
+          if (type === 'unlink') {
+            cache[filename] = undefined;
+            var dest = destFilePath(relative);
+            console.log('unlink %s', dest);
+            if (fs.existsSync(dest)) 
+              fs.unlink(dest);
+            if (fs.existsSync(dest + '.map'))
+              fs.unlink(dest + '.map');
+          } else {
+            var mtime = cache[filename];
+            if (!mtime || !stats || mtime !== stats.mtime.getTime()) {
+              cache[filename] = stats.mtime.getTime();
+              try {
+                handleFile(filename, relative);
+              } catch (err) {
+                console.error(err.stack);
+              }
+            }
           }
         });
       });

--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -84,9 +84,11 @@ module.exports = function (commander, filenames, opts) {
             if (fs.existsSync(dest + '.map'))
               fs.unlink(dest + '.map');
           } else {
+            var statsMtime;
+            if (stats) statsMtime = stats.mtime.getTime();
             var mtime = cache[filename];
-            if (!mtime || !stats || mtime !== stats.mtime.getTime()) {
-              cache[filename] = stats.mtime.getTime();
+            if (!mtime || mtime !== statsMtime) {
+              cache[filename] = statsMtime;
               try {
                 handleFile(filename, relative);
               } catch (err) {

--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -132,7 +132,7 @@ module.exports = function (commander, filenames, opts) {
         persistent: true,
         ignoreInitial: true
       }).on("all", function (type, filename, stats) {
-        if (type === "add" || type === "change" || type === 'unlink') {
+        if (type === "add" || type === "change" || type === "unlink") {
           var statsMtime;
           // no stats with unlink
           if (stats) statsMtime = stats.mtime.getTime();

--- a/packages/babel-cli/bin/babel/index.js
+++ b/packages/babel-cli/bin/babel/index.js
@@ -82,10 +82,6 @@ each(filenames, function (filename) {
   }
 });
 
-if (commander.outDir && !filenames.length) {
-  errors.push("filenames required for --out-dir");
-}
-
 if (commander.outFile && commander.outDir) {
   errors.push("cannot have --out-file and --out-dir");
 }
@@ -96,7 +92,7 @@ if (commander.watch) {
   }
 
   if (!filenames.length) {
-    errors.push("--watch requires filenames");
+    console.log("warning: --watch specified but no files to build yet...");
   }
 }
 

--- a/packages/babel-cli/bin/babel/index.js
+++ b/packages/babel-cli/bin/babel/index.js
@@ -4,12 +4,12 @@ var moduleFormatters = require("babel-core/lib/babel/transformation/modules");
 var commander        = require("commander");
 var transform        = require("babel-core").transform;
 var kebabCase        = require("lodash/string/kebabCase");
+var globParent       = require("glob-parent");
 var options          = require("babel-core").options;
 var util             = require("babel-core").util;
 var each             = require("lodash/collection/each");
 var keys             = require("lodash/object/keys");
 var fs               = require("fs");
-var glob             = require("glob");
 
 each(options, function (option, key) {
   if (option.hidden) return;
@@ -35,7 +35,7 @@ each(options, function (option, key) {
   if (option.description) desc.push(option.description);
 
   commander.option(arg, desc.join(" "));
-})
+});
 
 commander.option("-x, --extensions [extensions]", "List of extensions to compile when a directory has been input [.es6,.js,.es,.jsx]");
 commander.option("-w, --watch", "Recompile files on changes");
@@ -72,8 +72,8 @@ commander.parse(process.argv);
 
 var errors = [];
 
-var filenames = commander.args.reduce(function (globbed, input) {
-  return globbed.concat(glob.sync(input));
+var filenames = commander.args.reduce(function (parent, input) {
+  return parent.concat(globParent(input));
 }, []);
 
 each(filenames, function (filename) {
@@ -120,4 +120,4 @@ if (commander.outDir) {
   fn = require("./file");
 }
 
-fn(commander, filenames, exports.opts);
+fn(commander, exports.opts);

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -13,6 +13,7 @@
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^0.1.0",
     "glob": "^5.0.5",
+    "glob-parent": "^1.2.0",
     "lodash": "^3.2.0",
     "output-file-sync": "^1.1.0",
     "path-is-absolute": "^1.0.0",


### PR DESCRIPTION
Currently `babel --watch` option does not handle adding new files or removing files form watched locations.

This PR adds the ability to add new files and remove existing files from watched locations ensuring a rebuild.  Additionally, it is possible to watch empty glob folder which is useful in new projects or during refactoring when files are being moved around.

Caveats: I have not test this on nix platforms.