### PR TITLE
Set the correct node type in helper-remap-async-to-generator - fixes #2744

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -62,6 +62,8 @@ function plainFunction(path: NodePath, callId: Object) {
   let retFunction = container.body.body[1].argument;
 
   if (path.isFunctionDeclaration()) {
+    node.type = "FunctionExpression";
+
     let declar = t.variableDeclaration("let", [
       t.variableDeclarator(
         t.identifier(asyncFnId.name),


### PR DESCRIPTION
The exact problem was that helper-remap-async-to-generator would remap a async function declaration into a generator function expression without modifying the node type. This would cause plugin-transform-regenerator to emit incorrect code, because it thought that the function name was accessible in the declaring scope.