### PR TITLE
Tighten up block-hoist transformer

### DIFF
--- a/packages/babel/src/transformation/transformers/internal/block-hoist.js
+++ b/packages/babel/src/transformation/transformers/internal/block-hoist.js
@@ -26,7 +26,10 @@ export var visitor = {
       var hasChange = false;
       for (var i = 0; i < node.body.length; i++) {
         var bodyNode = node.body[i];
-        if (bodyNode && bodyNode._blockHoist != null) hasChange = true;
+        if (bodyNode && bodyNode._blockHoist != null) {
+          hasChange = true;
+          break;
+        }
       }
       if (!hasChange) return;
 


### PR DESCRIPTION
Stop looping when it's no longer necessary. Revision of #1725.

I was getting test failures on master (36b3d5b3b1d8ce3145e7eb346a145aeb2d362228), so I branched from `v5.8.19`