### PR TITLE
Minor fix for `referencesImport`

### DIFF
--- a/src/babel/traversal/path/verification.js
+++ b/src/babel/traversal/path/verification.js
@@ -199,7 +199,7 @@ export function referencesImport(moduleSource, importName) {
       return true;
     }
 
-    if (t.ImportNamespaceSpecifier(specifier) && importName === "*") {
+    if (t.isImportNamespaceSpecifier(specifier) && importName === "*") {
       return true;
     }
 


### PR DESCRIPTION
This commit also adds rudimentary tests for this feature.

---

This addresses a minor bug for the feature implemented in https://github.com/babel/babel/commit/eb4cee89c5e7b20d16caba342a49fcbe524d1465.