### PR TITLE
[speed] Don't init moduleFormatter unless we need it

### DIFF
--- a/src/babel/transformation/file/index.js
+++ b/src/babel/transformation/file/index.js
@@ -465,12 +465,14 @@ export default class File {
     this.checkPath(this.path);
     this.log.debug("End prepass");
 
-    this.log.debug("Start module formatter init");
-    var modFormatter = this.moduleFormatter = this.getModuleFormatter(this.opts.modules);
-    if (modFormatter.init && this.transformers["es6.modules"].canTransform()) {
-      modFormatter.init();
+    if (this.transformers["es6.modules"].canTransform()) {
+      this.log.debug("Start module formatter init");
+      var modFormatter = this.moduleFormatter = this.getModuleFormatter(this.opts.modules);
+      if (modFormatter.init) {
+        modFormatter.init();
+      }
+      this.log.debug("End module formatter init");
     }
-    this.log.debug("End module formatter init");
 
     this.call("pre");
     each(this.transformerStack, function (pass) {

--- a/src/babel/traversal/scope.js
+++ b/src/babel/traversal/scope.js
@@ -364,7 +364,7 @@ export default class Scope {
     }
 
     var file = this.file;
-    if (file) {
+    if (file && file.moduleFormatter) {
       this._renameFromMap(file.moduleFormatter.localImports, oldName, newName, state.binding);
       //this._renameFromMap(file.moduleFormatter.localExports, oldName, newName);
     }


### PR DESCRIPTION
Running on latest jquery with `whitelist: []`:

### Before
```
  babel [BABEL] unknown: Parse start +0ms
  babel [BABEL] unknown: Parse stop +379ms
  babel [BABEL] unknown: Start set AST +2ms
  babel [BABEL] unknown: Start scope building +0ms
  babel [BABEL] unknown: End scope building +1s
  babel [BABEL] unknown: End set AST +358ms
  babel [BABEL] unknown: Start prepass +0ms
  babel [BABEL] unknown: End prepass +303ms
  babel [BABEL] unknown: Start module formatter init +0ms
  babel [BABEL] unknown: End module formatter init +502ms
  babel [BABEL] unknown: Start transformer _validation +1ms
  babel [BABEL] unknown: Finish transformer _validation +253ms
  babel [BABEL] unknown: Start transformer _blockHoist +0ms
  babel [BABEL] unknown: Finish transformer _blockHoist +260ms
  babel [BABEL] unknown: Start transformer _shadowFunctions +0ms
  babel [BABEL] unknown: Finish transformer _shadowFunctions +537ms
  babel [BABEL] unknown: Start transformer _strict +0ms
  babel [BABEL] unknown: Finish transformer _strict +248ms
  babel [BABEL] unknown: Start transformer _moduleFormatter +0ms
  babel [BABEL] unknown: Finish transformer _moduleFormatter +1ms
  babel [BABEL] unknown: Generation start +0ms
[BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".
  babel [BABEL] unknown: Generation end +435ms
        5.19 real         5.44 user         0.17 sys
```

### After
```
  babel [BABEL] unknown: Parse start +0ms
  babel [BABEL] unknown: Parse stop +426ms
  babel [BABEL] unknown: Start set AST +2ms
  babel [BABEL] unknown: Start scope building +0ms
  babel [BABEL] unknown: End scope building +1s
  babel [BABEL] unknown: End set AST +326ms
  babel [BABEL] unknown: Start prepass +1ms
  babel [BABEL] unknown: End prepass +288ms
  babel [BABEL] unknown: Start transformer _validation +0ms
  babel [BABEL] unknown: Finish transformer _validation +251ms
  babel [BABEL] unknown: Start transformer _blockHoist +0ms
  babel [BABEL] unknown: Finish transformer _blockHoist +235ms
  babel [BABEL] unknown: Start transformer _shadowFunctions +0ms
  babel [BABEL] unknown: Finish transformer _shadowFunctions +503ms
  babel [BABEL] unknown: Start transformer _strict +0ms
  babel [BABEL] unknown: Finish transformer _strict +241ms
  babel [BABEL] unknown: Start transformer _moduleFormatter +0ms
  babel [BABEL] unknown: Finish transformer _moduleFormatter +1ms
  babel [BABEL] unknown: Generation start +0ms
[BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".
  babel [BABEL] unknown: Generation end +440ms
        4.65 real         4.91 user         0.16 sys
```
