### PR TITLE
Let dead code elimination run over exported functions

### DIFF
--- a/packages/babel-plugin-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-dead-code-elimination/src/index.js
@@ -21,6 +21,7 @@ export default function ({ Plugin, types: t }) {
       var binding = scope.getBinding(node.name);
       if (!binding || binding.references > 1 || !binding.constant) return;
       if (binding.kind === "param" || binding.kind === "module") return;
+      if (t.isExportDeclaration(binding.path.parent)) return;
 
       var replacement = binding.path.node;
       if (t.isVariableDeclarator(replacement)) {


### PR DESCRIPTION
We've had problems running the dead code elimination plugin over code of the form

```js
export function myFn() {
  // ...
}
```

This slight change prevents the plugin from attempting to rewrite any nodes directly beneath `ExportDeclaration`s