### PR TITLE
Fix `use strict` detection and string literal generation

### DIFF
--- a/src/babel/transformation/transformers/other/strict.js
+++ b/src/babel/transformation/transformers/other/strict.js
@@ -12,7 +12,7 @@ export var visitor = {
       var first = program.body[0];
 
       var directive;
-      if (t.isExpressionStatement(first) && t.isLiteral(first.expression, { value: "use strict" })) {
+      if (t.isExpressionStatement(first) && t.isLiteral(first.expression, { raw: "use strict" })) {
         directive = first;
       } else {
         directive = t.expressionStatement(t.literal("use strict"));


### PR DESCRIPTION
In this case the form of the raw source is significant even though evaluation leads to identical values.

If you have a better solution, then by all means.

This is actually not a complete solution yet anyway, because transforming...

```js
"use\x20strict";
```

...yields:

```js
"use strict";

"use strict";
```

It's not anything specific to `use strict` either. Transforming...

```js
"what\x20ever";
```

...yields:

```js
"use strict";

"what ever";
```

So, insignificant string literals are transformed into pragmas. I just discovered that, so I haven't even looked into it yet.