### PR TITLE
Upgrade Regenerator to 0.8.40

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -63,7 +63,7 @@
     "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",
-    "regenerator": "0.8.39",
+    "regenerator": "0.8.40",
     "regexpu": "^1.1.2",
     "repeating": "^1.1.2",
     "resolve": "^1.1.6",


### PR DESCRIPTION
Most notably, this pegs `regenerator` to a version of `recast` (0.10.33) which pegs `ast-types` to a version (0.8.12) that contains https://github.com/benjamn/ast-types/pull/128, so the Babel client bundle size will be a bit smaller.