### PR TITLE
Add punctuation to traverseNeedsParent message.

### DIFF
--- a/packages/babel-messages/src/index.js
+++ b/packages/babel-messages/src/index.js
@@ -32,7 +32,7 @@ export const MESSAGES = {
   undeclaredVariableType: "Referencing a type alias outside of a type annotation",
   undeclaredVariableSuggestion: "Reference to undeclared variable $1 - did you mean $2?",
 
-  traverseNeedsParent: "You must pass a scope and parentPath unless traversing a Program/File got a $1 node",
+  traverseNeedsParent: "You must pass a scope and parentPath unless traversing a Program/File. Instead of that you tried to traverse a $1 node without passing scope and parentPath.",
   traverseVerifyRootFunction: "You passed `traverse()` a function when it expected a visitor object, are you sure you didn't mean `{ enter: Function }`?",
   traverseVerifyVisitorProperty: "You passed `traverse()` a visitor object with the property $1 that has the invalid property $2",
   traverseVerifyNodeType: "You gave us a visitor for the node type $1 but it's not a valid type",


### PR DESCRIPTION
Is this how it's supposed to read? Saw it [here](https://github.com/documentationjs/documentation/pull/218/files#r46338346) and just thought it should be `a => an`, but then when I looked it up it seemed like it has a different meaning than I originally read it as.

> Error: You must pass a scope and parentPath unless traversing a Program/File got a undefined node
