### PR TITLE
Allow multiple inclusions of babel/polyfill, as long as the versions match

### DIFF
--- a/packages/babel/src/polyfill.js
+++ b/packages/babel/src/polyfill.js
@@ -1,7 +1,9 @@
-if (global._babelPolyfill) {
-  throw new Error("only one instance of babel/polyfill is allowed");
+import packageJson from '../package.json';
+
+if (global._babelPolyfill === packageJson.version) {
+  throw new Error(`Polyfill package ${packageJson.version} doesn't match previously loaded version: ${global._babelPolyfill}`);
 }
-global._babelPolyfill = true;
+global._babelPolyfill = packageJson.version;
 
 import "core-js/shim";
 import "regenerator/runtime";

--- a/packages/babel/src/polyfill.js
+++ b/packages/babel/src/polyfill.js
@@ -1,4 +1,4 @@
-import packageJson from '../package.json';
+import packageJson from "../package.json";
 
 if (global._babelPolyfill === packageJson.version) {
   throw new Error(`Polyfill package ${packageJson.version} doesn't match previously loaded version: ${global._babelPolyfill}`);


### PR DESCRIPTION
While including multiple versions of the polyfill will definitely cause heartache, it's still safe to include it as long as the versions match. This is super common in certain scenarios (i.e. where your tests include polyfill because it's needed but your main package also includes it).