### PR TITLE
chore(travis): faster travis with git --depth 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+---
+git:
+  depth: 1
 sudo: false
 language: node_js
 cache:


### PR DESCRIPTION
This is reducing the CI git clone time.