### PR TITLE
Use the babelrc option in babel-register

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -365,13 +365,13 @@ export default class OptionManager {
   init(opts: Object = {}): Object {
     let filename = opts.filename;
 
-    // resolve all .babelrc files
-    if (opts.babelrc !== false) {
-      this.findConfigs(filename);
-    }
-
     // merge in base options
     this.mergeOptions(opts, this.options, "base", null, filename && path.dirname(filename));
+
+    // resolve all .babelrc files
+    if (this.options.babelrc !== false) {
+      this.findConfigs(filename);
+    }
 
     // normalise
     this.normaliseOptions(opts);

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -54,7 +54,7 @@ function compile(filename) {
   // merge in base options and resolve all the plugins and presets relative to this file
   optsManager.mergeOptions(deepClone(transformOpts), "base", null, path.dirname(filename));
 
-  let opts = optsManager.init({ filename });
+  let opts = optsManager.init({ filename, babelrc: transformOpts.babelrc });
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
 

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -54,7 +54,7 @@ function compile(filename) {
   // merge in base options and resolve all the plugins and presets relative to this file
   optsManager.mergeOptions(deepClone(transformOpts), "base", null, path.dirname(filename));
 
-  let opts = optsManager.init({ filename, babelrc: transformOpts.babelrc });
+  let opts = optsManager.init({ filename });
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
 


### PR DESCRIPTION
This setting (to ignore `.babelrc` files) is currently ignored in babel-register. I could make it work with the following changes but I’m not sure if this is the best solution.