### PR TITLE
Add support for `import typeof`, fixes #1975

### DIFF
--- a/src/acorn/plugins/flow.js
+++ b/src/acorn/plugins/flow.js
@@ -791,16 +791,15 @@ acorn.plugins.flow = function (instance) {
 
   instance.extend("parseImportSpecifiers", function (inner) {
     return function (node) {
-      node.isType = false
-      if (this.isContextual("type")) {
-        var start = this.markPosition()
-        var typeId = this.parseIdent()
-        if ((this.type === tt.name && this.value !== "from") || this.type === tt.braceL || this.type === tt.star) {
-          node.isType = true
-        } else {
-          node.specifiers.push(this.parseImportSpecifierDefault(typeId, start))
-          if (this.isContextual("from")) return
-          this.eat(tt.comma)
+      node.importKind = "value"
+      var kind =
+        (this.type === tt._typeof ? "typeof" :
+        (this.isContextual("type") ? "type" : null))
+      if (kind) {
+        var lh = this.lookahead()
+        if ((lh.type === tt.name && lh.value !== "from") || lh.type === tt.braceL || lh.type === tt.star) {
+          this.next()
+          node.importKind = kind
         }
       }
       inner.call(this, node)

--- a/src/acorn/src/options.js
+++ b/src/acorn/src/options.js
@@ -1,4 +1,4 @@
-import {has, isArray} from "./util"
+import {has} from "./util"
 import {SourceLocation} from "./location"
 
 // A second optional argument can be given to further configure
@@ -94,11 +94,11 @@ export function getOptions(opts) {
   for (let opt in defaultOptions)
     options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions[opt]
 
-  if (isArray(options.onToken)) {
+  if (Array.isArray(options.onToken)) {
     let tokens = options.onToken
     options.onToken = (token) => tokens.push(token)
   }
-  if (isArray(options.onComment))
+  if (Array.isArray(options.onComment))
     options.onComment = pushComment(options, options.onComment)
 
   return options

--- a/src/acorn/src/util.js
+++ b/src/acorn/src/util.js
@@ -1,7 +1,3 @@
-export function isArray(obj) {
-  return Object.prototype.toString.call(obj) === "[object Array]"
-}
-
 // Checks if an object has a property.
 
 export function has(obj, propName) {

--- a/src/babel/generation/generators/modules.js
+++ b/src/babel/generation/generators/modules.js
@@ -90,8 +90,8 @@ function ExportDeclaration(node, print) {
 export function ImportDeclaration(node, print) {
   this.push("import ");
 
-  if (node.isType) {
-    this.push("type ");
+  if (node.importKind === "type" || node.importKind === "typeof") {
+    this.push(node.importKind + " ");
   }
 
   var specfiers = node.specifiers;

--- a/src/babel/transformation/transformers/es6/modules.js
+++ b/src/babel/transformation/transformers/es6/modules.js
@@ -15,7 +15,7 @@ export var metadata = {
 export var visitor = {
   ImportDeclaration(node, parent, scope, file) {
     // flow type
-    if (node.isType) return;
+    if (node.importKind === "type" || node.importKind === "typeof") return;
 
     var nodes = [];
 

--- a/src/babel/transformation/transformers/other/flow.js
+++ b/src/babel/transformation/transformers/other/flow.js
@@ -41,7 +41,7 @@ export var visitor = {
   },
 
   ImportDeclaration(node) {
-    if (node.isType) this.dangerouslyRemove();
+    if (node.importKind === "type" || node.importKind === "typeof") this.dangerouslyRemove();
   },
 
   ExportDeclaration() {

--- a/test/acorn/tests-flow.js
+++ b/test/acorn/tests-flow.js
@@ -6728,11 +6728,47 @@ var fbTestFixture = {
           end: { line: 1, column: 26 }
         }
       },
-      isType: true,
+      importKind: 'type',
       range: [0, 27],
       loc: {
         start: { line: 1, column: 0 },
         end: { line: 1, column: 27 }
+      }
+    },
+    'import typeof foo from "bar";': {
+      type: 'ImportDeclaration',
+      specifiers: [{
+        type: 'ImportDefaultSpecifier',
+        local: {
+          type: 'Identifier',
+          name: 'foo',
+          range: [14, 17],
+          loc: {
+            start: { line: 1, column: 14 },
+            end: { line: 1, column: 17 }
+          }
+        },
+        range: [14, 17],
+        loc: {
+          start: { line: 1, column: 14 },
+          end: { line: 1, column: 17 }
+        }
+      }],
+      source: {
+        type: 'Literal',
+        value: 'bar',
+        raw: '"bar"',
+        range: [23, 28],
+        loc: {
+          start: { line: 1, column: 23 },
+          end: { line: 1, column: 28 }
+        }
+      },
+      importKind: 'typeof',
+      range: [0, 29],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 29 }
       }
     },
     'import type {foo, bar} from "baz";': {
@@ -6798,17 +6834,26 @@ var fbTestFixture = {
           end: { line: 1, column: 33 }
         }
       },
-      isType: true,
+      importKind: 'type',
       range: [0, 34],
       loc: {
         start: { line: 1, column: 0 },
         end: { line: 1, column: 34 }
       }
     },
-    'import type {foo as bar} from "baz";': {
+    'import type {foo, bar} from "baz";': {
       type: 'ImportDeclaration',
       specifiers: [{
         type: 'ImportSpecifier',
+        local: {
+          type: 'Identifier',
+          name: 'foo',
+          range: [13, 16],
+          loc: {
+            start: { line: 1, column: 13 },
+            end: { line: 1, column: 16 }
+          }
+        },
         imported: {
           type: 'Identifier',
           name: 'foo',
@@ -6818,36 +6863,97 @@ var fbTestFixture = {
             end: { line: 1, column: 16 }
           }
         },
+        range: [13, 16],
+        loc: {
+          start: { line: 1, column: 13 },
+          end: { line: 1, column: 16 }
+        }
+      }, {
+        type: 'ImportSpecifier',
         local: {
           type: 'Identifier',
           name: 'bar',
-          range: [20, 23],
+          range: [18, 21],
           loc: {
-            start: { line: 1, column: 20 },
-            end: { line: 1, column: 23 }
+            start: { line: 1, column: 18 },
+            end: { line: 1, column: 21 }
           }
         },
-        range: [13, 23],
+        imported: {
+          type: 'Identifier',
+          name: 'bar',
+          range: [18, 21],
+          loc: {
+            start: { line: 1, column: 18 },
+            end: { line: 1, column: 21 }
+          }
+        },
+        range: [18, 21],
         loc: {
-          start: { line: 1, column: 13 },
-          end: { line: 1, column: 23 }
+          start: { line: 1, column: 18 },
+          end: { line: 1, column: 21 }
         }
       }],
       source: {
         type: 'Literal',
         value: 'baz',
         raw: '"baz"',
-        range: [30, 35],
+        range: [28, 33],
         loc: {
-          start: { line: 1, column: 30 },
-          end: { line: 1, column: 35 }
+          start: { line: 1, column: 28 },
+          end: { line: 1, column: 33 }
         }
       },
-      isType: true,
-      range: [0, 36],
+      importKind: 'type',
+      range: [0, 34],
       loc: {
         start: { line: 1, column: 0 },
-        end: { line: 1, column: 36 }
+        end: { line: 1, column: 34 }
+      }
+    },
+    'import typeof {foo as bar} from "baz";': {
+      type: 'ImportDeclaration',
+      specifiers: [{
+        type: 'ImportSpecifier',
+        imported: {
+          type: 'Identifier',
+          name: 'foo',
+          range: [15, 18],
+          loc: {
+            start: { line: 1, column: 15 },
+            end: { line: 1, column: 18 }
+          }
+        },
+        local: {
+          type: 'Identifier',
+          name: 'bar',
+          range: [22, 25],
+          loc: {
+            start: { line: 1, column: 22 },
+            end: { line: 1, column: 25 }
+          }
+        },
+        range: [15, 25],
+        loc: {
+          start: { line: 1, column: 15 },
+          end: { line: 1, column: 25 }
+        }
+      }],
+      source: {
+        type: 'Literal',
+        value: 'baz',
+        raw: '"baz"',
+        range: [32, 37],
+        loc: {
+          start: { line: 1, column: 32 },
+          end: { line: 1, column: 37 }
+        }
+      },
+      importKind: 'typeof',
+      range: [0, 38],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 38 }
       }
     },
     'import type from "foo";': {
@@ -6879,7 +6985,7 @@ var fbTestFixture = {
           end: { line: 1, column: 22 }
         }
       },
-      isType: false,
+      importKind: 'value',
       range: [0, 23],
       loc: {
         start: { line: 1, column: 0 },
@@ -6940,7 +7046,7 @@ var fbTestFixture = {
           end: { line: 1, column: 29 }
         }
       },
-      isType: false,
+      importKind: 'value',
       range: [0, 30],
       loc: {
         start: { line: 1, column: 0 },
@@ -6976,11 +7082,47 @@ var fbTestFixture = {
           end: { line: 1, column: 37 }
         }
       },
-      isType: true,
+      importKind: 'type',
       range: [0, 38],
       loc: {
         start: { line: 1, column: 0 },
         end: { line: 1, column: 38 }
+      }
+    },
+    'import typeof * as namespace from "bar";': {
+      type: 'ImportDeclaration',
+      specifiers: [{
+        type: 'ImportNamespaceSpecifier',
+        local: {
+          type: 'Identifier',
+          name: 'namespace',
+          range: [19, 28],
+          loc: {
+            start: { line: 1, column: 19 },
+            end: { line: 1, column: 28 }
+          }
+        },
+        range: [14, 28],
+        loc: {
+          start: { line: 1, column: 14 },
+          end: { line: 1, column: 28 }
+        }
+      }],
+      source: {
+        type: 'Literal',
+        value: 'bar',
+        raw: '"bar"',
+        range: [34, 39],
+        loc: {
+          start: { line: 1, column: 34 },
+          end: { line: 1, column: 39 }
+        }
+      },
+      importKind: 'typeof',
+      range: [0, 40],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 40 }
       }
     },
   },


### PR DESCRIPTION
We recently added `import typeof` to Flow. This updates acorn to support both `import typeof` and `import type` via an `importKind` field on `ImportDeclaration` and removes the `isType` field because it would now be meaningless.

This is all a bit tricky because `typeof` is a keyword but `type` is not. `type` can also be used as a regular import: `import type from 'Foo'` will import 'Foo' as `type`. However, `import typeof from 'Foo'` is invalid syntax because `export class typeof {}` for example is also invalid. This solution maintains this behavior. I've changed the implementation to defer to the inner function to correctly parse `type` if it is not used as a flow type import and I'm using a lookahead instead of consuming the token immediately. Now the flow plugin only consumes the token if it is a flow type and defers to the inner function otherwise. I've attached a gist to an alternative solution which is more verbose but maintains the original intent of the flow plugin. Let me know which one you prefer but I certainly do prefer the lookahead version because it is much simpler.

esprima change: https://github.com/facebook/esprima/commit/01e5f03ae650a228507504236ceb4ed06372e841
Alternative solution: https://gist.github.com/cpojer/d011b030ec880f0df881