### PR TITLE
Export bulk system.register variation

### DIFF
--- a/test/core/fixtures/transformation/es6.modules-system/exports-from/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-system/exports-from/expected.js
@@ -3,23 +3,26 @@ System.register(["foo"], function (_export) {
 
   return {
     setters: [function (_foo) {
+      var exportObj = {};
+
       for (var _key in _foo) {
-        _export(_key, _foo[_key]);
+        if (_key !== 'default')
+          exportObj[_key] = _foo[_key];
       }
 
-      _export("foo", _foo.foo);
+      exportObj["foo"] = _foo.foo;
 
-      _export("foo", _foo.foo);
+      exportObj["bar"] = _foo.bar;
 
-      _export("bar", _foo.bar);
+      exportObj["bar"] = _foo.foo;
 
-      _export("bar", _foo.foo);
+      exportObj["default"] = _foo.foo;
 
-      _export("default", _foo.foo);
+      exportObj["default"] = _foo.foo;
 
-      _export("default", _foo.foo);
+      exportObj["bar"] = _foo.bar;
 
-      _export("bar", _foo.bar);
+      _export(exportObj);
     }],
     execute: function () {}
   };


### PR DESCRIPTION
Here are some suggested tests for the new bulk export feature in the register output.

When there are deep `export *` chains, the performance is significantly degraded by having setters run completely down the binding chain during intermediate exports, which was affecting Aurelia.

This should hopefully help with this issue. The module loader issue is being tracked at https://github.com/ModuleLoader/es6-module-loader/issues/386.

@EisenbergEffect may be able to suggest a possible implementor if this is tricky.

The major concern is actually backwards compatibility here. Would it be possible to enable this behind some sort of flag pending Babel v6?

Thanks as always.