### PR TITLE
Add "mixed" Flow type

### DIFF
--- a/src/acorn/plugins/flow.js
+++ b/src/acorn/plugins/flow.js
@@ -415,6 +415,9 @@ pp.flow_identToTypeAnnotation = function (start, node, id) {
     case "boolean":
       return this.finishNode(node, "BooleanTypeAnnotation")
 
+    case "mixed":
+      return this.finishNode(node, "MixedTypeAnnotation")
+
     case "number":
       return this.finishNode(node, "NumberTypeAnnotation")
 

--- a/src/babel/generation/generators/flow.js
+++ b/src/babel/generation/generators/flow.js
@@ -103,6 +103,10 @@ export function IntersectionTypeAnnotation(node, print) {
   print.join(node.types, { separator: " & " });
 }
 
+export function MixedTypeAnnotation() {
+  this.push("mixed");
+}
+
 export function NullableTypeAnnotation(node, print) {
   this.push("?");
   print.plain(node.typeAnnotation);

--- a/src/babel/types/alias-keys.json
+++ b/src/babel/types/alias-keys.json
@@ -93,6 +93,7 @@
   "InterfaceExtends":            ["Flow"],
   "InterfaceDeclaration":        ["Flow", "Statement", "Declaration"],
   "IntersectionTypeAnnotation":  ["Flow"],
+  "MixedTypeAnnotation":         ["Flow"],
   "NullableTypeAnnotation":      ["Flow"],
   "NumberTypeAnnotation":        ["Flow"],
   "StringLiteralTypeAnnotation": ["Flow"],

--- a/src/babel/types/visitor-keys.json
+++ b/src/babel/types/visitor-keys.json
@@ -91,6 +91,7 @@
   "InterfaceExtends":            ["id", "typeParameters"],
   "InterfaceDeclaration":        ["id", "typeParameters", "extends", "body"],
   "IntersectionTypeAnnotation":  ["types"],
+  "MixedTypeAnnotation":         [],
   "NullableTypeAnnotation":      ["typeAnnotation"],
   "NumberTypeAnnotation":        [],
   "StringLiteralTypeAnnotation": [],

--- a/test/acorn/tests-flow.js
+++ b/test/acorn/tests-flow.js
@@ -2,7 +2,7 @@
 
 var fbTestFixture = {
   'Type Annotations': {
-    'function foo(numVal: any){}': {
+    'function foo(numVal: any, otherVal: mixed){}': {
       type: 'FunctionDeclaration',
       id: {
         type: 'Identifier',
@@ -37,22 +37,47 @@ var fbTestFixture = {
           start: { line: 1, column: 13 },
           end: { line: 1, column: 24 }
         }
+      },
+      {
+        type: 'Identifier',
+        name: 'otherVal',
+        typeAnnotation: {
+          type: 'TypeAnnotation',
+          typeAnnotation: {
+            type: 'MixedTypeAnnotation',
+            range: [36, 41],
+            loc: {
+              start: { line: 1, column: 36 },
+              end: { line: 1, column: 41 }
+            }
+          },
+          range: [34, 41],
+          loc: {
+            start: { line: 1, column: 34 },
+            end: { line: 1, column: 41 }
+          }
+        },
+        range: [26, 41],
+        loc: {
+          start: { line: 1, column: 26 },
+          end: { line: 1, column: 41 }
+        }
       }],
       body: {
         type: 'BlockStatement',
         body: [],
-        range: [25, 27],
+        range: [42, 44],
         loc: {
-          start: { line: 1, column: 25 },
-          end: { line: 1, column: 27 }
+          start: { line: 1, column: 42 },
+          end: { line: 1, column: 44 }
         }
       },
       generator: false,
       expression: false,
-      range: [0, 27],
+      range: [0, 44],
       loc: {
         start: { line: 1, column: 0 },
-        end: { line: 1, column: 27 }
+        end: { line: 1, column: 44 }
       }
     },
     'function foo(numVal: number){}': {


### PR DESCRIPTION
"mixed" is one of the base types listed here:

http://flowtype.org/docs/base-types.html

So this commit adds support for it.

Noticed while using babel-eslint to lint code using the "mixed" type, it was reporting spurious warnings for types like this:

```
type WrappedValue = {
  value: mixed;
  insertionCounter: number;
};
```

Printing:

```
/Users/glh/code/corpus/src/app/Heap.js
  11:9   error  "mixed" is not defined  no-undef
 ```

This is my first PR to babel, so please let me know if I'm doing anything wrong.

CC: @hzoo