### PR TITLE
Fixing some Windows build issues

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -22,13 +22,16 @@ gulp.task("build", function () {
     }))
     .pipe(through.obj(function (file, enc, callback) {
       file._path = file.path;
-      file.path = file.path.substr(0, __dirname.length) +
-        file.path.substr(__dirname.length).replace(/\bsrc\b/, 'lib');
-      if (file.path === file._path) {
-        callback(new Error('Failed to construct build path: ' + file._path))
-      } else {
-        callback(null, file);
+      // Replace src with lib
+      var sub = file.path.substr(__dirname.length);
+      var pathComp = path.normalize(sub).split(path.sep);
+      var idx = pathComp.indexOf("src");
+      if (idx < 0) {
+        return callback(new Error("Failed to construct build path: " + file.path));
       }
+      pathComp[idx] = "lib";
+      file.path = path.join(__dirname, path.join.apply(null, pathComp));
+      callback(null, file);
     }))
     .pipe(newer(dest))
     .pipe(through.obj(function (file, enc, callback) {

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -22,8 +22,13 @@ gulp.task("build", function () {
     }))
     .pipe(through.obj(function (file, enc, callback) {
       file._path = file.path;
-      file.path = file.path.replace(/^([^\\]+)\/src/, "$1/lib");
-      callback(null, file);
+      file.path = file.path.substr(0, __dirname.length) +
+        file.path.substr(__dirname.length).replace(/\bsrc\b/, 'lib');
+      if (file.path === file._path) {
+        callback(new Error('Failed to construct build path: ' + file._path))
+      } else {
+        callback(null, file);
+      }
     }))
     .pipe(newer(dest))
     .pipe(through.obj(function (file, enc, callback) {

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -83,7 +83,7 @@ async.parallelLimit(packages.map(function (root) {
             }, null, "  "), function (err) {
               if (err) return done(err);
 
-              fs.writeFile(linkDest + "/index.js", 'module.exports = require("' + linkSrc + '");', done);
+              fs.writeFile(linkDest + "/index.js", 'module.exports = require(' + JSON.stringify(linkSrc) + ');', done);
             });
           });
         });

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -35,7 +35,7 @@ ls("packages/*").forEach(function (loc) {
 
 var completed = false;
 
-var bar = new ProgressBar(":packagename ╢:bar╟", {
+var bar = !/^win/.test(process.platform) && new ProgressBar(":packagename ╢:bar╟", {
   total: packages.length,
   complete: "█",
   incomplete: "░",
@@ -105,7 +105,7 @@ async.parallelLimit(packages.map(function (root) {
     });
 
     tasks.push(function (done) {
-      if (!completed) bar.tick({
+      if (!completed && bar) bar.tick({
         packagename: pad(root.name.slice(0, 50), 50)
       });
       done();


### PR DESCRIPTION
- In the Gulpfile, replacing `src` with `lib` in the path name failed because of slash/backslash issues. This would cause Babel to overwrite the files in-place. Additionally, I happened to have the codebase under `C:\src\babel` (a path which contains `src`) and it didn't like that very much either.
- The `require` call generated by `bootstrap.js` didn't replace backslashes, so the path would become invalid. A `JSON.stringify` seemed like the easiest solution.
- Also in `bootstrap.js`, `progress` would crash on a call to `stream.clearLine()`. A quick Google search suggests that it's got something to do with `stream` being a `Socket` rather than a TTY but I didn't investigate it fully. Instead, I just disabled the progress bar on Windows to at least get the build working.