### PR TITLE
Delete orphan method `pretransform()`.

### DIFF
--- a/packages/babel/src/transformation/pipeline.js
+++ b/packages/babel/src/transformation/pipeline.js
@@ -113,19 +113,6 @@ export default class Pipeline {
    * [Please add a description.]
    */
 
-  pretransform(code: string, opts?: Object) {
-    var file = new File(opts, this);
-    return file.wrap(code, function () {
-      file.addCode(code);
-      file.parseCode(code);
-      return file;
-    });
-  }
-
-  /**
-   * [Please add a description.]
-   */
-
   transform(code: string, opts?: Object) {
     var file = new File(opts, this);
     return file.wrap(code, function () {


### PR DESCRIPTION
What is this method's story? I tried searching the code base for the name and didn't come up with anything, so I deleted it and tests still pass. I also don't see it in the API documentation.

`transform()` duplicates most of its code, so if `pretransform()` should be preserved for some reason it seems that `transform()` could be trimmed.