### PR TITLE
Added slash as needed dependency

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -17,7 +17,8 @@
     "lodash": "^3.2.0",
     "output-file-sync": "^1.1.0",
     "path-is-absolute": "^1.0.0",
-    "source-map": "^0.4.0"
+    "source-map": "^0.4.0",
+    "slash": "^1.0.0"
   },
   "bin": {
     "babel": "./bin/babel/index.js",


### PR DESCRIPTION
babel-cli depends on slash but you haven't included it in your package.json. Running babel gives the following error without it:

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'slash'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> ([path hidden]/node_modules/babel/bin/babel/file.js:4:24)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```