### PR TITLE
Fix transform-runtime's babel-runtime dependency

### DIFF
--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -9,6 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   }
 }


### PR DESCRIPTION
I was getting these kind of errors with browserify:
```
Cannot find module 'babel-runtime/helpers/slicedToArray' from '/...'
Cannot find module 'babel-runtime/helpers/classCallCheck' from '/...'
Cannot find module 'babel-runtime/helpers/createClass' from '/...'
Cannot find module 'babel-runtime/helpers/toConsumableArray' from '/...'
```