### PR TITLE
update eslint, babel-eslint, fix unused vars

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "parser": "babel-eslint",
+  "extends": "eslint:recommended",
   "rules": {
     "quotes": [2, "double", "avoid-escape"],
     "strict": 0,
@@ -21,7 +22,8 @@
     "no-unreachable": 0,
     "no-labels": 0,
     "no-process-exit": 0,
-    "camelcase": 0
+    "camelcase": 0,
+    "no-console": 0
   },
   "env": {
     "node": true

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "private": true,
   "devDependencies": {
     "babel": "5.8.19",
-    "babel-eslint": "^3.1.19",
+    "babel-eslint": "^4.0.6",
     "browserify": "^11.0.0",
     "chai": "^2.2.0",
     "es5-shim": "^4.1.7",
-    "eslint": "^0.21.2",
+    "eslint": "^1.1.0",
     "fs-readdir-recursive": "^0.1.2",
     "istanbul": "^0.3.5",
     "lodash": "^3.10.0",

--- a/packages/babel-cli/src/babel-plugin/templates/index.js
+++ b/packages/babel-cli/src/babel-plugin/templates/index.js
@@ -1,3 +1,4 @@
+/* eslint no-unused-vars:0 */
 export default function ({ Plugin, types: t }) {
   return new Plugin("NAME", {
     visitor: {

--- a/packages/babel/src/generation/generators/flow.js
+++ b/packages/babel/src/generation/generators/flow.js
@@ -22,7 +22,7 @@ export function ArrayTypeAnnotation(node, print) {
  * Prints BooleanTypeAnnotation.
  */
 
-export function BooleanTypeAnnotation(node) {
+export function BooleanTypeAnnotation() {
   this.push("bool");
 }
 
@@ -383,6 +383,6 @@ export function TypeCastExpression(node, print) {
  * Prints VoidTypeAnnotation.
  */
 
-export function VoidTypeAnnotation(node) {
+export function VoidTypeAnnotation() {
   this.push("void");
 }

--- a/packages/babel/src/generation/generators/types.js
+++ b/packages/babel/src/generation/generators/types.js
@@ -129,7 +129,7 @@ export { ArrayExpression as ArrayPattern };
  * Prints Literal, prints value, regex, raw, handles val type.
  */
 
-export function Literal(node, print) {
+export function Literal(node) {
   this.push(""); // hack: catch up indentation
   this._push(this._Literal(node));
 }

--- a/packages/babel/src/transformation/transformers/es6/for-of.js
+++ b/packages/babel/src/transformation/transformers/es6/for-of.js
@@ -52,7 +52,7 @@ export var visitor = {
  * [Please add a description.]
  */
 
-export function _ForOfStatementArray(node, scope, file) {
+export function _ForOfStatementArray(node, scope) {
   var nodes = [];
   var right = node.right;
 

--- a/packages/babel/src/transformation/transformers/filters.js
+++ b/packages/babel/src/transformation/transformers/filters.js
@@ -4,7 +4,7 @@ import includes from "lodash/collection/includes";
  * [Please add a description.]
  */
 
-export function internal(transformer, opts) {
+export function internal(transformer) {
   if (transformer.key[0] === "_") return true;
 }
 

--- a/packages/babel/src/traversal/path/inference/inferers.js
+++ b/packages/babel/src/traversal/path/inference/inferers.js
@@ -120,7 +120,7 @@ export function ConditionalExpression() {
  * [Please add a description.]
  */
 
-export function SequenceExpression(node) {
+export function SequenceExpression() {
   return this.get("expressions").pop().getTypeAnnotation();
 }
 
@@ -128,7 +128,7 @@ export function SequenceExpression(node) {
  * [Please add a description.]
  */
 
-export function AssignmentExpression(node) {
+export function AssignmentExpression() {
   return this.get("right").getTypeAnnotation();
 }
 

--- a/packages/babel/src/types/index.js
+++ b/packages/babel/src/types/index.js
@@ -92,6 +92,7 @@ export const TYPES = Object.keys(t.VISITOR_KEYS).concat(Object.keys(t.FLIPPED_AL
  */
 
 // @TODO should `skipAliasCheck` be removed?
+/*eslint-disable no-unused-vars */
 export function is(type: string, node: Object, opts?: Object, skipAliasCheck?: boolean): boolean {
   if (!node) return false;
 
@@ -104,6 +105,7 @@ export function is(type: string, node: Object, opts?: Object, skipAliasCheck?: b
     return t.shallowEqual(node, opts);
   }
 }
+/*eslint-enable no-unused-vars */
 
 /**
  * Test if a `nodeType` is a `targetType` or if `targetType` is an alias of `nodeType`.


### PR DESCRIPTION
update eslint to 1.1.0, babel-eslint

added `"extends": "eslint:recommended"` which adds the rules that would be gone in 1.0.0 since there's no rules on by default

fixes for unused vars