### PR TITLE
add missing build script for `external-helpers.js`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ build-dist: build
 	scripts/build-dist.sh
 	cd packages/babel-runtime; \
 	node scripts/build-dist.js
+	cd packages/babel-cli; \
+	scripts/build-dist.sh
 
 watch: clean
 	scripts/build.sh --watch

--- a/packages/babel-cli/scripts/build-dist.sh
+++ b/packages/babel-cli/scripts/build-dist.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -ex
+
+UGLIFY_CMD="../../node_modules/uglify-js/bin/uglifyjs"
+
+mkdir -p dist
+
+# Add a Unicode BOM so browsers will interpret the file as UTF-8
+node -p '"\uFEFF"' > dist/external-helpers.js
+node lib/babel-external-helpers.js \
+  >>dist/external-helpers.js
+node -p '"\uFEFF"' > dist/external-helpers.min.js
+node $UGLIFY_CMD dist/external-helpers.js \
+  --compress warnings=false \
+  --mangle \
+  >>dist/external-helpers.min.js


### PR DESCRIPTION
`external-helpers.js` has gone since 6.0.0.