### PR TITLE
Add license fields to packages

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -4,6 +4,7 @@
   "version": "5.3.1",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
+  "license": "MIT",
   "repository": "babel/babel",
   "preferGlobal": true,
   "dependencies": {

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -2,6 +2,7 @@
   "name": "babel-runtime",
   "description": "babel selfContained runtime",
   "version": "5.3.1",
+  "license": "MIT",
   "repository": "babel/babel",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {


### PR DESCRIPTION
This just ensures that these packages show up on npm as licensed. Right now they say "none license".