### PR TITLE
Add custom transform for babel-runtime builds to avoid circular deps - fixes T6644

### DIFF
--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -12,7 +12,6 @@
     "babel-helpers": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-template": "^6.3.13",
-    "babel-runtime": "^5.0.0",
     "babel-regenerator-runtime": "^6.3.13"
   }
 }

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -88,8 +88,9 @@ each(helpers.list, function (helperName) {
 
   // compat
   var helperAlias = _.kebabCase(helperName);
-  writeFile("helpers/_" + helperAlias + ".js", buildHelper(helperName));
-  writeFile("helpers/" + helperAlias + ".js", buildHelper(helperName));
+  var content = "module.exports = require(\"./" + helperName + ".js\");";
+  writeFile("helpers/_" + helperAlias + ".js", content);
+  if (helperAlias !== helperName) writeFile("helpers/" + helperAlias + ".js", content);
 });
 
 writeFile("regenerator/index.js", readFile("../../babel-regenerator-runtime/runtime-module", true));


### PR DESCRIPTION
There were a few things working together to cause `(0 , _typeof3.default) is not a function`.

`babel-runtime` contained statements like `require('babel-runtime/helpers/typeof')` rather than relative paths. However, on local dev, `babel-runtime@6.x` depended on `babel-runtime@5.x`, so the require would load 5.x, but in production it would be a circular reference

The circular reference _should_ have throws a max recursion error, but the old helpers injected `exports.__esModule = true;` at the bottom of the module rather than the top, so in cases where there were circular dependencies, the module interop would be executed before `__esModule` was assigned, causing the import to actually be an object with a `.default` property instead.

With those fixed, you'd actually get a max recursion depth error. To fix that, I specialized `helperGenerator` so that it would not attempt to insert a helper reference inside that same helper to avoid the stack overflow.