### PR TITLE
Printer: Don't put extra parens at returning a sequence

### DIFF
--- a/packages/babel/src/generation/node/parentheses.js
+++ b/packages/babel/src/generation/node/parentheses.js
@@ -135,7 +135,8 @@ export function SequenceExpression(node, parent) {
     return false;
   }
 
-  if (t.isExpressionStatement(parent) && parent.expression === node) {
+  if ((t.isExpressionStatement(parent) && parent.expression === node) ||
+      (t.isReturnStatement(parent) && parent.argument === node))  {
     return false;
   }
 

--- a/packages/babel/test/fixtures/generation/parentheses/sequence-expression/actual.js
+++ b/packages/babel/test/fixtures/generation/parentheses/sequence-expression/actual.js
@@ -1,0 +1,3 @@
+function foo() {
+  return (1, 1);
+}

--- a/packages/babel/test/fixtures/generation/parentheses/sequence-expression/expected.js
+++ b/packages/babel/test/fixtures/generation/parentheses/sequence-expression/expected.js
@@ -1,0 +1,3 @@
+function foo() {
+  return 1, 1;
+}


### PR DESCRIPTION
Fixes #2575.

This is a preview RFC, need to handle line preserving mode to catch the cases like:

```javascript
function foo() {
  return ( // bar
    1,
    2
  );
}
```

(will update the PR after the discussion)