### PR TITLE
Rest params with es6.arrowFunctions disabled throws

### DIFF
--- a/packages/babel/src/messages.js
+++ b/packages/babel/src/messages.js
@@ -23,7 +23,6 @@ export const MESSAGES = {
   unsupportedOutputType: "Unsupported output type $1",
   illegalMethodName: "Illegal method name $1",
   lostTrackNodePath: "We lost track of this node's position, likely because the AST was directly manipulated",
-  noRestArrowParam: "Arrow functions aren't allowed to have a rest when es6.arrowFunctions is disabled",
 
   modulesIllegalExportName: "Illegal export $1",
   modulesDuplicateDeclarations: "Duplicate module declarations with the same source but in different scopes",

--- a/packages/babel/src/messages.js
+++ b/packages/babel/src/messages.js
@@ -23,6 +23,7 @@ export const MESSAGES = {
   unsupportedOutputType: "Unsupported output type $1",
   illegalMethodName: "Illegal method name $1",
   lostTrackNodePath: "We lost track of this node's position, likely because the AST was directly manipulated",
+  noRestArrowParam: "Arrow functions aren't allowed to have a rest when es6.arrowFunctions is disabled",
 
   modulesIllegalExportName: "Illegal export $1",
   modulesDuplicateDeclarations: "Duplicate module declarations with the same source but in different scopes",

--- a/packages/babel/src/transformation/transformers/es6/parameters/rest.js
+++ b/packages/babel/src/transformation/transformers/es6/parameters/rest.js
@@ -1,5 +1,6 @@
 import * as util from  "../../../../util";
 import * as t from "../../../../types";
+import * as messages from "../../../../messages";
 
 /**
  * [Please add a description.]
@@ -130,7 +131,7 @@ export var visitor = {
    * [Please add a description.]
    */
 
-  Function(node, parent, scope) {
+  Function(node, parent, scope, file) {
     if (!hasRest(node)) return;
 
     var restParam = node.params.pop();
@@ -176,6 +177,9 @@ export var visitor = {
     if (!state.deopted && !state.references.length) {
       // we only have shorthands and there are no other references
       if (state.candidates.length) {
+        if (!file.transformers["es6.arrowFunctions"].canTransform()) {
+          throw file.errorWithNode(restParam, messages.get("noRestArrowParam"));
+        }
         for (var candidate of (state.candidates: Array)) {
           candidate.replaceWith(argsId);
           if (candidate.parentPath.isMemberExpression()) {

--- a/packages/babel/src/transformation/transformers/es6/parameters/rest.js
+++ b/packages/babel/src/transformation/transformers/es6/parameters/rest.js
@@ -177,7 +177,8 @@ export var visitor = {
     if (!state.deopted && !state.references.length) {
       // we only have shorthands and there are no other references
       if (state.candidates.length) {
-        if (!file.transformers["es6.arrowFunctions"].canTransform()) {
+        if (t.isArrowFunctionExpression(node) &&
+            !file.transformers["es6.arrowFunctions"].canTransform()) {
           throw file.errorWithNode(restParam, messages.get("noRestArrowParam"));
         }
         for (var candidate of (state.candidates: Array)) {


### PR DESCRIPTION
Addresses #2332.

Now when rest parameters are compiled down to the `arguments` object, check that `es6.arrowFunctions` is enabled. If it's not, throw an error.