### PR TITLE
Don't comma seperate decorators during generation + method decorator test case.

### DIFF
--- a/src/babel/generation/generators/classes.js
+++ b/src/babel/generation/generators/classes.js
@@ -1,5 +1,13 @@
+export function _decorators(decorators, print) {
+  if (!decorators || !decorators.length) return;
+  decorators.forEach(decorator => {
+    print.plain(decorator);
+    this.newline();
+  });
+}
+
 export function ClassDeclaration(node, print) {
-  print.list(node.decorators);
+  this._decorators(node.decorators, print);
   this.push("class");
 
   if (node.id) {
@@ -43,7 +51,7 @@ export function ClassBody(node, print) {
 
 
 export function ClassProperty(node, print) {
-  print.list(node.decorators);
+  this._decorators(node.decorators, print);
 
   if (node.static) this.push("static ");
   print.plain(node.key);
@@ -58,11 +66,8 @@ export function ClassProperty(node, print) {
 }
 
 export function MethodDefinition(node, print) {
-  print.list(node.decorators);
+  this._decorators(node.decorators, print);
 
-  if (node.static) {
-    this.push("static ");
-  }
-
+  if (node.static) this.push("static ");
   this._method(node, print);
 }

--- a/src/babel/generation/generators/expressions.js
+++ b/src/babel/generation/generators/expressions.js
@@ -75,7 +75,6 @@ export function Super() {
 export function Decorator(node, print) {
   this.push("@");
   print.plain(node.expression);
-  this.newline();
 }
 
 export function CallExpression(node, print) {

--- a/test/core/fixtures/generation/types/ClassBody-MethodDefinition/actual.js
+++ b/test/core/fixtures/generation/types/ClassBody-MethodDefinition/actual.js
@@ -1,6 +1,7 @@
 class Foo {
   async foo() {}
   foo() {}
+  @bar @baz foo() {}
   ["foo"]() {}
   get foo() {}
   set foo(bar) {}

--- a/test/core/fixtures/generation/types/ClassBody-MethodDefinition/expected.js
+++ b/test/core/fixtures/generation/types/ClassBody-MethodDefinition/expected.js
@@ -1,6 +1,9 @@
 class Foo {
   async foo() {}
   foo() {}
+  @bar
+  @baz
+  foo() {}
   ["foo"]() {}
   get foo() {}
   set foo(bar) {}

--- a/test/core/generation.js
+++ b/test/core/generation.js
@@ -35,11 +35,11 @@ _.each(helper.get("generation"), function (testSuite) {
             "es7.comprehensions": true,
             "es7.asyncFunctions": true,
             "es7.exportExtensions": true,
-            "es7.functionBind": true
+            "es7.functionBind": true,
+            "es7.decorators": true
           }
         });
         var actualCode = generate(actualAst, task.options, actual.code).code;
-
         chai.expect(actualCode).to.equal(expect.code, actual.loc + " !== " + expect.loc);
       });
     });


### PR DESCRIPTION
When using the generation module on methods with multiple decorators, I noticed that babel was incorrectly placing comma's between generators, when in fact decorators should not be comma separated. I changed it to only be newlines.

I also slightly changed how decorators were printed - moving the spacing logic out of `Decorator` in `expressions.js`, and into `_decorators` in `classes.js`.

Finally, I added a method decorator test to `ClassBody-MethodDefinition`.