### PR TITLE
Disallow async constructors

### DIFF
--- a/src/acorn/src/statement.js
+++ b/src/acorn/src/statement.js
@@ -504,7 +504,7 @@ pp.parseClass = function(node, isStatement) {
       this.parsePropertyName(method)
     }
     method.kind = "method"
-    if (!method.computed && !isGenerator) {
+    if (!method.computed && !isGenerator && !isAsync) {
       if (method.key.type === "Identifier") {
         if (this.type !== tt.parenL && (method.key.name === "get" || method.key.name === "set")) {
           method.kind = method.key.name

--- a/test/core/fixtures/transformation/validation/async-constructor/actual.js
+++ b/test/core/fixtures/transformation/validation/async-constructor/actual.js
@@ -1,0 +1,1 @@
+class X { async constructor() {} }

--- a/test/core/fixtures/transformation/validation/async-constructor/options.json
+++ b/test/core/fixtures/transformation/validation/async-constructor/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "Illegal kind for constructor method",
+  "optional": ["es7.asyncFunctions"]
+}


### PR DESCRIPTION
`node.kind` should be `"method"` instead of `"constructor"` for an async constructor, like it would be if it was a generator constructor.

Fixes #1454