### PR TITLE
Set the proper parents for new node paths - fixes T2763

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/actual.js
@@ -1,0 +1,1 @@
+export * from 'mod';

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
@@ -1,0 +1,23 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _mod = require('mod');
+
+var _loop = function (_key2) {
+  if (_key2 === "default") return 'continue';
+  Object.defineProperty(exports, _key2, {
+    enumerable: true,
+    get: function () {
+      return _mod[_key2];
+    }
+  });
+};
+
+for (var _key2 in _mod) {
+  var _ret = _loop(_key2);
+
+  if (_ret === 'continue') continue;
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-es2015-block-scoping",
+    "transform-es2015-modules-commonjs"
+  ]
+}

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -49,8 +49,8 @@ export function _containerInsert(from, nodes) {
       paths.push(path);
     } else {
       paths.push(NodePath.get({
-        parentPath: this,
-        parent: node,
+        parentPath: this.parentPath,
+        parent: this.parent,
         container: this.container,
         listKey: this.listKey,
         key: to


### PR DESCRIPTION
This logic is for inserting siblings, not children, so the parent should point at the same parent as the current path, not treat the current path as the parent.