### PR TITLE
Special case paren printing in for-loop init node

### DIFF
--- a/packages/babel/src/generation/generators/expressions.js
+++ b/packages/babel/src/generation/generators/expressions.js
@@ -234,7 +234,6 @@ export function AssignmentExpression(node, print, parent) {
   // todo: add cases where the spaces can be dropped when in compact mode
   print.plain(node.left);
 
-
   var spaces = node.operator === "in" || node.operator === "instanceof";
   spaces = true; // todo: https://github.com/babel/babel/issues/1835
   this.space(spaces);

--- a/packages/babel/src/generation/generators/expressions.js
+++ b/packages/babel/src/generation/generators/expressions.js
@@ -1,5 +1,6 @@
 import isInteger from "is-integer";
 import isNumber from "lodash/lang/isNumber";
+import n from "../node"
 import * as t from "../../types";
 
 /**
@@ -220,9 +221,19 @@ export function AssignmentPattern(node, print) {
  * Prints AssignmentExpression, prints left, operator, and right.
  */
 
-export function AssignmentExpression(node, print) {
+export function AssignmentExpression(node, print, parent) {
+  // Somewhere inside a for statement `init` node but doesn't usually
+  // needs a paren except for `in` expressions: `for (a in b ? a : b;;)`
+  var parens = this._inForStatementInit && node.operator === "in" &&
+               !n.needsParens(node, parent);
+
+  if (parens) {
+    this.push("(");
+  }
+
   // todo: add cases where the spaces can be dropped when in compact mode
   print.plain(node.left);
+
 
   var spaces = node.operator === "in" || node.operator === "instanceof";
   spaces = true; // todo: https://github.com/babel/babel/issues/1835
@@ -241,6 +252,10 @@ export function AssignmentExpression(node, print) {
   this.space(spaces);
 
   print.plain(node.right);
+
+  if (parens) {
+    this.push(")");
+  }
 }
 
 /**

--- a/packages/babel/src/generation/generators/statements.js
+++ b/packages/babel/src/generation/generators/statements.js
@@ -41,7 +41,9 @@ export function ForStatement(node, print) {
   this.keyword("for");
   this.push("(");
 
+  this._inForStatementInit = true;
   print.plain(node.init);
+  this._inForStatementInit = false;
   this.push(";");
 
   if (node.test) {

--- a/packages/babel/test/fixtures/generation/edgecase/for-loop-in/actual.js
+++ b/packages/babel/test/fixtures/generation/edgecase/for-loop-in/actual.js
@@ -1,0 +1,1 @@
+for ((a in b) ? a : b; i;);

--- a/packages/babel/test/fixtures/generation/edgecase/for-loop-in/expected.js
+++ b/packages/babel/test/fixtures/generation/edgecase/for-loop-in/expected.js
@@ -1,0 +1,1 @@
+for ((a in b) ? a : b; i;);


### PR DESCRIPTION
The printer doesn't have ancestry information so we have to set a flag before printing for's `node.init`.
We also need to make sure we're not printing extra parens so we check `node.needsParens` before adding them.

Fixes #2605 