### PR TITLE
Revert 5508f4de567ec59b2bc85f371deddd912be138ef

### DIFF
--- a/packages/babel-plugin-transform-regenerator/lib/visit.js
+++ b/packages/babel-plugin-transform-regenerator/lib/visit.js
@@ -146,10 +146,6 @@ function getOuterFnExpr(funPath) {
   var node = funPath.node;
   t.assertFunction(node);
 
-  if (!node.id) {
-    node.id = funPath.scope.parent.generateUidIdentifier("callee");
-  }
-
   if (node.generator && // Non-generator functions don't need to be marked.
       t.isFunctionDeclaration(node)) {
     var pp = funPath.findParent(function (path) {
@@ -175,7 +171,9 @@ function getOuterFnExpr(funPath) {
     );
   }
 
-  return node.id;
+  return node.id || (
+    node.id = funPath.scope.parent.generateUidIdentifier("callee")
+  );
 }
 
 function getRuntimeMarkDecl(blockPath) {


### PR DESCRIPTION
Reverts babel/babel#2858

Don't need to do this because of https://github.com/babel/babel/pull/2908

the previous code was erroring because of ` t.isFunctionDeclaration(node))` but now it is a function expression?