### PR TITLE
It's safe not to parenthesize SequenceExpressions in ReturnStatements

### DIFF
--- a/packages/babel/src/generation/node/parentheses.js
+++ b/packages/babel/src/generation/node/parentheses.js
@@ -139,6 +139,10 @@ export function SequenceExpression(node, parent) {
     return false;
   }
 
+  if (t.isReturnStatement(parent)) {
+    return false;
+  }
+
   // Otherwise err on the side of overparenthesization, adding
   // explicit exceptions above if this proves overzealous.
   return true;

--- a/packages/babel/test/fixtures/generation/types/ReturnStatement/actual.js
+++ b/packages/babel/test/fixtures/generation/types/ReturnStatement/actual.js
@@ -5,3 +5,7 @@ function foo() {
 function bar() {
   return "foo";
 }
+
+function foo() {
+  return 1, "foo";
+}

--- a/packages/babel/test/fixtures/generation/types/ReturnStatement/expected.js
+++ b/packages/babel/test/fixtures/generation/types/ReturnStatement/expected.js
@@ -5,3 +5,7 @@ function foo() {
 function bar() {
   return "foo";
 }
+
+function foo() {
+  return 1, "foo";
+}


### PR DESCRIPTION
Fixes #2575 