### PR TITLE
Fix the source maps merging

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -362,7 +362,7 @@ export default class File extends Store {
 
       inputMapConsumer.eachMapping(function (mapping) {
         mergedGenerator.addMapping({
-          source: inputMapConsumer.file,
+          source: mapping.source,
 
           original: {
             line: mapping.originalLine,


### PR DESCRIPTION
In the current state, when the inputSourceMap has multiple sources, all the generated source map will point to the first file. Use the mapping's source instead.