### PR TITLE
core: add dirname option

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -43,6 +43,11 @@ module.exports = {
     hidden: true
   },
 
+  dirname: {
+    type: "string",
+    default: false
+  },
+
   presets: {
     type: "list",
     description: "",

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -170,7 +170,7 @@ export default class OptionManager {
     });
 
     //
-    dirname = dirname || process.cwd();
+    dirname = dirname || opts.dirname || process.cwd();
     loc = loc || alias;
 
     for (let key in opts) {


### PR DESCRIPTION
Hey babel team, I used babel and `gulp-babel`, that's fucking awesome let me program with ES2015. But when I gonna create a global Node.js module which uses `gulp-babel`, I get the following build error:

```
cannot find presets 'es2015'
```

And I'm quite sure that the `babel-presets` are installed under the global module's "node_modules", so after having research on source code of babel-core, just found the key is the following:

```js
dirname = dirname || process.cwd();
```

in `option-manager.js`. The `process.cwd()` seems to be wrong in my scenario, so I added `dirname` option for babel as my first bleed to this project. Thank you :-)

/cc @sebmck 