### PR TITLE
Always print strings for consistency

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -221,7 +221,7 @@ export function MemberExpression(node: Object) {
     this.push("]");
   } else {
     if (t.isLiteral(node.object) && !t.isTemplateLiteral(node.object)) {
-      let val = this.getPossibleRaw(node.object) || this._stringLiteral(node.object);
+      let val = this._stringLiteral(node.object);
       if (isInteger(+val) && !SCIENTIFIC_NOTATION.test(val) && !ZERO_DECIMAL_INTEGER.test(val) && !this.endsWith(".")) {
         this.push(".");
       }

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -221,7 +221,13 @@ export function MemberExpression(node: Object) {
     this.push("]");
   } else {
     if (t.isLiteral(node.object) && !t.isTemplateLiteral(node.object)) {
-      let val = this._stringLiteral(node.object);
+      let val;
+      if (this.format.compact) {
+        val = this._stringLiteral(node.object);
+      } else {
+        val = this.getPossibleRaw(node.object) || this._stringLiteral(node.object);
+      }
+
       if (isInteger(+val) && !SCIENTIFIC_NOTATION.test(val) && !ZERO_DECIMAL_INTEGER.test(val) && !this.endsWith(".")) {
         this.push(".");
       }

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -89,22 +89,9 @@ export default class Printer extends Buffer {
     }
   }
 
-  getPossibleRaw(node) {
-    let extra = node.extra;
-    if (extra && extra.raw != null && extra.rawValue != null && node.value === extra.rawValue) {
-      return extra.raw;
-    }
-  }
-
   _print(node, parent) {
-    let extra = this.getPossibleRaw(node);
-    if (extra) {
-      this.push("");
-      this._push(extra);
-    } else {
-      let printMethod = this[node.type];
-      printMethod.call(this, node, parent);
-    }
+    let printMethod = this[node.type];
+    printMethod.call(this, node, parent);
   }
 
   printJoin(nodes: ?Array, parent: Object, opts = {}) {

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -89,7 +89,27 @@ export default class Printer extends Buffer {
     }
   }
 
+  getPossibleRaw(node) {
+    let extra = node.extra;
+    if (extra && extra.raw != null && extra.rawValue != null && node.value === extra.rawValue) {
+      return extra.raw;
+    }
+  }
+
   _print(node, parent) {
+    // In compact mode we need to produce as little bytes as needed
+    // and need to make sure that string quoting is consistent.
+    // That means we have to always reprint as opposed to getting
+    // the raw value.
+    if (!this.format.compact) {
+      let extra = this.getPossibleRaw(node);
+      if (extra) {
+        this.push("");
+        this._push(extra);
+        return;
+      }
+    }
+
     let printMethod = this[node.type];
     printMethod.call(this, node, parent);
   }

--- a/packages/babel-generator/test/fixtures/compact/literals/actual.js
+++ b/packages/babel-generator/test/fixtures/compact/literals/actual.js
@@ -1,0 +1,13 @@
+5;
+5.0;
+"foobar";
+'\x20';
+"\n\r";
+/foobar/g;
+null;
+true;
+false;
+5.;
+0b10;
+0o70;
+0X1F;

--- a/packages/babel-generator/test/fixtures/compact/literals/expected.js
+++ b/packages/babel-generator/test/fixtures/compact/literals/expected.js
@@ -1,0 +1,1 @@
+5;5;"foobar";" ";"\n\r";/foobar/g;null;true;false;5;2;56;31;


### PR DESCRIPTION
It's weird to mix single and double quotes (and really bad for gzip)