### PR TITLE
Have es2015 rest transform safely use `arguments`

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -105,7 +105,6 @@ export let visitor = {
     // otherwise `arguments` will be remapped in arrow functions
     argsId._shadowedFunctionLiteral = path;
 
-
     function optimiseCandidate(parent, parentPath, offset) {
       if (t.isReturnStatement(parentPath.parent) || t.isIdentifier(parentPath.parent.id)) {
         parentPath.replaceWith(loadRest({
@@ -125,18 +124,6 @@ export let visitor = {
           parent.property = newExpr;
         }
       }
-    }
-
-    // support patterns // no test case?
-    if (t.isPattern(rest)) {
-      let pattern = rest;
-      rest = scope.generateUidIdentifier("ref");
-
-      let declar = t.variableDeclaration("let", pattern.elements.map(function (elem, index) {
-        let accessExpr = t.memberExpression(rest, t.numericLiteral(index), true);
-        return t.variableDeclarator(elem, accessExpr);
-      }));
-      node.body.body.unshift(declar);
     }
 
     // check and optimise for extremely common cases
@@ -174,8 +161,6 @@ export let visitor = {
 
     // deopt shadowed functions as transforms like regenerator may try touch the allocation loop
     state.deopted = state.deopted || !!node.shadow;
-
-    //
 
     let start = t.numericLiteral(node.params.length);
     let key = scope.generateUidIdentifier("key");

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/actual.js
@@ -14,7 +14,7 @@ var somefun = function () {
     };
     var _d = args1[1];
   };
-  let get1stArg = (...args) => args[0];
+  let get3rdArg = (...args) => args[2];
 }
 
 function demo1(...args) {

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
@@ -1,21 +1,21 @@
 var concat = function () {
-  var x = arguments[0];
-  var y = arguments[1];
+  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
+  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
 };
 
 var somefun = function () {
   var get2ndArg = function (a, b) {
-    var _b = arguments[2];
+    var _b = arguments.length <= 2 || arguments[2] === undefined ? undefined : arguments[2];
     var somef = function (x, y, z) {
-      var _a = arguments[3];
+      var _a = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
     };
     var somefg = function (c, d, e, f) {
-      var _a = arguments[4];
+      var _a = arguments.length <= 4 || arguments[4] === undefined ? undefined : arguments[4];
     };
-    var _d = arguments[3];
+    var _d = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
   };
-  var get1stArg = function () {
-    return arguments[0];
+  var get3rdArg = function () {
+    return arguments.length <= 2 || arguments[2] === undefined ? undefined : arguments[2];
   };
 };
 

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
@@ -1,9 +1,9 @@
 var t = function () {
-    var x = arguments[0];
-    var y = arguments[1];
+    var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
+    var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
 };
 
 function t() {
-    var x = arguments[0];
-    var y = arguments[1];
+    var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
+    var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
 }


### PR DESCRIPTION
Hi, I audited some code generated by Babel and noticed that in some cases some improvements could be made to ensure that V8 optimiser (Crankshaft) will not bail out a little too soon. I focused on the use of `arguments`: using `arguments` in an unsafe way prevents V8 (and therefore Node.js) to optimise a function. Here is a first patch in the direction of using `arguments` safely in Babel es2015-transformed code. Although far from perfect in terms of implementation (first time contributor here, still learning Babel internals, happy to receive your comments and/or to chat on slack or by email) this patch will probably give an idea of what could be done, and could be followed by other patches aiming towards the goal of avoiding generation of V8-unoptimisable code.

With this PR I'm only focusing on the very first and easiest part of my findings. In the future, I'll try to fix some other unsafe uses of `arguments` in every transformation and then try to focus on other possible V8 optimisations.

From what I understood, performances are more important to Babel than prettiness. This patch somewhat impacts readability of es2015-presets generated code. But it also has impact on performance.

Although tests are green and I did my best to adhere to what I think are Babel's codebase best practices, please review very carefully. For example, I was not sure whether to include `optimiseLoadStatement` definition in `visitor` (as seen in `defaults.js`) or to define them outside of `visitor`'s scope.