### PR TITLE
Change exports-module-declaration helper to set prototype of exports to null. 

### DIFF
--- a/src/babel/transformation/templates/exports-module-declaration.js
+++ b/src/babel/transformation/templates/exports-module-declaration.js
@@ -1,3 +1,3 @@
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: { value: true }
 });

--- a/test/core/fixtures/transformation/es6.modules-amd/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/exports-from/expected.js
@@ -1,8 +1,10 @@
 define(["exports", "foo"], function (exports, _foo) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   babelHelpers.defaults(exports, babelHelpers.interopRequireWildcard(_foo));
   Object.defineProperty(exports, "foo", {

--- a/test/core/fixtures/transformation/es6.modules-amd/exports-named/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/exports-named/expected.js
@@ -1,8 +1,10 @@
 define(["exports"], function (exports) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   exports.foo = foo;
   exports.foo = foo;

--- a/test/core/fixtures/transformation/es6.modules-amd/exports-variable/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/exports-variable/expected.js
@@ -1,8 +1,10 @@
 define(["exports"], function (exports) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   exports.foo7 = foo7;
   var foo = 1;

--- a/test/core/fixtures/transformation/es6.modules-amd/hoist-function-exports/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/hoist-function-exports/expected.js
@@ -1,8 +1,10 @@
 define(["exports", "./evens"], function (exports, _evens) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   exports.nextOdd = nextOdd;
 

--- a/test/core/fixtures/transformation/es6.modules-amd/overview/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/overview/expected.js
@@ -1,8 +1,10 @@
 define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (exports, _foo, _fooBar, _directoryFooBar) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
 
   var _foo2 = babelHelpers.interopRequireDefault(_foo);

--- a/test/core/fixtures/transformation/es6.modules-amd/remap/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-amd/remap/expected.js
@@ -1,8 +1,10 @@
 define(["exports"], function (exports) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   var test = 2;
   exports.test = test;

--- a/test/core/fixtures/transformation/es6.modules-common/exports-default-non-function/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/exports-default-non-function/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports.Cachier = Cachier;
 exports["default"] = new Cachier();

--- a/test/core/fixtures/transformation/es6.modules-common/exports-default/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/exports-default/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports["default"] = foo;
 exports["default"] = 42;

--- a/test/core/fixtures/transformation/es6.modules-common/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/exports-from/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var _foo = require("foo");

--- a/test/core/fixtures/transformation/es6.modules-common/exports-named/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/exports-named/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports.foo = foo;
 exports.foo = foo;

--- a/test/core/fixtures/transformation/es6.modules-common/exports-variable/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/exports-variable/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports.foo7 = foo7;
 var foo = 1;

--- a/test/core/fixtures/transformation/es6.modules-common/hoist-function-exports/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/hoist-function-exports/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports.nextOdd = nextOdd;
 

--- a/test/core/fixtures/transformation/es6.modules-common/module-shadow/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/module-shadow/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports.module = _module;
 

--- a/test/core/fixtures/transformation/es6.modules-common/overview/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/overview/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 require("foo");

--- a/test/core/fixtures/transformation/es6.modules-common/remap/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-common/remap/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 var test = 2;
 exports.test = test;

--- a/test/core/fixtures/transformation/es6.modules-umd/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/exports-from/expected.js
@@ -13,8 +13,10 @@
 })(this, function (exports, _foo) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   babelHelpers.defaults(exports, babelHelpers.interopRequireWildcard(_foo));
   Object.defineProperty(exports, "foo", {

--- a/test/core/fixtures/transformation/es6.modules-umd/exports-named/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/exports-named/expected.js
@@ -13,8 +13,10 @@
 })(this, function (exports) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   exports.foo = foo;
   exports.foo = foo;

--- a/test/core/fixtures/transformation/es6.modules-umd/exports-variable/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/exports-variable/expected.js
@@ -13,8 +13,10 @@
 })(this, function (exports) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   exports.foo7 = foo7;
   var foo = 1;

--- a/test/core/fixtures/transformation/es6.modules-umd/hoist-function-exports/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/hoist-function-exports/expected.js
@@ -13,8 +13,10 @@
 })(this, function (exports, _evens) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   exports.nextOdd = nextOdd;
 

--- a/test/core/fixtures/transformation/es6.modules-umd/overview/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/overview/expected.js
@@ -13,8 +13,10 @@
 })(this, function (exports, _foo, _fooBar, _directoryFooBar) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
 
   var _foo2 = babelHelpers.interopRequireDefault(_foo);

--- a/test/core/fixtures/transformation/es6.modules-umd/remap/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-umd/remap/expected.js
@@ -13,8 +13,10 @@
 })(this, function (exports) {
   "use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+  exports = Object.create(null, {
+    __esModule: {
+      value: true
+    }
   });
   var test = 2;
   exports.test = test;

--- a/test/core/fixtures/transformation/es7.decorators/class-modules/expected.js
+++ b/test/core/fixtures/transformation/es7.decorators/class-modules/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var _foo = require("foo");

--- a/test/core/fixtures/transformation/es7.export-extensions/default-commonjs/expected.js
+++ b/test/core/fixtures/transformation/es7.export-extensions/default-commonjs/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var _bar = require("bar");

--- a/test/core/fixtures/transformation/es7.export-extensions/namespace-commonjs/expected.js
+++ b/test/core/fixtures/transformation/es7.export-extensions/namespace-commonjs/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var _bar = require("bar");

--- a/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1408/expected.js
+++ b/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1408/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports["default"] = new function A() {
   babelHelpers.classCallCheck(this, A);

--- a/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1523/expected.js
+++ b/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1523/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 function f(a) {
   return !a;

--- a/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1524/expected.js
+++ b/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1524/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 function* x() {
   var _arr = [];

--- a/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1546/expected.js
+++ b/test/core/fixtures/transformation/minification.dead-code-elimination/issue-1546/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var X = (function () {

--- a/test/core/fixtures/transformation/react/display-name-export-default/expected.js
+++ b/test/core/fixtures/transformation/react/display-name-export-default/expected.js
@@ -1,5 +1,7 @@
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 exports["default"] = React.createClass({
   displayName: "actual",

--- a/test/core/fixtures/transformation/runtime/full/expected.js
+++ b/test/core/fixtures/transformation/runtime/full/expected.js
@@ -2,7 +2,7 @@
 
 var _regeneratorRuntime = require("babel-runtime/regenerator")["default"];
 
-var _Object$defineProperty = require("babel-runtime/core-js/object/define-property")["default"];
+var _Object$create = require("babel-runtime/core-js/object/create")["default"];
 
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
 
@@ -10,10 +10,11 @@ var _interopRequireDefault = require("babel-runtime/helpers/interop-require-defa
 
 var _interopRequireWildcard = require("babel-runtime/helpers/interop-require-wildcard")["default"];
 
-_Object$defineProperty(exports, "__esModule", {
-  value: true
+exports = _Object$create(null, {
+  __esModule: {
+    value: true
+  }
 });
-
 exports.giveWord = giveWord;
 var marked0$0 = [giveWord].map(_regeneratorRuntime.mark);
 

--- a/test/core/fixtures/transformation/spec.function-name/modules-2/expected.js
+++ b/test/core/fixtures/transformation/spec.function-name/modules-2/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var _lodashArrayLast = require("lodash/array/last");

--- a/test/core/fixtures/transformation/spec.function-name/modules-3/expected.js
+++ b/test/core/fixtures/transformation/spec.function-name/modules-3/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+exports = Object.create(null, {
+  __esModule: {
+    value: true
+  }
 });
 
 var _store = require("./store");


### PR DESCRIPTION
Removed `module.exports` from the helper suggested in #1714 due to it not being declared in tests
and not being needed (according to @sebmck).

Fixes #1714.