### PR TITLE
[optimisation] Simplify rest transformation

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -12,7 +12,7 @@ let buildRest = template(`
 `);
 
 let loadRest = template(`
-  ARGUMENTS.length <= KEY || ARGUMENTS[KEY] === undefined ? undefined : ARGUMENTS[KEY]
+  ARGUMENTS.length <= INDEX ? undefined : ARGUMENTS[INDEX]
 `);
 
 let memberExpressionOptimisationVisitor = {
@@ -109,7 +109,7 @@ export let visitor = {
       if (t.isReturnStatement(parentPath.parent) || t.isIdentifier(parentPath.parent.id)) {
         parentPath.replaceWith(loadRest({
           ARGUMENTS: argsId,
-          KEY: t.numericLiteral(parent.property.value + offset)
+          INDEX: t.numericLiteral(parent.property.value + offset)
         }));
       } else {
         if (offset === 0) return;

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
@@ -1,21 +1,21 @@
 var concat = function () {
-  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var x = arguments.length <= 0 ? undefined : arguments[0];
+  var y = arguments.length <= 1 ? undefined : arguments[1];
 };
 
 var somefun = function () {
   var get2ndArg = function (a, b) {
-    var _b = arguments.length <= 2 || arguments[2] === undefined ? undefined : arguments[2];
+    var _b = arguments.length <= 2 ? undefined : arguments[2];
     var somef = function (x, y, z) {
-      var _a = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
+      var _a = arguments.length <= 3 ? undefined : arguments[3];
     };
     var somefg = function (c, d, e, f) {
-      var _a = arguments.length <= 4 || arguments[4] === undefined ? undefined : arguments[4];
+      var _a = arguments.length <= 4 ? undefined : arguments[4];
     };
-    var _d = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
+    var _d = arguments.length <= 3 ? undefined : arguments[3];
   };
   var get3rdArg = function () {
-    return arguments.length <= 2 || arguments[2] === undefined ? undefined : arguments[2];
+    return arguments.length <= 2 ? undefined : arguments[2];
   };
 };
 

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
@@ -1,9 +1,9 @@
 var t = function () {
-    var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-    var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+    var x = arguments.length <= 0 ? undefined : arguments[0];
+    var y = arguments.length <= 1 ? undefined : arguments[1];
 };
 
 function t() {
-    var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-    var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+    var x = arguments.length <= 0 ? undefined : arguments[0];
+    var y = arguments.length <= 1 ? undefined : arguments[1];
 }


### PR DESCRIPTION
As discussed here: https://github.com/babel/babel/pull/2833#discussion-diff-47472444 , the previous solution was good in terms of perfs but a bit ugly. Should be fixed in this PR.

