### PR TITLE
fix async-to-generator not passing arguments. closes #2708

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/expression/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/expression/expected.js
@@ -1,5 +1,3 @@
-var foo = function () {
-  return babelHelpers.asyncToGenerator(function* () {
-    var wat = yield bar();
-  })();
-};
+var foo = babelHelpers.asyncToGenerator(function* () {
+  var wat = yield bar();
+});

--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/named-expression/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/named-expression/expected.js
@@ -1,7 +1,5 @@
-var foo = function () {
-  return babelHelpers.asyncToGenerator(function* bar() {
-    console.log(bar);
-  })();
-};
+var foo = babelHelpers.asyncToGenerator(function* bar() {
+  console.log(bar);
+});
 
 foo();

--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/statement-with-args/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/statement-with-args/actual.js
@@ -1,0 +1,3 @@
+async function foo(bar) {
+  await baz(bar);
+}

--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/statement-with-args/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/statement-with-args/expected.js
@@ -1,0 +1,3 @@
+let foo = babelHelpers.asyncToGenerator(function* foo(bar) {
+  yield baz(bar);
+});

--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/statement/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/statement/expected.js
@@ -1,5 +1,3 @@
-let foo = function foo() {
-  return babelHelpers.asyncToGenerator(function* foo() {
-    var wat = yield bar();
-  })();
-};
+let foo = babelHelpers.asyncToGenerator(function* foo() {
+  var wat = yield bar();
+});

--- a/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/expression/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/expression/expected.js
@@ -1,6 +1,4 @@
 import { coroutine as _coroutine } from "bluebird";
-var foo = function () {
-  return _coroutine(function* () {
-    var wat = yield bar();
-  })();
-};
+var foo = _coroutine(function* () {
+  var wat = yield bar();
+});

--- a/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/named-expression/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/named-expression/expected.js
@@ -1,8 +1,6 @@
 import { coroutine as _coroutine } from "bluebird";
-var foo = function () {
-  return _coroutine(function* bar() {
-    console.log(bar);
-  })();
-};
+var foo = _coroutine(function* bar() {
+  console.log(bar);
+});
 
 foo();

--- a/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/statement-with-args/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/statement-with-args/actual.js
@@ -1,0 +1,3 @@
+async function foo(bar) {
+  await baz(bar);
+}

--- a/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/statement-with-args/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/statement-with-args/expected.js
@@ -1,0 +1,5 @@
+import { coroutine as _coroutine } from "bluebird";
+
+let foo = _coroutine(function* foo(bar) {
+  yield baz(bar);
+});

--- a/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/statement/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/bluebird-coroutines/statement/expected.js
@@ -1,7 +1,5 @@
 import { coroutine as _coroutine } from "bluebird";
 
-let foo = function foo() {
-  return _coroutine(function* foo() {
-    var wat = yield bar();
-  })();
-};
+let foo = _coroutine(function* foo() {
+  var wat = yield bar();
+});

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -34,9 +34,7 @@ export default function (path: NodePath, callId: Object) {
 
   path.traverse(awaitVisitor);
 
-  let container = t.functionExpression(null, [], t.blockStatement([
-    t.returnStatement(t.callExpression(t.callExpression(callId, [node]), []))
-  ]));
+  let container = t.callExpression(callId, [node]);
   node.shadow = container;
 
   if (path.isFunctionDeclaration()) {


### PR DESCRIPTION
Having trouble running tests locally so opening the PR without having run them. Let me know if my assumptions here are wrong.

Example of what happens:
```js
async function foo(bar) {
  await things(bar);
}

let foo = function foo() {
  return _asyncToGenerator(function *foo(bar) {
    yield things(bar);
  })();
};
```

Now, attempting to call it, `foo('stuff')`, however the arg obviously isn't available to the actual function.

I would expect (as I've updated the tests to expect) the following:
```js
let foo = _asyncToGenerator(function *foo(bar) {
  yield things(bar);
});
```

It could alternatively be the following, or similar, if it was felt the outer function is serving a purpose:
```js
let foo = function foo() {
  return _asyncToGenerator(function *foo(bar) {
    yield things(bar);
  }).apply(this, arguments);
};
```

I believe the class-method path is still broken, based off of the test expectations.