### PR TITLE
Change polyfill compression options

### DIFF
--- a/packages/babel-polyfill/scripts/build-dist.sh
+++ b/packages/babel-polyfill/scripts/build-dist.sh
@@ -12,6 +12,6 @@ node $BROWSERIFY_CMD lib/index.js \
   --plugin derequire/plugin \
   >dist/polyfill.js
 node $UGLIFY_CMD dist/polyfill.js \
-  --compress warnings=false \
-  --mangle \
+  --compress keep_fnames,keep_fargs,warnings=false \
+  --mangle keep_fnames \
   >dist/polyfill.min.js


### PR DESCRIPTION
Save names of named functions and unused arguments for correct `.name` and `.length` properties, price - +1kb for `core-js`, no ideas about `regenerator`.