### PR TITLE
Avoid defineProperty when not needed

### DIFF
--- a/src/babel/transformation/templates/helper-define-property.js
+++ b/src/babel/transformation/templates/helper-define-property.js
@@ -1,8 +1,18 @@
 (function (obj, key, value) {
-  return Object.defineProperty(obj, key, {
-    value: value,
-    enumerable: true,
-    configurable: true,
-    writable: true
-  });
+  // Shortcircuit the slow defineProperty path when possible.
+  // We are trying to avoid issues where setters defined on the
+  // prototype cause side effects under the fast path of simple
+  // assignment. By checking for existence of the property with
+  // the in operator, we can optimize most of this overhead away.
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+  return obj;
 });


### PR DESCRIPTION
This lets us use the fast path for most object literal assignments and then utilizes the defineProperty path when there is a chance that we could hit the setter issue described in #357.

10x performance boosts seen for the six-speed test case, going from 200k operations/sec to 2M ops/sec.