### PR TITLE
transform-regenerator: set node.id to an identifier if null - fixes #…

### DIFF
--- a/packages/babel-plugin-transform-regenerator/lib/visit.js
+++ b/packages/babel-plugin-transform-regenerator/lib/visit.js
@@ -146,6 +146,10 @@ function getOuterFnExpr(funPath) {
   var node = funPath.node;
   t.assertFunction(node);
 
+  if (!node.id) {
+    node.id = funPath.scope.parent.generateUidIdentifier("callee");
+  }
+
   if (node.generator && // Non-generator functions don't need to be marked.
       t.isFunctionDeclaration(node)) {
     var pp = funPath.findParent(function (path) {
@@ -171,9 +175,7 @@ function getOuterFnExpr(funPath) {
     );
   }
 
-  return node.id || (
-    node.id = funPath.scope.parent.generateUidIdentifier("callee")
-  );
+  return node.id;
 }
 
 function getRuntimeMarkDecl(blockPath) {


### PR DESCRIPTION
…2835

For the code `export async function foo(){}`

Looks like it is
```
var outerFnExpr = getOuterFnExpr(path);
      // Note that getOuterFnExpr has the side-effect of ensuring that the
      // function has a name (so node.id will always be an Identifier), even
      // if a temporary name has to be synthesized.
      t.assertIdentifier(node.id);
```
in https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-regenerator/lib/visit.js#L74-L78 and `node.id` is null.

Taking the path in https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-regenerator/lib/visit.js#L149-L172 means that node.id is still null so I just moved it above.

Not sure how the tests are working for this one so just goina submit and look into it