### PR TITLE
Rename the define method to defineType to disambiguate from AMD's “define”

### DIFF
--- a/packages/babel/src/types/definitions/core.js
+++ b/packages/babel/src/types/definitions/core.js
@@ -1,86 +1,86 @@
-import define from "./index";
+import defineType from "./index";
 
-define("ArrayExpression", {
+defineType("ArrayExpression", {
   visitor: ["elements"],
   aliases: ["Expression"]
 });
 
-define("AssignmentExpression", {
+  defineType("AssignmentExpression", {
   builder: ["operator", "left", "right"],
   visitor: ["left", "right"],
   aliases: ["Expression"]
 });
 
-define("BinaryExpression", {
+defineType("BinaryExpression", {
   builder: ["operator", "left", "right"],
   visitor: ["left", "right"],
   aliases: ["Binary", "Expression"]
 });
 
-define("BlockStatement", {
+defineType("BlockStatement", {
   visitor: ["body"],
   aliases: ["Scopable", "BlockParent", "Block", "Statement"]
 });
 
-define("BreakStatement", {
+defineType("BreakStatement", {
   visitor: ["label"],
   aliases: ["Statement", "Terminatorless", "CompletionStatement"]
 });
 
-define("CallExpression", {
+defineType("CallExpression", {
   visitor: ["callee", "arguments"],
   aliases: ["Expression"]
 });
 
-define("CatchClause", {
+defineType("CatchClause", {
   visitor: ["param", "body"],
   aliases: ["Scopable"]
 });
 
-define("ConditionalExpression", {
+defineType("ConditionalExpression", {
   visitor: ["test", "consequent", "alternate"],
   aliases: ["Expression"]
 });
 
-define("ContinueStatement", {
+defineType("ContinueStatement", {
   visitor: ["label"],
   aliases: ["Statement", "Terminatorless", "CompletionStatement"]
 });
 
-define("DebuggerStatement", {
+defineType("DebuggerStatement", {
   aliases: ["Statement"]
 });
 
-define("DoWhileStatement", {
+defineType("DoWhileStatement", {
   visitor: ["body", "test"],
   aliases: ["Statement", "BlockParent", "Loop", "While", "Scopable"]
 });
 
-define("EmptyStatement", {
+defineType("EmptyStatement", {
   aliases: ["Statement"]
 });
 
-define("ExpressionStatement", {
+defineType("ExpressionStatement", {
   visitor: ["expression"],
   aliases: ["Statement"]
 });
 
-define("File", {
+defineType("File", {
   builder: ["program", "comments", "tokens"],
   visitor: ["program"]
 });
 
-define("ForInStatement", {
+defineType("ForInStatement", {
   visitor: ["left", "right", "body"],
   aliases: ["Scopable", "Statement", "For", "BlockParent", "Loop", "ForXStatement"]
 });
 
-define("ForStatement", {
+defineType("ForStatement", {
   visitor: ["init", "test", "update", "body"],
   aliases: ["Scopable", "Statement", "For", "BlockParent", "Loop"]
 });
 
-define("FunctionDeclaration", {
+defineType("FunctionDeclaration", {
   builder: {
     id: null,
     params: null,
@@ -92,7 +92,7 @@ define("FunctionDeclaration", {
   aliases: ["Scopable", "Function", "Func", "BlockParent", "FunctionParent", "Statement", "Pure", "Declaration"]
 });
 
-define("FunctionExpression", {
+defineType("FunctionExpression", {
   builder: {
     id: null,
     params: null,
@@ -104,34 +104,34 @@ define("FunctionExpression", {
   aliases: ["Scopable", "Function", "Func", "BlockParent", "FunctionParent", "Expression", "Pure"]
 });
 
-define("Identifier", {
+defineType("Identifier", {
   builder: ["name"],
   visitor: ["typeAnnotation"],
   aliases: ["Expression"]
 });
 
-define("IfStatement", {
+defineType("IfStatement", {
   visitor: ["test", "consequent", "alternate"],
   aliases: ["Statement"]
 });
 
-define("LabeledStatement", {
+defineType("LabeledStatement", {
   visitor: ["label", "body"],
   aliases: ["Statement"]
 });
 
-define("Literal", {
+defineType("Literal", {
   builder: ["value"],
   aliases: ["Expression", "Pure"]
 });
 
-define("LogicalExpression", {
+defineType("LogicalExpression", {
   builder: ["operator", "left", "right"],
   visitor: ["left", "right"],
   aliases: ["Binary", "Expression"]
 });
 
-define("MemberExpression", {
+defineType("MemberExpression", {
   builder: {
     object: null,
     property: null,
@@ -141,22 +141,22 @@ define("MemberExpression", {
   aliases: ["Expression"]
 });
 
-define("NewExpression", {
+defineType("NewExpression", {
   visitor: ["callee", "arguments"],
   aliases: ["Expression"]
 });
 
-define("ObjectExpression", {
+defineType("ObjectExpression", {
   visitor: ["properties"],
   aliases: ["Expression"]
 });
 
-define("Program", {
+defineType("Program", {
   visitor: ["body"],
   aliases: ["Scopable", "BlockParent", "Block", "FunctionParent"]
 });
 
-define("Property", {
+defineType("Property", {
   builder: {
     kind: "init",
     key: null,
@@ -167,45 +167,45 @@ define("Property", {
   aliases: ["UserWhitespacable"]
 });
 
-define("RestElement", {
+defineType("RestElement", {
   visitor: ["argument", "typeAnnotation"]
 });
 
-define("ReturnStatement", {
+defineType("ReturnStatement", {
   visitor: ["argument"],
   aliases: ["Statement", "Terminatorless", "CompletionStatement"]
 });
 
-define("SequenceExpression", {
+defineType("SequenceExpression", {
   visitor: ["expressions"],
   aliases: ["Expression"]
 });
 
-define("SwitchCase", {
+defineType("SwitchCase", {
   visitor: ["test", "consequent"]
 });
 
-define("SwitchStatement", {
+defineType("SwitchStatement", {
   visitor: ["discriminant", "cases"],
   aliases: ["Statement", "BlockParent", "Scopable"]
 });
 
-define("ThisExpression", {
+defineType("ThisExpression", {
   aliases: ["Expression"]
 });
 
-define("ThrowStatement", {
+defineType("ThrowStatement", {
   visitor: ["argument"],
   aliases: ["Statement", "Terminatorless", "CompletionStatement"]
 });
 
-define("TryStatement", {
+defineType("TryStatement", {
   builder: ["block", "handler", "finalizer"],
   visitor: ["block", "handlers", "handler", "guardedHandlers", "finalizer"],
   aliases: ["Statement"]
 });
 
-define("UnaryExpression", {
+defineType("UnaryExpression", {
   builder: {
     operator: null,
     argument: null,
@@ -215,7 +215,7 @@ define("UnaryExpression", {
   aliases: ["UnaryLike", "Expression"]
 });
 
-define("UpdateExpression", {
+defineType("UpdateExpression", {
   builder: {
     operator: null,
     argument: null,
@@ -225,22 +225,22 @@ define("UpdateExpression", {
   aliases: ["Expression"]
 });
 
-define("VariableDeclaration", {
+defineType("VariableDeclaration", {
   builder: ["kind", "declarations"],
   visitor: ["declarations"],
   aliases: ["Statement", "Declaration"]
 });
 
-define("VariableDeclarator", {
+defineType("VariableDeclarator", {
   visitor: ["id", "init"]
 });
 
-define("WhileStatement", {
+defineType("WhileStatement", {
   visitor: ["test", "body"],
   aliases: ["Statement", "BlockParent", "Loop", "While", "Scopable"]
 });
 
-define("WithStatement", {
+defineType("WithStatement", {
   visitor: ["object", "body"],
   aliases: ["Statement"]
 });

--- a/packages/babel/src/types/definitions/es2015.js
+++ b/packages/babel/src/types/definitions/es2015.js
@@ -1,96 +1,96 @@
-import define from "./index";
+import defineType from "./index";
 
-define("AssignmentPattern", {
+defineType("AssignmentPattern", {
   visitor: ["left", "right"],
   aliases: ["Pattern"]
 });
 
-define("ArrayPattern", {
+defineType("ArrayPattern", {
   visitor: ["elements", "typeAnnotation"],
   aliases: ["Pattern"]
 });
 
-define("ArrowFunctionExpression", {
+defineType("ArrowFunctionExpression", {
   builder: ["params", "body", "async"],
   visitor: ["params", "body", "returnType"],
   aliases: ["Scopable", "Function", "Func", "BlockParent", "FunctionParent", "Expression", "Pure"]
 });
 
-define("ClassBody", {
+defineType("ClassBody", {
   visitor: ["body"]
 });
 
-define("ClassDeclaration", {
+defineType("ClassDeclaration", {
   visitor: ["id", "body", "superClass", "typeParameters", "superTypeParameters", "implements", "decorators"],
   aliases: ["Scopable", "Class", "Statement", "Declaration"]
 });
 
-define("ClassExpression", {
+defineType("ClassExpression", {
   visitor: ["id", "body", "superClass", "typeParameters", "superTypeParameters", "implements", "decorators"],
   aliases: ["Scopable", "Class", "Expression"]
 });
 
-define("ExportAllDeclaration", {
+defineType("ExportAllDeclaration", {
   visitor: ["source", "exported"],
   aliases: ["Statement", "Declaration", "ModuleDeclaration", "ExportDeclaration"]
 });
 
-define("ExportDefaultDeclaration", {
+defineType("ExportDefaultDeclaration", {
   visitor: ["declaration"],
   aliases: ["Statement", "Declaration", "ModuleDeclaration", "ExportDeclaration"]
 });
 
-define("ExportNamedDeclaration", {
+defineType("ExportNamedDeclaration", {
   visitor: ["declaration", "specifiers", "source"],
   aliases: ["Statement", "Declaration", "ModuleDeclaration", "ExportDeclaration"]
 });
 
-define("ExportDefaultSpecifier", {
+defineType("ExportDefaultSpecifier", {
   visitor: ["exported"],
   aliases: ["ModuleSpecifier"]
 });
 
-define("ExportNamespaceSpecifier", {
+defineType("ExportNamespaceSpecifier", {
   visitor: ["exported"],
   aliases: ["ModuleSpecifier"]
 });
 
-define("ExportSpecifier", {
+defineType("ExportSpecifier", {
   visitor: ["local", "exported"],
   aliases: ["ModuleSpecifier"]
 });
 
-define("ForOfStatement", {
+defineType("ForOfStatement", {
   visitor: ["left", "right", "body"],
   aliases: ["Scopable", "Statement", "For", "BlockParent", "Loop", "ForXStatement"]
 });
 
-define("ImportDeclaration", {
+defineType("ImportDeclaration", {
   visitor: ["specifiers", "source"],
   aliases: ["Statement", "Declaration", "ModuleDeclaration"]
 });
 
-define("ImportDefaultSpecifier", {
+defineType("ImportDefaultSpecifier", {
   visitor: ["local"],
   aliases: ["ModuleSpecifier"]
 });
 
-define("ImportNamespaceSpecifier", {
+defineType("ImportNamespaceSpecifier", {
   visitor: ["local"],
   aliases: ["ModuleSpecifier"]
 });
 
-define("ImportSpecifier", {
+defineType("ImportSpecifier", {
   visitor: ["local", "imported"],
   aliases: ["ModuleSpecifier"]
 });
 
-define("MetaProperty", {
+defineType("MetaProperty", {
   visitor: ["meta", "property"],
   aliases: ["Expression"]
 });
 
-define("MethodDefinition", {
+defineType("MethodDefinition", {
   builder: {
     key: null,
     value: null,
@@ -101,33 +101,33 @@ define("MethodDefinition", {
   visitor: ["key", "value", "decorators"]
 });
 
-define("ObjectPattern", {
+defineType("ObjectPattern", {
   visitor: ["properties", "typeAnnotation"],
   aliases: ["Pattern"]
 });
 
-define("SpreadElement", {
+defineType("SpreadElement", {
   visitor: ["argument"],
   aliases: ["UnaryLike"]
 });
 
-define("Super", {
+defineType("Super", {
   aliases: ["Expression"]
 });
 
-define("TaggedTemplateExpression", {
+defineType("TaggedTemplateExpression", {
   visitor: ["tag", "quasi"],
   aliases: ["Expression"]
 });
 
-define("TemplateElement");
+defineType("TemplateElement");
 
-define("TemplateLiteral", {
+defineType("TemplateLiteral", {
   visitor: ["quasis", "expressions"],
   aliases: ["Expression"]
 });
 
-define("YieldExpression", {
+defineType("YieldExpression", {
   builder: ["argument", "delegate"],
   visitor: ["argument"],
   aliases: ["Expression", "Terminatorless"]

--- a/packages/babel/src/types/definitions/experimental.js
+++ b/packages/babel/src/types/definitions/experimental.js
@@ -1,34 +1,34 @@
-import define from "./index";
+import defineType from "./index";
 
-define("AwaitExpression", {
+defineType("AwaitExpression", {
   builder: ["argument", "all"],
   visitor: ["argument"],
   aliases: ["Expression", "Terminatorless"]
 });
 
-define("BindExpression", {
+defineType("BindExpression", {
   visitor: ["object", "callee"]
 });
 
-define("ComprehensionBlock", {
+defineType("ComprehensionBlock", {
   visitor: ["left", "right"]
 });
 
-define("ComprehensionExpression", {
+defineType("ComprehensionExpression", {
   visitor: ["filter", "blocks", "body"],
   aliases: ["Expression", "Scopable"]
 });
 
-define("Decorator", {
+defineType("Decorator", {
   visitor: ["expression"]
 });
 
-define("DoExpression", {
+defineType("DoExpression", {
   visitor: ["body"],
   aliases: ["Expression"]
 });
 
-define("SpreadProperty", {
+defineType("SpreadProperty", {
   visitor: ["argument"],
   aliases: ["UnaryLike"]
 });

--- a/packages/babel/src/types/definitions/flow.js
+++ b/packages/babel/src/types/definitions/flow.js
@@ -1,172 +1,172 @@
-import define from "./index";
+import defineType from "./index";
 
-define("AnyTypeAnnotation", {
+defineType("AnyTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"]
 });
 
-define("ArrayTypeAnnotation", {
+defineType("ArrayTypeAnnotation", {
   visitor: ["elementType"],
   aliases: ["Flow"]
 });
 
-define("BooleanTypeAnnotation", {
+defineType("BooleanTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"]
 });
 
-define("BooleanLiteralTypeAnnotation", {
+defineType("BooleanLiteralTypeAnnotation", {
   aliases: ["Flow"]
 });
 
-define("ClassImplements", {
+defineType("ClassImplements", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"]
 });
 
-define("ClassProperty", {
+defineType("ClassProperty", {
   visitor: ["key", "value", "typeAnnotation", "decorators"],
   aliases: ["Flow"]
 });
 
-define("DeclareClass", {
+defineType("DeclareClass", {
   visitor: ["id", "typeParameters", "extends", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"]
 });
 
-define("DeclareFunction", {
+defineType("DeclareFunction", {
   visitor: ["id"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"]
 });
 
-define("DeclareModule", {
+defineType("DeclareModule", {
   visitor: ["id", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"]
 });
 
-define("DeclareVariable", {
+defineType("DeclareVariable", {
   visitor: ["id"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"]
 });
 
-define("FunctionTypeAnnotation", {
+defineType("FunctionTypeAnnotation", {
   visitor: ["typeParameters", "params", "rest", "returnType"],
   aliases: ["Flow"]
 });
 
-define("FunctionTypeParam", {
+defineType("FunctionTypeParam", {
   visitor: ["name", "typeAnnotation"],
   aliases: ["Flow"]
 });
 
-define("GenericTypeAnnotation", {
+defineType("GenericTypeAnnotation", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"]
 });
 
-define("InterfaceExtends", {
+defineType("InterfaceExtends", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"]
 });
 
-define("InterfaceDeclaration", {
+defineType("InterfaceDeclaration", {
   visitor: ["id", "typeParameters", "extends", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"]
 });
 
-define("IntersectionTypeAnnotation", {
+defineType("IntersectionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow"]
 });
 
-define("MixedTypeAnnotation", {
+defineType("MixedTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"]
 });
 
-define("NullableTypeAnnotation", {
+defineType("NullableTypeAnnotation", {
   visitor: ["typeAnnotation"],
   aliases: ["Flow"]
 });
 
-define("NumberLiteralTypeAnnotation", {
+defineType("NumberLiteralTypeAnnotation", {
   aliases: ["Flow"]
 });
 
-define("NumberTypeAnnotation", {
+defineType("NumberTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"]
 });
 
-define("StringLiteralTypeAnnotation", {
+defineType("StringLiteralTypeAnnotation", {
   aliases: ["Flow"]
 });
 
-define("StringTypeAnnotation", {
+defineType("StringTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"]
 });
 
-define("TupleTypeAnnotation", {
+defineType("TupleTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow"]
 });
 
-define("TypeofTypeAnnotation", {
+defineType("TypeofTypeAnnotation", {
   visitor: ["argument"],
   aliases: ["Flow"]
 });
 
-define("TypeAlias", {
+defineType("TypeAlias", {
   visitor: ["id", "typeParameters", "right"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"]
 });
 
-define("TypeAnnotation", {
+defineType("TypeAnnotation", {
   visitor: ["typeAnnotation"],
   aliases: ["Flow"]
 });
 
-define("TypeCastExpression", {
+defineType("TypeCastExpression", {
   visitor: ["expression", "typeAnnotation"],
   aliases: ["Flow"]
 });
 
-define("TypeParameterDeclaration", {
+defineType("TypeParameterDeclaration", {
   visitor: ["params"],
   aliases: ["Flow"]
 });
 
-define("TypeParameterInstantiation", {
+defineType("TypeParameterInstantiation", {
   visitor: ["params"],
   aliases: ["Flow"]
 });
 
-define("ObjectTypeAnnotation", {
+defineType("ObjectTypeAnnotation", {
   visitor: ["properties", "indexers", "callProperties"],
   aliases: ["Flow"]
 });
 
-define("ObjectTypeCallProperty", {
+defineType("ObjectTypeCallProperty", {
   visitor: ["value"],
   aliases: ["Flow", "UserWhitespacable"]
 });
 
-define("ObjectTypeIndexer", {
+defineType("ObjectTypeIndexer", {
   visitor: ["id", "key", "value"],
   aliases: ["Flow", "UserWhitespacable"]
 });
 
-define("ObjectTypeProperty", {
+defineType("ObjectTypeProperty", {
   visitor: ["key", "value"],
   aliases: ["Flow", "UserWhitespacable"]
 });
 
-define("QualifiedTypeIdentifier", {
+defineType("QualifiedTypeIdentifier", {
   visitor: ["id", "qualification"],
   aliases: ["Flow"]
 });
 
-define("UnionTypeAnnotation", {
+defineType("UnionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow"]
 });
 
-define("VoidTypeAnnotation", {
+defineType("VoidTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"]
 });

--- a/packages/babel/src/types/definitions/index.js
+++ b/packages/babel/src/types/definitions/index.js
@@ -8,7 +8,7 @@ function builderFromArray(arr) {
   return builder;
 }
 
-export default function define(type, opts = {}) {
+export default function defineType(type, opts = {}) {
   opts.visitor = opts.visitor || [];
   opts.aliases = opts.aliases || [];
 

--- a/packages/babel/src/types/definitions/jsx.js
+++ b/packages/babel/src/types/definitions/jsx.js
@@ -1,49 +1,49 @@
-import define from "./index";
+import defineType from "./index";
 
-define("JSXAttribute", {
+defineType("JSXAttribute", {
   visitor: ["name", "value"],
   aliases: ["JSX", "Immutable"]
 });
 
-define("JSXClosingElement", {
+defineType("JSXClosingElement", {
   visitor: ["name"],
   aliases: ["JSX", "Immutable"]
 });
 
-define("JSXElement", {
+defineType("JSXElement", {
   visitor: ["openingElement", "closingElement", "children"],
   aliases: ["JSX", "Immutable", "Expression"]
 });
 
-define("JSXEmptyExpression", {
+defineType("JSXEmptyExpression", {
   aliases: ["JSX", "Expression"]
 });
 
-define("JSXExpressionContainer", {
+defineType("JSXExpressionContainer", {
   visitor: ["expression"],
   aliases: ["JSX", "Immutable"]
 });
 
-define("JSXIdentifier", {
+defineType("JSXIdentifier", {
   aliases: ["JSX", "Expression"]
 });
 
-define("JSXMemberExpression", {
+defineType("JSXMemberExpression", {
   visitor: ["object", "property"],
   aliases: ["JSX", "Expression"]
 });
 
-define("JSXNamespacedName", {
+defineType("JSXNamespacedName", {
   visitor: ["namespace", "name"],
   aliases: ["JSX"]
 });
 
-define("JSXOpeningElement", {
+defineType("JSXOpeningElement", {
   visitor: ["name", "attributes"],
   aliases: ["JSX", "Immutable"]
 });
 
-define("JSXSpreadAttribute", {
+defineType("JSXSpreadAttribute", {
   visitor: ["argument"],
   aliases: ["JSX"]
 });

--- a/packages/babel/src/types/definitions/misc.js
+++ b/packages/babel/src/types/definitions/misc.js
@@ -1,10 +1,10 @@
-import define from "./index";
+import defineType from "./index";
 
-define("Noop", {
+defineType("Noop", {
   visitor: []
 });
 
-define("ParenthesizedExpression", {
+defineType("ParenthesizedExpression", {
   visitor: ["expression"],
   aliases: ["Expression"]
 });


### PR DESCRIPTION
Woud you terribly mind calling this method “defineType”?

I ran into a problem where I was trying to build a project that had this:

    var t = require('babel-core/lib/types');

When my build system (Webpack) hit the `define()` method, it assumed some AMD tomfoolery was afoot, and exploded.

Renaming this to “defineType” sidesteps the problem.