### PR TITLE
Added react-dispaly-name to the default react package

### DIFF
--- a/packages/babel-preset-react/index.js
+++ b/packages/babel-preset-react/index.js
@@ -4,5 +4,6 @@ module.exports = {
     require("babel-plugin-transform-flow-strip-types"),
     require("babel-plugin-syntax-flow"),
     require("babel-plugin-syntax-jsx"),
+    require("babel-plugin-transform-react-display-name"),
   ]
 };

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "babel-plugin-syntax-flow": "^6.0.14",
     "babel-plugin-syntax-jsx": "^6.0.14",
-    "babel-plugin-transform-react-jsx": "^6.0.14",
-    "babel-plugin-transform-flow-strip-types": "^6.0.14"
+    "babel-plugin-transform-flow-strip-types": "^6.0.14",
+    "babel-plugin-transform-react-display-name": "^6.0.14",
+    "babel-plugin-transform-react-jsx": "^6.0.14"
   }
 }


### PR DESCRIPTION
In babel 5 this was done by default, and now everyone is upgrading to Babel 6 with the React preset and we're seeing a lot of people ask why their React dev tools are showing "No Display Name". 

![](http://wes.io/dkB2/content)

Can we turn this on by default - its a big of a slog for people to install yet another preset just to get the React dev tools + good error messages working. 