### PR TITLE
Introduce exec tests for plugin regressions

### DIFF
--- a/packages/babel-core/test/_transformation-helper.js
+++ b/packages/babel-core/test/_transformation-helper.js
@@ -107,8 +107,8 @@ function run(task, done) {
         }
       };
 
-      var fn = new Function("require", "done", "exports", execCode);
-      fn.call(global, fakeRequire, chai.assert, {}, done);
+      var fn = new Function("require", "assert", "exports", "done", "transform", execCode);
+      fn.call(global, fakeRequire, chai.assert, {}, done, transform);
     } catch (err) {
       err.message = exec.loc + ": " + err.message;
       err.message += codeFrame(execCode);

--- a/packages/babel-core/test/fixtures/plugins/regression-2772/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/regression-2772/exec.js
@@ -1,0 +1,37 @@
+var code = `
+(function() {
+  function foo(b){
+    b === "lol";
+    foo(b);
+  }
+})();
+`;
+
+transform(code, {
+  plugins: [
+    function (b) {
+      var t = b.types;
+      return {
+        visitor: {
+          // Replace block statements with a new node without changing anything
+          BlockStatement: function(path) {
+            if (path.node.seen) {
+              return;
+            }
+            var node = t.blockStatement(path.node.body);
+            node.seen = true;
+            path.replaceWith(node);
+          },
+          // do type inference
+          BinaryExpression: function(path) {
+            var left  = path.get("left");
+            var right = path.get("right");
+            left.baseTypeStrictlyMatches(right);
+          }
+        }
+      };
+    }
+  ],
+  compact: true,
+  comments: false,
+}).code;

--- a/packages/babel-core/test/plugins.js
+++ b/packages/babel-core/test/plugins.js
@@ -1,0 +1,1 @@
+require("./_transformation-helper").run("plugins");


### PR DESCRIPTION
This makes it easier to catch regressions and to report plugin issues. Ideally we'd have an input and expected files. But that would require changes to mocha-fixtures too. This is good enough for now.

cc @sebmck @thejameskyle 