### PR TITLE
Fix typo

### DIFF
--- a/packages/babel-plugin-syntax-class-constructor-call/README.md
+++ b/packages/babel-plugin-syntax-class-constructor-call/README.md
@@ -1,11 +1,11 @@
-# babel-plugin-syntax-class-construtor-call
+# babel-plugin-syntax-class-constructor-call
 
 Allow parsing of do expressions.
 
 ## Installation
 
 ```sh
-$ npm install babel-plugin-syntax-class-construtor-call
+$ npm install babel-plugin-syntax-class-constructor-call
 ```
 
 ## Usage
@@ -16,20 +16,20 @@ $ npm install babel-plugin-syntax-class-construtor-call
 
 ```json
 {
-  "plugins": ["syntax-class-construtor-call"]
+  "plugins": ["syntax-class-constructor-call"]
 }
 ```
 
 ### Via CLI
 
 ```sh
-$ babel --plugins syntax-class-construtor-call script.js
+$ babel --plugins syntax-class-constructor-call script.js
 ```
 
 ### Via Node API
 
 ```javascript
 require("babel-core").transform("code", {
-  plugins: ["syntax-class-construtor-call"]
+  plugins: ["syntax-class-constructor-call"]
 });
 ```

--- a/packages/babel-plugin-transform-class-constructor-call/README.md
+++ b/packages/babel-plugin-transform-class-constructor-call/README.md
@@ -1,9 +1,9 @@
-# babel-plugin-transform-class-construtor-call
+# babel-plugin-transform-class-constructor-call
 
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-class-construtor-call
+$ npm install babel-plugin-transform-class-constructor-call
 ```
 
 ## Usage
@@ -14,20 +14,20 @@ $ npm install babel-plugin-transform-class-construtor-call
 
 ```json
 {
-  "plugins": ["transform-class-construtor-call"]
+  "plugins": ["transform-class-constructor-call"]
 }
 ```
 
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-class-construtor-call script.js
+$ babel --plugins transform-class-constructor-call script.js
 ```
 
 ### Via Node API
 
 ```javascript
 require("babel-core").transform("code", {
-  plugins: ["transform-class-construtor-call"]
+  plugins: ["transform-class-constructor-call"]
 });
 ```

--- a/packages/babel-plugin-transform-class-constructor-call/package.json
+++ b/packages/babel-plugin-transform-class-constructor-call/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-plugin-transform-class-construtor-call",
+  "name": "babel-plugin-transform-class-constructor-call",
   "version": "6.0.2",
   "description": "",
   "repository": "babel/babel",


### PR DESCRIPTION
Think the changes from https://github.com/babel/babel/pull/2638 were lost, and found another spot where there were some typos as well.