### PR TITLE
evaluation: evaluate typeof

### DIFF
--- a/packages/babel/src/traversal/path/evaluation.js
+++ b/packages/babel/src/traversal/path/evaluation.js
@@ -119,13 +119,20 @@ export function evaluate(): { confident: boolean; value: any } {
     }
 
     if (path.isUnaryExpression({ prefix: true })) {
-      var arg = evaluate(path.get("argument"));
+      var argument = path.get("argument");
+      var arg = evaluate(argument);
       switch (node.operator) {
         case "void": return undefined;
         case "!": return !arg;
         case "+": return +arg;
         case "-": return -arg;
         case "~": return ~arg;
+        case "typeof":
+          if (argument.isFunction()) {
+            return "function";
+          } else {
+            return typeof arg;
+          }
       }
     }
 


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/blob/e3bd223dac41ed8fcbbc3a139d78c68bcd50f628/lib/compress.js#L748

Looks like uglify has a specific check for functions/regexp which I'm not sure is needed? I went ahead and made the `function` change.

tests: https://github.com/mishoo/UglifyJS2/blob/master/test/compress/typeof.js - returns the same stuff.