### PR TITLE
Log `codeGeneratorDeopt` to STDOUT

### DIFF
--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -100,7 +100,7 @@ export class CodeGenerator extends Printer {
       format.compact = code.length > 100000; // 100KB
 
       if (format.compact) {
-        console.error("[BABEL] " + messages.get("codeGeneratorDeopt", opts.filename, "100KB"));
+        console.info("[BABEL] " + messages.get("codeGeneratorDeopt", opts.filename, "100KB"));
       }
     }
 


### PR DESCRIPTION
According to the [Node documentation for `console.error`][error]:

> Same as `console.log()` but prints to `stderr`.

This error message, although helpful information, doesn't crash the
program, and it doesn't include a stack trace.

Writing this information to `STDOUT` via [`console.info()`][info]
reduces the noise in `STDERR`.

[error]: https://nodejs.org/api/console.html#console_console_error_data
[info]: https://nodejs.org/api/console.html#console_console_info_data