### PR TITLE
Fix type annotation in babel-code-frame

### DIFF
--- a/packages/babel-code-frame/README.md
+++ b/packages/babel-code-frame/README.md
@@ -1,1 +1,3 @@
 # babel-code-frame
+
+Pretty prints a segment of code, primarily for use in error messages.

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -74,7 +74,7 @@ function highlight(text) {
  * Create a code frame, adding line numbers, code highlighting, and pointing to a given position.
  */
 
-export default function (lines: number, lineNumber: number, colNumber: number, opts = {}): string {
+export default function (lines: string, lineNumber: number, colNumber: number, opts = {}): string {
   colNumber = Math.max(colNumber, 0);
 
   var highlighted = opts.highlightCode && chalk.supportsColor;


### PR DESCRIPTION
Also add a one-sentence description to the readme