### PR TITLE
Register import bindings to the specifier instead of the declaration - fixes #2122

### DIFF
--- a/packages/babel/src/traversal/path/introspection.js
+++ b/packages/babel/src/traversal/path/introspection.js
@@ -171,27 +171,26 @@ export function referencesImport(moduleSource, importName) {
   if (!binding || binding.kind !== "module") return false;
 
   var path = binding.path;
-  if (!path.isImportDeclaration()) return false;
+  var parent = path.parentPath;
+  if (!parent.isImportDeclaration()) return false;
 
   // check moduleSource
-  if (path.node.source.value === moduleSource) {
+  if (parent.node.source.value === moduleSource) {
     if (!importName) return true;
   } else {
     return false;
   }
 
-  for (var specifier of (path.node.specifiers: Array)) {
-    if (t.isSpecifierDefault(specifier) && importName === "default") {
-      return true;
-    }
+  if (path.isImportDefaultSpecifier() && importName === "default") {
+    return true;
+  }
 
-    if (t.isImportNamespaceSpecifier(specifier) && importName === "*") {
-      return true;
-    }
+  if (path.isImportNamespaceSpecifier() && importName === "*") {
+    return true;
+  }
 
-    if (t.isImportSpecifier(specifier) && specifier.imported.name === importName) {
-      return true;
-    }
+  if (path.isImportSpecifier() && path.node.imported.name === importName) {
+    return true;
   }
 
   return false;

--- a/packages/babel/src/traversal/scope/index.js
+++ b/packages/babel/src/traversal/scope/index.js
@@ -540,8 +540,13 @@ export default class Scope {
       }
     } else if (path.isClassDeclaration()) {
       this.registerBinding("let", path);
-    } else if (path.isImportDeclaration() || path.isExportDeclaration()) {
-      this.registerBinding("module", path);
+    } else if (path.isImportDeclaration()) {
+      var specifiers = path.get("specifiers");
+      for (var specifier of (specifiers: Array)) {
+        this.registerBinding("module", specifier);
+      }
+    } else if (path.isExportDeclaration()) {
+      this.registerBinding("module", path.get("declaration"));
     } else {
       this.registerBinding("unknown", path);
     }


### PR DESCRIPTION
How does this look @sebmck? A couple things:

- I didn't touch the export bindings. Should I change those too?
- I wasn't sure where to add tests so I just used this little diddy to test it out:

```js
import * as babel from "./babel";

let plugin = new babel.Transformer('babel-plugin-test-2122', {
  CallExpression(node, parent, scope, state) {
    let refsAny = false,
        refsDefault = false,
        refsNamespace = false,
        refsFoo = false;

    let callee = this.get('callee');
    if (callee.referencesImport('./my-lib')) refsAny = true;
    if (callee.referencesImport('./my-lib', 'default')) refsDefault = true;
    if (callee.referencesImport('./my-lib', 'foo')) refsFoo = true;
    if (callee.referencesImport('./my-lib', '*')) refsNamespace = true;

    console.log(
      `CallExpression (${callee.node.name}): ` +
      `any=${refsAny} default=${refsDefault} ` +
      `namespace=${refsNamespace} foo=${refsFoo}`
    );
  }
});

let src = `
  import { foo as FOO, bar as BAR, default as DEFAULT1 } from './my-lib';
  import DEFAULT2 from './my-lib';
  import * as NAMESPACE from './my-lib';

  DEFAULT1();
  DEFAULT2();
  NAMESPACE();
  FOO();
  OTHER();
`;

babel.transform(src, {
  plugins: [plugin]
});
```

which results in

```
~/Projects/babel/packages $ babel-node test-2122.js
CallExpression (DEFAULT1): any=true default=true namespace=false foo=false
CallExpression (DEFAULT2): any=true default=true namespace=false foo=false
CallExpression (NAMESPACE): any=true default=false namespace=true foo=false
CallExpression (FOO): any=true default=false namespace=false foo=true
CallExpression (OTHER): any=false default=false namespace=false foo=false
```