### PR TITLE
Allow use of instanceof without Symbol

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -181,7 +181,7 @@ export let inherits = template(`
 
 export let _instanceof = template(`
   (function (left, right) {
-    if (right != null && right[Symbol.hasInstance]) {
+    if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
       return right[Symbol.hasInstance](left);
     } else {
       return left instanceof right;


### PR DESCRIPTION
The change in 31a6cb9c5750253f30a6d3db6e441e5bdb879499 made it so the `typeof` helper would still work where `Symbol` is not defined.  This change does the same for `instanceof`.

See also https://github.com/babel/babel/issues/2745#issuecomment-153139018 (in case the correct fix is to use `transform-runtime` instead).