### PR TITLE
Upgrade Regenerator to v0.8.39

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -63,7 +63,7 @@
     "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",
-    "regenerator": "0.8.35",
+    "regenerator": "0.8.39",
     "regexpu": "^1.1.2",
     "repeating": "^1.1.2",
     "resolve": "^1.1.6",


### PR DESCRIPTION
Most notably, this release fixes a bug that made it difficult for `Promise` implementations to track unhandled rejections when using `async` functions: https://github.com/facebook/regenerator/commit/3d8ee21f3ae918edcc04b8b18b0b5f7208883bf0