### PR TITLE
Fix return super(); in class constructor - fixes T2997

### DIFF
--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
@@ -2,10 +2,10 @@ var Foo = (function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {
-    var _temp, _this;
+    var _temp, _this, _ret;
 
     babelHelpers.classCallCheck(this, Foo);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = (_this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this, ...args)), _this), _this.bar = "foo", _temp));
+    return _ret = (_temp = (_this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this, ...args)), _this), _this.bar = "foo", _temp), babelHelpers.possibleConstructorReturn(_this, _ret);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -433,7 +433,15 @@ export default class ClassTransformer {
     }
 
     for (let returnPath of this.superReturns) {
-      returnPath.get("argument").replaceWith(wrapReturn(returnPath.node.argument));
+      if (returnPath.node.argument) {
+        let ref = returnPath.scope.generateDeclaredUidIdentifier("ret");
+        returnPath.get("argument").replaceWithMultiple([
+          t.assignmentExpression("=", ref, returnPath.node.argument),
+          wrapReturn(ref)
+        ]);
+      } else {
+        returnPath.get("argument").replaceWith(wrapReturn())
+      }
     }
   }
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/actual.js
@@ -1,0 +1,7 @@
+class A {}
+
+class B extends A {
+  constructor() {
+    return super();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var A = function A() {
+  babelHelpers.classCallCheck(this, A);
+};
+
+var B = (function (_A) {
+  babelHelpers.inherits(B, _A);
+
+  function B() {
+    var _this, _ret;
+
+    babelHelpers.classCallCheck(this, B);
+
+    return _ret = (_this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(B).call(this)), _this), babelHelpers.possibleConstructorReturn(_this, _ret);
+  }
+
+  return B;
+})(A);
+


### PR DESCRIPTION
When `return super();` or a similar expression appears in the constructor, the emitted code is something like `return _possibleConstructorReturn(_this, _this = something);`. This causes the first argument to `_possibleConstructorReturn()` to be undefined and a runtime error. This PR changes the emitted code to something like `return _ret = (_this = something), _possibleConstructorReturn(_this, _ret);`. The change will happen regardless of whether `super()` was actually used in the return statement or not, but this shouldn't affect the semantics of the emitted code in any way.