### PR TITLE
helper-remap-async-to-generator: account for ObjectMethod - fixes #2838

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/object-method/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/object-method/actual.js
@@ -1,0 +1,6 @@
+let obj = {
+  a: 123,
+  async foo(bar) {
+    return await baz(bar);
+  }
+}

--- a/packages/babel-core/test/fixtures/transformation/async-to-generator/object-method/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/async-to-generator/object-method/expected.js
@@ -1,0 +1,8 @@
+let obj = {
+  a: 123,
+  foo(bar) {
+    return babelHelpers.asyncToGenerator(function* () {
+      return yield baz(bar);
+    })();
+  }
+};

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -24,7 +24,7 @@ let awaitVisitor = {
   }
 };
 
-function classMethod(path: NodePath, callId: Object) {
+function classOrObjectMethod(path: NodePath, callId: Object) {
   let node = path.node;
   let body = node.body;
 
@@ -99,8 +99,8 @@ export default function (path: NodePath, callId: Object) {
 
   path.traverse(awaitVisitor);
 
-  if (path.isClassMethod()) {
-    return classMethod(path, callId);
+  if (path.isClassMethod() || path.isObjectMethod()) {
+    return classOrObjectMethod(path, callId);
   } else {
     return plainFunction(path, callId);
   }


### PR DESCRIPTION
Not sure why my local doesn't seem to be updating when making changes (or I guess I have to npm link `helper-remap-async-to-generator` manually in `transform-async-to-generator`