### PR TITLE
Fix #2772

### DIFF
--- a/packages/babel-core/test/fixtures/plugins/regression-2772/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/regression-2772/exec.js
@@ -1,7 +1,8 @@
 var code = multiline([
   "(function() {",
+  "  var bar = 'lol';",
   "  function foo(b){",
-  '    b === "lol";',
+  "    b === bar;",
   "    foo(b);",
   "  }",
   "})();",

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -313,7 +313,7 @@ export function _guessExecutionStatusRelativeToDifferentFunctions(targetFuncPare
   for (let path of referencePaths) {
     // if a reference is a child of the function we're checking against then we can
     // safelty ignore it
-    let childOfFunction = !!path.find(path => path === targetFuncPath);
+    let childOfFunction = !!path.find(path => path.node === targetFuncPath.node);
     if (childOfFunction) continue;
 
     let status = this._guessExecutionStatusRelativeTo(path);


### PR DESCRIPTION
Similar to the issue we had with comparing scopes. In this case the we're comparing two references to what should be the same path object but that's not the case. This hints at a deeper issue in babel with path references.

I tracked down the stale path references to the `scope.getFunctionParent()` https://github.com/babel/babel/blob/e63ac82d80b82583a3f14790404c313d6a163792/packages/babel-traverse/src/path/introspection.js#L237