### PR TITLE
save relative path to source in source maps

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -154,11 +154,9 @@ export default class File extends Store {
       filenameRelative: opts.filename
     });
 
-    let basenameRelative = path.basename(opts.filenameRelative);
-
     defaults(opts, {
-      sourceFileName:   basenameRelative,
-      sourceMapTarget:  basenameRelative
+      sourceFileName:   opts.filenameRelative,
+      sourceMapTarget:  opts.filenameRelative
     });
 
     return opts;


### PR DESCRIPTION
## Before fix:
<img width="178" alt="screen shot 2015-11-22 at 14 06 05" src="https://cloud.githubusercontent.com/assets/6995947/11323610/3d82a3a2-9127-11e5-889a-fd04545b442a.png">

## After fix:
<img width="179" alt="screen shot 2015-11-22 at 15 29 45" src="https://cloud.githubusercontent.com/assets/6995947/11323811/5446798a-912f-11e5-80cc-931975871261.png">


## Simple gulp task to reproduce it:
```
const gulp        = require('gulp');
const babel       = require('gulp-babel');
const sourcemaps  = require('gulp-sourcemaps');

gulp.task('default', () => {
  return gulp.src('src/**/*.js')
    .pipe( sourcemaps.init() )
    .pipe( babel({ presets: ['es2015'] }) )
    .pipe( sourcemaps.write() )
    .pipe( gulp.dest('dest') )
  ;
});
```

## Folders structure of this example:
```
src
├── nested
│   ├── nested
│   │   └── source3.js
│   └── source2.js
└── source1.js
```