### PR TITLE
Remove assert from regenerator plugin

### DIFF
--- a/packages/babel-plugin-transform-regenerator/lib/emit.js
+++ b/packages/babel-plugin-transform-regenerator/lib/emit.js
@@ -923,8 +923,6 @@ Ep.explodeExpression = function(path, ignoreResult) {
   // control the precise order in which the generated code realizes the
   // side effects of those subexpressions.
   function explodeViaTempVar(tempVar, childPath, ignoreChildResult) {
-    assert.ok(childPath instanceof traverse.NodePath);
-
     assert.ok(
       !ignoreChildResult || !tempVar,
       "Ignoring the result of a child expression but forcing it to " +


### PR DESCRIPTION
This was breaking code like the example below, I think because npm might have installed a different copy of babel-traverse, so the instanceof check failed:

```javascript
(async function() {
   console.log(await foo());
})();
```