### PR TITLE
add angular2 non-standard parser plugin

### DIFF
--- a/packages/babel/src/helpers/parse.js
+++ b/packages/babel/src/helpers/parse.js
@@ -20,6 +20,7 @@ export default function (code, opts = {}) {
   if (opts.nonStandard) {
     parseOpts.plugins.jsx = true;
     parseOpts.plugins.flow = true;
+    parseOpts.plugins.angular = true;
   }
 
   return babylon.parse(code, parseOpts);

--- a/packages/babylon/src/index.js
+++ b/packages/babylon/src/index.js
@@ -13,8 +13,10 @@ import "./tokenizer/context";
 
 import flowPlugin from "./plugins/flow";
 import jsxPlugin from "./plugins/jsx";
+import angularPlugin from "./plugins/angular";
 plugins.flow = flowPlugin;
 plugins.jsx = jsxPlugin;
+plugins.angular = angularPlugin;
 
 export function parse(input, options) {
   return new Parser(options, input).parse();

--- a/packages/babylon/src/plugins/angular.js
+++ b/packages/babylon/src/plugins/angular.js
@@ -1,0 +1,43 @@
+import { types as tt } from "../tokenizer/types";
+import Parser from "../parser";
+
+var pp = Parser.prototype;
+
+pp.angularParseBindingList = function (close, allowEmpty, allowTrailingComma) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (first) first = false;
+    else this.expect(tt.comma);
+    if (allowEmpty && this.match(tt.comma)) {
+      elts.push(null);
+    } else if (allowTrailingComma && this.eat(close)) {
+      break;
+    } else if (this.match(tt.ellipsis)) {
+      elts.push(this.parseAssignableListItemTypes(this.parseRest()));
+      this.expect(close);
+      break;
+    } else {
+      var decorators = [];
+      while (this.match(tt.at)) {
+        decorators.push(this.parseDecorator());
+      }
+      var left = this.parseMaybeDefault();
+      if (decorators.length > 0) {
+        left.decorators = decorators;
+      }
+      this.parseAssignableListItemTypes(left);
+      elts.push(this.parseMaybeDefault(null, null, left));
+    }
+  }
+  return elts;
+};
+
+export default function (instance) {
+
+  instance.extend("parseBindingList", function () {
+    return function (close, allowEmpty, allowTrailingComma) {
+      return this.angularParseBindingList(close, allowEmpty, allowTrailingComma);
+    };
+  });
+
+}

--- a/packages/babylon/test/fixtures/angular/constructor-decorators/1/actual.js
+++ b/packages/babylon/test/fixtures/angular/constructor-decorators/1/actual.js
@@ -1,0 +1,4 @@
+export class HelloComponent {
+  constructor(@Yes({ key: "value" }) @No() foo: Foo, @Maybe() bar: Bar, baz: Baz) {
+  }
+}

