### PR TITLE
Allow functions to filter ignores

### DIFF
--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -161,8 +161,10 @@ hookExtensions(util.canCompile.EXTENSIONS);
 
 export default function (opts = {}) {
   if (opts.only != null) only = util.arrayify(opts.only, util.regexify);
-  if (opts.ignore != null) ignore = util.arrayify(opts.ignore, util.regexify, isFunction);
-
+  if (opts.ignore != null) {
+      ignore = util.arrayify(opts.ignore,
+      item => isFunction(item) ? item : util.regexify(item));
+  }
   if (opts.extensions) hookExtensions(util.arrayify(opts.extensions));
 
   if (opts.cache === false) cache = null;

--- a/src/babel/api/register/node.js
+++ b/src/babel/api/register/node.js
@@ -4,6 +4,7 @@ import resolveRc from "../../transformation/file/options/resolve-rc";
 import extend from "lodash/object/extend";
 import * as babel from "../node";
 import each from "lodash/collection/each";
+import isFunction from "lodash/lang/isFunction";
 import * as util from  "../../util";
 import fs from "fs";
 import path from "path";
@@ -160,7 +161,7 @@ hookExtensions(util.canCompile.EXTENSIONS);
 
 export default function (opts = {}) {
   if (opts.only != null) only = util.arrayify(opts.only, util.regexify);
-  if (opts.ignore != null) ignore = util.arrayify(opts.ignore, util.regexify);
+  if (opts.ignore != null) ignore = util.arrayify(opts.ignore, util.regexify, isFunction);
 
   if (opts.extensions) hookExtensions(util.arrayify(opts.extensions));
 

--- a/src/babel/transformation/file/index.js
+++ b/src/babel/transformation/file/index.js
@@ -165,7 +165,8 @@ export default class File {
 
     opts.basename = path.basename(opts.filename, path.extname(opts.filename));
 
-    opts.ignore = util.arrayify(opts.ignore, util.regexify);
+    opts.ignore = util.arrayify(opts.ignore,
+          item => isFunction(item) ? item : util.regexify(item));
 
     if (opts.only) {
       opts.only = util.arrayify(opts.only, util.regexify);

--- a/src/babel/util.js
+++ b/src/babel/util.js
@@ -91,21 +91,15 @@ export function regexify(val: any): RegExp {
   throw new TypeError("illegal type for regexify");
 }
 
-export function arrayify(val: any, mapFn?: Function, mapExcludeFn?: Function): Array {
+export function arrayify(val: any, mapFn?: Function): Array {
+
   if (!val) return [];
   if (isBoolean(val)) return arrayify([val], mapFn);
+  if (isFunction(val)) return arrayify([val], mapFn);
   if (isString(val)) return arrayify(list(val), mapFn);
 
   if (Array.isArray(val)) {
-    if (mapExcludeFn && mapFn) {
-      val = val.map(function (v) {
-        if (mapExcludeFn(v)) {
-          return v;
-        } else {
-          return mapFn.apply(null, arguments);
-        }
-      });
-    } else if (mapFn) {
+    if (mapFn) {
       val = val.map(mapFn);
     }
 

--- a/src/babel/util.js
+++ b/src/babel/util.js
@@ -9,6 +9,7 @@ import minimatch from "minimatch";
 import contains from "lodash/collection/contains";
 import traverse from "./traversal";
 import isString from "lodash/lang/isString";
+import isFunction from "lodash/lang/isFunction";
 import isRegExp from "lodash/lang/isRegExp";
 import Module from "module";
 import isEmpty from "lodash/lang/isEmpty";
@@ -101,7 +102,7 @@ export function arrayify(val: any, mapFn?: Function, mapExcludeFn?: Function): A
         if (mapExcludeFn(v)) {
           return v;
         } else {
-          mapFn.apply(null, arguments);
+          return mapFn.apply(null, arguments);
         }
       });
     } else if (mapFn) {
@@ -121,9 +122,15 @@ export function booleanify(val: any) {
 }
 
 function testIgnore(ignore, filename) {
-  if (ignore instanceof Function) {
-    if (ignore(filename)) return true;
-  } else if (ignore.test(filename)) return true;
+  if (isFunction(ignore)) {
+    if (ignore(filename)) {
+      return true;
+    }
+  } else if (isRegExp(ignore)) {
+    if (ignore.test(filename)) {
+      return true;
+    }
+  }
 }
 
 export function shouldIgnore(filename, ignore, only) {

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -179,6 +179,25 @@ suite("api", function () {
       ignore: "foo/node_modules/*.bar",
       filename: "/foo/node_modules/foo.bar"
     }).ignored);
+
+    assert.ok(transform("", {
+      ignore: function (fname) {
+        if (fname.indexOf("foo.bar") > 0) {
+          return true;
+        }
+      },
+      filename: "/foo/node_modules/foo.bar"
+    }).ignored);
+
+    assert.ok(!transform("", {
+      ignore: function (fname) {
+        console.log(fname);
+        if (fname.indexOf("zap") > 0) {
+          return true;
+        }
+      },
+      filename: "/foo/foo.bar"
+    }).ignored);
   });
 
   test("only option", function () {

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -72,6 +72,25 @@ suite("util", function () {
     assert.deepEqual(util.arrayify("foo,bar"), ["foo", "bar"]);
     assert.deepEqual(util.arrayify(["foo", "bar"]), ["foo", "bar"]);
     assert.deepEqual(util.arrayify({ foo: "bar" }), [{ foo: "bar" }]);
+
+    assert.deepEqual(util.arrayify(["foo", "bar"], function (v) {
+      return v + "-babel";
+    }), ["foo-babel", "bar-babel"]);
+
+    assert.deepEqual(util.arrayify(["foo", "bar"], function (v) {
+      return v + "-babel";
+    }, function (v) {
+      if (v === "foo") {
+        return true;
+      }
+    }), ["foo", "bar-babel"]);
+
+
+    assert.deepEqual(util.arrayify(["foo", "bar"], null, function (v) {
+      if (v === "foo") {
+        return true;
+      }
+    }), ["foo", "bar"]);
   });
 
   test("regexify", function () {

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -73,24 +73,17 @@ suite("util", function () {
     assert.deepEqual(util.arrayify(["foo", "bar"]), ["foo", "bar"]);
     assert.deepEqual(util.arrayify({ foo: "bar" }), [{ foo: "bar" }]);
 
-    assert.deepEqual(util.arrayify(["foo", "bar"], function (v) {
+    assert.deepEqual(util.arrayify("foo", function (v) {
+      return v + "-babel";
+    }), ["foo-babel"]);
+
+    assert.deepEqual(util.arrayify("foo,bar", function (v) {
       return v + "-babel";
     }), ["foo-babel", "bar-babel"]);
 
     assert.deepEqual(util.arrayify(["foo", "bar"], function (v) {
       return v + "-babel";
-    }, function (v) {
-      if (v === "foo") {
-        return true;
-      }
-    }), ["foo", "bar-babel"]);
-
-
-    assert.deepEqual(util.arrayify(["foo", "bar"], null, function (v) {
-      if (v === "foo") {
-        return true;
-      }
-    }), ["foo", "bar"]);
+    }), ["foo-babel", "bar-babel"]);
   });
 
   test("regexify", function () {

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -110,4 +110,20 @@ suite("util", function () {
     assert.equal(t.toIdentifier(t.identifier("swag")), "swag");
     assert.equal(t.toIdentifier("swag-lord"), "swagLord");
   });
+
+  test("shouldIgnore", function () {
+    var reIgnore = /\-reIgnore\.js/;
+    var fnIgnore = function (src) {
+      if (src.indexOf("fnIgnore") > 0) {
+        return true;
+      }
+    };
+
+    assert.equal(util.shouldIgnore("test.js", []), false);
+    assert.equal(util.shouldIgnore("test-reIgnore.js", [fnIgnore]), false);
+    assert.equal(util.shouldIgnore("test-reIgnore.js", [reIgnore]), true);
+
+    assert.equal(util.shouldIgnore("test-fnIgnore.js", [fnIgnore]), true);
+    assert.equal(util.shouldIgnore("test-fnIgnore.js", [reIgnore]), false);
+  });
 });


### PR DESCRIPTION
This provides ability to provide functions with `ignore` when using require hook (#1859). If this is fine, I will replicate it for `only`.
All tests are passing.