### PR TITLE
Enable plugins built with Babel 6.0

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -115,6 +115,7 @@ export default class OptionManager {
         let pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname);
         if (pluginLoc) {
           plugin = require(pluginLoc);
+          plugin = plugin.__esModule ? plugin.default : plugin;
         } else {
           throw new ReferenceError(messages.get("pluginUnknown", plugin, loc, i));
         }


### PR DESCRIPTION
[Babel 6.0 removed `module.exports` interop](https://github.com/babel/babel/issues/2212). Now babel itself should embrace it.

Otherwise I get an error like:

```
λ npm test

> babel-plugin-angular2-annotations@2.0.1 test /Users/shuhei/work/js/babel-plugin-angular2-annotations
> node test

- no-annotation
/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-plugin-external-helpers-2/lib/index.js
/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-plugin-syntax-decorators/lib/index.js
/Users/shuhei/work/js/babel-plugin-angular2-annotations/src/index.js
/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/plugin.js:124
      throw new Error(messages.get("pluginInvalidProperty", loc, i, key));
      ^

Error: Plugin 2 specified in "base" provided an invalid property of "default"
    at Plugin.init (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/plugin.js:124:13)
    at Function.normalisePlugin (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/options/option-manager.js:155:12)
    at /Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/options/option-manager.js:184:30
    at Array.map (native)
    at Function.normalisePlugins (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/options/option-manager.js:161:20)
    at OptionManager.mergeOptions (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/options/option-manager.js:254:36)
    at OptionManager.init (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/options/option-manager.js:396:10)
    at File.initOptions (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/index.js:191:75)
    at new File (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/file/index.js:122:22)
    at Pipeline.transform (/Users/shuhei/work/js/babel-plugin-angular2-annotations/node_modules/babel-core/lib/transformation/pipeline.js:42:16)
npm ERR! Test failed.  See above for more details.
```

 The official plugins are working well because they are still built with Babel 5.8.