### PR TITLE
Ensure that default exports have a name before splitting them - fixes T6750

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/actual.js
@@ -1,0 +1,6 @@
+export default function() {
+  return class Select {
+    query(query) {
+    }
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/expected.js
@@ -1,0 +1,19 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+function _default() {
+  return (function () {
+    function Select() {
+      babelHelpers.classCallCheck(this, Select);
+    }
+
+    babelHelpers.createClass(Select, [{
+      key: "query",
+      value: function query(_query) {}
+    }]);
+    return Select;
+  })();
+}
+exports.default = _default;

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -40,6 +40,14 @@ export default class Renamer {
 
     // build specifiers that point back to this export declaration
     let isDefault = exportDeclar.isExportDefaultDeclaration();
+
+    if (isDefault && (parentDeclar.isFunctionDeclaration() ||
+        parentDeclar.isClassDeclaration())&& !parentDeclar.node.id) {
+      // Ensure that default class and function exports have a name so they have a identifier to
+      // reference from the export specifier list.
+      parentDeclar.node.id = parentDeclar.scope.generateUidIdentifier("default");
+    }
+
     let bindingIdentifiers = parentDeclar.getOuterBindingIdentifiers();
     let specifiers = [];
 


### PR DESCRIPTION
Honestly not 100% clear on why this renaming is happening in this case. That said, either way there is a renamer bug here. Basically it was building an export specifier list from the name of the function, but because it had none, it was inserting a standalone `export {}`