### PR TITLE
Ensure we always push into a BlockStatement - fixes T3051

### DIFF
--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/actual.js
@@ -1,0 +1,14 @@
+function withContext(ComposedComponent) {
+    return class WithContext extends Component {
+
+        static propTypes = {
+            context: PropTypes.shape(
+                {
+                    addCss: PropTypes.func,
+                    setTitle: PropTypes.func,
+                    setMeta: PropTypes.func,
+                }
+            ),
+        };
+    };
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
@@ -1,0 +1,20 @@
+function withContext(ComposedComponent) {
+    var _class, _temp;
+
+    return _temp = _class = (function (_Component) {
+        babelHelpers.inherits(WithContext, _Component);
+
+        function WithContext() {
+            babelHelpers.classCallCheck(this, WithContext);
+            return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(WithContext).apply(this, arguments));
+        }
+
+        return WithContext;
+    })(Component), _class.propTypes = {
+        context: PropTypes.shape({
+            addCss: PropTypes.func,
+            setTitle: PropTypes.func,
+            setMeta: PropTypes.func
+        })
+    }, _temp;
+}

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -745,13 +745,13 @@ export default class Scope {
       path = this.getFunctionParent().path;
     }
 
+    if (!path.isBlockStatement() && !path.isProgram()) {
+      path = this.getBlockParent().path;
+    }
+
     if (path.isLoop() || path.isCatchClause() || path.isFunction()) {
       t.ensureBlock(path.node);
       path = path.get("body");
-    }
-
-    if (!path.isBlockStatement() && !path.isProgram()) {
-      path = this.getBlockParent().path;
     }
 
     let unique = opts.unique;


### PR DESCRIPTION
Basically we were trying to push into the FunctionExpression.body instead of BlockStatement.body