### PR TITLE
Requeue generators for re-traversal so we pick up regeneratorRuntime - fixes T6676

### DIFF
--- a/packages/babel-plugin-transform-regenerator/src/visit.js
+++ b/packages/babel-plugin-transform-regenerator/src/visit.js
@@ -129,6 +129,11 @@ exports.visitor = {
       if (wasGeneratorFunction && t.isExpression(node)) {
         path.replaceWith(t.callExpression(util.runtimeProperty("mark"), [node]));
       }
+
+      // Generators are processed in 'exit' handlers so that regenerator only has to run on
+      // an ES5 AST, but that means traversal will not pick up newly inserted references
+      // to things like 'regeneratorRuntime'. To avoid this, we explicitly re-queue.
+      path.requeue();
     }
   }
 };

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
@@ -10,18 +10,20 @@ var _marked = [_callee].map(regeneratorRuntime.mark);
 function _callee() {
   var x;
   return regeneratorRuntime.wrap(function _callee$(_context) {
-    while (1) switch (_context.prev = _context.next) {
-      case 0:
-        _context.next = 2;
-        return 5;
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 5;
 
-      case 2:
-        x = _context.sent;
-        return _context.abrupt("return", 5);
+        case 2:
+          x = _context.sent;
+          return _context.abrupt("return", 5);
 
-      case 4:
-      case "end":
-        return _context.stop();
+        case 4:
+        case "end":
+          return _context.stop();
+      }
     }
   }, _marked[0], this);
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/full/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/full/expected.js
@@ -7,7 +7,7 @@ import foo, * as bar from "someModule";
 
 export const myWord = _Symbol("abc");
 export function giveWord() {
-  return regeneratorRuntime.wrap(function giveWord$(_context) {
+  return _regeneratorRuntime.wrap(function giveWord$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:
         _context.next = 2;


### PR DESCRIPTION
If you can think of a better way to address this, I'm all for it, but nothing came to mind. The only other simple solution I see is having `regenerator` explicitly check `state.get("regeneratorIdentifier")` so it behaves more like a standard Babel helper, but there isn't one general place to easily add that, which I assume what drove the current implementation.