### PR TITLE
Add Meteor as a Monorepo example

### DIFF
--- a/doc/design/monorepo.md
+++ b/doc/design/monorepo.md
@@ -22,7 +22,7 @@ This is quite taboo but let's look at the pros and cons:
 
 ## This is dumb! Nobody in open source does this!
 
-[React](https://github.com/facebook/react/tree/master/packages) and [Ember](https://github.com/emberjs/ember.js/tree/master/packages), among others, do this.
+[React](https://github.com/facebook/react/tree/master/packages), [Meteor](https://github.com/meteor/meteor/tree/devel/packages), and [Ember](https://github.com/emberjs/ember.js/tree/master/packages), among others, do this.
 
 ## Previous discussion
 


### PR DESCRIPTION
Meteor is a popular project (almost 30K stars on GitHub) that follows the monorepo approach to develop a lot of independent packages, so I thought this might be a good example to cite.