### PR TITLE
es6.spec.arrowFunctions

### DIFF
--- a/src/babel/transformation/file/index.js
+++ b/src/babel/transformation/file/index.js
@@ -85,6 +85,7 @@ export default class File {
     "get",
     "set",
     "class-call-check",
+    "new-arrow-check",
     "object-destructuring-empty",
     "temporal-undefined",
     "temporal-assert-defined",

--- a/src/babel/transformation/templates/helper-new-arrow-check.js
+++ b/src/babel/transformation/templates/helper-new-arrow-check.js
@@ -1,0 +1,5 @@
+(function (instance, arrowFn) {
+  if (instance instanceof arrowFn) {
+    throw new TypeError("Cannot instantiate an arrow function");
+  }
+});

--- a/src/babel/transformation/templates/helper-new-arrow-check.js
+++ b/src/babel/transformation/templates/helper-new-arrow-check.js
@@ -1,5 +1,5 @@
-(function (instance, arrowFn) {
-  if (instance instanceof arrowFn) {
+(function (innerThis, boundThis) {
+  if (innerThis !== boundThis) {
     throw new TypeError("Cannot instantiate an arrow function");
   }
 });

--- a/src/babel/transformation/transformers/es6/arrow-functions.js
+++ b/src/babel/transformation/transformers/es6/arrow-functions.js
@@ -5,5 +5,5 @@ export function ArrowFunctionExpression(node) {
 
   node.expression = false;
   node.type = "FunctionExpression";
-  node.shadow = true;
+  node.shadow = node.shadow || true;
 }

--- a/src/babel/transformation/transformers/es6/spec.arrow-functions.js
+++ b/src/babel/transformation/transformers/es6/spec.arrow-functions.js
@@ -1,0 +1,26 @@
+import * as t from "../../../types";
+
+export var metadata = {
+  optional: true
+};
+
+export function ArrowFunctionExpression(node, parent, scope, file) {
+  if (node.shadow) return;
+  node.shadow = { this: false };
+
+  var {id} = node;
+  var expr = node;
+
+  if (!id) {
+    id = scope.parent.generateDeclaredUidIdentifier("arrow");
+    expr = t.assignmentExpression("=", id, expr);
+  }
+
+  // make sure that arrow function won't be instantiated
+  t.ensureBlock(node).body.unshift(t.expressionStatement(t.callExpression(file.addHelper("new-arrow-check"), [
+    t.thisExpression(),
+    id
+  ])));
+
+  return t.callExpression(t.memberExpression(expr, t.identifier("bind")), [t.thisExpression()]);
+}

--- a/src/babel/transformation/transformers/es6/spec.arrow-functions.js
+++ b/src/babel/transformation/transformers/es6/spec.arrow-functions.js
@@ -8,19 +8,14 @@ export function ArrowFunctionExpression(node, parent, scope, file) {
   if (node.shadow) return;
   node.shadow = { this: false };
 
-  var {id} = node;
-  var expr = node;
-
-  if (!id) {
-    id = scope.parent.generateDeclaredUidIdentifier("arrow");
-    expr = t.assignmentExpression("=", id, expr);
-  }
+  var boundThis = t.thisExpression();
+  boundThis._shadowedFunctionLiteral = false;
 
   // make sure that arrow function won't be instantiated
   t.ensureBlock(node).body.unshift(t.expressionStatement(t.callExpression(file.addHelper("new-arrow-check"), [
     t.thisExpression(),
-    id
+    boundThis
   ])));
 
-  return t.callExpression(t.memberExpression(expr, t.identifier("bind")), [t.thisExpression()]);
+  return t.callExpression(t.memberExpression(node, t.identifier("bind")), [t.thisExpression()]);
 }

--- a/src/babel/transformation/transformers/index.js
+++ b/src/babel/transformation/transformers/index.js
@@ -26,6 +26,7 @@ export default {
   "es7.decorators":                        require("./es7/decorators"),
   "validation.undeclaredVariableCheck":    require("./validation/undeclared-variable-check"),
   "validation.react":                      require("./validation/react"),
+  "es6.spec.arrowFunctions":               require("./es6/spec.arrow-functions"),
   "es6.arrowFunctions":                    require("./es6/arrow-functions"),
   "spec.blockScopedFunctions":             require("./spec/block-scoped-functions"),
   "optimisation.react.constantElements":   require("./optimisation/react.constant-elements"),

--- a/src/babel/transformation/transformers/internal/shadow-functions.js
+++ b/src/babel/transformation/transformers/internal/shadow-functions.js
@@ -23,13 +23,11 @@ function remap(path, key, create) {
 }
 
 export function ThisExpression(node) {
-  if (!node._shadowedFunctionLiteral) {
-    return remap(this, "this", () => t.thisExpression());
-  }
+  return remap(this, "this", () => t.thisExpression());
 }
 
 export function ReferencedIdentifier(node) {
-  if (node.name === "arguments" && !node._shadowedFunctionLiteral) {
+  if (node.name === "arguments") {
     return remap(this, "arguments", () => t.identifier("arguments"));
   }
 }

--- a/src/babel/transformation/transformers/internal/shadow-functions.js
+++ b/src/babel/transformation/transformers/internal/shadow-functions.js
@@ -6,7 +6,7 @@ export var metadata = {
 
 function remap(path, key, create) {
   // ensure that we're shadowed
-  if (!path.inShadow()) return;
+  if (!path.inShadow(key)) return;
 
   var fnPath = path.findParent((path) => !path.is("shadow") && (path.isFunction() || path.isProgram()));
 
@@ -22,8 +22,10 @@ function remap(path, key, create) {
   return id;
 }
 
-export function ThisExpression() {
-  return remap(this, "this", () => t.thisExpression());
+export function ThisExpression(node) {
+  if (!node._shadowedFunctionLiteral) {
+    return remap(this, "this", () => t.thisExpression());
+  }
 }
 
 export function ReferencedIdentifier(node) {

--- a/src/babel/traversal/path/ancestry.js
+++ b/src/babel/traversal/path/ancestry.js
@@ -62,11 +62,12 @@ export function inType(types) {
  * Description
  */
 
-export function inShadow() {
+export function inShadow(key) {
   var path = this;
   while (path) {
     if (path.isFunction()) {
-      if (path.node.shadow) {
+      var {shadow} = path.node;
+      if (shadow && (shadow === true || shadow[key] !== false)) {
         return path;
       } else {
         return null;

--- a/src/babel/traversal/path/ancestry.js
+++ b/src/babel/traversal/path/ancestry.js
@@ -64,9 +64,13 @@ export function inType(types) {
 
 export function inShadow(key) {
   var path = this;
+  var dontShadow = path.node._shadowedFunctionLiteral;
+  if (dontShadow !== undefined) {
+    return !dontShadow;
+  }
   while (path) {
     if (path.isFunction()) {
-      var {shadow} = path.node;
+      var { shadow } = path.node;
       if (shadow && (shadow === true || shadow[key] !== false)) {
         return path;
       } else {

--- a/test/core/fixtures/transformation/es6.arrow-functions/spec/actual.js
+++ b/test/core/fixtures/transformation/es6.arrow-functions/spec/actual.js
@@ -1,0 +1,5 @@
+arr.map(x => x * x);
+var f = (x, y) => x * y;
+(function () {
+  return () => this;
+})();

--- a/test/core/fixtures/transformation/es6.arrow-functions/spec/expected.js
+++ b/test/core/fixtures/transformation/es6.arrow-functions/spec/expected.js
@@ -1,25 +1,20 @@
 "use strict";
 
-var _arrow;
+var _this = this;
 
-function _newArrowCheck(instance, arrowFn) { if (instance instanceof arrowFn) { throw new TypeError("Cannot instantiate an arrow function"); } }
-
-arr.map((_arrow = function (x) {
-  _newArrowCheck(this, _arrow);
-
+arr.map((function (x) {
+  babelHelpers.newArrowCheck(this, _this);
   return x * x;
 }).bind(this));
 var f = (function f(x, y) {
-  _newArrowCheck(this, f);
-
+  babelHelpers.newArrowCheck(this, _this);
   return x * y;
 }).bind(this);
 (function () {
-  var _arrow2;
+  var _this2 = this;
 
-  return (_arrow2 = function () {
-    _newArrowCheck(this, _arrow2);
-
+  return (function () {
+    babelHelpers.newArrowCheck(this, _this2);
     return this;
   }).bind(this);
 })();

--- a/test/core/fixtures/transformation/es6.arrow-functions/spec/expected.js
+++ b/test/core/fixtures/transformation/es6.arrow-functions/spec/expected.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var _arrow;
+
+function _newArrowCheck(instance, arrowFn) { if (instance instanceof arrowFn) { throw new TypeError("Cannot instantiate an arrow function"); } }
+
+arr.map((_arrow = function (x) {
+  _newArrowCheck(this, _arrow);
+
+  return x * x;
+}).bind(this));
+var f = (function f(x, y) {
+  _newArrowCheck(this, f);
+
+  return x * y;
+}).bind(this);
+(function () {
+  var _arrow2;
+
+  return (_arrow2 = function () {
+    _newArrowCheck(this, _arrow2);
+
+    return this;
+  }).bind(this);
+})();

--- a/test/core/fixtures/transformation/es6.arrow-functions/spec/options.json
+++ b/test/core/fixtures/transformation/es6.arrow-functions/spec/options.json
@@ -1,0 +1,3 @@
+{
+	"optional": ["es6.spec.arrowFunctions"]
+}

--- a/test/core/fixtures/transformation/es6.arrow-functions/spec/options.json
+++ b/test/core/fixtures/transformation/es6.arrow-functions/spec/options.json
@@ -1,3 +1,4 @@
 {
+  "externalHelpers": true,
 	"optional": ["es6.spec.arrowFunctions"]
 }


### PR DESCRIPTION
Added transformer against `new` on arrow expressions.

This is required by spec, but made it optional.