### PR TITLE
add required prop for JSXIdentifier

### DIFF
--- a/src/babel/types/visitor-keys.json
+++ b/src/babel/types/visitor-keys.json
@@ -117,7 +117,7 @@
   "JSXElement":                ["openingElement", "closingElement", "children"],
   "JSXEmptyExpression":        [],
   "JSXExpressionContainer":    ["expression"],
-  "JSXIdentifier":             [],
+  "JSXIdentifier":             ["name"],
   "JSXMemberExpression":       ["object", "property"],
   "JSXNamespacedName":         ["namespace", "name"],
   "JSXOpeningElement":         ["name", "attributes"],


### PR DESCRIPTION
Trying to make a plugin that adds a jsx attribute, and it errored b/c JSXIdentifier has a `name` attribute that needs to be populated.
I fixed it by just doing `theid.name = "thing"`, but I imagine it should be changed here.