### PR TITLE
[es6.tailCall] Move '<arg> = undefined' to the place in front of Continue statement. 

### DIFF
--- a/packages/babel/src/transformation/transformers/es6/tail-call.js
+++ b/packages/babel/src/transformation/transformers/es6/tail-call.js
@@ -240,20 +240,6 @@ class TailCallTransformer {
       bodyNode._blockHoist = 2;
     }
 
-    if (this.vars.length > 0) {
-      var declarations = flatten(map(this.vars, function (decl) {
-        return decl.declarations;
-      }));
-
-      var assignment = reduceRight(declarations, function (expr, decl) {
-        return t.assignmentExpression("=", decl.id, expr);
-      }, t.identifier("undefined"));
-
-      var statement = t.expressionStatement(assignment);
-      statement._blockHoist = Infinity;
-      body.unshift(statement);
-    }
-
     var paramDecls = this.paramDecls;
     if (paramDecls.length > 0) {
       var paramDecl = t.variableDeclaration("var", paramDecls);
@@ -491,6 +477,19 @@ class TailCallTransformer {
     body.push(t.expressionStatement(
       t.assignmentExpression("=", this.getAgainId(), t.literal(true))
     ));
+
+    if (this.vars.length > 0) {
+      var declarations = flatten(map(this.vars, function (decl) {
+        return decl.declarations;
+      }));
+
+      var assignment = reduceRight(declarations, function (expr, decl) {
+        return t.assignmentExpression("=", decl.id, expr);
+      }, t.identifier("undefined"));
+
+      var statement = t.expressionStatement(assignment);
+      body.push(statement);
+    }
 
     body.push(t.continueStatement(this.getFunctionId()));
 

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters-black-es6-block-scoping/actual.js
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters-black-es6-block-scoping/actual.js
@@ -1,0 +1,6 @@
+function sum(a=1, b=2) {
+  if (b > 0) {
+    return sum(a + 1, b - 1);
+  }
+  return a;
+}

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters-black-es6-block-scoping/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters-black-es6-block-scoping/expected.js
@@ -1,0 +1,20 @@
+"use strict";
+
+function sum() {
+  var _arguments = arguments;
+  var _again = true;
+
+  _function: while (_again) {
+    let a = _arguments.length <= 0 || _arguments[0] === undefined ? 1 : _arguments[0];
+    _again = false;
+    let b = _arguments.length <= 1 || _arguments[1] === undefined ? 2 : _arguments[1];
+
+    if (b > 0) {
+      _arguments = [a + 1, b - 1];
+      _again = true;
+      a = b = undefined;
+      continue _function;
+    }
+    return a;
+  }
+}

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters-black-es6-block-scoping/options.json
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters-black-es6-block-scoping/options.json
@@ -1,0 +1,3 @@
+{
+  "blacklist": ["es6.blockScoping"]
+}

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/default-parameters/expected.js
@@ -5,7 +5,6 @@ function sum() {
   var _again = true;
 
   _function: while (_again) {
-    a = b = undefined;
     var a = _arguments.length <= 0 || _arguments[0] === undefined ? 1 : _arguments[0];
     _again = false;
     var b = _arguments.length <= 1 || _arguments[1] === undefined ? 2 : _arguments[1];
@@ -13,6 +12,7 @@ function sum() {
     if (b > 0) {
       _arguments = [a + 1, b - 1];
       _again = true;
+      a = b = undefined;
       continue _function;
     }
     return a;

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/factorial/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/factorial/expected.js
@@ -6,12 +6,12 @@ function fact(_x2) {
 
   _function: while (_again) {
     var n = _x2;
-    acc = undefined;
     _again = false;
     var acc = _arguments.length <= 1 || _arguments[1] === undefined ? 1 : _arguments[1];
     if (n > 1) {
       _arguments = [_x2 = n - 1, acc * n];
       _again = true;
+      acc = undefined;
       continue _function;
     } else {
       return acc;

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/max-args/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/max-args/expected.js
@@ -5,13 +5,13 @@ var count = function count() {
   var _again = true;
 
   _function: while (_again) {
-    i = undefined;
     _again = false;
     var i = _arguments.length <= 0 || _arguments[0] === undefined ? 10 : _arguments[0];
 
     if (!i) return;
     _arguments = [i - 1];
     _again = true;
+    i = undefined;
     continue _function;
   }
 };
@@ -21,13 +21,13 @@ function count2() {
   var _again2 = true;
 
   _function2: while (_again2) {
-    i = undefined;
     _again2 = false;
     var i = _arguments2.length <= 0 || _arguments2[0] === undefined ? 10 : _arguments2[0];
 
     if (!i) return;
     _arguments2 = [i - 1];
     _again2 = true;
+    i = undefined;
     continue _function2;
   }
 }

--- a/packages/babel/test/fixtures/transformation/es6.tail-call/recursion/expected.js
+++ b/packages/babel/test/fixtures/transformation/es6.tail-call/recursion/expected.js
@@ -6,7 +6,6 @@
 
   _function: while (_again) {
     var n = _x2;
-    m = local1 = local2 = local3 = undefined;
 
     var g = function g() {};
 
@@ -25,6 +24,7 @@
     g = 123;
     _arguments = [_x2 = n - 1];
     _again = true;
+    m = local1 = local2 = local3 = undefined;
     continue _function;
   }
 })(1e6, true) === "foo";


### PR DESCRIPTION
Fixed #2401.