### PR TITLE
Make babel-cli watching only given files and extensions. 

### DIFF
--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -137,6 +137,8 @@ module.exports = function (commander, filenames, opts) {
         persistent: true,
         ignoreInitial: true
       }).on("all", function (type, filename) {
+        if (util.shouldIgnore(filename) || !util.canCompile(filename, commander.extensions)) return;
+
         if (type === "add" || type === "change") {
           util.log(type + " " + filename);
           try {


### PR DESCRIPTION
Use --only, --ignore and --extensions while process filenames with --out-file option.