### PR TITLE
Fix require hook under istanbul

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -125,7 +125,7 @@ var normalLoader = function (m, filename) {
 };
 
 var registerExtension = function (ext) {
-  var old = oldHandlers[ext] || oldHandlers[".js"];
+  var old = oldHandlers[ext] || oldHandlers[".js"] || require.extensions[".js"];
 
   var loader = normalLoader;
   if (process.env.running_under_istanbul) loader = istanbulLoader;


### PR DESCRIPTION
When using the require hook under instanbul, if you specify custom extensions and do not include `.js` you get an error when trying to require any file.

for example the following will error on the `require("./test.es6");` call.
```js
process.env.running_under_istanbul = true;

require("babel/register")({
  extensions: [".es6"]
});

require("./test.es6");
```

issue is that when calling the require hook with `extensions: [".es6"]` there is no `oldHandlers[".js"]` defined.