### PR TITLE
Add `defineId` option for `amd` formatter.

### DIFF
--- a/packages/babel/src/transformation/file/options/config.json
+++ b/packages/babel/src/transformation/file/options/config.json
@@ -30,6 +30,13 @@
     "type": "string"
   },
 
+  "defineId": {
+    "description": "specify a custom name for the AMDFormatter to use as a define function",
+    "type": "string",
+    "default": "define",
+    "hidden": true
+  },
+
   "getModuleId": {
     "hidden": true
   },

--- a/packages/babel/src/transformation/modules/amd.js
+++ b/packages/babel/src/transformation/modules/amd.js
@@ -59,9 +59,22 @@ export default class AMDFormatter extends DefaultFormatter {
     var moduleName = this.getModuleName();
     if (moduleName) defineArgs.unshift(t.literal(moduleName));
 
-    var call = t.callExpression(t.identifier("define"), defineArgs);
+    var call = t.callExpression(this.getDefineIdentifier(), defineArgs);
 
     program.body = [t.expressionStatement(call)];
+  }
+
+  /**
+   * Get the module definition function identifier. Defaults to `define`, but
+   * can be overridden via `opts.defineId`.
+   */
+  getDefineIdentifier() {
+    var defineId = "define";
+    if (this.file.opts.defineId) {
+      defineId = this.file.opts.defineId;
+    }
+
+    return t.identifier(defineId);
   }
 
   /**

--- a/packages/babel/test/fixtures/transformation/es6.modules-amd/get-define-id-option/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.modules-amd/get-define-id-option/expected.js
@@ -1,0 +1,3 @@
+enifed(["exports"], function (exports) {
+  "use strict";
+});

--- a/packages/babel/test/fixtures/transformation/es6.modules-amd/get-define-id-option/options.json
+++ b/packages/babel/test/fixtures/transformation/es6.modules-amd/get-define-id-option/options.json
@@ -1,0 +1,3 @@
+{
+  "defineId": "enifed"
+}


### PR DESCRIPTION
Allows users to use a custom `define` function as needed.

---

When using a `define` function that is only available inside a closure, tools like `r.js` are not aware of the closure (they use a [regexp to look for define statements](https://github.com/jrburke/r.js/blob/2fdfddd959f371b775027c0145b00aed334a58f6/dist.js#L79)). To prevent downstream users of a library that does this type of concatentation inside an IIFE, we generally use a tool to rewrite the `define` calls into `enifed`.  Adding this option, allows us to simply write the module output correctly upon transpilation.