### PR TITLE
Fix a slight bug in optional properties

### DIFF
--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -256,7 +256,6 @@ pp.flowParseObjectTypeCallProperty = function (node, isStatic) {
 pp.flowParseObjectType = function (allowStatic) {
   var nodeStart = this.startNode();
   var node;
-  var optional = false;
   var propertyKey;
   var isStatic;
 
@@ -288,9 +287,7 @@ pp.flowParseObjectType = function (allowStatic) {
         // This is a method property
         nodeStart.properties.push(this.flowParseObjectTypeMethod(startPos, startLoc, isStatic, propertyKey));
       } else {
-        if (this.eat(tt.question)) {
-          optional = true;
-        }
+        var optional = this.eat(tt.question) ? true : false;
         node.key = propertyKey;
         node.value = this.flowParseTypeInitialiser();
         node.optional = optional;

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -287,10 +287,9 @@ pp.flowParseObjectType = function (allowStatic) {
         // This is a method property
         nodeStart.properties.push(this.flowParseObjectTypeMethod(startPos, startLoc, isStatic, propertyKey));
       } else {
-        var optional = this.eat(tt.question) ? true : false;
+        node.optional = this.eat(tt.question);
         node.key = propertyKey;
         node.value = this.flowParseTypeInitialiser();
-        node.optional = optional;
         node.static = isStatic;
         this.flowObjectTypeSemicolon();
         nodeStart.properties.push(this.finishNode(node, "ObjectTypeProperty"));


### PR DESCRIPTION
In the example http://felix-kling.de/esprima_ast_explorer/#/hJ2lpkEIJm/1 (you will have to switch from Esprima to Babel to see the AST), there seems to be a slight bug where the property `valueC` is marked as optional, even though it is not (only `valueB` is actually optional). Looking at the parser, it seems that the optional property is initialized to false outside the loop, then set to true when the first optional property is encountered. I have fixed this to set the optional property inside the loop.

The offending example:
```javascript
export type ValueTypeA = {
  valueA: boolean;
  valueB?: string;
  valueC: number;
};
```