### PR TITLE
Use source-map@^0.5.0 and optimize bundle builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "devDependencies": {
     "babel": "5.8.19",
     "babel-eslint": "^4.0.6",
-    "browserify": "^11.0.0",
+    "browserify": "^11.2.0",
+    "bundle-collapser": "^1.2.1",
     "chai": "^2.2.0",
+    "derequire": "^2.0.2",
     "es5-shim": "^4.1.7",
     "eslint": "^1.1.0",
     "fs-readdir-recursive": "^0.1.2",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -18,7 +18,7 @@
     "output-file-sync": "^1.1.0",
     "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
-    "source-map": "^0.4.0",
+    "source-map": "^0.5.0",
     "slash": "^1.0.0"
   },
   "bin": {

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -69,7 +69,7 @@
     "resolve": "^1.1.6",
     "shebang-regex": "^1.0.0",
     "slash": "^1.0.0",
-    "source-map": "^0.4.0",
+    "source-map": "^0.5.0",
     "source-map-support": "^0.2.10",
     "to-fast-properties": "^1.0.0",
     "trim-right": "^1.0.0",

--- a/packages/babel/scripts/build-dist.sh
+++ b/packages/babel/scripts/build-dist.sh
@@ -3,24 +3,54 @@ set -e
 
 BROWSERIFY_CMD="../../node_modules/browserify/bin/cmd.js"
 UGLIFY_CMD="../../node_modules/uglify-js/bin/uglifyjs"
-BROWSERIFY_IGNORE="-i esprima-fb"
+BROWSERIFY_IGNORE="-i esprima-fb -i through"
+
+set -x
 
 mkdir -p dist
 
 node scripts/cache-templates
 
-node $BROWSERIFY_CMD -e lib/polyfill.js >dist/polyfill.js
-node $UGLIFY_CMD dist/polyfill.js >dist/polyfill.min.js
+node $BROWSERIFY_CMD lib/polyfill.js \
+  --insert-global-vars 'global' \
+  --plugin bundle-collapser/plugin \
+  --plugin derequire/plugin \
+  >dist/polyfill.js
+node $UGLIFY_CMD dist/polyfill.js \
+  --compress warnings=false \
+  --mangle \
+  >dist/polyfill.min.js
 
 # Add a Unicode BOM so browsers will interpret the file as UTF-8
 node -p '"\uFEFF"' > dist/browser.js
-node $BROWSERIFY_CMD lib/api/browser.js -s babel $BROWSERIFY_IGNORE >>dist/browser.js
+node $BROWSERIFY_CMD lib/api/browser.js \
+  --standalone babel \
+  --plugin bundle-collapser/plugin \
+  --plugin derequire/plugin \
+  $BROWSERIFY_IGNORE \
+  >>dist/browser.js
 node -p '"\uFEFF"' > dist/browser.min.js
-node $UGLIFY_CMD dist/browser.js >>dist/browser.min.js
+node $UGLIFY_CMD dist/browser.js \
+  --compress warnings=false \
+  --mangle \
+  >>dist/browser.min.js
 
-node $BROWSERIFY_CMD lib/api/node.js --node $BROWSERIFY_IGNORE >dist/node.js
+node $BROWSERIFY_CMD lib/api/node.js \
+  --standalone babel \
+  --node \
+  --plugin bundle-collapser/plugin \
+  --plugin derequire/plugin \
+  $BROWSERIFY_IGNORE \
+  >dist/node.js
+node $UGLIFY_CMD dist/node.js \
+  --compress warnings=false \
+  --mangle \
+  >dist/node.min.js
 
 node ../babel-cli/lib/babel-external-helpers >dist/external-helpers.js
-node $UGLIFY_CMD dist/external-helpers.js >dist/external-helpers.min.js
+node $UGLIFY_CMD dist/external-helpers.js \
+  --compress warnings=false \
+  --mangle \
+  >dist/external-helpers.min.js
 
 rm -rf templates.json


### PR DESCRIPTION
This PR should be merged simultaneously with https://github.com/babel/babel/pull/2424, so there aren't multiple versions of `source-map` installed. Notable changes include:

* Builds are run through [derequire](https://github.com/calvinmetcalf/derequire) and [bundle-collapser](https://github.com/substack/bundle-collapser). So they're smaller and safe to rebundle (if that's your thing).
* Minified files are compressed and mangled – that's something you have to specify in the CLI.
* Added a minified version of the node bundle. I ran some quick tests and using that instead of babel-core shaves 2 seconds off my builds. But, it does mean that the package then has another 860K to carry around. **Feel free to remove this if you want**
* Switched all the flags to their long-form so you know what they do. Also turned on bash debugging (`set -x`) as a poor-man's progress indicator.

| before | after | file |
| -----: | ----: | ---- |
| 2.1M   | 1.9M  | browser.js |
| 1.3M   | 871K  | browser.min.js |
|  12K   |  12K  | external-helpers.js |
| 8.7K   | 5.7K  | external-helpers.min.js |
| 2.0M   | 1.9M  | node.js |
|  n/a   | 860K  | node.min.js |
| 151K   | 135K  | polyfill.js |
| 103K   | 55K   | polyfill.min.js |