### PR TITLE
update 6.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
   * The `Property` node type has been renamed to `ObjectProperty`.
   * The `Property` node type with the boolean flag `method` has been renamed to `ObjectMethod` and it's `FunctionExpression` `value` property has been coerced into the main method node.
   * The `Literal` node type has been unoverloaded and split into `BooleanLiteral`, `RegexLiteral`, `NumberLiteral`, `StringLiteral` and `NullLiteral`.
-  * `SpreadProperty` (from `object-rest-spread`) node type has been split into `RestProperty` (for `ObjectPattern`) and `SpreadProperty` (for `ObjectExpression`)
+  * The `SpreadProperty` (from `object-rest-spread`) node type has been split into `RestProperty` (for `ObjectPattern`) and `SpreadProperty` (for `ObjectExpression`)
   * Remove `module.exports` export interop for CommonJS module formatter.
   * `externalHelpers` option has been moved into the plugin `babel-plugin-external-helper-2`.
  * **New Feature**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,11 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
   * Plugins now just return a plain object rather than construct a `Plugin` instance.
   * Change the signature of visitor methods to `.call(state, path, state)` rather than `.call(path, node, parent, scope, state)`.
   * All plugin traversals are now merged for performance.
-  * The `MethodDefinition` node type has been renamed to `ClassMethod` and it's `FunctionExprsesion` `value` property has been coerced into the main method node.
+  * The `MethodDefinition` node type has been renamed to `ClassMethod` and it's `FunctionExpression` `value` property has been coerced into the main method node.
   * The `Property` node type has been renamed to `ObjectProperty`.
-  * The `Property` node type with the boolean flag `method` has been renamed to `ObjectMethod` and it's `FunctionExprsesion` `value` property has been coerced into the main method node.
-  * The `Literal` node type has been unoverloaded and split into `RegexLiteral`, `NumberLiteral`, `StringLiteral` and `NullLiteral`.
+  * The `Property` node type with the boolean flag `method` has been renamed to `ObjectMethod` and it's `FunctionExpression` `value` property has been coerced into the main method node.
+  * The `Literal` node type has been unoverloaded and split into `BooleanLiteral`, `RegexLiteral`, `NumberLiteral`, `StringLiteral` and `NullLiteral`.
+  * `SpreadProperty` (from `object-rest-spread`) node type has been split into `RestProperty` (for `ObjectPattern`) and `SpreadProperty` (for `ObjectExpression`)
   * Remove `module.exports` export interop for CommonJS module formatter.
   * `externalHelpers` option has been moved into the plugin `babel-plugin-external-helper-2`.
  * **New Feature**


### PR DESCRIPTION
fix spelling, add missing `BooleanLiteral`, and and `Spread/RestProperty`