### PR TITLE
adding check for existing literal displayName when adding inferred displayNames

### DIFF
--- a/src/babel/transformation/helpers/build-react-transformer.js
+++ b/src/babel/transformation/helpers/build-react-transformer.js
@@ -161,7 +161,7 @@ export default function (exports, opts) {
 
     for (var i = 0; i < props.length; i++) {
       var prop = props[i];
-      if (t.isIdentifier(prop.key, { name: "displayName" })) {
+      if (t.isIdentifier(prop.key, { name: "displayName" }) || prop.key.value === "displayName") {
         safe = false;
         break;
       }


### PR DESCRIPTION
Hello,

Our component library uses literals when using React.createClass, since this check is only looking for identifiers with the name of "displayName" this is adding duplicate displayName properties to our components with literal displayName definitions (this causes problems in strictmode).

This is an example of our components:

```javascript
module.exports = React.createClass({
  'displayName'     : 'InstallTrends',
  'getInitialState' : function() {
    return {
      'focusIds'   : [],
      'setByClick' : false,
      'widget'     : {}
    };
  }.........
```

Tests are all passing, I didn't write any additional ones for this but I'm more than willing to. Let me know if you have any feedback or if there is a reason to not check the key value this way.

Thanks!