### PR TITLE
Wrap for enviroments with overriden Object.keys Method

### DIFF
--- a/src/babel/traversal/scope/index.js
+++ b/src/babel/traversal/scope/index.js
@@ -152,7 +152,7 @@ export default class Scope {
     this.crawl();
   }
 
-  static globals = flatten([globals.builtin, globals.browser, globals.node].map(Object.keys));
+  static globals = flatten([globals.builtin, globals.browser, globals.node].map(global => Object.keys(global)));
   static contextVariables = ["this", "arguments", "super"];
 
   /**


### PR DESCRIPTION
This fix is mainly due to problems in Atom with the atom-eslint plugin. If another plugin overrides the Object.keys Method it often breaks it. One example is autocomplete.bibtex.
It is not really a bug in babel but it would simplify it for atom users.

If you do not see this as babels task to make it harder for people to misuse it (as overriding Native methods shouldn't be done - here we see why) feel free to deny the pull request.