### PR TITLE
New plugin for pipeline operator proposal

### DIFF
--- a/packages/babel-plugin-syntax-pipeline-operator/README.md
+++ b/packages/babel-plugin-syntax-pipeline-operator/README.md
@@ -1,0 +1,35 @@
+# babel-plugin-syntax-pipeline-operator
+
+Allow parsing of the pipeline operator `|>`. See [the ES.next proposal](https://github.com/mindeavor/es-pipeline-operator) for details.
+
+## Installation
+
+```sh
+$ npm install babel-plugin-syntax-pipeline-operator
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["syntax-pipeline-operator"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins syntax-pipeline-operator script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["syntax-pipeline-operator"]
+});
+```

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "babel-plugin-syntax-pipeline-operator",
+  "version": "6.3.13",
+  "description": "Allow parsing of the pipeline operator",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "babel-runtime": "^5.0.0"
+  },
+  "devDependencies": {
+    "babel-helper-plugin-test-runner": "^6.3.13"
+  }
+}

--- a/packages/babel-plugin-syntax-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-syntax-pipeline-operator/src/index.js
@@ -1,0 +1,7 @@
+export default function () {
+  return {
+    manipulateOptions(opts, parserOpts) {
+      parserOpts.plugins.push("pipelineOperator");
+    }
+  };
+}

--- a/packages/babel-plugin-transform-pipeline-operator/README.md
+++ b/packages/babel-plugin-transform-pipeline-operator/README.md
@@ -1,0 +1,35 @@
+# babel-plugin-transform-pipeline-operator
+
+Compile pipeline operator `|>` usage to ES5. See [the ES.next proposal](https://github.com/mindeavor/es-pipeline-operator) for details.
+
+## Installation
+
+```sh
+$ npm install babel-plugin-transform-pipeline-operator
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["transform-pipeline-operator"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins transform-pipeline-operator script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-pipeline-operator"]
+});
+```

--- a/packages/babel-plugin-transform-pipeline-operator/package.json
+++ b/packages/babel-plugin-transform-pipeline-operator/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "babel-plugin-transform-pipeline-operator",
+  "version": "6.3.13",
+  "description": "Compile pipeline operator usage to ES5",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-pipeline-operator",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "babel-plugin-syntax-pipeline-operator": "^6.3.13",
+    "babel-runtime": "^5.0.0"
+  },
+  "devDependencies": {
+    "babel-helper-plugin-test-runner": "^6.3.13"
+  }
+}

--- a/packages/babel-plugin-transform-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-transform-pipeline-operator/src/index.js
@@ -1,0 +1,65 @@
+export default function ({ types: t }) {
+  return {
+    inherits: require("babel-plugin-syntax-pipeline-operator"),
+
+    visitor: {
+
+      BinaryExpression(path) {
+        if (path.node.operator === "|>") {
+          let right = path.node.right;
+
+          if (
+            right.type === "ArrowFunctionExpression" &&
+            right.params.length === 1 &&
+            t.isIdentifier(right.params[0]) &&
+            t.isExpression(right.body)
+          ) {
+            //
+            // Optimize away arrow function!
+            //
+            // This step converts:
+            //    let result = arg |> x => x + x;
+            // To:
+            //    let _x = arg;
+            //    let result = arg |> x => x + x;
+            //
+            let paramName = right.params[0].name;
+            let placeholder = path.scope.generateUidIdentifier(paramName);
+            path.parentPath.insertBefore(t.variableDeclarator(placeholder, path.node.left));
+
+            //
+            // This step converts:
+            //    let _x = arg;
+            //    let result = arg |> x => x + x;
+            // To:
+            //    let _x = arg;
+            //    let result = arg |> _x => _x + _x;
+            //
+            path.get("right").scope.rename(paramName, placeholder.name);
+
+            //
+            // This step converts:
+            //    let _x = arg;
+            //    let result = arg |> _x => _x + _x;
+            // To:
+            //    let _x = arg;
+            //    let result = _x + _x;
+            //
+            path.replaceWith(right.body);
+          } else {
+            //
+            // Simple invocation.
+            //
+            // Converts:
+            //    x |> obj.f;
+            // To:
+            //    obj.f(x);
+            //
+            path.replaceWith(t.callExpression(path.node.right, [ path.node.left ]));
+          }
+        }
+      }
+
+    }
+  };
+}

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/arrow-functions.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/arrow-functions.js
@@ -1,0 +1,14 @@
+var result = [5,10]
+  |> _ => _.map(x => x * 2)
+  |> _ => _.reduce( (a,b) => a + b )
+  |> sum => sum + 1
+
+assert.equal(result, 31)
+
+
+var inc = (x) => x + 1;
+var double = (x) => x * 2;
+
+var result2 = [4, 9].map( x => x |> inc |> double )
+
+assert.deepEqual(result2, [10, 20])

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/basic.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/basic.js
@@ -1,0 +1,3 @@
+var inc = (x) => x + 1
+
+assert.equal(10 |> inc, 11);

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/chaining.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/chaining.js
@@ -1,0 +1,4 @@
+var inc = (x) => x + 1;
+var double = (x) => x * 2;
+
+assert.equal(10 |> inc |> double, 22);

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/currying.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/currying.js
@@ -1,0 +1,6 @@
+
+var map = (fn) => (array) => array.map(fn);
+
+var result = [10,20] |> map(x => x * 20);
+
+assert.deepEqual(result, [200, 400])

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/multiple-argument-use.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/multiple-argument-use.js
@@ -1,0 +1,5 @@
+var array = [10,20,30];
+
+var last = array |> a => a[a.length-1];
+
+assert.equal(last, 30);

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/options.json
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-pipeline-operator"]
+}

