### PR TITLE
Add resolution of additional module paths as an option

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -112,7 +112,7 @@ export default class OptionManager {
     return plugin;
   }
 
-  static normalisePlugins(loc, dirname, plugins) {
+  static normalisePlugins(loc, dirnames, plugins) {
     return plugins.map(function (val, i) {
       let plugin, options;
 
@@ -127,7 +127,9 @@ export default class OptionManager {
 
       // allow plugins to be specified as strings
       if (typeof plugin === "string") {
-        let pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname);
+        let pluginLoc;
+        dirnames.find((dirname) =>
+          pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname));
         if (pluginLoc) {
           plugin = require(pluginLoc);
         } else {
@@ -190,6 +192,7 @@ export default class OptionManager {
     //
     dirname = dirname || process.cwd();
     loc = loc || alias;
+    const dirnames = [dirname, ...(opts.modulePaths || [])]
 
     for (let key in opts) {
       let option = config[key];
@@ -205,7 +208,7 @@ export default class OptionManager {
 
     // resolve plugins
     if (opts.plugins) {
-      opts.plugins = OptionManager.normalisePlugins(loc, dirname, opts.plugins);
+      opts.plugins = OptionManager.normalisePlugins(loc, dirnames, opts.plugins);
     }
 
     // add extends clause
@@ -221,7 +224,7 @@ export default class OptionManager {
 
     // resolve presets
     if (opts.presets) {
-      this.mergePresets(opts.presets, dirname);
+      this.mergePresets(opts.presets, dirnames);
       delete opts.presets;
     }
 
@@ -240,15 +243,17 @@ export default class OptionManager {
     this.mergeOptions(envOpts, `${alias}.env.${envKey}`);
   }
 
-  mergePresets(presets: Array<string | Object>, dirname: string) {
+  mergePresets(presets: Array<string | Object>, dirnames: Array<string>) {
     for (let val of presets) {
       if (typeof val === "string") {
-        let presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+        let presetLoc;
+        dirnames.find((dirname) =>
+          presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname));
         if (presetLoc) {
           let presetOpts = require(presetLoc);
           this.mergeOptions(presetOpts, presetLoc, presetLoc, path.dirname(presetLoc));
         } else {
-          throw new Error(`Couldn't find preset ${JSON.stringify(val)}`);
+          throw new Error(`Couldn't find preset ${val}`);
         }
       } else if (typeof val === "object") {
         this.mergeOptions(val);


### PR DESCRIPTION
I made this because `babel-node` doesn't allow an ES6 REPL unless presets/plugins are installed in `node_modules/`. With this change, you could do something like this to run ES6 anywhere:

`~/.babelrc`
```
{
  "presets": ["es2015", "stage-0"],
  "modulePaths": ["/usr/local/lib/node_modules/"]
}
```

```bash
$ npm install -g babel-preset-es2015 babel-preset-stage-0
```