### PR TITLE
Move destructuring statements off export statements before processing - fixes T6720

### DIFF
--- a/packages/babel-plugin-transform-es2015-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/src/index.js
@@ -325,6 +325,25 @@ export default function ({ types: t }) {
 
   return {
     visitor: {
+      ExportNamedDeclaration(path){
+        let declaration = path.get("declaration");
+        if (!declaration.isVariableDeclaration()) return;
+        if (!variableDeclarationHasPattern(declaration.node)) return;
+
+        let specifiers = [];
+
+        for (let name in path.getOuterBindingIdentifiers(path)){
+          let id = t.identifier(name);
+          specifiers.push(t.exportSpecifier(id, id));
+        }
+
+        // Split the declaration and export list into two declarations so that the variable
+        // declaration can be split up later without needing to worry about not being a
+        // top-level statement.
+        path.replaceWith(declaration.node);
+        path.insertAfter(t.exportNamedDeclaration(null, specifiers));
+      },
+
       ForXStatement(path, file) {
         let { node, scope } = path;
         let left = node.left;

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/export-variable/actual.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/export-variable/actual.js
@@ -1,0 +1,2 @@
+
+export let {a, b, c: {d, e: {f = 4}}} = {};

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/export-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/export-variable/expected.js
@@ -1,0 +1,8 @@
+var _ref = {};
+var a = _ref.a;
+var b = _ref.b;
+var _ref$c = _ref.c;
+var d = _ref$c.d;
+var _ref$c$e$f = _ref$c.e.f;
+var f = _ref$c$e$f === undefined ? 4 : _ref$c$e$f;
+export { a, b, d, f };


### PR DESCRIPTION
Convert

    export let {a, b, c: {d, e: {f = 4}}} = {};

to

    let {a, b, c: {d, e: {f = 4}}} = {};
    export {a, b, d, f};

before processing destructuring.