### PR TITLE
transformation-react-inline-elements: ensure invalid identifier JSX attribute keys are quoted - fixes #2808

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/optimisation.react.inline-elements/key/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/optimisation.react.inline-elements/key/actual.js
@@ -1,1 +1,1 @@
-<Foo key="foo" />
+<Foo key="foo" data-value="bar" />

--- a/packages/babel-core/test/fixtures/transformation/optimisation.react.inline-elements/key/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/optimisation.react.inline-elements/key/expected.js
@@ -3,6 +3,8 @@
   type: Foo,
   key: "foo",
   ref: null,
-  props: babelHelpers.defaultProps(Foo.defaultProps, {}),
+  props: babelHelpers.defaultProps(Foo.defaultProps, {
+    "data-value": "bar"
+  }),
   _owner: null
 });

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -55,7 +55,9 @@ export default function ({ types: t }) {
           if (isJSXAttributeOfName(attr, "key")) {
             key = attr.value;
           } else {
-            pushProp(props.properties, t.identifier(attr.name.name), attr.value || t.identifier("true"));
+            let name = attr.name.name;
+            let propertyKey = t.isValidIdentifier(name) ? t.identifier(name) : t.stringLiteral(name);
+            pushProp(props.properties, propertyKey, attr.value || t.identifier("true"));
           }
         }
 


### PR DESCRIPTION
Fixes #2808 

Same as https://github.com/babel/babel/commit/309a7556ff7031f23c9b1419a005eec50f86963c