### PR TITLE
Resolve "babel-plugin-" name before trying the plain name.

### DIFF
--- a/src/babel/transformation/file/plugin-manager.js
+++ b/src/babel/transformation/file/plugin-manager.js
@@ -35,7 +35,7 @@ export default class PluginManager {
     var match = name.match(/^(.*?):(after|before)$/);
     if (match) [, name, position] = match;
 
-    var loc = util.resolveRelative(name) || util.resolveRelative(`babel-plugin-${name}`);
+    var loc = util.resolveRelative(`babel-plugin-${name}`) || util.resolveRelative(name);
     if (loc) {
       return {
         position: position,


### PR DESCRIPTION
Otherwise you get situations like the following: `plugins: [ 'object-assign']` resolves to the module `object-assign` (an Object.assign polyfill) instead of the intended plugin packaged named: `babel-plugin-object-assign`.