### PR TITLE
[Flow] Add failing tests for printing comments w/ type alias

### DIFF
--- a/test/core/fixtures/transformation/flow/type-comments/actual.js
+++ b/test/core/fixtures/transformation/flow/type-comments/actual.js
@@ -1,0 +1,4 @@
+var x = 1;
+// comment 1
+type FunWithComments = number
+var y = 2;

--- a/test/core/fixtures/transformation/flow/type-comments/expected.js
+++ b/test/core/fixtures/transformation/flow/type-comments/expected.js
@@ -1,0 +1,3 @@
+var x = 1;
+// comment 1
+var y = 2;


### PR DESCRIPTION
Prints the comment in the wrong position which may cause syntax error (e.g. prints `}` on the same line as a comment).

```
      + expected - actual

       var x = 1;
      +// comment 1
      +var y = 2;
      -
      -var y = 2;
      -// comment 1
```

p.s. I think there are failing tests on master (`traceur/TemplateLiterals InModule.module`, `traceur/Math fround.module`) 