### PR TITLE
Fixed Remove Debugger transformer to use DebuggerStatement

### DIFF
--- a/src/babel/transformation/transformers/minification/remove-debugger.js
+++ b/src/babel/transformation/transformers/minification/remove-debugger.js
@@ -5,8 +5,6 @@ export var metadata = {
   group: "builtin-setup"
 };
 
-export function ExpressionStatement(node) {
-  if (this.get("expression").isIdentifier({ name: "debugger" })) {
-    this.remove();
-  }
+export function DebuggerStatement(node) {  
+  this.remove();  
 }


### PR DESCRIPTION
Hi,
Problem: removeDebugger transfromer didn't work for me.
Solution: I understand that now there is a special statement for debugger that should be used.

Note: First time for me with Babel and process - so please take a a look (is it o.k to use master for fixes ?)