### PR TITLE
fix(typo): missing "s" maybe ?

### DIFF
--- a/packages/babel-core/scripts/build-dist.sh
+++ b/packages/babel-core/scripts/build-dist.sh
@@ -14,7 +14,7 @@ node $BROWSERIFY_CMD lib/api/browser.js \
   --plugin bundle-collapser/plugin \
   --plugin derequire/plugin \
   $BROWSERIFY_IGNORE \
-  >>dist/browser.j
+  >>dist/browser.js
 node -p '"\uFEFF"' > dist/browser.min.js
 node $UGLIFY_CMD dist/browser.js \
   --compress warnings=false \


### PR DESCRIPTION
Yo @sebmck

I just figured that the published packages aren't containing a thing in the "brower" files (see https://npm.jspm.io/babel-core@6.0.17/browser.js)
Isn't just a missing **s** that I'm spotting here  ;)