### PR TITLE
[optimisation] Fixing T6818

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -69,6 +69,7 @@ let memberExpressionOptimisationVisitor = {
       if (parentPath.isMemberExpression({ computed: false, object: node })) {
         let prop = parentPath.get("property");
         if (prop.node.name === "length") {
+          state.replaceOnly = true;
           state.candidates.push(path);
           return;
         }
@@ -144,7 +145,10 @@ export let visitor = {
       name: rest.name,
 
       // whether any references to the rest parameter were made in a function
-      deopted: false
+      deopted: false,
+
+      // whether all we need to do is replace rest parameter identifier with 'arguments'
+      replaceOnly: false
     };
 
     path.traverse(memberExpressionOptimisationVisitor, state);
@@ -154,7 +158,9 @@ export let visitor = {
       if (state.candidates.length) {
         for (let candidate of (state.candidates: Array)) {
           candidate.replaceWith(argsId);
-          optimiseCandidate(candidate.parent, candidate.parentPath, state.offset);
+          if (!state.replaceOnly) {
+            optimiseCandidate(candidate.parent, candidate.parentPath, state.offset);
+          }
         }
       }
       return;

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -12,7 +12,7 @@ let buildRest = template(`
 `);
 
 let loadRest = template(`
-  ARGUMENTS.length <= KEY || ARGUMENTS[KEY] === undefined ? undefined : ARGUMENTS[KEY]
+  ARGUMENTS.length <= INDEX ? undefined : ARGUMENTS[INDEX]
 `);
 
 let memberExpressionOptimisationVisitor = {
@@ -124,7 +124,7 @@ export let visitor = {
       if (t.isReturnStatement(parentPath.parent) || t.isIdentifier(parentPath.parent.id)) {
         parentPath.replaceWith(loadRest({
           ARGUMENTS: argsId,
-          KEY: t.numericLiteral(parent.property.value + offset)
+          INDEX: t.numericLiteral(parent.property.value + offset)
         }));
       } else {
         if (offset === 0) return;

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -121,7 +121,7 @@ export let visitor = {
     argsId._shadowedFunctionLiteral = path;
 
     function optimiseCandidate(parent, parentPath, offset) {
-      if (t.isReturnStatement(parentPath.parent) || t.isIdentifier(parentPath.parent.id)) {
+      if (t.isReturnStatement(parentPath.parent) || t.isIdentifier(parentPath.parent.id) || t.isIdentifier(parentPath.parent.left)) {
         parentPath.replaceWith(loadRest({
           ARGUMENTS: argsId,
           INDEX: t.numericLiteral(parent.property.value + offset)

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -121,23 +121,11 @@ export let visitor = {
     argsId._shadowedFunctionLiteral = path;
 
     function optimiseCandidate(parent, parentPath, offset) {
-      if (t.isReturnStatement(parentPath.parent) || t.isIdentifier(parentPath.parent.id) || t.isIdentifier(parentPath.parent.left)) {
+      if (parent.property) {
         parentPath.replaceWith(loadRest({
           ARGUMENTS: argsId,
           INDEX: t.numericLiteral(parent.property.value + offset)
         }));
-      } else {
-        if (offset === 0) return;
-        let newExpr;
-        let prop = parent.property;
-
-        if (t.isLiteral(prop)) {
-          prop.value += offset;
-          prop.raw = String(prop.value);
-        } else { // UnaryExpression, BinaryExpression
-          newExpr = t.binaryExpression("+", prop, t.numericLiteral(offset));
-          parent.property = newExpr;
-        }
       }
     }
 

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
@@ -1,21 +1,21 @@
 var concat = function () {
-  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var x = arguments.length <= 0 ? undefined : arguments[0];
+  var y = arguments.length <= 1 ? undefined : arguments[1];
 };
 
 var somefun = function () {
   var get2ndArg = function (a, b) {
-    var _b = arguments.length <= 2 || arguments[2] === undefined ? undefined : arguments[2];
+    var _b = arguments.length <= 2 ? undefined : arguments[2];
     var somef = function (x, y, z) {
-      var _a = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
+      var _a = arguments.length <= 3 ? undefined : arguments[3];
     };
     var somefg = function (c, d, e, f) {
-      var _a = arguments.length <= 4 || arguments[4] === undefined ? undefined : arguments[4];
+      var _a = arguments.length <= 4 ? undefined : arguments[4];
     };
-    var _d = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
+    var _d = arguments.length <= 3 ? undefined : arguments[3];
   };
   var get3rdArg = function () {
-    return arguments.length <= 2 || arguments[2] === undefined ? undefined : arguments[2];
+    return arguments.length <= 2 ? undefined : arguments[2];
   };
 };
 

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/actual.js
@@ -15,3 +15,10 @@ function t(...items) {
   }
   return a;
 }
+
+// https://github.com/babel/babel/pull/2833#issuecomment-166039291
+function t(...items) {
+  for (let i = 0; i < items.length; i++) {
+    return items[i];
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
@@ -1,11 +1,11 @@
 var t = function () {
-  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var x = arguments.length <= 0 ? undefined : arguments[0];
+  var y = arguments.length <= 1 ? undefined : arguments[1];
 };
 
 function t() {
-  var x = arguments.length <= 0 || arguments[0] === undefined ? undefined : arguments[0];
-  var y = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var x = arguments.length <= 0 ? undefined : arguments[0];
+  var y = arguments.length <= 1 ? undefined : arguments[1];
 }
 
 function t() {

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
@@ -15,3 +15,14 @@ function t() {
   }
   return a;
 }
+
+// https://github.com/babel/babel/pull/2833#issuecomment-166039291
+function t() {
+  for (var _len = arguments.length, items = Array(_len), _key = 0; _key < _len; _key++) {
+    items[_key] = arguments[_key];
+  }
+
+  for (var i = 0; i < items.length; i++) {
+    return items[i];
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/actual.js
@@ -13,6 +13,7 @@ function t(f, ...items) {
 function u(f, g, ...items) {
     var x = f;
     var y = g;
-    x = items[0];
-    y = items[1];
+    x[12] = items[0];
+    y.prop = items[1];
+    var z = items[2] | 0 || 12;
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/actual.js
@@ -9,3 +9,10 @@ function t(f, ...items) {
     x = items[0];
     x = items[1];
 }
+
+function u(f, g, ...items) {
+    var x = f;
+    var y = g;
+    x = items[0];
+    y = items[1];
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/expected.js
@@ -1,11 +1,18 @@
 var t = function (f) {
     var x = f;
-    x = arguments[1];
-    x = arguments[2];
+    x = arguments.length <= 1 ? undefined : arguments[1];
+    x = arguments.length <= 2 ? undefined : arguments[2];
 };
 
 function t(f) {
     var x = f;
-    x = arguments[1];
-    x = arguments[2];
+    x = arguments.length <= 1 ? undefined : arguments[1];
+    x = arguments.length <= 2 ? undefined : arguments[2];
+}
+
+function u(f, g) {
+    var x = f;
+    var y = g;
+    x = arguments.length <= 2 ? undefined : arguments[2];
+    y = arguments.length <= 3 ? undefined : arguments[3];
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/expected.js
@@ -13,6 +13,7 @@ function t(f) {
 function u(f, g) {
     var x = f;
     var y = g;
-    x = arguments.length <= 2 ? undefined : arguments[2];
-    y = arguments.length <= 3 ? undefined : arguments[3];
+    x[12] = arguments.length <= 2 ? undefined : arguments[2];
+    y.prop = arguments.length <= 3 ? undefined : arguments[3];
+    var z = (arguments.length <= 4 ? undefined : arguments[4]) | 0 || 12;
 }


### PR DESCRIPTION
#2833 : applying the same transform to multiple params ending with rest.

Without this PR:
```js
var t = function (...items) {
    var x = items[0];
    var y = items[1];
}
// ==>
var t = function () {
    var x = arguments.length <= 0 ? undefined : arguments[0];
    var y = arguments.length <= 1 ? undefined : arguments[1];
};
// BUT:
function u(f, g, ...items) {
    var x = f;
    var y = g;
    x = items[0];
    y = items[1];
}
// ==>
function u(f, g) {
    var x = f;
    var y = g;
    x = arguments[2];
    y = arguments[3];
}
```

After this PR:
```js
function u(f, g, ...items) {
    var x = f;
    var y = g;
    x[12] = items[0];
    y.prop = items[1];
    var z = items[2] | 0 || 12;
}
// ==>
function u(f, g) {
    var x = f;
    var y = g;
    x[12] = arguments.length <= 2 ? undefined : arguments[2];
    y.prop = arguments.length <= 3 ? undefined : arguments[3];
    var z = (arguments.length <= 4 ? undefined : arguments[4]) | 0 || 12;
}
```

Usual biased benchmark: https://gist.github.com/vhf/804cbddf89e4c8c8d8e2
```
before x 19,363 ops/sec ±0.94% (86 runs sampled)
 after x 78,760 ops/sec ±0.72% (97 runs sampled)
```