--- a/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/precedence.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/fixtures/pipeline-operator/precedence.js
@@ -1,0 +1,12 @@
+
+var inc = (x) => x + 1;
+
+var result = 4 || 9 |> inc;
+assert.equal(result, 5);
+
+
+var f = (x) => x + 10
+var h = (x) => x + 20
+
+var result2 = 10 |> f || h |> inc;
+assert.equal(result2, 21);

--- a/packages/babel-plugin-transform-pipeline-operator/test/index.js
+++ b/packages/babel-plugin-transform-pipeline-operator/test/index.js
@@ -1,0 +1,1 @@
+require("babel-helper-plugin-test-runner")(__dirname);

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -189,6 +189,12 @@ pp.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, noIn) {
 
       let startPos = this.state.start;
       let startLoc = this.state.startLoc;
+
+      if (node.operator === "|>") {
+        // Support syntax such as 10 |> x => x + 1
+        this.state.potentialArrowAt = startPos;
+      }
+
       node.right = this.parseExprOp(this.parseMaybeUnary(), startPos, startLoc, op.rightAssociative ? prec - 1 : prec, noIn);
 
       this.finishNode(node, (op === tt.logicalOR || op === tt.logicalAND) ? "LogicalExpression" : "BinaryExpression");

--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -316,8 +316,12 @@ export default class Tokenizer {
     return this.finishOp(type, width);
   }
 
-  readToken_pipe_amp(code) { // '|&'
+  readToken_pipe_amp(code) { // '|&', '|>'
     let next = this.input.charCodeAt(this.state.pos + 1);
+
+    if (code === 124 && next === 62 && this.hasPlugin("pipelineOperator")) {
+      return this.finishOp(tt.pipeline, 2);
+    }
     if (next === code) return this.finishOp(code === 124 ? tt.logicalOR : tt.logicalAND, 2);
     if (next === 61) return this.finishOp(tt.assign, 2);
     return this.finishOp(code === 124 ? tt.bitwiseOR : tt.bitwiseAND, 1);
@@ -444,7 +448,7 @@ export default class Tokenizer {
       case 37: case 42: // '%*'
         return this.readToken_mult_modulo(code);
 
-      case 124: case 38: // '|&'
+      case 124: case 38: // '|&', '|>'
         return this.readToken_pipe_amp(code);
 
       case 94: // '^'

--- a/packages/babylon/src/tokenizer/types.js
+++ b/packages/babylon/src/tokenizer/types.js
@@ -27,7 +27,7 @@ export class TokenType {
     this.isAssign = !!conf.isAssign;
     this.prefix = !!conf.prefix;
     this.postfix = !!conf.postfix;
-    this.binop = conf.binop || null;
+    this.binop = (conf.binop === 0) ? 0 : (conf.binop || null);
     this.updateContext = null;
   }
 }
@@ -82,6 +82,7 @@ export const types = {
   assign: new TokenType("_=", {beforeExpr: true, isAssign: true}),
   incDec: new TokenType("++/--", {prefix: true, postfix: true, startsExpr: true}),
   prefix: new TokenType("prefix", {beforeExpr: true, prefix: true, startsExpr: true}),
+  pipeline: binop("|>", 0),
   logicalOR: binop("||", 1),
   logicalAND: binop("&&", 2),
   bitwiseOR: binop("|", 3),


### PR DESCRIPTION
First let me say I am **not** suggesting this be merged in as a stage 0 plugin. I only want others to have the ability to try out (via an explicit flag) an [ES.next proposal](https://github.com/mindeavor/es-pipeline-operator) that [has](https://twitter.com/markdalgleish/status/673581814028492800) [clear](https://twitter.com/mattpodwysocki/status/673320103300227072) [interest](https://www.reddit.com/r/javascript/comments/3vox7x/es7_proposal_the_pipeline_operator/) in the community, via everyone's favorite JavaScript compiler.

At the very least, perhaps this PR can open the discussion topic, "what can Babel do to support plugins like this one as standalone plugins?"

Thanks for reading.