### PR TITLE
add shabang to babel/cli.js

### DIFF
--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 console.error("The CLI has been moved into the package `babel-cli`.");
 console.log();
 console.log("$ npm install -g babel-cli");


### PR DESCRIPTION
show deprecated message instead of syntax error.

Before:

```sh
$ npm install -g babel
$ babel
/Users/user/.nodebrew/current/bin/babel: line 1: syntax error near unexpected token `"The CLI has been moved into the package `babel-cli`."'
/Users/user/.nodebrew/current/bin/babel: line 1: `console.error("The CLI has been moved into the package `babel-cli`.");'
```

After:

```sh
$ babel
The CLI has been moved into the package `babel-cli`.

$ npm install -g babel-cli
```