### PR TITLE
Disable babelrc processing on the already-processed configuration - fixes T6690

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -70,6 +70,9 @@ function compile(filename) {
 
   if (!result) {
     result = babel.transformFileSync(filename, extend(opts, {
+      // Do not process config files since has already been done with the OptionManager
+      // calls above and would introduce duplicates.
+      babelrc: false,
       sourceMap: "both",
       ast:       false
     }));


### PR DESCRIPTION
See explanation in https://phabricator.babeljs.io/T6690