### PR TITLE
fix tryCreateRegexp function scope

### DIFF
--- a/packages/babylon/src/tokenize.js
+++ b/packages/babylon/src/tokenize.js
@@ -486,10 +486,10 @@ pp.readRegexp = function() {
   // Rhino's regular expression parser is flaky and throws uncatchable exceptions,
   // so don't do detection if we are running under Rhino
   if (!isRhino) {
-    tryCreateRegexp(tmp, undefined, start);
+    tryCreateRegexp.call(this, tmp, undefined, start);
     // Get a regular expression object for this pattern-flag pair, or `null` in
     // case the current environment doesn't support the flags it uses.
-    value = tryCreateRegexp(content, mods);
+    value = tryCreateRegexp.call(this, content, mods);
   }
   return this.finishToken(tt.regexp, {pattern: content, flags: mods, value: value});
 };


### PR DESCRIPTION
This is the edgiest of edge cases, but as I was incorporating some RegExp heavy code into my project today I started getting type errors from Babel.

```
TypeError: [...]: Cannot read property 'raise' of undefined
    at tryCreateRegexp ([...]\node_modules\babelify\node_modules\babel-core\node_modules\babylon\lib\tokenize.js:464:41)
    ...
```

I tracked down the error to the `tryCreateRegexp` function, which was calling `this.raise`. But `this` was undefined because the function was called directly, not as a method of `pp` like most of the other functions. I fixed it by providing the scope of the calling function.