### PR TITLE
Avoid duplicating traversal of class declarations - fixes T2694

### DIFF
--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-export/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-export/expected.js
@@ -8,5 +8,5 @@ var MyClass2 = function MyClass2() {
   babelHelpers.classCallCheck(this, MyClass2);
 };
 
-export default MyClass2;
 MyClass2.property = value;
+export default MyClass2;

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -8,15 +8,22 @@ export default function ({ types: t }) {
 
   return {
     visitor: {
+      ExportDefaultDeclaration(path){
+        if (!path.get("declaration").isClassDeclaration()) return;
+
+        let { node } = path;
+        let ref = node.declaration.id || path.scope.generateUidIdentifier("class");
+        node.declaration.id = ref;
+
+        // Split the class declaration and the export into two separate statements.
+        path.replaceWith(node.declaration);
+        path.insertAfter(t.exportDefaultDeclaration(ref));
+      },
+
       ClassDeclaration(path) {
         let { node } = path;
 
         let ref = node.id || path.scope.generateUidIdentifier("class");
-
-        if (path.parentPath.isExportDefaultDeclaration()) {
-          path = path.parentPath;
-          path.insertAfter(t.exportDefaultDeclaration(ref));
-        }
 
         path.replaceWith(t.variableDeclaration("let", [
           t.variableDeclarator(ref, t.toExpression(node))

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/actual.js
@@ -1,0 +1,16 @@
+class b {
+}
+
+class a1 extends b {
+  constructor() {
+    super();
+    this.x = () => this;
+  }
+}
+
+export default class a2 extends b {
+  constructor() {
+    super();
+    this.x = () => this;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
@@ -1,0 +1,45 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var b = function b() {
+  babelHelpers.classCallCheck(this, b);
+};
+
+var a1 = (function (_b) {
+  babelHelpers.inherits(a1, _b);
+
+  function a1() {
+    babelHelpers.classCallCheck(this, a1);
+
+    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(a1).call(this));
+
+    _this.x = function () {
+      return _this;
+    };
+    return _this;
+  }
+
+  return a1;
+})(b);
+
+var a2 = (function (_b2) {
+  babelHelpers.inherits(a2, _b2);
+
+  function a2() {
+    babelHelpers.classCallCheck(this, a2);
+
+    var _this2 = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(a2).call(this));
+
+    _this2.x = function () {
+      return _this2;
+    };
+    return _this2;
+  }
+
+  return a2;
+})(b);
+
+exports.default = a2;


### PR DESCRIPTION
Fixes the final issue mentioned in https://phabricator.babeljs.io/T2694.

The root cause of our `'this' is not allowed before super() (This is an error on an internal node. Probably an internal error)` is that, with the previous setup for classes, we were actually traversing the class twice on accident when `export default` was used. Essentially doing

    path.parentPath.replaceWith(...)

but when you do that, traversal will actually continue within `path` even though it has been replaced. This lead us to a weird case where the class body of class declarations inside `export default` blocks was actually traversed _before_ the class itself, whereas the opposite is true for all other cases.