### PR TITLE
Fix template loading when hidden files exist

### DIFF
--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -222,7 +222,7 @@ function loadTemplates(): Object {
   }
 
   for (var name of (fs.readdirSync(templatesLoc): Array)) {
-    if (name[0] === ".") return;
+    if (name[0] === ".") continue;
 
     var key  = path.basename(name, path.extname(name));
     var loc  = path.join(templatesLoc, name);


### PR DESCRIPTION
This made debugging https://github.com/babel/babel/pull/2352 confusing because I had some vim swap files so it didn't load any of the templates. (I assume this was the original intention.)