### PR TITLE
Get React.Element#$$typeof from an element instead of inlining it.

### DIFF
--- a/packages/babel/src/transformation/templates/helper-typeof-react-element.js
+++ b/packages/babel/src/transformation/templates/helper-typeof-react-element.js
@@ -1,1 +1,1 @@
-(typeof Symbol === "function" && Symbol.for && Symbol.for("react.element")) || 0xeac7
+require('react').createElement('div').$$typeof


### PR DESCRIPTION
Fixes #2517; Symbol polyfill could break the element check.