### PR TITLE
Fixing T3028: 'this' is not allowed before super() error when using class properties with "this"

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/actual.js
@@ -1,0 +1,16 @@
+class b {
+}
+
+class a1 extends b {
+  constructor() {
+    super();
+    this.x = () => this;
+  }
+}
+
+export default class a2 extends b {
+  constructor() {
+    super();
+    this.x = () => this;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
@@ -1,0 +1,45 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var b = function b() {
+  babelHelpers.classCallCheck(this, b);
+};
+
+var a1 = (function (_b) {
+  babelHelpers.inherits(a1, _b);
+
+  function a1() {
+    babelHelpers.classCallCheck(this, a1);
+
+    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(a1).call(this));
+
+    _this.x = function () {
+      return _this;
+    };
+    return _this;
+  }
+
+  return a1;
+})(b);
+
+var a2 = (function (_b2) {
+  babelHelpers.inherits(a2, _b2);
+
+  function a2() {
+    babelHelpers.classCallCheck(this, a2);
+
+    var _this2 = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(a2).call(this));
+
+    _this2.x = function () {
+      return _this2;
+    };
+    return _this2;
+  }
+
+  return a2;
+})(b);
+
+exports.default = a2;


### PR DESCRIPTION
Fixing T3028: ['this' is not allowed before super() error when using class properties with "this"](https://phabricator.babeljs.io/T3028)