### PR TITLE
Add jspm package configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,15 @@
     "mocha": "2.2.0",
     "rimraf": "^2.3.2",
     "uglify-js": "^2.4.16"
+  },
+  "jspm": {
+    "main": "browser.js",
+    "dependencies": {},
+    "jspmNodeConversion": false,
+    "shim": {
+      "browser": {
+        "exports": "babel"
+      }
+    }
   }
 }

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -7,5 +7,11 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {
     "core-js": "^0.9.0"
+  },
+  "jspm": {
+    "main": false,
+    "map": {
+      "./core-js": "core-js"
+    }
   }
 }


### PR DESCRIPTION
I don't expect this to land and understand if this configuration is not maintainable within this repo. These package configurations are currently managed in the jspm registry at https://github.com/jspm/registry/blob/master/package-overrides/npm/babel-runtime%405.4.7.json and https://github.com/jspm/registry/blob/master/package-overrides/npm/babel-core%405.0.0.json.

The main thing I wanted to mention here is the contract that jspm is relying on for Babel, and how its configuration is working. Some time recently it seems the core-js helpers were moved into the runtime repo or something like that perhaps? I think that may have caused some issues in jspm's handling of the core-js runtime, which needed to be fixed by the map in the override in https://github.com/jspm/registry/blob/master/package-overrides/npm/babel-runtime%405.4.7.json.

If it's possible to get some idea of the stability of these runtime modularity conventions that would be a great help, to know how often I need to check these overrides are working.

Many thanks!