### PR TITLE
evaluation: add UpdateExpression check (fixes #2295)

### DIFF
--- a/packages/babel/src/traversal/path/evaluation.js
+++ b/packages/babel/src/traversal/path/evaluation.js
@@ -104,6 +104,14 @@ export function evaluate(): { confident: boolean; value: any } {
       }
     }
 
+    if (path.isUpdateExpression()) {
+      var argument = evaluate(path.get("argument"));
+      switch (node.operator) {
+        case "++": return argument + 1;
+        case "--": return argument - 1;
+      }
+    }
+
     if (path.isReferencedIdentifier()) {
       var binding = path.scope.getBinding(node.name);
       if (binding && binding.hasValue) {


### PR DESCRIPTION
### Input

```js
var i = 0;
i += 1;
++i;
i++;
--i;
i--;
i;
```

### Output

```js
var i = 0;
i += 1;
2;
2;
0;
0;
1;
```

An issue is that the last `i` is still `1`.

Maybe the solution is keep `++i` not transformed?

Oh however this Input doesn't change (outputs the same thing), so maybe it's still good then

```js
var a = 2;
var b = ++a; // a = 3, b = 3
var c = a;
c++;
b++;
a++;
```