### PR TITLE
Allow more certainty when evaluating Logical Expressions

### DIFF
--- a/packages/babel/test/evaluation.js
+++ b/packages/babel/test/evaluation.js
@@ -1,0 +1,164 @@
+var evaluation = require("../lib/traversal/path/evaluation");
+var traverse   = require('../lib/traversal');
+var parse      = require("../lib/helpers/parse");
+var assert     = require("assert");
+
+suite("evaluation", function () {
+  test("binary expression", function () {
+    traverse(parse("5 + 5"), {
+      enter: function (node) {
+        if (this.isBinaryExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: 10 });
+        }
+      }
+    });
+
+    traverse(parse("'str' === 'str'"), {
+      enter: function(node) {
+        if (this.isBinaryExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'four' === 4"), {
+      enter: function(node) {
+        if (this.isBinaryExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: false });
+        }
+      }
+    });
+  });
+
+  test("logical expression", function () {
+    traverse(parse("'abc' === 'abc' && 1 === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'abc' && 1 === 10"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: false });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'xyz' && 1 === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: false });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'xyz' && 1 === 10"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: false });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'abc' || 1 === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'abc' || 1 === 10"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'xyz' || 1 === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'xyz' || 1 === 10"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: false });
+        }
+      }
+    });
+  });
+
+  test("logical expression without certainty", function () {
+    traverse(parse("'abc' === 'abc' || config.flag === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("obj.a === 'abc' || config.flag === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: false, value: undefined });
+        }
+      }
+    });
+
+    traverse(parse("'abc' !== 'abc' && config.flag === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: false });
+        }
+      }
+    });
+
+    traverse(parse("obj.a === 'abc' && 1 === 1"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: false, value: undefined });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'abc' && (1 === 1 || config.flag)"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'xyz' || (1 === 1 && config.flag)"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: false, value: undefined });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'xyz' || (1 === 1 && 'four' === 'four')"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+
+    traverse(parse("'abc' === 'abc' && (1 === 1 && 'four' === 'four')"), {
+      enter: function(node) {
+        if (this.isLogicalExpression()) {
+          assert.deepEqual(this.evaluate(), { confident: true, value: true });
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
If half of an `&&` expression is known to be `false`, or half of an `||` expression is known to be `true`, we can evaluate the entire expression with certainty.

This is handy for the dead code elimination plugin, since it allows expressions like
```js
if ('development' === 'production' && someSetting.enabled) {
 // ...
}
```
to be completely eliminated.
Right now, I have to write these forms as nested `if` blocks.

There wasn't an obvious location to place the tests, so I'm happy to revise / move them.