### PR TITLE
Map commonjs named imports back to the correct location - fixes #1987

### DIFF
--- a/packages/babel/src/transformation/modules/common.js
+++ b/packages/babel/src/transformation/modules/common.js
@@ -92,7 +92,8 @@ export default class CommonJSFormatter extends DefaultFormatter {
         ]));
       } else {
         // import { foo } from "foo";
-        this.remaps.add(scope, variableName.name, t.memberExpression(ref, specifier.imported));
+        this.remaps.add(scope, variableName.name,
+          t.memberExpression(ref, t.identifier(specifier.imported.name)));
       }
     }
   }

--- a/packages/babel/test/fixtures/transformation/es6.modules-common/imports-named/source-mappings.json
+++ b/packages/babel/test/fixtures/transformation/es6.modules-common/imports-named/source-mappings.json
@@ -1,0 +1,19 @@
+[{
+  "original": {
+    "line": 6,
+    "column": 0
+  },
+  "generated": {
+    "line": 5,
+    "column": 6
+  }
+}, {
+  "original": {
+    "line": 9,
+    "column": 0
+  },
+  "generated": {
+    "line": 8,
+    "column": 6
+  }
+}]


### PR DESCRIPTION
The import identifier is being used as the property in the new member expression, but still had its original location information.