### PR TITLE
transform-es2015-typeof-symbol: check for undefined - fixes #2865

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/transform-es2015-typeof-symbol/non-typeof/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/transform-es2015-typeof-symbol/non-typeof/actual.js
@@ -1,0 +1,5 @@
+export default function (number) {
+    if (!isNaN(number)) {
+        return 1;
+    }
+}

--- a/packages/babel-core/test/fixtures/transformation/transform-es2015-typeof-symbol/non-typeof/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/transform-es2015-typeof-symbol/non-typeof/expected.js
@@ -1,0 +1,5 @@
+export default function (number) {
+    if (!isNaN(number)) {
+        return 1;
+    }
+}

--- a/packages/babel-core/test/fixtures/transformation/transform-es2015-typeof-symbol/options.json
+++ b/packages/babel-core/test/fixtures/transformation/transform-es2015-typeof-symbol/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-typeof-symbol"]
+}

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
@@ -6,7 +6,7 @@ export default function ({ types: t }) {
       UnaryExpression(path) {
         let { node, parent } = path;
         if (node[IGNORE]) return;
-        if (path.find(path => !!path.node._generated)) return;
+        if (path.find(path => path.node && !!path.node._generated)) return;
 
         if (path.parentPath.isBinaryExpression() && t.EQUALITY_BINARY_OPERATORS.indexOf(parent.operator) >= 0) {
           // optimise `typeof foo === "string"` since we can determine that they'll never need to handle symbols


### PR DESCRIPTION
`path.node` can be undefined since we are traversing up `.parentPath` so this just adds a check

```js
if (path.find(function (path) {
  return !!path.node._generated;
})) return;
```

```js
"use strict";
function find(callback) {
  var path = this;
  do {
    if (callback(path)) return path;
  } while (path = path.parentPath);
  return null;
}
```

Might be good to do a early return: `node.operator !== 'typeof'`?