### PR TITLE
Prevent ForInStatement from assigning to const bindings

### DIFF
--- a/src/babel/transformation/transformers/es6/constants.js
+++ b/src/babel/transformation/transformers/es6/constants.js
@@ -1,29 +1,40 @@
 import * as messages from "../../../messages";
+import * as t from "../../../types";
+
+function validateAssignment(node, parent, scope, file) {
+  const name = node.name;
+
+  var binding = scope.getBinding(name);
+
+  // no binding exists
+  if (!binding) return;
+
+  // not a constant
+  if (binding.kind !== "const" && binding.kind !== "module") return;
+
+  // check if the assignment id matches the constant declaration id
+  // if it does then it was the id used to initially declare the
+  // constant so we can just ignore it
+  if (binding.identifier === node) return;
+
+  throw file.errorWithNode(node, messages.get("readOnly", name));
+}
 
 export function AssignmentExpression(node, parent, scope, file) {
   var ids = this.getBindingIdentifiers();
 
   for (var name in ids) {
-    var id = ids[name];
-
-    var binding = scope.getBinding(name);
-
-    // no binding exists
-    if (!binding) continue;
-
-    // not a constant
-    if (binding.kind !== "const" && binding.kind !== "module") continue;
-
-    // check if the assignment id matches the constant declaration id
-    // if it does then it was the id used to initially declare the
-    // constant so we can just ignore it
-    if (binding.identifier === id) continue;
-
-    throw file.errorWithNode(id, messages.get("readOnly", name));
+    validateAssignment(ids[name], parent, scope, file);
   }
 }
 
 export { AssignmentExpression as UpdateExpression };
+
+export function ForInStatement(node, parent, scope, file) {
+  if (t.isIdentifier(node.left)) {
+    validateAssignment(node.left, parent, scope, file);
+  }
+}
 
 export function VariableDeclaration(node) {
   if (node.kind === "const") node.kind = "let";

--- a/test/core/fixtures/transformation/es6.constants/no-for-in/actual.js
+++ b/test/core/fixtures/transformation/es6.constants/no-for-in/actual.js
@@ -1,0 +1,2 @@
+const k = 1;
+for (k in {2: 2});

--- a/test/core/fixtures/transformation/es6.constants/no-for-in/options.json
+++ b/test/core/fixtures/transformation/es6.constants/no-for-in/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "\"k\" is read-only"
+}


### PR DESCRIPTION
`ForOfStatement`s don't allow this, but `ForInStatement`s do:

```javascript
const k = 1;
for (k in {2: 2});
console.log(k); // 2
```

Should this also be tracked as a "constant violation" [here](https://github.com/babel/babel/blob/v5.4.7/src/babel/traversal/scope/index.js#L77)?