### PR TITLE
Fix typo related to name change.

### DIFF
--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -1,5 +1,5 @@
 if (global._babelPolyfill) {
-  throw new Error("only one instance of babel/polyfill is allowed");
+  throw new Error("only one instance of babel-polyfill is allowed");
 }
 global._babelPolyfill = true;
 


### PR DESCRIPTION
Hi!

I love babel, and while looking through the code, I noticed a small mistake that got lost in v6 (The error thrown by loading `babel-polyfill` more than once references `babel/polyfill`), so I fixed it.

Enjoy!