### PR TITLE
Ensure that the original state is restored on lookahead - fixes #2086

### DIFF
--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -91,7 +91,8 @@ export default class Tokenizer {
   // TODO
 
   lookahead() {
-    var old = this.state.clone();
+    var old = this.state;
+    this.state = old.clone();
     this.next();
     var curr = this.state.clone();
     this.state = old;

--- a/packages/babylon/test/fixtures/experimental/uncategorised/62/actual.js
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/62/actual.js
@@ -1,0 +1,3 @@
+@decorate((arg) => null)
+class Ex {
+}

--- a/packages/babylon/test/fixtures/experimental/uncategorised/62/expected.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/62/expected.json
@@ -1,0 +1,185 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 37,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 37,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 25,
+        "end": 37,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "decorators": [
+          {
+            "type": "Decorator",
+            "start": 0,
+            "end": 24,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 24
+              }
+            },
+            "expression": {
+              "type": "CallExpression",
+              "start": 1,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 24
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 1,
+                "end": 9,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 9
+                  }
+                },
+                "name": "decorate"
+              },
+              "arguments": [
+                {
+                  "type": "ArrowFunctionExpression",
+                  "start": 10,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 23
+                    }
+                  },
+                  "id": null,
+                  "generator": false,
+                  "expression": true,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 11,
+                      "end": 14,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 14
+                        }
+                      },
+                      "name": "arg"
+                    }
+                  ],
+                  "body": {
+                    "type": "Literal",
+                    "start": 19,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 19
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 23
+                      }
+                    },
+                    "value": null,
+                    "rawValue": null,
+                    "raw": "null"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "id": {
+          "type": "Identifier",
+          "start": 31,
+          "end": 33,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 8
+            }
+          },
+          "name": "Ex"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 34,
+          "end": 37,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": []
+        }
+      }
+    ]
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/uncategorised/62/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/62/options.json
@@ -1,0 +1,5 @@
+{
+  "features": {
+    "es7.decorators": true
+  }
+}


### PR DESCRIPTION
This fixes this issue for things using `lookahead`, but I could see it occurring again elsewhere in the code. I'll leaving to @sebmck to think that through more.

This issue came down to

    this.state.decorators.push(this.parseDecorator());

looks totally normal, but the issue is that `parseDecorator` actually triggers a lookahead in certain cases, and lookahead was removing, cloning, and reassigning `this.state`. Breaking down that line:

    var decorators = this.state.decorators;
    decorators.push(this.parseDecorator());

which meant that the lookahead could swap out the decorator array with a clone of it, but then the decorator would be pushed into the old copy of the `decorators` array.

The `lookahead` case is totally fixable, but it looks like there are other cases where `this.state` is cloned like this, and it's not clear to me if they have the same chance of causing a bug like this.