### PR TITLE
transform-es2015-classes: check if node.id is null

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/es6.classes/export-super-class/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/es6.classes/export-super-class/actual.js
@@ -1,0 +1,1 @@
+export default class extends A {}

--- a/packages/babel-core/test/fixtures/transformation/es6.classes/export-super-class/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/es6.classes/export-super-class/expected.js
@@ -1,0 +1,12 @@
+var _class = (function (_A) {
+  babelHelpers.inherits(_class, _A);
+
+  function _class() {
+    babelHelpers.classCallCheck(this, _class);
+    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(_class).apply(this, arguments));
+  }
+
+  return _class;
+})(A);
+
+export default _class;

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -8,13 +8,15 @@ export default function ({ types: t }) {
       ClassDeclaration(path) {
         let { node } = path;
 
+        let ref = node.id || path.scope.generateUidIdentifier("class");
+
         if (path.parentPath.isExportDefaultDeclaration()) {
           path = path.parentPath;
-          path.insertAfter(t.exportDefaultDeclaration(node.id));
+          path.insertAfter(t.exportDefaultDeclaration(ref));
         }
 
         path.replaceWith(t.variableDeclaration("let", [
-          t.variableDeclarator(node.id, t.toExpression(node))
+          t.variableDeclarator(ref, t.toExpression(node))
         ]));
       },
 


### PR DESCRIPTION
Ref https://github.com/babel/babel/issues/2694#issuecomment-153288054

Not sure if this is the right fix

```bash
TypeError: index.js: Property id of VariableDeclarator expected node to be of a type ["LVal"] but instead got null
    at Object.validate (/Users/hzhu/dev/babel/packages/babel-types/lib/definitions/index.js:99:13)
    at validate (/Users/hzhu/dev/babel/packages/babel-types/lib/index.js:295:9)
    at Object.builder (/Users/hzhu/dev/babel/packages/babel-types/lib/index.js:248:7)
    at PluginPass.ClassDeclaration (/Users/hzhu/dev/test-jscs/node_modules/babel-preset-es2015/node_modules/babel-plugin-transform-es2015-classes/lib/index.js:36:58)
```

at `t.variableDeclarator(node.id, t.toExpression(node));` I guess node.id is null since it is `export default class extends`

https://github.com/babel/babel/blob/4d1145f8721a05cee79201d52583559d4f5939f4/packages/babel-plugin-transform-es2015-classes/src/index.js#L17