### PR TITLE
Check for empty decorators array on property nodes

### DIFF
--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -51,7 +51,7 @@ export default function ({ types: t }) {
 
         for (let prop of props) {
           let propNode = prop.node;
-          if (propNode.decorators) continue;
+          if (propNode.decorators && propNode.decorators.length > 0) continue;
           if (!propNode.value) continue;
 
           let isStatic = propNode.static;


### PR DESCRIPTION
This fixes https://phabricator.babeljs.io/T6714

I'm not sure how to add a test, because the bug only occurs on ASTs with empty Array-valued, not null-valued, `decorator` property on ClassProperty nodes. This can't be setup via a source fixture.