### PR TITLE
Use source-map ^0.5.0

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -50,7 +50,7 @@
     "regenerator": "0.8.35",
     "shebang-regex": "^1.0.0",
     "slash": "^1.0.0",
-    "source-map": "^0.4.0",
+    "source-map": "^0.5.0",
     "source-map-support": "^0.2.10"
   },
   "devDependencies": {

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -18,7 +18,7 @@
     "is-integer": "^1.0.4",
     "lodash": "^3.10.1",
     "repeating": "^1.1.3",
-    "source-map": "^0.4.4",
+    "source-map": "^0.5.0",
     "trim-right": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #2836 by reapplying some of the changes from #2425. To test, I had to symlink `babel-core`'s `babel-generator` locally so that it would use the version with the updated `source-map`. I didn't look into the npm publishing script, but it's very important that `babel-browser/scripts/build-dist.sh` runs last and with updated deps – not just for this PR to work, but for any change.

cc: @sebmck 