### PR TITLE
`global.document` changed to `global.document.currentScript.ownerDocument`

### DIFF
--- a/packages/babel-core/src/api/browser.js
+++ b/packages/babel-core/src/api/browser.js
@@ -32,6 +32,14 @@ export function load(url: string, callback: Function, opts: Object = {}, hold?: 
   xhr.send(null);
 }
 
+/**
+ * <script> tags may be children of documents other than window.document,
+ * e.g. inside imported documents via <link rel="import" ...>.
+ * currentDocument points to the document to which this script is attached.
+ */
+let currentScript = global.document._currentScript || global.document.currentScript;
+let currentDocument = currentScript ? currentScript.ownerDocument : global.document;
+
 function runScripts() {
   let scripts: Array<Array<any> | Object> = [];
   let types   = ["text/ecmascript-6", "text/6to5", "text/babel", "module"];
@@ -70,7 +78,7 @@ function runScripts() {
 
   // Collect scripts with Babel `types`.
 
-  let _scripts = global.document.getElementsByTagName("script");
+  let _scripts = currentDocument.getElementsByTagName("script");
 
   for (let i = 0; i < _scripts.length; ++i) {
     let _script = _scripts[i];
@@ -87,9 +95,20 @@ function runScripts() {
 /**
  * Register load event to transform and execute scripts.
  */
+let ifNativeHtmlImports = ("import" in global.document.createElement("link"));
+let ifInsideHtmlImport  = currentDocument !== global.document;
 
-if (global.addEventListener) {
-  global.addEventListener("DOMContentLoaded", runScripts, false);
-} else if (global.attachEvent) {
-  global.attachEvent("onload", runScripts);
+let documentLoadedEvent = "DOMContentLoaded";
+let eventSource = currentDocument;
+
+if ( ifInsideHtmlImport && !ifNativeHtmlImports ) {
+  // Assume webcomponents.js is the polyfill in use.
+  eventSource = global.document;
+  documentLoadedEvent = "HTMLImportsLoaded"; // webcomponents.js polyfill emits this event.
+}
+
+if (currentDocument.addEventListener) {
+  eventSource.addEventListener( documentLoadedEvent, runScripts, false );
+} else if (currentDocument.attachEvent) {
+  eventSource.attachEvent("onload", runScripts);
 }


### PR DESCRIPTION
[The issue](https://github.com/babel/babel/issues/2344)  

#### Tests

Windows/Chrome:
  1. components: _ok_
  2. global document: _ok_

Windows/FireFox:
  1. components: __fail__ (no DomContentLoaded event or any other when Webcomponents.js is used)
  2. global document: _ok_

Windows/Edge:
  1. components: __fail__
  2. global document: _ok_

Tested on `babel-core` npm package, did't tried to build it from the repo.
