### PR TITLE
Handle single child when using React inlining

### DIFF
--- a/src/babel/transformation/transformers/optimisation/react.inline-elements.js
+++ b/src/babel/transformation/transformers/optimisation/react.inline-elements.js
@@ -49,7 +49,9 @@ export var visitor = {
     pushElemProp("ref", t.literal(null));
 
     if (node.children.length) {
-      pushProp(props.properties, t.identifier("children"), t.arrayExpression(react.buildChildren(node)));
+      var children = react.buildChildren(node);
+      children = children.length === 1 ? children[0] : t.arrayExpression(children);
+      pushProp(props.properties, t.identifier("children"), children);
     }
 
     // props

--- a/test/core/fixtures/transformation/optimisation.react.constant-elements/inline-elements/expected.js
+++ b/test/core/fixtures/transformation/optimisation.react.constant-elements/inline-elements/expected.js
@@ -16,7 +16,7 @@ function render() {
     type: "foo",
     ref: null,
     props: {
-      children: [text]
+      children: text
     },
     key: null
   };

--- a/test/core/fixtures/transformation/optimisation.react.inline-elements/nested-html-elements/expected.js
+++ b/test/core/fixtures/transformation/optimisation.react.inline-elements/nested-html-elements/expected.js
@@ -4,7 +4,7 @@
   type: "div",
   ref: null,
   props: {
-    children: [bar],
+    children: bar,
     className: "foo"
   },
   key: null


### PR DESCRIPTION
Changes `optimisation.react.inlineElements` to handle a single child as the
value of the `children` property instead of wrapping it with an array.
This matches the behavior of `React.createElement`.

Fixes [this example](https://github.com/gaearon/redux#smart-components), when the children prop is used for things other than React elements. Also fixes `React.Children.only(this.props.children)`.