### PR TITLE
fix code generation for ExportAllDeclaration

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
@@ -5,13 +5,15 @@ define(["exports", "foo"], function (exports, _foo) {
     value: true
   });
 
-  for (let _key in _foo) {
+  for (var _key in _foo) {
     if (_key === "default") continue;
     Object.defineProperty(exports, _key, {
       enumerable: true,
-      get: function () {
-        return _foo[_key];
-      }
+      get: (function (k) {
+        return function () {
+          return _foo[k];
+        };
+      })(_key)
     });
   }
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -30,14 +30,16 @@ let buildExportsAssignment = template(`
 `);
 
 let buildExportAll = template(`
-  for (let KEY in OBJECT) {
+  for (var KEY in OBJECT) {
     if (KEY === "default") continue;
 
     Object.defineProperty(exports, KEY, {
       enumerable: true,
-      get: function () {
-        return OBJECT[KEY];
-      }
+      get: (function (k) {
+        return function () {
+          return OBJECT[k];
+        };
+      })(KEY)
     });
   }
 `);

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
@@ -6,13 +6,15 @@ Object.defineProperty(exports, "__esModule", {
 
 var _foo = require("foo");
 
-for (let _key in _foo) {
+for (var _key in _foo) {
   if (_key === "default") continue;
   Object.defineProperty(exports, _key, {
     enumerable: true,
-    get: function () {
-      return _foo[_key];
-    }
+    get: (function (k) {
+      return function () {
+        return _foo[k];
+      };
+    })(_key)
   });
 }
 

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
@@ -17,13 +17,15 @@
     value: true
   });
 
-  for (let _key in _foo) {
+  for (var _key in _foo) {
     if (_key === "default") continue;
     Object.defineProperty(exports, _key, {
       enumerable: true,
-      get: function () {
-        return _foo[_key];
-      }
+      get: (function (k) {
+        return function () {
+          return _foo[k];
+        };
+      })(_key)
     });
   }
 


### PR DESCRIPTION
Cannot use `let` as `babel-plugin-transform-es2015-block-scoping` transpiles it into a `var` and then the last value of `KEY` is returned for __all__ exported members.