### PR TITLE
Fix .babelrc

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -172,5 +172,11 @@ module.exports = {
   moduleId: {
     description: "specify a custom name for module ids",
     type: "string"
+  },
+
+  extends: {
+    description: "specify another .babelrc you wish to extend",
+    type: "string",
+    hidden: true
   }
 };

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -143,6 +143,8 @@ export default class OptionManager {
 
     this.mergeOptions(opts, loc);
     this.resolvedConfigs.push(loc);
+
+    return typeof opts !== "undefined";
   }
 
   /**
@@ -270,9 +272,8 @@ export default class OptionManager {
         }
 
         let pkgLoc = path.join(loc, PACKAGE_FILENAME);
-        if (exists(pkgLoc)) {
-          this.addConfig(pkgLoc, "babel", JSON);
-          foundConfig = true;
+        if (!foundConfig && exists(pkgLoc)) {
+          foundConfig = this.addConfig(pkgLoc, "babel", JSON);
         }
       }
 


### PR DESCRIPTION
* Added "extend" property to the allowed set of options. Threw `"Unknown option"` before that. (see #2383, #2214)
* When a `.babelrc` was present, the `"babel"` property in an adjacent `package.json` was merged, instead of ignored.
* `package.json` files without a `"babel"` property are now ignored. (My usecase was a `package.json` without babel configuration in a subdirectory: when using babel in said subdirectory, I expected the parent folder’s `.babelrc` to be used)