### PR TITLE
Fix T2864

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -359,11 +359,15 @@ export default class File extends Store {
         sourceRoot: inputMapConsumer.sourceRoot
       });
 
+      // This assumes the output map always has a single source, since Babel always compiles a single source file to a
+      // single output file.
+      const source = outputMapConsumer.sources[0];
+
       inputMapConsumer.eachMapping(function (mapping) {
         const generatedPosition = outputMapConsumer.generatedPositionFor({
           line: mapping.generatedLine,
           column: mapping.generatedColumn,
-          source: outputMapConsumer.file
+          source: source
         });
         if(generatedPosition.column != null) {
           mergedGenerator.addMapping({

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -360,20 +360,23 @@ export default class File extends Store {
       });
 
       inputMapConsumer.eachMapping(function (mapping) {
-        mergedGenerator.addMapping({
-          source: mapping.source,
-
-          original: {
-            line: mapping.originalLine,
-            column: mapping.originalColumn
-          },
-
-          generated: outputMapConsumer.generatedPositionFor({
-            line: mapping.generatedLine,
-            column: mapping.generatedColumn,
-            source: outputMapConsumer.file
-          })
+        const generatedPosition = outputMapConsumer.generatedPositionFor({
+          line: mapping.generatedLine,
+          column: mapping.generatedColumn,
+          source: outputMapConsumer.file
         });
+        if(generatedPosition.column != null) {
+          mergedGenerator.addMapping({
+            source: mapping.source,
+
+            original: {
+              line: mapping.originalLine,
+              column: mapping.originalColumn
+            },
+
+            generated: generatedPosition
+          });
+        }
       });
 
       let mergedMap = mergedGenerator.toJSON();


### PR DESCRIPTION
This PR fixes [issue 2864](https://phabricator.babeljs.io/T2864) as well as another, minor mistake.

Babel doesn't generate mappings for leading comments, but it assumes its own sourcemap can map any input position.  Other tools, such as Typescript, *do* create mappings for leading comments.  Babel's sourcemap can't handle those mappings, hence the "Invalid mapping."  Fortunately, it's fine to omit them, which is what my patch does.

The second commit fixes the `source` path being passed to `generatedPositionFor`.  The output sourcemap's `file` and `source[0]` were, coincidentally, both `"unknown"`, which is why the mistake wasn't causing a bug.  I still think this change is warranted since it clarifies the code and avoids a possible future bug.

Let me know if I need to reformat for code style or split this into two PRs.  Thanks!