### PR TITLE
Improved UMD global exports

### DIFF
--- a/packages/babel/src/transformation/file/options/config.json
+++ b/packages/babel/src/transformation/file/options/config.json
@@ -109,6 +109,12 @@
     "description": "insert an explicit id for modules"
   },
 
+  "globalModuleRoot": {
+    "type": "boolean",
+    "deafault": "false",
+    "description": "if true, use the moduleRoot as the base global object and extend it."
+  },
+
   "loose": {
     "type": "transformerList",
     "description": "list of transformers to enable loose mode ON",

--- a/packages/babel/src/transformation/modules/umd.js
+++ b/packages/babel/src/transformation/modules/umd.js
@@ -81,10 +81,12 @@ export default class UMDFormatter extends AMDFormatter {
       COMMON_ARGUMENTS: commonArgs,
       BROWSER_ARGUMENTS: browserArgs,
       GLOBAL_ARG: globalArg,
-      GLOBAL_MODULE_ROOT: t.literal(this.file.opts.moduleRoot),
-      GLOBAL_MODULE_NAME: t.literal(moduleName.replace(this.file.opts.moduleRoot + "/", ""))
+      GLOBAL_MODULE_ROOT: t.literal(this.file.opts.moduleRoot)
     };
-    var templateName = this.file.opts.globalModuleRoot ? "umd-runner-body-global-root" : "umd-runner-body";
+    if (moduleName) {
+      templateOpts.GLOBAL_MODULE_NAME = t.literal(moduleName.replace(this.file.opts.moduleRoot + "/", ""));
+    }
+    var templateName = this.file.opts.globalModuleRoot && moduleName ? "umd-runner-body-global-root" : "umd-runner-body";
     var runner = util.template(templateName, templateOpts);
 
     //

--- a/packages/babel/src/transformation/modules/umd.js
+++ b/packages/babel/src/transformation/modules/umd.js
@@ -81,8 +81,8 @@ export default class UMDFormatter extends AMDFormatter {
       COMMON_ARGUMENTS: commonArgs,
       BROWSER_ARGUMENTS: browserArgs,
       GLOBAL_ARG: globalArg,
-      MODULE_ROOT: t.literal(this.file.opts.moduleRoot),
-      MODULE_NAME: t.literal(moduleName)
+      GLOBAL_MODULE_ROOT: t.literal(this.file.opts.moduleRoot),
+      GLOBAL_MODULE_NAME: t.literal(moduleName.replace(this.file.opts.moduleRoot + "/", ""))
     };
     var templateName = this.file.opts.globalModuleRoot ? "umd-runner-body-global-root" : "umd-runner-body";
     var runner = util.template(templateName, templateOpts);

--- a/packages/babel/src/transformation/modules/umd.js
+++ b/packages/babel/src/transformation/modules/umd.js
@@ -75,13 +75,17 @@ export default class UMDFormatter extends AMDFormatter {
     if (moduleName) globalArg = moduleName;
     globalArg = t.identifier(t.toIdentifier(globalArg));
 
-    var runner = util.template("umd-runner-body", {
+    var templateOpts = {
       AMD_ARGUMENTS: defineArgs,
       COMMON_TEST: commonTests,
       COMMON_ARGUMENTS: commonArgs,
       BROWSER_ARGUMENTS: browserArgs,
-      GLOBAL_ARG: globalArg
-    });
+      GLOBAL_ARG: globalArg,
+      MODULE_ROOT: t.literal(this.file.opts.moduleRoot),
+      MODULE_NAME: t.literal(moduleName)
+    };
+    var templateName = this.file.opts.globalModuleRoot ? "umd-runner-body-global-root" : "umd-runner-body";
+    var runner = util.template(templateName, templateOpts);
 
     //
 

--- a/packages/babel/src/transformation/templates/umd-runner-body-global-root.js
+++ b/packages/babel/src/transformation/templates/umd-runner-body-global-root.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(AMD_ARGUMENTS, factory);
+  } else if (COMMON_TEST) {
+    factory(COMMON_ARGUMENTS);
+  } else {
+    var mod = { exports: {} };
+    factory(mod.exports, BROWSER_ARGUMENTS);
+    global[MODULE_NAME] = mod.exports;
+  }
+});

--- a/packages/babel/src/transformation/templates/umd-runner-body-global-root.js
+++ b/packages/babel/src/transformation/templates/umd-runner-body-global-root.js
@@ -6,6 +6,7 @@
   } else {
     var mod = { exports: {} };
     factory(mod.exports, BROWSER_ARGUMENTS);
-    global[MODULE_NAME] = mod.exports;
+    global[GLOBAL_MODULE_ROOT] = global[GLOBAL_MODULE_ROOT] || {};
+    global[GLOBAL_MODULE_ROOT][GLOBAL_MODULE_NAME] = mod.exports;
   }
 });

--- a/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/actual.js
+++ b/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/actual.js
@@ -1,0 +1,1 @@
+myModule();

--- a/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/expected.js
@@ -8,7 +8,8 @@
       exports: {}
     };
     factory(mod.exports);
-    global["mylib/es6.modules-umd/exports-umd-global-root/expected"] = mod.exports;
+    global["mylib"] = global["mylib"] || {};
+    global["mylib"]["es6.modules-umd/exports-umd-global-root/expected"] = mod.exports;
   }
 })(this, function (exports) {
   "use strict";

--- a/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/expected.js
@@ -1,0 +1,17 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("mylib/es6.modules-umd/exports-umd-global-root/expected", ["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global["mylib/es6.modules-umd/exports-umd-global-root/expected"] = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  myModule();
+});

--- a/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/options.json
+++ b/packages/babel/test/fixtures/transformation/es6.modules-umd/exports-umd-global-root/options.json
@@ -1,0 +1,6 @@
+{
+  "moduleIds": true,
+  "moduleRoot": "mylib",
+  "globalModuleRoot": true,
+  "modules": "umd"
+}


### PR DESCRIPTION
When using UMD modules, I'm not a fan of how each individual module name is made into a camelCased identifier based on the module name.  I want my module to be collected into an object, with the module names as keys.  This PR introduces a `globalModuleRoot` boolean option to accomplish this.

An object is created on `window.{moduleRoot}` and each module is added as a key.  `moduleIds` must be true for this feature to work.

Here is an example of how [a project of mine](https://github.com/lincolndbryant/waitsfor) would look with this change merged https://gist.github.com/lincolndbryant/644a01bc060e3d5e58ca  The global object ends up looking like this

![screen shot 2015-08-21 at 7 55 20 pm](https://cloud.githubusercontent.com/assets/455026/9421288/a4e10fc0-483e-11e5-812a-cd8a5b7542af.png)

I'm glad to add more tests, but want to get some feedback first.  Thanks for the great product!