### PR TITLE
[asyncToGenerator] don't move comments after the async fn into the CallExpression

### DIFF
--- a/packages/babel/src/transformation/helpers/remap-async-to-generator.js
+++ b/packages/babel/src/transformation/helpers/remap-async-to-generator.js
@@ -69,6 +69,10 @@ export default function (path, callId) {
       t.variableDeclarator(id, call)
     ]);
     declar._blockHoist = true;
+
+    declar.trailingComments = node.trailingCOmments;
+    delete node.trailingComments;
+
     return declar;
   } else {
     if (id) {

--- a/packages/babel/test/fixtures/transformation/async-to-generator/comment-after-statement/actual.js
+++ b/packages/babel/test/fixtures/transformation/async-to-generator/comment-after-statement/actual.js
@@ -1,0 +1,4 @@
+async function a() {}
+
+/* comment */
+function b() {}

--- a/packages/babel/test/fixtures/transformation/async-to-generator/comment-after-statement/expected.js
+++ b/packages/babel/test/fixtures/transformation/async-to-generator/comment-after-statement/expected.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var a = babelHelpers.asyncToGenerator(function* () {});
+
+/* comment */
+function b() {}


### PR DESCRIPTION
This pr should fix #2489 