### PR TITLE
[babel-plugin-transform-es2015-parameters][T6774] more opportunities for optimizations

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -28,3 +28,7 @@ var b = function (foo, ...bar) {
   var join = "join";
   return bar[join];
 };
+
+var b = function (...bar) {
+  return bar.len;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -53,3 +53,11 @@ var b = function (foo) {
 
   return bar[join];
 };
+
+var b = function () {
+  for (var _len7 = arguments.length, bar = Array(_len7), _key7 = 0; _key7 < _len7; _key7++) {
+    bar[_key7] = arguments[_key7];
+  }
+
+  return bar.len;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/actual.js
@@ -1,9 +1,17 @@
 var t = function (...items) {
-    var x = items[0];
-    var y = items[1];
+  var x = items[0];
+  var y = items[1];
 }
 
 function t(...items) {
-    var x = items[0];
-    var y = items[1];
+  var x = items[0];
+  var y = items[1];
+}
+
+function t(...items) {
+  var a = [];
+  for (var i = 0; i < items.length; i++) {
+    a.push(i);
+  }
+  return a;
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
@@ -1,9 +1,17 @@
 var t = function () {
-    var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-    var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
+  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
 };
 
 function t() {
-    var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-    var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
+  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+}
+
+function t() {
+  var a = [];
+  for (var i = 0; i < arguments.length; i++) {
+    a.push(i);
+  }
+  return a;
 }


### PR DESCRIPTION
Babel's arguments transform is pretty cool, it does some optimizations based on a whitelist of checks, but that list could have 2 more items added:

* arguments.length;
* `<any-function>`.apply(`<any>`, arguments);

The second one is a bit controversial because we can't guarantee that `apply` is the native function's function (unless we have flow support, let me know if we do). But most of the time the implemented check is accurate and we should be shooting for the common case not the edge case (IMHO).

I could confirm that when I add any of those patterns the args array is created, when using http://babeljs.io/repl/.

This is based on: https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#what-is-safe-arguments-usage
And I was also able to see myself functions with these patterns being optimized on V8.

https://phabricator.babeljs.io/T6774