### PR TITLE
Some fixes in babel-traverse

### DIFF
--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -87,7 +87,7 @@ traverse.clearNode = function (node) {
     if (key[0] === "_" && node[key] != null) node[key] = undefined;
   }
 
-  let syms: Array<Symbol> = Object.getOwnPropertyNames(node);
+  let syms: Array<Symbol> = Object.getOwnPropertySymbols(node);
   for (let sym of syms) {
     node[sym] = null;
   }

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -33,7 +33,8 @@ function getCache(node, parentScope, self) {
     }
   } else if (!node[CACHE_MULTIPLE_KEY]) {
     // no scope has ever been associated with this node
-    return node[CACHE_SINGLE_KEY] = self;
+    node[CACHE_SINGLE_KEY] = self;
+    return;
   }
 
   // looks like we have either a single scope association that was never matched or


### PR DESCRIPTION
1. Sometimes the scope cache would return the scope that was just inserted to it instead of returning undefined
2. `clearNode()` function would clear all of the properties instead of all the symbols