### PR TITLE
Replace compiled file name for nodejs

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -113,7 +113,8 @@ var istanbulLoader = function (m, filename, old) {
 };
 
 var normalLoader = function (m, filename) {
-  m._compile(compile(filename), filename);
+  var compiledName = filename.replace(/(.*)\.(.*)$/, '$1.compiled.$2');
+  m._compile(compile(filename), compiledName);
 };
 
 var registerExtension = function (ext) {


### PR DESCRIPTION
Source and compiled files in nodejs have equal name.
This works wrong then we try to present it in resources tree.

```
root
// loading script source

root
-> test.js (compiled)
// processing sourceMapUrl

root
-> test.js (compiled)
-> test.js.map (maybe inline)
// processing source paths is source map

root
-> test.js (compiled)
-> test.js (source)
-> test.js.map (maybe inline)
// Unresolved situation
```

I'm not friendly with babel sources, so this can be bad fix, but it demonstrates a problem.