### PR TITLE
correct cli source map file and sourceRoot behaviour

### DIFF
--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -13,8 +13,11 @@ module.exports = function (commander, filenames, opts) {
 
     var dest = path.join(commander.outDir, relative);
 
+    var sourceFileName = opts.sourceRoot ? src.replace(/^\.[\\/]/, '') : path.relative(dest + "/..", src);
+
     var data = util.compile(src, {
-      sourceFileName: slash(path.relative(dest + "/..", src))
+      sourceFileName:  slash(sourceFileName),
+      sourceMapName: path.basename(relative)
     });
     if (data.ignored) return;
 

--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -13,7 +13,7 @@ module.exports = function (commander, filenames, opts) {
 
     var dest = path.join(commander.outDir, relative);
 
-    var sourceFileName = opts.sourceRoot ? src.replace(/^\.[\\/]/, '') : path.relative(dest + "/..", src);
+    var sourceFileName = opts.sourceRoot ? src.replace(/^\.[\\/]/, "") : path.relative(dest + "/..", src);
 
     var data = util.compile(src, {
       sourceFileName:  slash(sourceFileName),

--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -13,7 +13,7 @@ module.exports = function (commander, filenames, opts) {
 
     var dest = path.join(commander.outDir, relative);
 
-    var sourceFileName = opts.sourceRoot ? src.replace(/^\.[\\/]/, "") : path.relative(dest + "/..", src);
+    var sourceFileName = opts.sourceRoot ? src : path.relative(dest + "/..", src);
 
     var data = util.compile(src, {
       sourceFileName:  slash(sourceFileName),

--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -33,7 +33,7 @@ module.exports = function (commander, filenames, opts) {
         var sourceFilename = filename;
         if (commander.outFile) {
           sourceFilename = opts.sourceRoot ? 
-              sourceFilename.replace(/^\.[\\/]/, "") :
+              sourceFilename :
               path.relative(path.dirname(commander.outFile), sourceFilename);
         }
         sourceFilename = slash(sourceFilename);

--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -33,7 +33,7 @@ module.exports = function (commander, filenames, opts) {
         var sourceFilename = filename;
         if (commander.outFile) {
           sourceFilename = opts.sourceRoot ? 
-              sourceFilename.replace(/^\.[\\/]/, '') :
+              sourceFilename.replace(/^\.[\\/]/, "") :
               path.relative(path.dirname(commander.outFile), sourceFilename);
         }
         sourceFilename = slash(sourceFilename);

--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -16,7 +16,8 @@ module.exports = function (commander, filenames, opts) {
 
   var buildResult = function () {
     var map = new sourceMap.SourceMapGenerator({
-      file: slash(commander.outFile || "stdout")
+      file: path.basename(commander.outFile) || "stdout",
+      sourceRoot: opts.sourceRoot
     });
 
     var code = "";
@@ -31,7 +32,9 @@ module.exports = function (commander, filenames, opts) {
 
         var sourceFilename = filename;
         if (commander.outFile) {
-          sourceFilename = path.relative(path.dirname(commander.outFile), sourceFilename);
+          sourceFilename = opts.sourceRoot ? 
+              sourceFilename.replace(/^\.[\\/]/, '') :
+              path.relative(path.dirname(commander.outFile), sourceFilename);
         }
         sourceFilename = slash(sourceFilename);
 


### PR DESCRIPTION
@sebmck, this PR is an attempt to get source map `file:` and `sourceRoot:` attributes to work according to 'spec'.

In all cases `file:` becomes the basename of the target filename.
If `sourceRoot:` is specified on the command line all `sources:` will behave as if relative to the location of `sourceRoot:`

I have tested this with node-inspector in node.js and it behaves as expected.

It is difficult to determine exactly where to make these changes since there are a lot of updates/changes to the `options` throughout the code-path, so this is just a best guess!

Since there is no real spec for V3 these were my references:
[Source Map Revision 3 Proposal](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit)
[mozilla/source-map API](https://github.com/mozilla/source-map#new-sourcemapconsumerrawsourcemap)
