### PR TITLE
Use `pirates` for require hooks.

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -15,6 +15,7 @@
     "lodash": "^3.10.0",
     "mkdirp": "^0.5.1",
     "path-exists": "^1.0.0",
+    "pirates": "^2.1.1",
     "source-map-support": "^0.2.10"
   }
 }


### PR DESCRIPTION
Hi!

As was discussed in #3062, this PR uses `pirates` to implement require hooks. That means that the `babel-register` require hook implementation is drastically simpler, and plays nicely with other hooks.

This change is completely transparent (a patch version bump), and all the tests still pass.

Fixes #3062.