### PR TITLE
Additional validators for CallExpression, NewExpresion and SequenceExpression

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -53,6 +53,12 @@ function plainFunction(path: NodePath, callId: Object) {
   let asyncFnId = node.id;
   node.id = null;
 
+  let isDeclaration = path.isFunctionDeclaration();
+
+  if (isDeclaration) {
+    node.type = "FunctionExpression";
+  }
+
   let built = t.callExpression(callId, [node]);
   let container = buildWrapper({
     FUNCTION: built,
@@ -61,9 +67,7 @@ function plainFunction(path: NodePath, callId: Object) {
 
   let retFunction = container.body.body[1].argument;
 
-  if (path.isFunctionDeclaration()) {
-    node.type = "FunctionExpression";
-
+  if (isDeclaration) {
     let declar = t.variableDeclaration("let", [
       t.variableDeclarator(
         t.identifier(asyncFnId.name),

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -112,7 +112,7 @@ defineType("CallExpression", {
       validate: assertNodeType("Expression")
     },
     arguments: {
-      validate: assertValueType("array")
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement")))
     }
   },
   aliases: ["Expression"]
@@ -435,7 +435,7 @@ defineType("NewExpression", {
       validate: assertNodeType("Expression")
     },
     arguments: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement")))
     }
   }
 });
@@ -554,7 +554,9 @@ defineType("ReturnStatement", {
 defineType("SequenceExpression", {
   visitor: ["expressions"],
   fields: {
-    expressions: { validate: assertValueType("array") }
+    expressions: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
+    }
   },
   aliases: ["Expression"]
 });

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -12,6 +12,7 @@ import {
 import defineType, {
   assertValueType,
   assertNodeType,
+  assertNodeOrValueType,
   assertEach,
   chain,
   assertOneOf,
@@ -20,7 +21,7 @@ import defineType, {
 defineType("ArrayExpression", {
   fields: {
     elements: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeOrValueType("null", "Expression", "SpreadElement")))
     }
   },
   visitor: ["elements"],

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -20,7 +20,7 @@ import defineType, {
 defineType("ArrayExpression", {
   fields: {
     elements: {
-      validate: assertValueType("array")
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement")))
     }
   },
   visitor: ["elements"],

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -329,7 +329,12 @@ defineType("TemplateLiteral", {
   visitor: ["quasis", "expressions"],
   aliases: ["Expression", "Literal"],
   fields: {
-    // todo
+    quasis: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("TemplateElement")))
+    },
+    expressions: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
+    }
   }
 });
 

--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -61,6 +61,27 @@ export function assertNodeType(...types: Array<string>): Function {
   return validate;
 }
 
+export function assertNodeOrValueType(...types: Array<string>): Function {
+  function validate(node, key, val) {
+    let valid = false;
+
+    for (let type of types) {
+      if (getType(val) === type || t.is(type, val)) {
+        valid = true;
+        break;
+      }
+    }
+
+    if (!valid) {
+      throw new TypeError(`Property ${key} of ${node.type} expected node to be of a type ${JSON.stringify(types)} but instead got ${JSON.stringify(val && val.type)}`);
+    }
+  }
+
+  validate.oneOfNodeOrValueTypes = types;
+
+  return validate;
+}
+
 export function assertValueType(type: string): Function {
   function validate(node, key, val) {
     let valid = getType(val) === type;


### PR DESCRIPTION
Recently I fixed an issue with async-to-generator, which could probably have been identified and fixed faster if validators for `CallExpression` were in place, so I'm adding them, and some other missing validators I found.