### PR TITLE
Feature: remove react-components propTypes

### DIFF
--- a/src/babel/transformation/transformers/index.js
+++ b/src/babel/transformation/transformers/index.js
@@ -9,6 +9,7 @@ export default {
   "utility.inlineEnvironmentVariables":    require("./utility/inline-environment-variables"),
   "minification.inlineExpressions":        require("./minification/inline-expressions"),
   "minification.deadCodeElimination":      require("./minification/dead-code-elimination"),
+  "minification.removeReactPropTypes":     require("./minification/remove-react-prop-types"),
   _modules:                                require("./internal/modules"),
   "spec.functionName":                     require("./spec/function-name"),
 

--- a/src/babel/transformation/transformers/minification/remove-react-prop-types.js
+++ b/src/babel/transformation/transformers/minification/remove-react-prop-types.js
@@ -1,0 +1,14 @@
+import * as t from "../../../types";
+
+export var metadata = {
+  optional: true,
+  group: "builtin-setup"
+};
+
+export var Property = {
+  exit(node) {
+    if (node.key.name === 'propTypes') {
+      this.remove();
+    }
+  }
+};

--- a/src/babel/transformation/transformers/minification/remove-react-prop-types.js
+++ b/src/babel/transformation/transformers/minification/remove-react-prop-types.js
@@ -1,5 +1,3 @@
-import * as t from "../../../types";
-
 export var metadata = {
   optional: true,
   group: "builtin-setup"
@@ -7,7 +5,15 @@ export var metadata = {
 
 export var Property = {
   exit(node) {
-    if (node.key.name === 'propTypes') {
+    if (node.computed || node.key.name !== "propTypes") {
+      return;
+    }
+
+    const parent = this.findParent((parent) => {
+      return parent.type === "CallExpression";
+    });
+
+    if (parent && parent.get("callee").matchesPattern("React.createClass")) {
       this.remove();
     }
   }

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/create-class/actual.js
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/create-class/actual.js
@@ -1,0 +1,5 @@
+React.createClass({
+  propTypes: {
+    foo: React.PropTypes.string
+  }
+});

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/create-class/expected.js
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/create-class/expected.js
@@ -1,0 +1,3 @@
+"use strict";
+
+React.createClass({});

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/actual.js
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/actual.js
@@ -1,0 +1,5 @@
+var foo = {
+  propTypes: {
+    foo: 'bar'
+  }
+};

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/actual.js
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/actual.js
@@ -1,5 +1,5 @@
 var foo = {
   propTypes: {
-    foo: 'bar'
+    foo: "bar"
   }
 };

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/expected.js
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/expected.js
@@ -2,6 +2,6 @@
 
 var foo = {
   propTypes: {
-    foo: 'bar'
+    foo: "bar"
   }
 };

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/expected.js
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/not-react/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var foo = {
+  propTypes: {
+    foo: 'bar'
+  }
+};

--- a/test/core/fixtures/transformation/minification.remove-react-prop-types/options.json
+++ b/test/core/fixtures/transformation/minification.remove-react-prop-types/options.json
@@ -1,0 +1,3 @@
+{
+  "optional": ["minification.removeReactPropTypes"]
+}


### PR DESCRIPTION
Before:
```js
const Foo = React.createClass({
  propTypes: {
    foo: React.PropTypes.string
  }
});
```
After, with `"optional": ["minification.removeReactPropTypes"]`
```js
const Foo = React.createClass({});
```