--- a/packages/babylon/test/fixtures/angular/constructor-decorators/1/expected.json
+++ b/packages/babylon/test/fixtures/angular/constructor-decorators/1/expected.json
@@ -1,0 +1,574 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 119,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 119,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 119,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start": 7,
+          "end": 119,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 13,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "name": "HelloComponent"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start": 28,
+            "end": 119,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 4,
+                "column": 1
+              }
+            },
+            "body": [
+              {
+                "type": "MethodDefinition",
+                "start": 32,
+                "end": 117,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 3
+                  }
+                },
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 32,
+                  "end": 43,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 13
+                    }
+                  },
+                  "name": "constructor"
+                },
+                "static": false,
+                "kind": "constructor",
+                "value": {
+                  "type": "FunctionExpression",
+                  "start": 43,
+                  "end": 117,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 3
+                    }
+                  },
+                  "id": null,
+                  "generator": false,
+                  "expression": false,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 73,
+                      "end": 81,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 43
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 51
+                        }
+                      },
+                      "name": "foo",
+                      "decorators": [
+                        {
+                          "type": "Decorator",
+                          "start": 44,
+                          "end": 66,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 14
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 36
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 45,
+                            "end": 66,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 15
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 36
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 45,
+                              "end": 48,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 18
+                                }
+                              },
+                              "name": "Yes"
+                            },
+                            "arguments": [
+                              {
+                                "type": "ObjectExpression",
+                                "start": 49,
+                                "end": 65,
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 19
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 35
+                                  }
+                                },
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "start": 51,
+                                    "end": 63,
+                                    "loc": {
+                                      "start": {
+                                        "line": 2,
+                                        "column": 21
+                                      },
+                                      "end": {
+                                        "line": 2,
+                                        "column": 33
+                                      }
+                                    },
+                                    "method": false,
+                                    "shorthand": false,
+                                    "computed": false,
+                                    "key": {
+                                      "type": "Identifier",
+                                      "start": 51,
+                                      "end": 54,
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 21
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 24
+                                        }
+                                      },
+                                      "name": "key"
+                                    },
+                                    "value": {
+                                      "type": "Literal",
+                                      "start": 56,
+                                      "end": 63,
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 26
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 33
+                                        }
+                                      },
+                                      "value": "value",
+                                      "rawValue": "value",
+                                      "raw": "\"value\""
+                                    },
+                                    "kind": "init"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Decorator",
+                          "start": 67,
+                          "end": 72,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 37
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 42
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 68,
+                            "end": 72,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 38
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 42
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 68,
+                              "end": 70,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 38
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 40
+                                }
+                              },
+                              "name": "No"
+                            },
+                            "arguments": []
+                          }
+                        }
+                      ],
+                      "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 76,
+                        "end": 81,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 46
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 51
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "GenericTypeAnnotation",
+                          "start": 78,
+                          "end": 81,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 48
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 51
+                            }
+                          },
+                          "typeParameters": null,
+                          "id": {
+                            "type": "Identifier",
+                            "start": 78,
+                            "end": 81,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 48
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 51
+                              }
+                            },
+                            "name": "Foo"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "Identifier",
+                      "start": 92,
+                      "end": 100,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 62
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 70
+                        }
+                      },
+                      "name": "bar",
+                      "decorators": [
+                        {
+                          "type": "Decorator",
+                          "start": 83,
+                          "end": 91,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 53
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 61
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 84,
+                            "end": 91,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 54
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 61
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 84,
+                              "end": 89,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 54
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 59
+                                }
+                              },
+                              "name": "Maybe"
+                            },
+                            "arguments": []
+                          }
+                        }
+                      ],
+                      "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 95,
+                        "end": 100,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 65
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 70
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "GenericTypeAnnotation",
+                          "start": 97,
+                          "end": 100,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 67
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 70
+                            }
+                          },
+                          "typeParameters": null,
+                          "id": {
+                            "type": "Identifier",
+                            "start": 97,
+                            "end": 100,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 67
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 70
+                              }
+                            },
+                            "name": "Bar"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "Identifier",
+                      "start": 102,
+                      "end": 110,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 72
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 80
+                        }
+                      },
+                      "name": "baz",
+                      "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 105,
+                        "end": 110,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 75
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 80
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "GenericTypeAnnotation",
+                          "start": 107,
+                          "end": 110,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 77
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 80
+                            }
+                          },
+                          "typeParameters": null,
+                          "id": {
+                            "type": "Identifier",
+                            "start": 107,
+                            "end": 110,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 77
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 80
+                              }
+                            },
+                            "name": "Baz"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 112,
+                    "end": 117,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 82
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 3
+                      }
+                    },
+                    "body": []
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "specifiers": [],
+        "source": null
+      }
+    ]
+  }
+}

--- a/packages/babylon/test/fixtures/angular/options.json
+++ b/packages/babylon/test/fixtures/angular/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": { "flow": true, "angular": true },
+  "features": { "es7.decorators": true }
+}


### PR DESCRIPTION
Following the discussion in #2128 and #1351, here is a small parser plugin for angular2 (based on @shuhei's initial work).

It looks like pluggable parsers aren't coming before the next major release, however this is needed today for angular2. With this parser, we can use babel as an alternative to typescript for our angular2 applications, many developers would really like that.

You already support flow/jsx syntax, adding angular2 support would show to the community that babel isn't tied to one companies' syntaxes. Once pluggable parsers are ready, this would move out of the core (for the next major release). 

edit: Travis seems to fail on v0.12 for an unrelated reason, maybe re-run the tests?