### PR TITLE
Add the 'keepModuleIdExtensions' option, fixes T6669

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -210,7 +210,9 @@ export default class File extends Store {
     }
 
     // remove extension
-    filenameRelative = filenameRelative.replace(/\.(\w*?)$/, "");
+    if (!opts.keepModuleIdExtensions) {
+      filenameRelative = filenameRelative.replace(/\.(\w*?)$/, "");
+    }
 
     moduleName += filenameRelative;
 

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -177,5 +177,12 @@ module.exports = {
   moduleId: {
     description: "specify a custom name for module ids",
     type: "string"
+  },
+
+  keepModuleIdExtensions: {
+    type: "boolean",
+    default: false,
+    shorthand: "k",
+    description: "keep extensions when generating module ids"
   }
 };

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/keep-module-id-extensions-option/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/keep-module-id-extensions-option/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+System.register("systemjs/keep-module-id-extensions-option/expected.js", [], function (_export) {
+  return {
+    setters: [],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/keep-module-id-extensions-option/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/keep-module-id-extensions-option/options.json
@@ -1,0 +1,4 @@
+{
+  "keepModuleIdExtensions": true,
+  "moduleIds": true
+}


### PR DESCRIPTION
This adds the "keepModuleIdExtensions" option, fixing https://phabricator.babeljs.io/T6669. This option was present in pre-6 versions.

This PR includes the option definition, implementation, command-line shorthand (`-k`) and a SystemJS test.
