### PR TITLE
use `home-or-tmp` module instead of `user-home`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "esutils": "^2.0.0",
     "fs-readdir-recursive": "^0.1.0",
     "globals": "^6.4.0",
+    "home-or-tmp": "^1.0.0",
     "is-integer": "^1.0.4",
     "js-tokens": "1.0.0",
     "leven": "^1.0.1",
@@ -60,8 +61,7 @@
     "source-map-support": "^0.2.10",
     "strip-json-comments": "^1.0.2",
     "to-fast-properties": "^1.0.0",
-    "trim-right": "^1.0.0",
-    "user-home": "^1.1.1"
+    "trim-right": "^1.0.0"
   },
   "devDependencies": {
     "babel": "5.3.1",

--- a/src/babel/api/register/cache.js
+++ b/src/babel/api/register/cache.js
@@ -1,9 +1,9 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import userHome from "user-home";
+import homeOrTmp from "home-or-tmp";
 
-const FILENAME = process.env.BABEL_CACHE_PATH || path.join(userHome || os.tmpdir(), ".babel.json");
+const FILENAME = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json");
 var data = {};
 
 export function save() {


### PR DESCRIPTION
The main point about using this instead of just falling back in code is that it depends on a [`os.tmpdir()` polyfill](https://github.com/sindresorhus/os-tmpdir), which means the tmpdir handling is the same no matter node/iojs version. This is useful as the core `os.tmpdir()` function has changed a lot between node versions.

---

`os.tmpdir()` diff between Node 0.10.38 and iojs 2.0.2

```diff
+const trailingSlashRe = isWindows ? /[^:]\\$/
+                                  : /.\/$/;
+
 exports.tmpdir = function() {
-  return process.env.TMPDIR ||
-         process.env.TMP ||
-         process.env.TEMP ||
-         (process.platform === 'win32' ? 'c:\\windows\\temp' : '/tmp');
+  var path;
+  if (isWindows) {
+    path = process.env.TEMP ||
+           process.env.TMP ||
+           (process.env.SystemRoot || process.env.windir) + '\\temp';
+  } else {
+    path = process.env.TMPDIR ||
+           process.env.TMP ||
+           process.env.TEMP ||
+           '/tmp';
+  }
+  if (trailingSlashRe.test(path))
+    path = path.slice(0, -1);
+  return path;
 };
```