### PR TITLE
Fix flow optional object keys

### DIFF
--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -256,7 +256,6 @@ pp.flowParseObjectTypeCallProperty = function (node, isStatic) {
 pp.flowParseObjectType = function (allowStatic) {
   var nodeStart = this.startNode();
   var node;
-  var optional = false;
   var propertyKey;
   var isStatic;
 
@@ -267,6 +266,7 @@ pp.flowParseObjectType = function (allowStatic) {
   this.expect(tt.braceL);
 
   while (!this.match(tt.braceR)) {
+    var optional = false;
     var startPos = this.state.start, startLoc = this.state.startLoc;
     node = this.startNode();
     if (allowStatic && this.isContextual("static")) {

--- a/packages/babylon/test/fixtures/flow/type-annotations/98/actual.js
+++ b/packages/babylon/test/fixtures/flow/type-annotations/98/actual.js
@@ -1,0 +1,1 @@
+var a: {param1?: number; param2: string; param3: string;}

--- a/packages/babylon/test/fixtures/flow/type-annotations/98/expected.json
+++ b/packages/babylon/test/fixtures/flow/type-annotations/98/expected.json
@@ -1,0 +1,259 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 57,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 57
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 57,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 57
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 57,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 57
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 57,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 57
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 57,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 57
+                }
+              },
+              "name": "a",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 5,
+                "end": 57,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 57
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "ObjectTypeAnnotation",
+                  "start": 7,
+                  "end": 57,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 57
+                    }
+                  },
+                  "callProperties": [],
+                  "properties": [
+                    {
+                      "type": "ObjectTypeProperty",
+                      "start": 8,
+                      "end": 24,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 24
+                        }
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "start": 8,
+                        "end": 14,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 14
+                          }
+                        },
+                        "name": "param1"
+                      },
+                      "value": {
+                        "type": "NumberTypeAnnotation",
+                        "start": 17,
+                        "end": 23,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 17
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 23
+                          }
+                        }
+                      },
+                      "optional": true
+                    },
+                    {
+                      "type": "ObjectTypeProperty",
+                      "start": 25,
+                      "end": 40,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 25
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 40
+                        }
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "start": 25,
+                        "end": 31,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 25
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 31
+                          }
+                        },
+                        "name": "param2"
+                      },
+                      "value": {
+                        "type": "StringTypeAnnotation",
+                        "start": 33,
+                        "end": 39,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 33
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 39
+                          }
+                        }
+                      },
+                      "optional": false
+                    },
+                    {
+                      "type": "ObjectTypeProperty",
+                      "start": 41,
+                      "end": 56,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 41
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 56
+                        }
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "start": 41,
+                        "end": 47,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 41
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 47
+                          }
+                        },
+                        "name": "param3"
+                      },
+                      "value": {
+                        "type": "StringTypeAnnotation",
+                        "start": 49,
+                        "end": 55,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 49
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 55
+                          }
+                        }
+                      },
+                      "optional": false
+                    }
+                  ],
+                  "indexers": []
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "var"
+      }
+    ]
+  },
+  "comments": []
+}


### PR DESCRIPTION
Found a bug which all keys after an optional object key become optional. 

For example:

```js
var a: {param1?: number; param2: string; param3: string;}
```

There param1, param2, and param3 are all currently being marked as optional.

This PR fixes it so that only param1 is marked as optional.