### PR TITLE
Babylon README: Correct option name: features => plugins.

### DIFF
--- a/packages/babylon/README.md
+++ b/packages/babylon/README.md
@@ -46,7 +46,7 @@ require("babylon").parse("code", {
   // parse in strict mode and allow module declarations
   sourceType: "module",
 
-  features: [
+  plugins: [
     // enable experimental async functions
     "asyncFunctions",
 


### PR DESCRIPTION
Should I just merge this kind of thing myself?

EDIT: Fix #3042.