### PR TITLE
Properly regenerate scope for replaced nodes - fixes #1773

### DIFF
--- a/src/babel/traversal/scope/index.js
+++ b/src/babel/traversal/scope/index.js
@@ -146,7 +146,7 @@ export default class Scope {
     }
 
     var cached = path.getData("scope");
-    if (cached && cached.parent === parent) {
+    if (cached && cached.parent === parent && cached.block === path.node) {
       return cached;
     } else {
       path.setData("scope", this);

--- a/test/core/fixtures/transformation/es6.classes/constructor/actual.js
+++ b/test/core/fixtures/transformation/es6.classes/constructor/actual.js
@@ -10,3 +10,12 @@ class Foo extends Bar {
     this.state = "test";
   }
 }
+
+class ConstructorScoping {
+  constructor(){
+    let bar;
+    {
+      let bar;
+    }
+  }
+}

--- a/test/core/fixtures/transformation/es6.classes/constructor/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/constructor/expected.js
@@ -17,3 +17,12 @@ var Foo = (function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);
+
+var ConstructorScoping = function ConstructorScoping() {
+  babelHelpers.classCallCheck(this, ConstructorScoping);
+
+  var bar = undefined;
+  {
+    var _bar = undefined;
+  }
+};


### PR DESCRIPTION
This fixes https://github.com/babel/babel/issues/1773. Swapping the node on the `NodePath` should also invalidate the scope cache.

The `ClassExpression` node is replaced with a `FunctionExpression` node when the class contains only a constructor, but the scope object was being pulled from the cache instead of recreated because the replacement of the node was not properly recognized as a cause of cache invalidation.