### PR TITLE
RHS of AssignmentPattern can be a reference to a bound variable

### DIFF
--- a/packages/babel/src/types/validators.js
+++ b/packages/babel/src/types/validators.js
@@ -119,9 +119,9 @@ export function isReferenced(node: Object, parent: Object): boolean {
       return parent.right === node;
 
     // no: [NODE = foo] = [];
-    // no: [foo = NODE] = [];
+    // yes: [foo = NODE] = [];
     case "AssignmentPattern":
-      return false;
+      return parent.right === node;
 
     // no: [NODE] = [];
     // no: ({ NODE }) = [];


### PR DESCRIPTION
Fixes #2345.

This bug only occurs when RHS is an Identifier, not some other type of Expression.

This bug may be related to a [refactor](https://github.com/babel/babel/commit/9db43ca7a9509b0f38241cd4ac7a57fa1d41e84a) from June.

Repro the buggy behavior with
```js
function foo(a, b=a) {
    var {c = a} = {};
    return {
        a() { return a; },
    };
}
```