### PR TITLE
Fixes @jsx pragma detection + tests

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -1,5 +1,5 @@
 export default function ({ types: t }) {
-  let JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
+  let JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
 
   let visitor = require("babel-helper-builder-react-jsx")({
     pre(state) {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-multiline/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-multiline/actual.js
@@ -1,0 +1,10 @@
+/**
+ * @jsx React.DOM
+ */
+
+<Foo></Foo>;
+
+var profile = <div>
+  <img src="avatar.png" className="profile" />
+  <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-multiline/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-multiline/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "The @jsx React.DOM pragma has been deprecated as of React 0.12"
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-simple/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-simple/actual.js
@@ -1,0 +1,8 @@
+/* @jsx React.DOM */
+
+<Foo></Foo>;
+
+var profile = <div>
+  <img src="avatar.png" className="profile" />
+  <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-simple/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-simple/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "The @jsx React.DOM pragma has been deprecated as of React 0.12"
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-singleline/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-singleline/actual.js
@@ -1,0 +1,8 @@
+// @jsx React.DOM
+
+<Foo></Foo>;
+
+var profile = <div>
+  <img src="avatar.png" className="profile" />
+  <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-singleline/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom-singleline/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "The @jsx React.DOM pragma has been deprecated as of React 0.12"
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom/actual.js
@@ -1,0 +1,8 @@
+/** @jsx React.DOM */
+
+<Foo></Foo>;
+
+var profile = <div>
+  <img src="avatar.png" className="profile" />
+  <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-custom-jsx-comment-sets-react-dom/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "The @jsx React.DOM pragma has been deprecated as of React 0.12"
+}


### PR DESCRIPTION
Fixes [T6648: transform-react-jsx plugin doesn't throw when finding @jsx React.DOM annotation](https://phabricator.babeljs.io/T6648).

I added four test cases that cover common comment styles.