### PR TITLE
remove empty strings from beginning of template - fixes #1732

### DIFF
--- a/test/core/fixtures/transformation/es6.template-literals/expression-first/actual.js
+++ b/test/core/fixtures/transformation/es6.template-literals/expression-first/actual.js
@@ -1,0 +1,8 @@
+const foo = 5;
+const bar = 10;
+const baz = 15;
+
+const example = `${"a"}`;
+const example2 = `${1}`;
+const example3 = 1 + `${foo}${bar}${baz}`;
+const example4 = 1 + `${foo}bar${baz}`;

--- a/test/core/fixtures/transformation/es6.template-literals/expression-first/expected.js
+++ b/test/core/fixtures/transformation/es6.template-literals/expression-first/expected.js
@@ -1,0 +1,10 @@
+"use strict";
+
+var foo = 5;
+var bar = 10;
+var baz = 15;
+
+var example = "a";
+var example2 = "" + 1;
+var example3 = 1 + ("" + foo + bar + baz);
+var example4 = 1 + (foo + "bar" + baz);


### PR DESCRIPTION
#1732 I'l give it a try?

Not sure if we want to check `if (nodes.length > 1) {` twice there but yeah