### PR TITLE
Remove `leven` dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,6 @@ your [`$PATH`](http://unix.stackexchange.com/questions/26047/how-to-correctly-ad
 
 + [js-tokens](http://ghub.io/js-tokens) This is used to get tokens for syntax error highlighting.
 
-+ [leven](http://ghub.io/leven) A levenstein algorithm to determine how close a word is to another. This is used to offer suggestions when using the utility.undeclaredVariableCheck transformer.
-
 + [line-numbers](http://ghub.io/line-numbers) Used to produce the code frames in syntax errors.
 
 + [lodash](http://ghub.io/lodash) Used for various utilities.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "home-or-tmp": "^1.0.0",
     "is-integer": "^1.0.4",
     "js-tokens": "1.0.1",
-    "leven": "^1.0.1",
     "line-numbers": "0.2.0",
     "lodash": "^3.6.0",
     "minimatch": "^2.0.3",


### PR DESCRIPTION
This dependency seems not used as of https://github.com/babel/babel/commit/822eb47ee751a0a2d363a69de1b1995146409bb5.