### PR TITLE
Avoid deopt in iterable destructure template

### DIFF
--- a/src/babel/transformation/templates/helper-sliced-to-array.js
+++ b/src/babel/transformation/templates/helper-sliced-to-array.js
@@ -1,7 +1,7 @@
-(function (arr, i) {
+(function () {
   // Broken out into a separate function to avoid deoptimizations due to the try/catch for the
   // array iterator case.
-  function sliceIterator() {
+  function sliceIterator(arr, i) {
     // this is an expanded form of `for...of` that properly supports abrupt completions of
     // iterators etc. variable names have been minimised to reduce the size of this massive
     // helper. sometimes spec compliancy is annoying :(
@@ -34,11 +34,13 @@
     return _arr;
   }
 
-  if (Array.isArray(arr)) {
-    return arr;
-  } else if (Symbol.iterator in Object(arr)) {
-    return sliceIterator();
-  } else {
-    throw new TypeError("Invalid attempt to destructure non-iterable instance");
-  }
-});
+  return function (arr, i) {
+    if (Array.isArray(arr)) {
+      return arr;
+    } else if (Symbol.iterator in Object(arr)) {
+      return sliceIterator(arr, i);
+    } else {
+      throw new TypeError("Invalid attempt to destructure non-iterable instance");
+    }
+  };
+})();

--- a/src/babel/transformation/templates/helper-sliced-to-array.js
+++ b/src/babel/transformation/templates/helper-sliced-to-array.js
@@ -1,7 +1,7 @@
 (function (arr, i) {
-  if (Array.isArray(arr)) {
-    return arr;
-  } else if (Symbol.iterator in Object(arr)) {
+  // Broken out into a separate function to avoid deoptimizations due to the try/catch for the
+  // array iterator case.
+  function sliceIterator() {
     // this is an expanded form of `for...of` that properly supports abrupt completions of
     // iterators etc. variable names have been minimised to reduce the size of this massive
     // helper. sometimes spec compliancy is annoying :(
@@ -32,6 +32,12 @@
       }
     }
     return _arr;
+  }
+
+  if (Array.isArray(arr)) {
+    return arr;
+  } else if (Symbol.iterator in Object(arr)) {
+    return sliceIterator();
   } else {
     throw new TypeError("Invalid attempt to destructure non-iterable instance");
   }


### PR DESCRIPTION
The try/catch was forcing deoptimization under most engines. This roughly doubles throughput under V8 and 7x increases were seen under Firefox.

Performance numbers based on https://github.com/kpdecker/six-speed/tree/master/tests/destructuring