### PR TITLE
babel-generator: ignore if TemplateLiteral - fixes #2821

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -206,7 +206,7 @@ export function MemberExpression(node: Object) {
     this.print(node.property, node);
     this.push("]");
   } else {
-    if (t.isLiteral(node.object)) {
+    if (t.isLiteral(node.object) && !t.isTemplateLiteral(node.object)) {
       let val = this.getPossibleRaw(node.object) || this._stringLiteral(node.object);
       if (isInteger(+val) && !SCIENTIFIC_NOTATION.test(val) && !this.endsWith(".")) {
         this.push(".");


### PR DESCRIPTION
Not sure if its the right fix but this does solve the issue.

`let val = this.getPossibleRaw(node.object) || this._stringLiteral(node.object);`

Basically `_stringLiteral` calls JSON.stringify on `node.object` which results in the circular structure issue.

----

Or we just remove ` || this._stringLiteral(node.object)` assuming the literals we want are covered by `getPossibleRaw`? (a `NumericLiteral`)