### PR TITLE
Fix block scoping with strict mode turned off

### DIFF
--- a/packages/babel/src/transformation/transformers/es6/block-scoping.js
+++ b/packages/babel/src/transformation/transformers/es6/block-scoping.js
@@ -116,6 +116,18 @@ export var visitor = {
       var blockScoping = new BlockScoping(null, this, parent, scope, file);
       blockScoping.run();
     }
+  },
+
+  Function: {
+    exit(node, parent, scope, file) {
+      if (file.transformers["es6.spec.blockScoping"].canTransform()) {
+        var blockScoping = new BlockScoping(null, this, parent, scope, file);
+        blockScoping.run();
+        if (blockScoping.hasLetReferences) {
+          node.params = [];
+        }
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #2374

This is an attempt to fix the issue of mutated arguments without strict mode enabled (IE 9).

Two tests currently fail, but my knowledge of babel internals is non-existant, so I have no clue where they come from and more importantly no idea how to fix it. But maybe it's enough of a starting point for someone who knows his way around to finish this off quickly.