### PR TITLE
Fixed specifying custom React pragma

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -19,7 +19,7 @@ export default function ({ types: t }) {
 
   visitor.Program = function (path, state) {
     let { file } = state;
-    let id = state.opts.pragma || "React.createElement";
+    let id = file.opts.pragma || "React.createElement";
 
     for (let comment of (file.ast.comments: Array<Object>)) {
       let matches = JSX_ANNOTATION_REGEX.exec(comment.value);


### PR DESCRIPTION
`opts` is a property of `state.file`, not `state`