### PR TITLE
Added jsx-source plugin

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-source/.npmignore
+++ b/packages/babel-plugin-transform-react-jsx-source/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+*.log
+src
+test

--- a/packages/babel-plugin-transform-react-jsx-source/README.md
+++ b/packages/babel-plugin-transform-react-jsx-source/README.md
@@ -1,0 +1,48 @@
+# babel-plugin-transform-react-jsx-source
+
+Adds source file and line number to JSX elements.
+
+## Example
+
+###In
+
+```
+<sometag />
+```
+###Out
+
+```
+<sometag __source={{fileName: 'this/file.js', lineNumber: 10}}/>
+```
+
+## Installation
+
+```sh
+$ npm install babel-plugin-transform-react-jsx-source
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["transform-react-jsx-source"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins transform-react-jsx-source script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-react-jsx-source"]
+});
+```

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "babel-plugin-transform-react-jsx-source",
+  "version": "6.0.14",
+  "description": "Add a __source prop to all JSX Elements",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "babel-runtime": "^5.0.0",
+    "babel-plugin-syntax-jsx": "^6.0.14"
+  },
+  "devDependencies": {
+    "babel-helper-plugin-test-runner": "^6.0.0"
+  }
+}

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -1,0 +1,56 @@
+
+ /**
+ * This adds {fileName, lineNumber} annotations to React component definitions
+ * and to jsx tag literals.
+ *
+ *
+ * == JSX Literals ==
+ *
+ * <sometag />
+ *
+ * becomes:
+ *
+ * <sometag __source={{fileName: 'this/file.js', lineNumber: 10}}/>
+ */
+
+
+import path from "path";
+
+const TRACE_ID = "__source";
+
+export default function ({ types: t }) {
+  function objectToAst(object) {
+    const properties = Object.keys(object).map((attr) => {
+      let value;
+      switch(typeof object[attr]) {
+        case "number": value = t.numericLiteral(object[attr]); break;
+        default: value = t.stringLiteral(object[attr].toString());
+      }
+      return t.objectProperty(t.identifier(attr), value);
+    });
+    return t.objectExpression(properties);
+  }
+
+  function makeTrace(fileName, lineNumber) {
+    return objectToAst({
+      fileName,
+      lineNumber,
+    });
+  }
+
+  let visitor = {
+    JSXOpeningElement(node, state) {
+      const id = t.jSXIdentifier(TRACE_ID);
+      const fileName = state.file.log.filename !== "unknown" 
+        ? path.relative(__dirname, state.file.log.filename) 
+        : null;
+      const trace = makeTrace(fileName, node.container.openingElement.loc.start.line);
+
+      node.container.openingElement.attributes.push(t.jSXAttribute(id, t.jSXExpressionContainer(trace)));
+    }
+  };
+
+  return {
+    visitor
+  };
+}

--- a/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/actual.js
+++ b/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/actual.js
@@ -1,0 +1,1 @@
+var x = <sometag />

--- a/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/expected.js
+++ b/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/expected.js
@@ -1,0 +1,4 @@
+var x = <sometag __source={{
+  fileName: "../test/fixtures/react-source/basic-sample/actual.js",
+  lineNumber: 1
+}} />;

--- a/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/options.json
+++ b/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-jsx", "transform-react-jsx-source"]
+}

--- a/packages/babel-plugin-transform-react-jsx-source/test/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/test/index.js
@@ -1,0 +1,1 @@
+require("babel-helper-plugin-test-runner")(__dirname);

--- a/packages/babel-preset-react/index.js
+++ b/packages/babel-preset-react/index.js
@@ -5,5 +5,12 @@ module.exports = {
     require("babel-plugin-syntax-flow"),
     require("babel-plugin-syntax-jsx"),
     require("babel-plugin-transform-react-display-name"),
-  ]
+  ],
+  env: {
+    development: {
+      plugins: [
+        require("babel-plugin-transform-react-jsx-source")
+      ]
+    }
+  }
 };

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -12,6 +12,7 @@
     "babel-plugin-syntax-jsx": "^6.0.14",
     "babel-plugin-transform-flow-strip-types": "^6.0.14",
     "babel-plugin-transform-react-display-name": "^6.0.14",
-    "babel-plugin-transform-react-jsx": "^6.0.14"
+    "babel-plugin-transform-react-jsx": "^6.0.14",
+    "babel-plugin-transform-react-jsx-source": "^6.0.14"
   }
 }


### PR DESCRIPTION
jsx-source plugin adds {fileName, lineNumber} annotations to React jsx tag literals such that `<sometag />` becomes `<sometag __source={{fileName: 'this/file.js', lineNumber: 10}}/>`

cc @sebmck Let's chat before merging, come find me when you get a moment.