### PR TITLE
Use OS-specific newlines

### DIFF
--- a/packages/babel/src/generation/generators/base.js
+++ b/packages/babel/src/generation/generators/base.js
@@ -1,3 +1,5 @@
+import { EOL } from "os";
+
 /**
  * Print File.program
  */
@@ -23,7 +25,7 @@ export function BlockStatement(node, print) {
   if (node.body.length) {
     this.newline();
     print.sequence(node.body, { indent: true });
-    if (!this.format.retainLines) this.removeLast("\n");
+    if (!this.format.retainLines) this.removeLast(EOL);
     this.rightBrace();
   } else {
     print.printInnerComments();

--- a/packages/babel/src/transformation/file/index.js
+++ b/packages/babel/src/transformation/file/index.js
@@ -19,6 +19,7 @@ import Hub from "../../traversal/hub";
 import * as util from  "../../util";
 import path from "path";
 import * as t from "../../types";
+import { EOL } from "os";
 
 /**
  * [Please add a description.]
@@ -753,7 +754,7 @@ export default class File {
     }
 
     if (opts.sourceMaps === "inline" || opts.sourceMaps === "both") {
-      result.code += "\n" + convertSourceMap.fromObject(result.map).toComment();
+      result.code += EOL + convertSourceMap.fromObject(result.map).toComment();
     }
 
     if (opts.sourceMaps === "inline") {


### PR DESCRIPTION
This came about from babel/broccoli-babel-transpiler/issues/54.

These are the changes necessary to get the Windows tests to pass. I made minor changes to account for the 2 char newline.

cc @stefanpenner 