### PR TITLE
NormalizeAst accepts File as well

### DIFF
--- a/packages/babel/src/helpers/normalize-ast.js
+++ b/packages/babel/src/helpers/normalize-ast.js
@@ -7,9 +7,12 @@ import * as t from "../types";
  */
 
 export default function (ast, comments, tokens) {
-  if (ast && ast.type === "Program") {
-    return t.file(ast, comments || [], tokens || []);
-  } else {
-    throw new Error("Not a valid ast?");
+  switch (ast && ast.type) {
+    case "File":
+      return ast;
+    case "Program":
+      return t.file(ast, comments || [], tokens || []);
+    default:
+      throw new Error("Not a valid ast?");
   }
 }


### PR DESCRIPTION
It allows us to chain the `babel.transformFile & babel.transform.fromAst` calls.

EDIT: Not sure why but my local test failed with the following message:

```
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory
./scripts/test.sh: line 8:  4987 Abort trap: 6           node node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts mocha.opts --grep "$TEST_GREP"
make: *** [test] Error 134
```

EDIT2: If possible, could you release a new version to npm after merging this? Thanks! :)