### PR TITLE
Fix missing `presets` option

### DIFF
--- a/packages/babel/src/transformation/file/options/config.json
+++ b/packages/babel/src/transformation/file/options/config.json
@@ -128,6 +128,12 @@
     "default": []
   },
 
+  "presets": {
+    "type": "list",
+    "description": "",
+    "default": []
+  },
+
   "ignore": {
     "type": "list",
     "description": "list of glob paths to **not** compile",


### PR DESCRIPTION
The `presets` option is missing in the configuration file used to validate options provided to the transform API, such as `babel.transform(data, { presets: "react" })`.