### PR TITLE
Skip name inference on hard-to-replace classes - fixes T2494

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -16,7 +16,7 @@ let buildPropertyMethodAssignmentWrapper = template(`
   })(FUNCTION)
 `);
 
-let buldGeneratorPropertyMethodAssignmentWrapper = template(`
+let buildGeneratorPropertyMethodAssignmentWrapper = template(`
   (function (FUNCTION_KEY) {
     function* FUNCTION_ID() {
       return yield* FUNCTION_KEY.apply(this, arguments);
@@ -51,9 +51,12 @@ function wrap(state, method, id, scope) {
       // we can just munge the local binding
       scope.rename(id.name);
     } else {
+      // we don't currently support wrapping class expressions
+      if (!t.isFunction(method)) return;
+
       // need to add a wrapper since we can't change the references
       let build = buildPropertyMethodAssignmentWrapper;
-      if (method.generator) build = buldGeneratorPropertyMethodAssignmentWrapper;
+      if (method.generator) build = buildGeneratorPropertyMethodAssignmentWrapper;
       let template = build({
         FUNCTION: method,
         FUNCTION_ID: id,

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/actual.js
@@ -1,0 +1,3 @@
+var x = {
+  Foo: class extends Foo {}
+};

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/expected.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var x = {
+  Foo: (function (_Foo) {
+    babelHelpers.inherits(_class, _Foo);
+
+    function _class() {
+      babelHelpers.classCallCheck(this, _class);
+      return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(_class).apply(this, arguments));
+    }
+
+    return _class;
+  })(Foo)
+};


### PR DESCRIPTION
We could probably come up with a way to do this, like we do with functions, but at least now we won't crash when this case is hit.