### PR TITLE
Fix transform-react-inline-elements' dependency

### DIFF
--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.1.18"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.1.18"


### PR DESCRIPTION
I was getting this error when use webpack with babel-loader:

```
ModuleNotFoundError: Module not found: Error: Cannot resolve module 'babel-runtime/helpers/jsx'
```