### PR TITLE
Fix invalid codegen for number member expr

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -221,14 +221,8 @@ export function MemberExpression(node: Object) {
     this.print(node.property, node);
     this.push("]");
   } else {
-    if (t.isLiteral(node.object) && !t.isTemplateLiteral(node.object)) {
-      let val;
-      if (this.format.minified) {
-        val = this._stringLiteral(node.object);
-      } else {
-        val = this.getPossibleRaw(node.object) || this._stringLiteral(node.object);
-      }
-
+    if (t.isNumericLiteral(node.object)) {
+      let val = this.getPossibleRaw(node.object) || node.object.value;
       if (isInteger(+val) && !SCIENTIFIC_NOTATION.test(val) && !ZERO_DECIMAL_INTEGER.test(val) && !this.endsWith(".")) {
         this.push(".");
       }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -16,6 +16,11 @@ suite("generation", function () {
       assert.ok(t.VISITOR_KEYS[type], type + " should not exist");
     });
   });
+
+  test("valid code", function() {
+    // Should not generate `0.foo`
+    new Function(generate.default(t.memberExpression(t.numericLiteral(60702), t.identifier("foo"))).code);
+  });
 });
 
 var suites = require("babel-helper-fixtures").default(__dirname + "/fixtures");

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -19,7 +19,8 @@ suite("generation", function () {
 
   test("valid code", function() {
     // Should not generate `0.foo`
-    new Function(generate.default(t.memberExpression(t.numericLiteral(60702), t.identifier("foo"))).code);
+    var mem = t.memberExpression(t.numericLiteral(60702), t.identifier("foo"));
+    new Function(generate.default(mem).code);
   });
 });
 


### PR DESCRIPTION
Expected: `5..foo`
Actual: `5.foo`