### PR TITLE
Fix up semicolon omission in compact mode

### DIFF
--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -101,7 +101,9 @@ export default class Buffer {
 
   rightBrace() {
     this.newline(true);
-    //if (this.format.compact) this._removeLast(";");
+    if (this.format.compact && !this._lastPrintedIsEmptyStatement) {
+      this._removeLast(";");
+    }
     this.push("}");
   }
 

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -130,6 +130,7 @@ export let YieldExpression = buildYieldAwait("yield");
 export let AwaitExpression = buildYieldAwait("await");
 
 export function EmptyStatement() {
+  this._lastPrintedIsEmptyStatement = true;
   this.semicolon();
 }
 

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -13,6 +13,8 @@ export default class Printer extends Buffer {
   print(node, parent, opts = {}) {
     if (!node) return;
 
+    this._lastPrintedIsEmptyStatement = false;
+
     if (parent && parent._compact) {
       node._compact = true;
     }
@@ -144,12 +146,11 @@ export default class Printer extends Buffer {
 
   printBlock(parent) {
     let node = parent.body;
-    if (t.isEmptyStatement(node)) {
-      this.semicolon();
-    } else {
-      this.push(" ");
-      this.print(node, parent);
+    if (!t.isEmptyStatement(node)) {
+      this.space();
     }
+
+    this.print(node, parent);
   }
 
   generateComment(comment) {

--- a/packages/babel-generator/test/fixtures/compact/no-semicolon/actual.js
+++ b/packages/babel-generator/test/fixtures/compact/no-semicolon/actual.js
@@ -1,6 +1,12 @@
 function foo() {
+  var x = 1;
+  y();
   if (bar) {
     baz();
   }
   return;
+}
+
+function bar() {
+    for(;;);
 }

--- a/packages/babel-generator/test/fixtures/compact/no-semicolon/expected.js
+++ b/packages/babel-generator/test/fixtures/compact/no-semicolon/expected.js
@@ -1,1 +1,1 @@
-function foo(){if(bar){baz();}return;}
+function foo(){var x=1;y();if(bar){baz()}return}function bar(){for(;;);}

--- a/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-and-compact-option/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-and-compact-option/expected.js
@@ -1,4 +1,4 @@
 function foo(l){
 return (
 
-l);}
+l)}


### PR DESCRIPTION
Not proud of the implementation but that's the only thing I can come up with. We've chatted about this before but we need to consider rewriting the generator to be more context sensitive.

cc @sebmck @DmitrySoshnikov 