### PR TITLE
Output auxiliaryCommentAfter before trail comment

### DIFF
--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -48,6 +48,9 @@ export default class Printer extends Buffer {
 
     this._print(node, parent);
 
+    // Check again if any of our children may have left an aux comment on the stack
+    if (node.loc) this.printAuxAfterComment();
+
     this.printTrailingComments(node, parent);
 
     if (needsParens) this.push(")");

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/actual.js
@@ -9,6 +9,8 @@ import {foo as bar2} from "foo5";
 export {test};
 export var test = 5;
 
-bar;
+bar(foo);
+
+/* my comment */
 bar2;
 foo;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
@@ -26,7 +26,8 @@ var _foo5 = require("foo5");
 exports. /*after*/test = test;
 var test = /*before*/exports. /*after*/test = 5;
 
-/*before*/_foo4. /*after*/bar;
+/*before*/(0, _foo4. /*after*/bar)( /*before*/_foo2.default) /*after*/;
+
+/* my comment */
 /*before*/_foo5. /*after*/foo;
-/*before*/_foo2.default;
-/*after*/
+/*before*/_foo2.default; /*after*/


### PR DESCRIPTION
Quick fix for the case where generated comment is the terminal leaf in a subtree that is followed by a trailing comment.

Partial for #3034