### PR TITLE
matchPattern fixes and "this" handling

### DIFF
--- a/src/babel/traversal/path/introspection.js
+++ b/src/babel/traversal/path/introspection.js
@@ -40,8 +40,8 @@ export function matchesPattern(pattern: string, allowPartial?: boolean): boolean
         // we can't deal with this
         return false;
       } else {
-        search.push(node.object);
-        search.push(node.property);
+        search.unshift(node.property);
+        search.unshift(node.object);
         continue;
       }
     } else if (t.isThisExpression(node)) {
@@ -57,7 +57,7 @@ export function matchesPattern(pattern: string, allowPartial?: boolean): boolean
     }
   }
 
-  return true;
+  return i === parts.length;
 }
 
 /**

--- a/src/babel/traversal/path/introspection.js
+++ b/src/babel/traversal/path/introspection.js
@@ -10,11 +10,10 @@ import * as t from "../../types";
  */
 
 export function matchesPattern(pattern: string, allowPartial?: boolean): boolean {
- var parts = pattern.split(".");
-
   // not a member expression
   if (!this.isMemberExpression()) return false;
 
+  var parts = pattern.split(".");
   var search = [this.node];
   var i = 0;
 
@@ -45,6 +44,8 @@ export function matchesPattern(pattern: string, allowPartial?: boolean): boolean
         search.push(node.property);
         continue;
       }
+    } else if (t.isThisExpression(node)) {
+      if (!matches("this")) return false;
     } else {
       // we can't deal with this
       return false;


### PR DESCRIPTION
...also moved the `split` after the guard clause.

```
// given code like this:
process.env.NODE_ENV.cats

// before
matchesPattern("process.env.NODE_ENV.cats") // false
matchesPattern("cats.NODE_ENV.process.env") // true
matchesPattern("cats.NODE_ENV.process.env.more.stuff") // true

// after
matchesPattern("process.env.NODE_ENV.cats") // true
matchesPattern("process.env.NODE_ENV.cats.more.stuff") // false
matchesPattern("cats.NODE_ENV.process.env") // false
matchesPattern("cats.NODE_ENV.process.env.more.stuff") // false
```

@sebmck where can I put tests for this? `test/core/path.js`? also, what's the simplest way to get from source to a `NodePath` for the test setup?