### PR TITLE
Start version created by babel-plugin init @ 0.0.0

### DIFF
--- a/packages/babel-cli/src/babel-plugin/index.js
+++ b/packages/babel-cli/src/babel-plugin/index.js
@@ -82,7 +82,7 @@ var cmds = {
 
       write("package.json", JSON.stringify({
         name: templateData.FULL_NAME,
-        version: "1.0.0",
+        version: "0.0.0",
         description: templateData.DESCRIPTION,
         repository: repo || undefined,
         license: "MIT",


### PR DESCRIPTION
Re: https://github.com/UXtemple/babel-plugin-react-autoprefix/commit/8d16a530d2ec3d277613ecd6c51ab2de6482b465