### PR TITLE
correct cli source map file: value, honor sourceRoot when using -o opion

### DIFF
--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -14,7 +14,8 @@ module.exports = function (commander, filenames, opts) {
     var dest = path.join(commander.outDir, relative);
 
     var data = util.compile(src, {
-      sourceFileName: slash(path.relative(dest + "/..", src))
+      sourceFileName: slash(path.relative(dest + "/..", src)),
+      sourceMapName: path.basename(relative)
     });
     if (data.ignored) return;
 

--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -16,7 +16,8 @@ module.exports = function (commander, filenames, opts) {
 
   var buildResult = function () {
     var map = new sourceMap.SourceMapGenerator({
-      file: slash(commander.outFile || "stdout")
+      file: path.basename(commander.outFile) || "stdout",
+      sourceRoot: opts.sourceRoot
     });
 
     var code = "";


### PR DESCRIPTION
This PR corrects the source map `file:` value to be the target/output file name and honors `--source-root:` when specified together with `-o` option on the command line.

@sebmck, when `--source-root` is specified on the command line the resultant view in `node-inspector` sources is not always as expected.  It appears that unless a URL is specified, the `sourceRoot:` in the source maps have to be made relative to a root location for them to show up in the same directory tree in `node-inspector`. I.e.:
```
// app.js.map
  "sources": ["src/app.es6"],
  "sourceRoot": "my-source",

// lib/greeter.js.map
  "sources": ["src/lib/greeter.es6"],
  "sourceRoot": "../my-source",
```