### PR TITLE
Allow use of global plugins and presets

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -36,6 +36,7 @@
     "babylon": "^6.3.15",
     "convert-source-map": "^1.1.0",
     "debug": "^2.1.1",
+    "global-modules": "^0.2.0",
     "json5": "^0.4.0",
     "lodash": "^3.10.0",
     "minimatch": "^2.0.3",

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -55,6 +55,13 @@ module.exports = {
     description: ""
   },
 
+  global: {
+    type: "boolean",
+    default: false,
+    description: "load plugins and presets from globally installed node modules if not found locally",
+    shorthand: "g"
+  },
+
   ignore: {
     type: "list",
     description: "list of glob paths to **not** compile",


### PR DESCRIPTION
Fixes https://phabricator.babeljs.io/T6772

I'm not sure how to approach testing this, but my best idea is to mock the `global-modules` package that I introduce as a dependency.

Use of globally installed modules is purely opt-in option, and locally installed modules will still be preferred. Enabled via the `--global`/`-g` option.