### PR TITLE
Add __moduleName support to System.register

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -2,7 +2,7 @@ import hoistVariables from "babel-helper-hoist-variables";
 import template from "babel-template";
 
 let buildTemplate = template(`
-  System.register(MODULE_NAME, [SOURCES], function (EXPORT_IDENTIFIER) {
+  System.register(MODULE_NAME, [SOURCES], function (EXPORT_IDENTIFIER, __moduleName) {
     BEFORE_BODY;
     return {
       setters: [SETTERS],

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-default/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export) {
+System.register([], function (_export, __moduleName) {
   _export("default", function () {});
 
   _export("default", class {});

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-default/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export, __moduleName) {
+System.register([], function (_export, _context) {
   _export("default", function () {});
 
   _export("default", class {});

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export, __moduleName) {
+System.register(["foo"], function (_export, _context) {
   return {
     setters: [function (_foo) {
       var _exportObj = {};

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export) {
+System.register(["foo"], function (_export, __moduleName) {
   return {
     setters: [function (_foo) {
       var _exportObj = {};

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export) {
+System.register([], function (_export, __moduleName) {
   return {
     setters: [],
     execute: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export, __moduleName) {
+System.register([], function (_export, _context) {
   return {
     setters: [],
     execute: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-variable/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export) {
+System.register([], function (_export, __moduleName) {
   return {
     setters: [],
     execute: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-variable/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export, __moduleName) {
+System.register([], function (_export, _context) {
   return {
     setters: [],
     execute: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/get-module-name-option/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/get-module-name-option/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register("my custom module name", [], function (_export, __moduleName) {
+System.register("my custom module name", [], function (_export, _context) {
   return {
     setters: [],
     execute: function () {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/get-module-name-option/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/get-module-name-option/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register("my custom module name", [], function (_export) {
+System.register("my custom module name", [], function (_export, __moduleName) {
   return {
     setters: [],
     execute: function () {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["./evens"], function (_export, __moduleName) {
+System.register(["./evens"], function (_export, _context) {
   var isEven, p, a, i, j, isOdd;
   return {
     setters: [function (_evens) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["./evens"], function (_export) {
+System.register(["./evens"], function (_export, __moduleName) {
   var isEven, p, a, i, j, isOdd;
   return {
     setters: [function (_evens) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-default/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export) {
+System.register(["foo"], function (_export, __moduleName) {
   var foo, foo2;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-default/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export, __moduleName) {
+System.register(["foo"], function (_export, _context) {
   var foo, foo2;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-glob/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export) {
+System.register(["foo"], function (_export, __moduleName) {
   var foo;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-glob/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export, __moduleName) {
+System.register(["foo"], function (_export, _context) {
   var foo;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-mixing/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export, __moduleName) {
+System.register(["foo"], function (_export, _context) {
   var foo, xyz;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-mixing/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export) {
+System.register(["foo"], function (_export, __moduleName) {
   var foo, xyz;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-named/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export) {
+System.register(["foo"], function (_export, __moduleName) {
   var bar, bar2, baz, baz2, baz3, xyz;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-named/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo"], function (_export, __moduleName) {
+System.register(["foo"], function (_export, _context) {
   var bar, bar2, baz, baz2, baz3, xyz;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, __moduleName) {
+System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, _context) {
   return {
     setters: [function (_foo) {}, function (_fooBar) {}, function (_directoryFooBar) {}],
     execute: function () {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export) {
+System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, __moduleName) {
   return {
     setters: [function (_foo) {}, function (_fooBar) {}, function (_directoryFooBar) {}],
     execute: function () {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/actual.js
@@ -1,0 +1,1 @@
+export var name = __moduleName;

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/expected.js
@@ -1,0 +1,13 @@
+"use strict";
+
+System.register([], function (_export, __moduleName) {
+  var name;
+  return {
+    setters: [],
+    execute: function () {
+      _export("name", name = __moduleName);
+
+      _export("name", name);
+    }
+  };
+});

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/expected.js
@@ -1,11 +1,11 @@
 "use strict";
 
-System.register([], function (_export, __moduleName) {
+System.register([], function (_export, _context) {
   var name;
   return {
     setters: [],
     execute: function () {
-      _export("name", name = __moduleName);
+      _export("name", name = _context.id);
 
       _export("name", name);
     }

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/overview/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, __moduleName) {
+System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, _context) {
   var foo, foo2, bar, bar2, test2;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/overview/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export) {
+System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, __moduleName) {
   var foo, foo2, bar, bar2, test2;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export, __moduleName) {
+System.register([], function (_export, _context) {
   var test, a, b, d;
   return {
     setters: [],

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-System.register([], function (_export) {
+System.register([], function (_export, __moduleName) {
   var test, a, b, d;
   return {
     setters: [],


### PR DESCRIPTION
See https://github.com/systemjs/builder/issues/416 for the discussion here.

Ideally this would only add the argument to modules that explicitly use a `__moduleName` reference. My Babel plugin knowledge is still pretty limited, so any suggestions how to quickly check if `__moduleName` is a bound to the outer scope and omit it in this case would be very welcome.