### PR TITLE
Check for source map file existence before passing it on

### DIFF
--- a/packages/babel/src/transformation/file/index.js
+++ b/packages/babel/src/transformation/file/index.js
@@ -461,17 +461,19 @@ export default class File {
     var inputMap = opts.inputSourceMap;
 
     if (inputMap) {
-      map.sources[0] = inputMap.file;
+      if(inputMap.hasOwnProperty("file")){
+        map.sources[0] = inputMap.file;
 
-      var inputMapConsumer   = new sourceMap.SourceMapConsumer(inputMap);
-      var outputMapConsumer  = new sourceMap.SourceMapConsumer(map);
-      var outputMapGenerator = sourceMap.SourceMapGenerator.fromSourceMap(outputMapConsumer);
-      outputMapGenerator.applySourceMap(inputMapConsumer);
+        var inputMapConsumer   = new sourceMap.SourceMapConsumer(inputMap);
+        var outputMapConsumer  = new sourceMap.SourceMapConsumer(map);
+        var outputMapGenerator = sourceMap.SourceMapGenerator.fromSourceMap(outputMapConsumer);
+        outputMapGenerator.applySourceMap(inputMapConsumer);
 
-      var mergedMap = outputMapGenerator.toJSON();
-      mergedMap.sources = inputMap.sources;
-      mergedMap.file    = inputMap.file;
-      return mergedMap;
+        var mergedMap = outputMapGenerator.toJSON();
+        mergedMap.sources = inputMap.sources;
+        mergedMap.file    = inputMap.file;
+        return mergedMap;
+      }
     }
 
     return map;


### PR DESCRIPTION
## Tests run:
- TEST_GREP=transformation
- TEST_GREP=file

Tried to run a full suite and also TEST_ONLY=babel, but it consistently runs out of memory on my Linode, even with a large swap disk, but it's probable that I've misconfigured the swap, so it's not important.

## Rationalization
As far as I can tell, this won't have many side effects, as it's defensive rather than actively changing the map. My understanding of Babel's structure is far from adequate, though, so I'd really love feedback if that's not the case.

This should indirectly fix babel/babel-loader#103 and STRML/react-grid-layout#39 (the post-close-of-issue error), as well as webpack/webpack#888. (I ran into this behaviour when loading bluebird before babel-loader so that [the polyfill doesn't get overridden](https://github.com/babel/babel-loader#custom-polyfills-eg-promise-library) at webpack compile-time.) It should fix knock-on issues anywhere Babel output is hot-reloaded, compiled, or otherwise manipulated, eg. andreypopp/styling#5.

edit: it's likely that this is a contributor to babel/babel-loader#106 as well.

## The bug
Basically, sometimes when Babel exists within a series of compilers/transpilers/code manipulators, it is possible for it to be passed a source map that doesn't have a file associated with it. In this case, it may well have code and a reference attached, but not having a file/filename to pass on causes an error in [mozilla/source-map](https://github.com/mozilla/source-map/blob/master/lib/util.js#L33) regex matching, with the supremely unhelpful message ` Cannot read property 'match' of undefined` or `Cannot call method 'match' of undefined`.

In other words, Babel attempts to merge an undefined file with the output sourcemap.

Therefore, if the inputMap.file property is undefined in the mergeSourceMaps step, then we just return the outputMap that we know exists, since there's nothing to merge it with.