### PR TITLE
Use path-exists module instead of fs.exists.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash": "^3.6.0",
     "minimatch": "^2.0.3",
     "output-file-sync": "^1.1.0",
+    "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",
     "regenerator": "0.8.31",

--- a/packages/babel-cli/bin/babel-plugin/index.js
+++ b/packages/babel-cli/bin/babel-plugin/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-var readline = require("readline");
-var child    = require("child_process");
-var path     = require("path");
-var fs       = require("fs");
+var pathExists = require("path-exists");
+var readline   = require("readline");
+var child      = require("child_process");
+var path       = require("path");
+var fs         = require("fs");
 
 function spawn(cmd, args, callback) {
   console.log(">", cmd, args);
@@ -98,7 +99,7 @@ var cmds = {
 
         write("README.md", template("README.md", templateData));
 
-        if (!fs.existsSync("src")) {
+        if (!pathExists.sync("src")) {
           fs.mkdirSync("src");
           write("src/index.js", template("index.js", templateData));
         }

--- a/packages/babel-cli/bin/babel/dir.js
+++ b/packages/babel-cli/bin/babel/dir.js
@@ -1,4 +1,5 @@
 var outputFileSync = require("output-file-sync");
+var pathExists     = require("path-exists");
 var chokidar       = require("chokidar");
 var slash          = require("slash");
 var path           = require("path");
@@ -41,7 +42,7 @@ module.exports = function (commander, filenames, opts) {
   };
 
   var handle = function (filename) {
-    if (!fs.existsSync(filename)) return;
+    if (!pathExists.sync(filename)) return;
 
     var stat = fs.statSync(filename);
 

--- a/packages/babel-cli/bin/babel/file.js
+++ b/packages/babel-cli/bin/babel/file.js
@@ -100,7 +100,7 @@ module.exports = function (commander, filenames, opts) {
     results = [];
 
     _.each(filenames, function (filename) {
-      if (!fs.existsSync(filename)) return;
+      if (!pathExists.sync(filename)) return;
 
       var stat = fs.statSync(filename);
       if (stat.isDirectory()) {

--- a/packages/babel-cli/bin/babel/index.js
+++ b/packages/babel-cli/bin/babel/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var moduleFormatters = require("babel-core/lib/babel/transformation/modules");
+var pathExists       = require("path-exists");
 var commander        = require("commander");
 var transform        = require("babel-core").transform;
 var kebabCase        = require("lodash/string/kebabCase");
@@ -88,7 +89,7 @@ var filenames = commander.args.reduce(function (globbed, input) {
 filenames = uniq(filenames);
 
 each(filenames, function (filename) {
-  if (!fs.existsSync(filename)) {
+  if (!pathExists.sync(filename)) {
     errors.push(filename + " doesn't exist");
   }
 });

--- a/src/babel/api/register/cache.js
+++ b/src/babel/api/register/cache.js
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import homeOrTmp from "home-or-tmp";
+import pathExists from "path-exists";
 
 const FILENAME = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json");
 var data = {};
@@ -15,7 +16,7 @@ export function load() {
   process.on("exit", save);
   process.nextTick(save);
 
-  if (!fs.existsSync(FILENAME)) return;
+  if (!pathExists.sync(FILENAME)) return;
 
   try {
     data = JSON.parse(fs.readFileSync(FILENAME));

--- a/src/babel/transformation/file/options/resolve-rc.js
+++ b/src/babel/transformation/file/options/resolve-rc.js
@@ -3,16 +3,15 @@ import { normaliseOptions } from "./index";
 import merge from "../../../helpers/merge";
 import path from "path";
 import fs from "fs";
+import pathExists from "path-exists";
 
 var cache = {};
 var jsons = {};
 
 function exists(filename) {
-  if (!fs.existsSync) return false;
-
   var cached = cache[filename];
   if (cached != null) return cached;
-  return cache[filename] = fs.existsSync(filename);
+  return cache[filename] = pathExists.sync(filename);
 }
 
 export default function (loc, opts = {}) {

--- a/src/babel/util.js
+++ b/src/babel/util.js
@@ -18,6 +18,7 @@ import has from "lodash/object/has";
 import fs from "fs";
 import * as t from "./types";
 import slash from "slash";
+import pathExists from "path-exists";
 
 export { inherits, inspect } from "util";
 
@@ -182,7 +183,7 @@ function loadTemplates() {
   var templates = {};
 
   var templatesLoc = path.join(__dirname, "transformation/templates");
-  if (!fs.existsSync(templatesLoc)) {
+  if (!pathExists.sync(templatesLoc)) {
     throw new ReferenceError(messages.get("missingTemplatesDirectory"));
   }
 

--- a/test/core/_helper.js
+++ b/test/core/_helper.js
@@ -1,8 +1,9 @@
-var esvalid = require("esvalid");
-var util    = require("../../lib/babel/util");
-var path    = require("path");
-var fs      = require("fs");
-var _       = require("lodash");
+var pathExists = require("path-exists");
+var esvalid    = require("esvalid");
+var util       = require("../../lib/babel/util");
+var path       = require("path");
+var fs         = require("fs");
+var _          = require("lodash");
 
 var humanize = function (val, noext) {
   if (noext) val = path.basename(val, path.extname(val));
@@ -10,7 +11,7 @@ var humanize = function (val, noext) {
 };
 
 var readFile = exports.readFile = function (filename) {
-  if (fs.existsSync(filename)) {
+  if (pathExists.sync(filename)) {
     var file = fs.readFileSync(filename, "utf8").trim();
     file = file.replace(/\r\n/g, "\n");
     return file;
@@ -31,7 +32,7 @@ exports.esvalid = function (ast, code, loc) {
 };
 
 exports.assertVendor = function (name) {
-  if (!fs.existsSync(__dirname + "/../../vendor/" + name)) {
+  if (!pathExists.sync(__dirname + "/../../vendor/" + name)) {
     console.error("No vendor/" + name + " - run `make bootstrap`");
     process.exit(1);
   }
@@ -130,13 +131,13 @@ exports.get = function (entryName, entryLoc) {
       suite.tests.push(test);
 
       var sourceMappingsLoc = taskDir + "/source-mappings.json";
-      if (fs.existsSync(sourceMappingsLoc)) {
+      if (pathExists.sync(sourceMappingsLoc)) {
         test.options.sourceMap = true;
         test.sourceMappings = require(sourceMappingsLoc);
       }
 
       var sourceMap = taskDir + "/source-map.json";
-      if (fs.existsSync(sourceMap)) {
+      if (pathExists.sync(sourceMap)) {
         test.options.sourceMap = true;
         test.sourceMap = require(sourceMap);
       }

--- a/test/core/bin.js
+++ b/test/core/bin.js
@@ -9,6 +9,7 @@ var child          = require("child_process");
 var path           = require("path");
 var chai           = require("chai");
 var fs             = require("fs");
+var pathExists     = require("path-exists");
 var _              = require("lodash");
 
 var fixtureLoc = __dirname + "/fixtures/bin";
@@ -16,7 +17,7 @@ var tmpLoc = __dirname + "/tmp";
 
 var readDir = function (loc) {
   var files = {};
-  if (fs.existsSync(loc)) {
+  if (pathExists.sync(loc)) {
     _.each(readdir(loc), function (filename) {
       var contents = helper.readFile(loc + "/" + filename);
       files[filename] = contents;
@@ -112,7 +113,7 @@ var buildTest = function (binName, testName, opts) {
 
 var clear = function () {
   process.chdir(__dirname);
-  if (fs.existsSync(tmpLoc)) rimraf.sync(tmpLoc);
+  if (pathExists.sync(tmpLoc)) rimraf.sync(tmpLoc);
   fs.mkdirSync(tmpLoc);
   process.chdir(tmpLoc);
 };
@@ -132,11 +133,11 @@ _.each(fs.readdirSync(fixtureLoc), function (binName) {
       };
 
       var optionsLoc = testLoc + "/options.json"
-      if (fs.existsSync(optionsLoc)) _.merge(opts, require(optionsLoc));
+      if (pathExists.sync(optionsLoc)) _.merge(opts, require(optionsLoc));
 
       _.each(["stdout", "stdin", "stderr"], function (key) {
         var loc = testLoc + "/" + key + ".txt";
-        if (fs.existsSync(loc)) {
+        if (pathExists.sync(loc)) {
           opts[key] = helper.readFile(loc);
         } else {
           opts[key] = opts[key] || "";


### PR DESCRIPTION
Fixes #1826.

This removes the test in `src/babel/transformation/file/options/resolve-rc.js` that checks if `fs.existsSync` is truthy, because it is always truthy in the case of using `path-exists`.