### PR TITLE
Fix a bug where an undefined class property cannot be decorated

### DIFF
--- a/src/babel/transformation/templates/helper-define-decorated-property-descriptor.js
+++ b/src/babel/transformation/templates/helper-define-decorated-property-descriptor.js
@@ -7,7 +7,7 @@
   for (var _key in _descriptor) descriptor[_key] = _descriptor[_key];
 
   // initialize it
-  descriptor.value = descriptor.initializer.call(target);
+  descriptor.value = descriptor.initializer ? descriptor.initializer.call(target) : undefined;
 
   Object.defineProperty(target, key, descriptor);
 })


### PR DESCRIPTION
The following code doesn't work ([you can try it in Babel's REPL](http://babeljs.io/repl/#?experimental=true&evaluate=true&loose=false&spec=false&playground=false&code=function%20decorate()%7B%7D%0A%0Aclass%20Foo%20%7B%0A%20%20%40decorate%0A%20%20bar%3B%0A%7D%0A%0Anew%20Foo%3B)):

```js
function decorate(){}

class Foo {
  @decorate
  bar;
}

new Foo;
```

When `Foo` is instanciated, the following error is thrown:

```
Cannot read property 'call' of null
```

This is caused by the generated code, creating a decorated class without any initializer for the `bar` property:

```js
// ...

  _createDecoratedClass(Foo, [{
    key: "bar",
    decorators: [decorate],
    initializer: null,
    enumerable: true
  }], null, _instanceInitializers);

// ...
```

The `_defineDecoratedPropertyDescriptor` helper tries to call the initializer but it throws an error since it is `null`. I fixed this behaviour by checking if the initializer is defined before using the `call` method on it.