### PR TITLE
evaluation: don't evaluate `in` and `instanceof` binary exp - fixes #…

### DIFF
--- a/packages/babel/src/traversal/path/evaluation.js
+++ b/packages/babel/src/traversal/path/evaluation.js
@@ -175,8 +175,6 @@ export function evaluate(): { confident: boolean; value: any } {
         case "<<": return left << right;
         case ">>": return left >> right;
         case ">>>": return left >>> right;
-        case "in": return left in right;
-        case "instanceof": return left instanceof right;
       }
     }
 


### PR DESCRIPTION
…2355

#2355

Regression due to some changes made in #2300. Removing due to the common case being mostly dynamic.