### PR TITLE
babel-plugin-constant-folding: special case for string concatenation

### DIFF
--- a/packages/babel-plugin-transform-constant-folding/src/index.js
+++ b/packages/babel-plugin-transform-constant-folding/src/index.js
@@ -1,4 +1,14 @@
 export default function ({ types: t }) {
+  function isString(node) {
+    if (t.isBinaryExpression(node)) {
+      return node.operator == "+" && (isString(node.left) || isString(node.right));
+    } else if (t.isLiteral(node)) {
+      return typeof node.value === "string";
+    } else {
+      return false;
+    }
+  }
+
   return {
     visitor: {
       AssignmentExpression() {
@@ -62,6 +72,49 @@ export default function ({ types: t }) {
         exit(path) {
           var res = path.evaluate();
           if (res.confident) return t.valueToNode(res.value);
+        }
+      },
+
+      BinaryExpression: {
+        exit(node, parent, scope, file) {
+          let { left, right, operator } = node;
+
+          // "str1" + "str2" + a -> "str1str2" + a
+          if (t.isLiteral(left) &&
+              t.isBinaryExpression(right) &&
+              right.operator === "+" &&
+              t.isLiteral(right.left) &&
+              isString(right)) {
+            return t.binaryExpression("+",
+              t.literal("" + left.value + right.left.value),
+              right.right);
+          }
+
+          // a + "str1" + "str2" -> a + "str1str2"
+          if (t.isLiteral(right) &&
+              t.isBinaryExpression(left) &&
+              left.operator === "+" &&
+              t.isLiteral(left.right) &&
+              isString(left)) {
+            return t.binaryExpression("+",
+              left.left,
+              t.literal("" + left.right.value + right.value));
+          }
+
+          // a + "str1" + ("str2" + b) -> a + "str1str2" + b
+          if (t.isBinaryExpression(left) &&
+              left.operator === "+" &&
+              isString(left) &&
+              t.isBinaryExpression(right) &&
+              right.operator === "+" &&
+              isString(right)
+              ) {
+            return t.binaryExpression("+",
+              t.binaryExpression("+",
+                left.left,
+                t.literal(" " + left.right.value + right.left.value)),
+              right.right);
+          }
         }
       }
     }


### PR DESCRIPTION
this is on the development branch

Ran through https://github.com/mishoo/UglifyJS2/blob/master/test/compress/concat-strings.js tests

```js
// Input
var a = "foo" + "bar" + x() + "moo" + "foo" + y() + "x" + "y" + "z" + q();
// Output
var a = "foobar" + x() + "moofoo" + y() + "xyz" + q();
```

Simple string concatenation:
- `string + string` covered in `evaluate()`
- `string + BinaryExpression`, where `right.left` is a string
- `BinaryExpression + string`, where `left.right` is a string
- `BinaryExpression + BinaryExpression`, where `right.left` and `left.right` are strings

figured it would be in part of the plugin rather than in `evaluate()`?