### PR TITLE
Run Flow before Regenerator is run

### DIFF
--- a/packages/babel/src/transformation/transformers/index.js
+++ b/packages/babel/src/transformation/transformers/index.js
@@ -55,6 +55,9 @@ export default {
   "es7.functionBind":                      require("./es7/function-bind"),
   "spec.undefinedToVoid":                  require("babel-plugin-undefined-to-void"),
 
+  //- Strip flow annotations before running transformers that don't expect flow nodes in the AST
+  flow:                                    require("./other/flow"),
+
   //- builtin-advanced
   "es6.spread":                            require("./es6/spread"),
   "es6.parameters":                        require("./es6/parameters"),
@@ -85,6 +88,5 @@ export default {
   "minification.propertyLiterals":         require("babel-plugin-property-literals"),
   _blockHoist:                             require("./internal/block-hoist"),
   jscript:                                 require("babel-plugin-jscript"),
-  flow:                                    require("./other/flow"),
   "optimisation.modules.system":           require("./optimisation/modules.system"),
 };


### PR DESCRIPTION
Should resolve https://github.com/babel/babel/issues/2477

I've tested this change only on a small bit of my own code so far. Sorry, I didn't write any automated tests for this. I couldn't get the test suite to run (on Master, without my changes). It aborted with an out of memory error. At that point I stopped figuring out how to add a new test.

I'd love to write a test for it though, if someone wouldn't mind lending some direction.