### PR TITLE
Optimize NodePath#call a bit

### DIFF
--- a/src/babel/traversal/path/context.js
+++ b/src/babel/traversal/path/context.js
@@ -9,31 +9,31 @@ export function call(key) {
   if (!node) return;
 
   var opts = this.opts;
-  if (!opts[key] && !opts[node.type]) return;
 
-  var fns = [].concat(opts[key]);
-  if (opts[node.type]) fns = fns.concat(opts[node.type][key]);
+  for (var fns of [opts[key], opts[node.type] && opts[node.type][key]]){
+    if (!fns) continue;
 
-  for (var fn of (fns: Array)) {
-    if (!fn) continue;
+    for (var fn of (fns: Array)) {
+      if (!fn) continue;
 
-    let node = this.node;
-    if (!node) return;
+      let node = this.node;
+      if (!node) return;
 
-    var previousType = this.type;
+      var previousType = this.type;
 
-    // call the function with the params (node, parent, scope, state)
-    var replacement = fn.call(this, node, this.parent, this.scope, this.state);
+      // call the function with the params (node, parent, scope, state)
+      var replacement = fn.call(this, node, this.parent, this.scope, this.state);
 
-    if (replacement) {
-      this.replaceWith(replacement, true);
-    }
+      if (replacement) {
+        this.replaceWith(replacement, true);
+      }
 
-    if (this.shouldStop || this.shouldSkip || this.removed) return;
+      if (this.shouldStop || this.shouldSkip || this.removed) return;
 
-    if (previousType !== this.type) {
-      this.queueNode(this);
-      return;
+      if (previousType !== this.type) {
+        this.queueNode(this);
+        return;
+      }
     }
   }
 }

--- a/src/babel/traversal/visitors.js
+++ b/src/babel/traversal/visitors.js
@@ -21,6 +21,8 @@ export function explode(visitor) {
   // ensure visitors are objects
   ensureEntranceObjects(visitor);
 
+  ensureCallbackArrays(visitor);
+
   // add type wrappers
   for (let nodeType in visitor) {
     if (shouldIgnoreKey(nodeType)) continue;
@@ -71,6 +73,12 @@ export function explode(visitor) {
         visitor[alias] = clone(fns);
       }
     }
+  }
+
+  for (let nodeType in visitor) {
+    if (shouldIgnoreKey(nodeType)) continue;
+
+    ensureCallbackArrays(visitor[nodeType]);
   }
 
   return visitor;
@@ -124,6 +132,11 @@ function ensureEntranceObjects(obj) {
       obj[key] = { enter: fns };
     }
   }
+}
+
+function ensureCallbackArrays(obj){
+  if (obj.enter && !Array.isArray(obj.enter)) obj.enter = [obj.enter];
+  if (obj.exit && !Array.isArray(obj.exit)) obj.exit = [obj.exit];
 }
 
 function addQueries(visitor) {


### PR DESCRIPTION
On my machine, building ember goes down ~10%ish.

It seems like building multiple temporary array (via concat) slows things down. I tried just making a single temp array and pushing into it and that was a bit faster, but I had to start checking if the options were a single callback or a list of callbacks, so it just seemed easiest to split that check out entirely and drop joining the arrays entirely.