### PR TITLE
Reenable input source map option

### DIFF
--- a/packages/babel/src/transformation/file/options/config.json
+++ b/packages/babel/src/transformation/file/options/config.json
@@ -11,10 +11,6 @@
     "type": "string"
   },
 
-  "inputSourceMap": {
-    "hidden": true
-  },
-
   "extra": {
     "hidden": true,
     "default": {}
@@ -238,6 +234,12 @@
   "sourceFileName": {
     "type": "string",
     "description": "set `sources[0]` on returned source map"
+  },
+
+  "inputSourceMap": {
+    "type": "boolean",
+    "description": "use existing source map for source map generation - only works with inline source maps",
+    "default": false
   },
 
   "sourceRoot": {


### PR DESCRIPTION
This change is to revive the work done for #827 that got disabled in
5a319fd553ff28761488c29995d90545e7873c29. Note that some transformers
when used with `--input-source-map` do not produce the correct result
(e.g., `strict` transformer generates the same source map as the
original).

Closes #2336