### PR TITLE
Add ObjectMember abstract type

### DIFF
--- a/doc/ast/spec.md
+++ b/doc/ast/spec.md
@@ -53,8 +53,9 @@ This document specifies the core ESTree AST node types that support the ES5 gram
   - [AwaitExpression](#awaitexpression)
   - [ArrayExpression](#arrayexpression)
   - [ObjectExpression](#objectexpression)
-    - [ObjectProperty](#objectproperty)
-    - [ObjectMethod](#objectmethod)
+    - [ObjectMember](#objectmember)
+      - [ObjectProperty](#objectproperty)
+      - [ObjectMethod](#objectmethod)
   - [RestProperty](#restproperty)
   - [SpreadProperty](#spreadproperty)
   - [FunctionExpression](#functionexpression)
@@ -631,29 +632,32 @@ interface ObjectExpression <: Expression {
 
 An object expression.
 
-### ObjectProperty
+### ObjectMember
 
 ```js
-interface ObjectProperty <: Node {
-  type: "ObjectProperty";
+interface ObjectMember <: Node {
   key: Expression;
   computed: boolean;
   value: Expression;
-  shorthand: boolean;
   decorators: [ Decorator ];
 }
 ```
 
-### ObjectMethod
+#### ObjectProperty
 
 ```js
-interface ObjectMethod <: Function {
+interface ObjectProperty <: ObjectMember {
+  type: "ObjectProperty";
+  shorthand: boolean;
+}
+```
+
+#### ObjectMethod
+
+```js
+interface ObjectMethod <: ObjectMember, Function {
   type: "ObjectMethod";
-  key: Expression;
-  computed: boolean;
-  value: Expression;
   kind: "get" | "set" | "method";
-  decorators: [ Decorator ];
 }
 ```
 

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -498,7 +498,7 @@ defineType("ObjectMethod", {
     }
   },
   visitor: ["key", "params", "body", "decorators", "returnType", "typeParameters"],
-  aliases: ["UserWhitespacable", "Function", "Scopable", "BlockParent", "FunctionParent", "Method"]
+  aliases: ["UserWhitespacable", "Function", "Scopable", "BlockParent", "FunctionParent", "Method", "ObjectMember"]
 });
 
 defineType("ObjectProperty", {
@@ -527,7 +527,7 @@ defineType("ObjectProperty", {
     }
   },
   visitor: ["key", "value", "decorators"],
-  aliases: ["UserWhitespacable", "Property"]
+  aliases: ["UserWhitespacable", "Property", "ObjectMember"]
 });
 
 defineType("RestElement", {


### PR DESCRIPTION
Based on a conversation @sebmck and I had.

There have been a few times where I want to work with just `ObjectProperty`s and `ObjectMethod`s, and end up needing to manually specifying them to avoid `SpreadProperty`.

They are extremely similar node types so it makes sense to extend from a shared interface.