### PR TITLE
babel-traverse: 6.3.2 changes caused my webpack build to stop working

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -745,13 +745,13 @@ export default class Scope {
       path = this.getFunctionParent().path;
     }
 
-    if (!path.isBlockStatement() && !path.isProgram()) {
-      path = this.getBlockParent().path;
-    }
-
     if (path.isLoop() || path.isCatchClause() || path.isFunction()) {
       t.ensureBlock(path.node);
       path = path.get("body");
+    }
+
+    if (!path.isBlockStatement() && !path.isProgram()) {
+      path = this.getBlockParent().path;
     }
 
     let unique = opts.unique;


### PR DESCRIPTION
`6.3.2` switched two if statements, which inexplicably caused our webpack build to die with the following cryptic message for everyone who've run `npm install` on my office:

````
ERROR in ./components/layout/layout.js
Module build failed: TypeError: /Users/oskar/src/xxxx/components/layout/layout.js: Cannot read property '0' of undefined
    at Function.get (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/index.js:89:31)
    at NodePath.unshiftContainer (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/modification.js:244:33)
    at Scope.push (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/scope/index.js:1037:41)
    at Scope.maybeGenerateMemoised (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/scope/index.js:469:27)
    at PluginPass.CallExpression (/Users/oskar/src/xxxx/node_modules/babel-preset-es2015-loose/node_modules/babel-plugin-transform-es2015-spread/lib/index.js:116:28)
    at newFn (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/visitors.js:276:19)
    at NodePath._call (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:74:18)
    at NodePath.call (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:46:17)
    at NodePath.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:104:12)
    at TraversalContext.visitQueue (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:153:16)
    at TraversalContext.visitSingle (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:113:19)
    at TraversalContext.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:197:19)
    at Function.traverse.node (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/index.js:139:17)
    at NodePath.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:114:22)
    at TraversalContext.visitQueue (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:153:16)
    at TraversalContext.visitMultiple (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:108:17)
    at TraversalContext.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:195:19)
    at Function.traverse.node (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/index.js:139:17)
    at NodePath.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:114:22)
    at TraversalContext.visitQueue (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:153:16)
    at TraversalContext.visitMultiple (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:108:17)
    at TraversalContext.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:195:19)
    at Function.traverse.node (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/index.js:139:17)
    at NodePath.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:114:22)
    at TraversalContext.visitQueue (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:153:16)
    at TraversalContext.visitMultiple (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:108:17)
    at TraversalContext.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:195:19)
    at Function.traverse.node (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/index.js:139:17)
    at NodePath.visit (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/path/context.js:114:22)
    at TraversalContext.visitQueue (/Users/oskar/src/xxxx/node_modules/babel-core/node_modules/babel-traverse/lib/context.js:153:16)
````

Unfortunately I cannot provide you with `layout.js` right now (please don't kill me) but this small change causes the error message to disappear. Someone who's a bit more familiar with the actual code maybe knows why it was moved?

The git blame says @loganfsmyth is the one who switched the code, maybe you can provide some input?

Thank you!