### PR TITLE
Optimize spec typeof transformer.

### DIFF
--- a/src/babel/transformation/transformers/es6/spec.symbols.js
+++ b/src/babel/transformation/transformers/es6/spec.symbols.js
@@ -8,6 +8,20 @@ export function UnaryExpression(node, parent, scope, file) {
   if (node._ignoreSpecSymbols) return;
 
   if (node.operator === "typeof") {
+    if (t.isBinaryExpression(parent)) {
+      var {operator, left, right} = parent;
+      if (right === node) {
+        [left, right] = [right, left];
+      }
+      if (t.isLiteral(right)) {
+        if ((operator === "==" || operator === "===") && right.value !== "symbol") {
+          return;
+        }
+        if ((operator === "!=" || operator === "!==") && right.value !== "symbol" && right.value !== "object") {
+          return;
+        }
+      }
+    }
     var call = t.callExpression(file.addHelper("typeof"), [node.argument]);
     if (this.get("argument").isIdentifier()) {
       var undefLiteral = t.literal("undefined");

--- a/src/babel/transformation/transformers/es6/spec.symbols.js
+++ b/src/babel/transformation/transformers/es6/spec.symbols.js
@@ -13,13 +13,9 @@ export function UnaryExpression(node, parent, scope, file) {
       if (right === node) {
         [left, right] = [right, left];
       }
-      if (t.isLiteral(right)) {
-        if ((operator === "==" || operator === "===") && right.value !== "symbol") {
-          return;
-        }
-        if ((operator === "!=" || operator === "!==") && right.value !== "symbol" && right.value !== "object") {
-          return;
-        }
+      if (t.isLiteral(right) && right.value !== "symbol" && right.value !== "object" &&
+          (operator === "==" || operator === "===" || operator === "!=" || operator === "!==")) {
+        return;
       }
     }
     var call = t.callExpression(file.addHelper("typeof"), [node.argument]);

--- a/test/core/fixtures/transformation/es6.spec.symbols/typeof/actual.js
+++ b/test/core/fixtures/transformation/es6.spec.symbols/typeof/actual.js
@@ -1,3 +1,6 @@
 var s = Symbol("s");
 assert.equal(typeof s, "symbol");
 assert.equal(typeof typeof s.foo, "symbol");
+assert(typeof "abc" === "string");
+assert(typeof 12 === "number");
+assert(typeof x !== "boolean");

--- a/test/core/fixtures/transformation/es6.spec.symbols/typeof/expected.js
+++ b/test/core/fixtures/transformation/es6.spec.symbols/typeof/expected.js
@@ -3,3 +3,6 @@
 var s = Symbol("s");
 assert.equal(typeof s === "undefined" ? "undefined" : babelHelpers._typeof(s), "symbol");
 assert.equal(babelHelpers._typeof(babelHelpers._typeof(s.foo)), "symbol");
+assert(typeof "abc" === "string");
+assert(typeof 12 === "number");
+assert(typeof x !== "boolean");


### PR DESCRIPTION
The most usual case for `typeof x` is immediate comparison with literal string value, and while I did want to be able to use `typeof x === "symbol"`, I didn't want all those simple checks to be wrapped all across the code, so optimized for this case.

I think might be useful for others as well.