### PR TITLE
Only special-case for..on declaration hoisting - fixes #1929

### DIFF
--- a/src/babel/transformation/modules/system.js
+++ b/src/babel/transformation/modules/system.js
@@ -33,8 +33,7 @@ var hoistVariablesVisitor = {
     }
 
     // for (var i in test)
-    // for (var i = 0;;)
-    if (t.isFor(parent) && (parent.left === node || parent.init === node)) {
+    if (t.isFor(parent) && parent.left === node) {
       return node.declarations[0].id;
     }
 

--- a/test/core/fixtures/transformation/es6.modules-system/hoist-function-exports/actual.js
+++ b/test/core/fixtures/transformation/es6.modules-system/hoist-function-exports/actual.js
@@ -8,6 +8,8 @@ export var p = 5;
 
 for (var a in b) ;
 
+for (var i = 0, j = 0;;) ;
+
 export var isOdd = (function (isEven) {
   return function (n) {
     return !isEven(n);

--- a/test/core/fixtures/transformation/es6.modules-system/hoist-function-exports/expected.js
+++ b/test/core/fixtures/transformation/es6.modules-system/hoist-function-exports/expected.js
@@ -1,7 +1,7 @@
 System.register(["./evens"], function (_export) {
   "use strict";
 
-  var isEven, p, a, isOdd;
+  var isEven, p, a, i, j, isOdd;
 
   _export("nextOdd", nextOdd);
 
@@ -19,6 +19,8 @@ System.register(["./evens"], function (_export) {
       _export("p", p);
 
       for (a in b);
+
+      for (i = 0, j = 0;;);
 
       isOdd = (function (isEven) {
         return function (n) {


### PR DESCRIPTION
Fixes https://github.com/babel/babel/issues/1929

I can't tell why this was special-cased like this. https://github.com/babel/babel/commit/9b12f799f7d489afe5dfd179aa4f93a714c2cecd introduced this, but the logic seems to just be wrong.