### PR TITLE
Print a block when the consequent is an if statement

### DIFF
--- a/packages/babel-core/test/fixtures/plugins/nested-if-alternate/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/nested-if-alternate/exec.js
@@ -1,0 +1,18 @@
+var res = transform('', {
+  plugins: function (b) {
+    var t = b.types;
+    return {
+      visitor: {
+        Program: function(path) {
+          if (this.done) return;
+          var inner = t.ifStatement(t.booleanLiteral(true), t.expressionStatement(t.numericLiteral(42)), null);
+          var outer = t.ifStatement(t.booleanLiteral(false), inner, t.expressionStatement(t.numericLiteral(23)));
+          path.replaceWith(t.program([outer]));
+          this.done = true;
+        }
+      }
+    }
+  }
+});
+
+assert.equal(eval(res.code), 23);

--- a/packages/babel-core/test/fixtures/plugins/nested-if-alternate/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/nested-if-alternate/exec.js
@@ -5,6 +5,7 @@ var res = transform('', {
       visitor: {
         Program: function(path) {
           if (this.done) return;
+          // if (false) { if (true) 42; } else 23;
           var inner = t.ifStatement(t.booleanLiteral(true), t.expressionStatement(t.numericLiteral(42)), null);
           var outer = t.ifStatement(t.booleanLiteral(false), inner, t.expressionStatement(t.numericLiteral(23)));
           path.replaceWith(t.program([outer]));

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -16,7 +16,20 @@ export function IfStatement(node: Object) {
   this.push(")");
   this.space();
 
+  let consequentIsIf = t.isIfStatement(node.consequent);
+  if (consequentIsIf) {
+    this.push("{");
+    this.newline();
+    this.indent();
+  }
+
   this.printAndIndentOnComments(node.consequent, node);
+
+  if (consequentIsIf) {
+    this.dedent();
+    this.newline();
+    this.push("}");
+  }
 
   if (node.alternate) {
     if (this.isLast("}")) this.space();

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -16,8 +16,8 @@ export function IfStatement(node: Object) {
   this.push(")");
   this.space();
 
-  let consequentIsIf = t.isIfStatement(node.consequent);
-  if (consequentIsIf) {
+  let needsBlock = node.alternate && t.isIfStatement(node.consequent);
+  if (needsBlock) {
     this.push("{");
     this.newline();
     this.indent();
@@ -25,7 +25,7 @@ export function IfStatement(node: Object) {
 
   this.printAndIndentOnComments(node.consequent, node);
 
-  if (consequentIsIf) {
+  if (needsBlock) {
     this.dedent();
     this.newline();
     this.push("}");


### PR DESCRIPTION
When generating code for an if statement that has a consequent that is also an if statement but also has an alternate, then the generated code will show that the alternate belongs to the inner if statement. 