### PR TITLE
babel-plugin-constant-folding: evaluate only if resulting value is le…

### DIFF
--- a/packages/babel-plugin-constant-folding/src/index.js
+++ b/packages/babel-plugin-constant-folding/src/index.js
@@ -66,7 +66,11 @@ export default function ({ Plugin, types: t }) {
       Expression: {
         exit() {
           var res = this.evaluate();
-          if (res.confident) return t.valueToNode(res.value);
+          // check if evaluated code is less bytes than original code
+          // 1/3 vs 0.3333333
+          if (res.confident && this.getSource().length >= String(res.value).length) {
+            return t.valueToNode(res.value);
+          }
         }
       }
     }


### PR DESCRIPTION
…ss bytes than original

Not sure if this would be the right implementation - I guess it depends on if a minified file or more optimized one is wanted? Maybe it could be a plugin option value in the future?

```js
// Input 
1 / 3
// Output
0.333333333333333
// Output - check the output length
1 / 3
```