### PR TITLE
Hoist class inheritance call so it runs before prototype use.

### DIFF
--- a/src/babel/transformation/transformers/es6/classes/vanilla.js
+++ b/src/babel/transformation/transformers/es6/classes/vanilla.js
@@ -592,8 +592,10 @@ export default class ClassTransformer {
   pushInherits() {
     if (!this.isDerived || this.pushedInherits) return;
 
+    // Unshift to ensure that the constructor inheritance is set up before
+    // any properties can be assigned to the prototype.
     this.pushedInherits = true;
-    this.body.push(t.expressionStatement(t.callExpression(
+    this.body.unshift(t.expressionStatement(t.callExpression(
       this.file.addHelper("inherits"),
       [this.classRef, this.superName]
     )));

--- a/test/core/fixtures/transformation/es6.classes-loose/accessing-super-class/expected.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/accessing-super-class/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     var _Foo$prototype$test, _Foo$prototype$test2;
 
@@ -16,8 +18,6 @@ var Test = (function (_Foo) {
     (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [this].concat(babelHelpers.slice.call(arguments)));
     (_Foo$prototype$test2 = _Foo.prototype.test).call.apply(_Foo$prototype$test2, [this, "test"].concat(babelHelpers.slice.call(arguments)));
   }
-
-  babelHelpers.inherits(Test, _Foo);
 
   Test.prototype.test = function test() {
     var _Foo$prototype$test3, _Foo$prototype$test4;

--- a/test/core/fixtures/transformation/es6.classes-loose/accessing-super-properties/expected.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/accessing-super-properties/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
@@ -9,6 +11,5 @@ var Test = (function (_Foo) {
     _Foo.prototype.test.whatever;
   }
 
-  babelHelpers.inherits(Test, _Foo);
   return Test;
 })(Foo);

--- a/test/core/fixtures/transformation/es6.classes-loose/calling-super-properties/expected.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/calling-super-properties/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
@@ -8,8 +10,6 @@ var Test = (function (_Foo) {
     _Foo.prototype.test.whatever();
     _Foo.prototype.test.call(this);
   }
-
-  babelHelpers.inherits(Test, _Foo);
 
   Test.test = function test() {
     return _Foo.wow.call(this);

--- a/test/core/fixtures/transformation/es6.classes-loose/method-order/actual.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/method-order/actual.js
@@ -1,0 +1,11 @@
+class Foo {}
+
+class Bar extends Foo {
+  methodA(){}
+
+  constructor(){
+    super();
+  }
+
+  methodB(){}
+}

--- a/test/core/fixtures/transformation/es6.classes-loose/method-order/expected.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/method-order/expected.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var Foo = function Foo() {
+  babelHelpers.classCallCheck(this, Foo);
+};
+
+var Bar = (function (_Foo) {
+  babelHelpers.inherits(Bar, _Foo);
+
+  Bar.prototype.methodA = function methodA() {};
+
+  function Bar() {
+    babelHelpers.classCallCheck(this, Bar);
+
+    _Foo.call(this);
+  }
+
+  Bar.prototype.methodB = function methodB() {};
+
+  return Bar;
+})(Foo);

--- a/test/core/fixtures/transformation/es6.classes-loose/super-class-id-member-expression/expected.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/super-class-id-member-expression/expected.js
@@ -1,23 +1,25 @@
 "use strict";
 
 var BaseController = (function (_Chaplin$Controller) {
+  babelHelpers.inherits(BaseController, _Chaplin$Controller);
+
   function BaseController() {
     babelHelpers.classCallCheck(this, BaseController);
 
     _Chaplin$Controller.apply(this, arguments);
   }
 
-  babelHelpers.inherits(BaseController, _Chaplin$Controller);
   return BaseController;
 })(Chaplin.Controller);
 
 var BaseController2 = (function (_Chaplin$Controller$Another) {
+  babelHelpers.inherits(BaseController2, _Chaplin$Controller$Another);
+
   function BaseController2() {
     babelHelpers.classCallCheck(this, BaseController2);
 
     _Chaplin$Controller$Another.apply(this, arguments);
   }
 
-  babelHelpers.inherits(BaseController2, _Chaplin$Controller$Another);
   return BaseController2;
 })(Chaplin.Controller.Another);

--- a/test/core/fixtures/transformation/es6.classes-loose/super-class/expected.js
+++ b/test/core/fixtures/transformation/es6.classes-loose/super-class/expected.js
@@ -1,12 +1,13 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
     _Foo.apply(this, arguments);
   }
 
-  babelHelpers.inherits(Test, _Foo);
   return Test;
 })(Foo);

--- a/test/core/fixtures/transformation/es6.classes/accessing-super-class/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/accessing-super-class/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     var _babelHelpers$get, _babelHelpers$get2;
 
@@ -17,7 +19,6 @@ var Test = (function (_Foo) {
     (_babelHelpers$get2 = babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", this)).call.apply(_babelHelpers$get2, [this, "test"].concat(babelHelpers.slice.call(arguments)));
   }
 
-  babelHelpers.inherits(Test, _Foo);
   babelHelpers.createClass(Test, [{
     key: "test",
     value: function test() {

--- a/test/core/fixtures/transformation/es6.classes/accessing-super-properties/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/accessing-super-properties/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
@@ -9,6 +11,5 @@ var Test = (function (_Foo) {
     babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", this).whatever;
   }
 
-  babelHelpers.inherits(Test, _Foo);
   return Test;
 })(Foo);

--- a/test/core/fixtures/transformation/es6.classes/calling-super-properties/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/calling-super-properties/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
@@ -9,7 +11,6 @@ var Test = (function (_Foo) {
     babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", this).call(this);
   }
 
-  babelHelpers.inherits(Test, _Foo);
   babelHelpers.createClass(Test, null, [{
     key: "test",
     value: function test() {

--- a/test/core/fixtures/transformation/es6.classes/constructor/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/constructor/expected.js
@@ -7,6 +7,8 @@ var Test = function Test() {
 };
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
@@ -14,7 +16,6 @@ var Foo = (function (_Bar) {
     this.state = "test";
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);
 

--- a/test/core/fixtures/transformation/es6.classes/delay-arrow-function-for-bare-super-derived/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/delay-arrow-function-for-bare-super-derived/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
@@ -11,6 +13,5 @@ var Foo = (function (_Bar) {
     var _this = this;
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);

--- a/test/core/fixtures/transformation/es6.classes/derived-constructor-must-call-super/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/derived-constructor-must-call-super/expected.js
@@ -1,10 +1,11 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);

--- a/test/core/fixtures/transformation/es6.classes/super-class-anonymous/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/super-class-anonymous/expected.js
@@ -1,12 +1,13 @@
 "use strict";
 
 var TestEmpty = (function (_ref) {
+  babelHelpers.inherits(TestEmpty, _ref);
+
   function TestEmpty() {
     babelHelpers.classCallCheck(this, TestEmpty);
     babelHelpers.get(Object.getPrototypeOf(TestEmpty.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(TestEmpty, _ref);
   return TestEmpty;
 })((function () {
   function _class() {
@@ -17,12 +18,13 @@ var TestEmpty = (function (_ref) {
 })());
 
 var TestConstructorOnly = (function (_ref2) {
+  babelHelpers.inherits(TestConstructorOnly, _ref2);
+
   function TestConstructorOnly() {
     babelHelpers.classCallCheck(this, TestConstructorOnly);
     babelHelpers.get(Object.getPrototypeOf(TestConstructorOnly.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(TestConstructorOnly, _ref2);
   return TestConstructorOnly;
 })((function () {
   function _class2() {
@@ -33,12 +35,13 @@ var TestConstructorOnly = (function (_ref2) {
 })());
 
 var TestMethodOnly = (function (_ref3) {
+  babelHelpers.inherits(TestMethodOnly, _ref3);
+
   function TestMethodOnly() {
     babelHelpers.classCallCheck(this, TestMethodOnly);
     babelHelpers.get(Object.getPrototypeOf(TestMethodOnly.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(TestMethodOnly, _ref3);
   return TestMethodOnly;
 })((function () {
   function _class3() {
@@ -53,12 +56,13 @@ var TestMethodOnly = (function (_ref3) {
 })());
 
 var TestConstructorAndMethod = (function (_ref4) {
+  babelHelpers.inherits(TestConstructorAndMethod, _ref4);
+
   function TestConstructorAndMethod() {
     babelHelpers.classCallCheck(this, TestConstructorAndMethod);
     babelHelpers.get(Object.getPrototypeOf(TestConstructorAndMethod.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(TestConstructorAndMethod, _ref4);
   return TestConstructorAndMethod;
 })((function () {
   function _class4() {
@@ -73,12 +77,13 @@ var TestConstructorAndMethod = (function (_ref4) {
 })());
 
 var TestMultipleMethods = (function (_ref5) {
+  babelHelpers.inherits(TestMultipleMethods, _ref5);
+
   function TestMultipleMethods() {
     babelHelpers.classCallCheck(this, TestMultipleMethods);
     babelHelpers.get(Object.getPrototypeOf(TestMultipleMethods.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(TestMultipleMethods, _ref5);
   return TestMultipleMethods;
 })((function () {
   function _class5() {

--- a/test/core/fixtures/transformation/es6.classes/super-class-id-member-expression/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/super-class-id-member-expression/expected.js
@@ -1,21 +1,23 @@
 "use strict";
 
 var BaseController = (function (_Chaplin$Controller) {
+  babelHelpers.inherits(BaseController, _Chaplin$Controller);
+
   function BaseController() {
     babelHelpers.classCallCheck(this, BaseController);
     babelHelpers.get(Object.getPrototypeOf(BaseController.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(BaseController, _Chaplin$Controller);
   return BaseController;
 })(Chaplin.Controller);
 
 var BaseController2 = (function (_Chaplin$Controller$Another) {
+  babelHelpers.inherits(BaseController2, _Chaplin$Controller$Another);
+
   function BaseController2() {
     babelHelpers.classCallCheck(this, BaseController2);
     babelHelpers.get(Object.getPrototypeOf(BaseController2.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(BaseController2, _Chaplin$Controller$Another);
   return BaseController2;
 })(Chaplin.Controller.Another);

--- a/test/core/fixtures/transformation/es6.classes/super-class/expected.js
+++ b/test/core/fixtures/transformation/es6.classes/super-class/expected.js
@@ -1,11 +1,12 @@
 "use strict";
 
 var Test = (function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
     babelHelpers.get(Object.getPrototypeOf(Test.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(Test, _Foo);
   return Test;
 })(Foo);

--- a/test/core/fixtures/transformation/es6.parameters/rest-nested-iife/expected.js
+++ b/test/core/fixtures/transformation/es6.parameters/rest-nested-iife/expected.js
@@ -14,13 +14,13 @@ function broken(x) {
   if (true) {
     var _ret = (function () {
       var Foo = (function (_Bar) {
+        _inherits(Foo, _Bar);
+
         function Foo() {
           _classCallCheck(this, Foo);
 
           _get(Object.getPrototypeOf(Foo.prototype), "constructor", this).apply(this, arguments);
         }
-
-        _inherits(Foo, _Bar);
 
         return Foo;
       })(Bar);

--- a/test/core/fixtures/transformation/es7.class-properties/derived/expected.js
+++ b/test/core/fixtures/transformation/es7.class-properties/derived/expected.js
@@ -1,12 +1,13 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
     babelHelpers.get(Object.getPrototypeOf(Foo.prototype), "constructor", this).apply(this, arguments);
     this.bar = "foo";
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);

--- a/test/core/fixtures/transformation/es7.class-properties/super-expression/expected.js
+++ b/test/core/fixtures/transformation/es7.class-properties/super-expression/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     var _temp;
 
@@ -9,6 +11,5 @@ var Foo = (function (_Bar) {
     foo((_temp = babelHelpers.get(Object.getPrototypeOf(Foo.prototype), "constructor", this).call(this), this.bar = "foo", _temp));
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);

--- a/test/core/fixtures/transformation/es7.class-properties/super-statement/expected.js
+++ b/test/core/fixtures/transformation/es7.class-properties/super-statement/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
@@ -8,6 +10,5 @@ var Foo = (function (_Bar) {
     this.bar = "foo";
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);

--- a/test/core/fixtures/transformation/es7.decorators/class-super/expected.js
+++ b/test/core/fixtures/transformation/es7.decorators/class-super/expected.js
@@ -1,26 +1,28 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, _Foo);
 
     babelHelpers.get(Object.getPrototypeOf(_Foo.prototype), "constructor", this).call(this);
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   var _Foo = Foo;
   Foo = bar(Foo) || Foo;
   return Foo;
 })(Bar);
 
 var Foo2 = (function (_Bar2) {
+  babelHelpers.inherits(Foo2, _Bar2);
+
   function Foo2() {
     babelHelpers.classCallCheck(this, _Foo2);
 
     babelHelpers.get(Object.getPrototypeOf(_Foo2.prototype), "constructor", this).call(this);
   }
 
-  babelHelpers.inherits(Foo2, _Bar2);
   var _Foo2 = Foo2;
   Foo2 = bar(Foo2) || Foo2;
   return Foo2;

--- a/test/core/fixtures/transformation/misc/regression-1155/expected.js
+++ b/test/core/fixtures/transformation/misc/regression-1155/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo(options) {
     babelHelpers.classCallCheck(this, Foo);
 
@@ -11,6 +13,5 @@ var Foo = (function (_Bar) {
     babelHelpers.get(Object.getPrototypeOf(Foo.prototype), "constructor", this).call(this, parentOptions);
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);

--- a/test/core/fixtures/transformation/react/optimisation.react.constant-elements/expected.js
+++ b/test/core/fixtures/transformation/react/optimisation.react.constant-elements/expected.js
@@ -9,12 +9,13 @@ var _ref = React.createElement(
 );
 
 var App = (function (_React$Component) {
+  babelHelpers.inherits(App, _React$Component);
+
   function App() {
     babelHelpers.classCallCheck(this, App);
     babelHelpers.get(Object.getPrototypeOf(App.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(App, _React$Component);
   babelHelpers.createClass(App, [{
     key: "render",
     value: function render() {

--- a/test/core/fixtures/transformation/spec.function-name/modules-3/expected.js
+++ b/test/core/fixtures/transformation/spec.function-name/modules-3/expected.js
@@ -7,12 +7,13 @@ Object.defineProperty(exports, "__esModule", {
 var _store = require("./store");
 
 var Login = (function (_React$Component) {
+  babelHelpers.inherits(Login, _React$Component);
+
   function Login() {
     babelHelpers.classCallCheck(this, Login);
     babelHelpers.get(Object.getPrototypeOf(Login.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(Login, _React$Component);
   babelHelpers.createClass(Login, [{
     key: "getForm",
     value: function getForm() {

--- a/test/core/fixtures/transformation/spec.proto-to-assign/class/expected.js
+++ b/test/core/fixtures/transformation/spec.proto-to-assign/class/expected.js
@@ -1,11 +1,12 @@
 "use strict";
 
 var Foo = (function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
     babelHelpers.get(Object.getPrototypeOf(Foo.prototype), "constructor", this).apply(this, arguments);
   }
 
-  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 })(Bar);


### PR DESCRIPTION
As far as I can see, the constructor will always be a function declaration, so this is safe.