### PR TITLE
Attempt to resolve presets relative to target file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-node_modules
+node_modules/*
+packages/*/node_modules/*
 test/tmp
 *.log
 *.cache

--- a/packages/babel-core/.gitignore
+++ b/packages/babel-core/.gitignore
@@ -1,0 +1,2 @@
+!test/fixtures/api/node_modules/babel-preset-fixture/index.js
+!test/fixtures/api/node_modules/babel-preset-fixture/package.json

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -221,7 +221,7 @@ export default class OptionManager {
 
     // resolve presets
     if (opts.presets) {
-      this.mergePresets(opts.presets, dirname);
+      this.mergePresets(opts.presets, dirname, opts.filename);
       delete opts.presets;
     }
 
@@ -240,10 +240,15 @@ export default class OptionManager {
     this.mergeOptions(envOpts, `${alias}.env.${envKey}`);
   }
 
-  mergePresets(presets: Array<string | Object>, dirname: string) {
+  mergePresets(presets: Array<string | Object>, dirname: string, filename: string) {
     for (let val of presets) {
       if (typeof val === "string") {
         let presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+        if (filename && !presetLoc)  {
+          dirname = path.dirname(filename);
+          presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+        }
+
         if (presetLoc) {
           let presetOpts = require(presetLoc);
           this.mergeOptions(presetOpts, presetLoc, presetLoc, path.dirname(presetLoc));

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -4,6 +4,7 @@ var Pipeline             = require("../lib/transformation/pipeline");
 var sourceMap            = require("source-map");
 var assert               = require("assert");
 var File                 = require("../lib/transformation/file").default;
+var path                 = require("path");
 
 function assertIgnored(result) {
   assert.ok(result.ignored);
@@ -41,6 +42,16 @@ suite("api", function () {
       plugins: [__dirname + "/../../babel-plugin-syntax-jsx"]
     }).then(function (result) {
       assert.ok(result.options.plugins[0][0].manipulateOptions.toString().indexOf("jsx") >= 0);
+    });
+  });
+
+  test("OptionManager resolves presets relative to current file if not found", function () {
+    var filename = path.join(__dirname, 'fixtures', 'api', 'file.js');
+    var manager = new babel.OptionManager();
+
+    manager.mergePresets(['fixture'], process.cwd(), filename);
+    assert.throws(function () {
+      manager.mergePresets(['babel-preset-missing'], process.cwd(), filename);
     });
   });
 

--- a/packages/babel-core/test/fixtures/api/node_modules/babel-preset-fixture/index.js
+++ b/packages/babel-core/test/fixtures/api/node_modules/babel-preset-fixture/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: []
+}

--- a/packages/babel-core/test/fixtures/api/node_modules/babel-preset-fixture/package.json
+++ b/packages/babel-core/test/fixtures/api/node_modules/babel-preset-fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "babel-preset-fixture",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
This PR will make babel attempt to resolve the preset from the current file if unable to resolve a preset relative to `dirname` or `process.cwd()`.

This is required for the new version of babelify to correctly resolve local babel presets specified in a dependency's package.json file, e.g.:

    {
      "browserify": {
        "transform": ["babelify", {"presets":["es2015"]}]
      }
    }

The above previously would work in the project root, but not in a dependency's package.json. babelify will instead expect the user to install each required preset in their project which breaks expected behaviour for packages using browserify transforms.

Hope this helps — thanks!