### PR TITLE
Making babel able to run in node_modules directory

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -6,6 +6,7 @@ import * as babel from "../node";
 import each from "lodash/collection/each";
 import * as util from  "../../util";
 import fs from "fs";
+import path from "path";
 
 sourceMapSupport.install({
   handleUncaughtExceptions: false,
@@ -36,6 +37,12 @@ var only;
 
 var oldHandlers   = {};
 var maps          = {};
+
+var cwd = require.main ? require.main.filename : process.cwd();
+
+var getRelativePath = function (filename){
+  return path.relative(cwd, filename);
+};
 
 var mtime = function (filename) {
   return +fs.statSync(filename).mtime;
@@ -81,7 +88,7 @@ var compile = function (filename) {
 
 var shouldIgnore = function (filename) {
   if (!ignore && !only) {
-    return /node_modules/.test(filename);
+    return /node_modules/.test(getRelativePath(filename));
   } else {
     return util.shouldIgnore(filename, ignore || [], only || []);
   }


### PR DESCRIPTION
E.G. case if app is installed by _npm install \<git tarball url\>_ which is not very popular but comfortable thing (postinstall hooks, automatic package installation and so on) babel is unable to run over packages:

```
 ~/node_modules/some_app$ echo 'import fs from "fs";' > app.js
 ~/node_modules/some_app$ node-babel app.js
(function (exports, require, module, __filename, __dirname) { import fs from '
                                                              ^^^^^^
SyntaxError: Unexpected reserved word...
  ```
 is crashing as babel do not want in node_modules directory.

 relative path gives ability to check whether lib is in node_modules _relative_ to current app, so that if app is ran in node_modules by itself it will not be captured.

I'm not sure how to create an automated test for it, but there is no test for now which is testing this function, and I checked it manually, everything is working - both require('./node_modules...') does not compile and running require('babel/register') whilst working insides node_modules directory works.