### PR TITLE
only include the `lib` folder in the `babel-generator` package

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -7,6 +7,9 @@
   "license": "MIT",
   "repository": "babel/babel",
   "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "babel-messages": "^6.0.12",
     "babel-runtime": "^6.0.12",


### PR DESCRIPTION
currently, over a megabyte is wasted on including the `test` folder