### PR TITLE
babel-types: make changes to Identifier validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
 
     * `babel-types`: Start test suite.
 
+    * Replace deprecated calls: `t.isValidIdentifier() => t.isSpecIdentifier()`.
+
 ## 6.4.3 (2016-01-13)
 
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
 
 ## Unreleased
 
+  * **New Feature**
+
+    * `babel-types`: Add `isSpecIdentifierName()`.
+
   * **Internal**
 
     * `babel-types`: Start test suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 > - [Documentation]
 > - [Internal]
 > - [Polish]
+> - [Deprecated]
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
@@ -22,6 +23,10 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
     * `babel-types`: Implement validation for `name` field in `Identifier` builder. It's limited to validating that it's a `spec.IdentifierName` since `ast.Identifier` is used to represent those as well. So in cases where the value must be a `spec.Identifier`, this validation will fail to error.
 
     * `babel-types`: Add `isSpecIdentifier()` as new name for `isValidIdentifier()`.
+
+  * **Deprecated**
+
+    * `babel-types`: `isValidIdentifier()`. The name is confusing due to differences between the AST type `Identifier` and the specification production. Use `isSpecIdentifier()` instead.
 
   * **Internal**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
 
     * `babel-types`: Add `isSpecIdentifierName()`.
 
+    * `babel-types`: Implement validation for `name` field in `Identifier` builder. It's limited to validating that it's a `spec.IdentifierName` since `ast.Identifier` is used to represent those as well. So in cases where the value must be a `spec.Identifier`, this validation will fail to error.
+
   * **Internal**
 
     * `babel-types`: Start test suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
 
+## Unreleased
+
+  * **Internal**
+
+    * `babel-types`: Start test suite.
+
 ## 6.4.3 (2016-01-13)
 
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ See [CHANGELOG - 6to5](CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
 
     * `babel-types`: Implement validation for `name` field in `Identifier` builder. It's limited to validating that it's a `spec.IdentifierName` since `ast.Identifier` is used to represent those as well. So in cases where the value must be a `spec.Identifier`, this validation will fail to error.
 
+    * `babel-types`: Add `isSpecIdentifier()` as new name for `isValidIdentifier()`.
+
   * **Internal**
 
     * `babel-types`: Start test suite.

--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -67,7 +67,7 @@ export default function (opts) {
       value.value = value.value.replace(/\n\s+/g, " ");
     }
 
-    if (t.isValidIdentifier(node.name.name)) {
+    if (t.isSpecIdentifier(node.name.name)) {
       node.name.type = "Identifier";
     } else {
       node.name = t.stringLiteral(node.name.name);

--- a/packages/babel-plugin-transform-es3-member-expression-literals/src/index.js
+++ b/packages/babel-plugin-transform-es3-member-expression-literals/src/index.js
@@ -4,7 +4,7 @@ export default function ({ types: t }) {
       MemberExpression: {
         exit({ node }) {
           let prop = node.property;
-          if (!node.computed && t.isIdentifier(prop) && !t.isValidIdentifier(prop.name)) {
+          if (!node.computed && t.isIdentifier(prop) && !t.isSpecIdentifier(prop.name)) {
             // foo.default -> foo["default"]
             node.property = t.stringLiteral(prop.name);
             node.computed = true;

--- a/packages/babel-plugin-transform-es3-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-es3-property-literals/src/index.js
@@ -4,7 +4,7 @@ export default function ({ types: t }) {
       ObjectProperty: {
         exit({node}) {
           let key = node.key;
-          if (!node.computed && t.isIdentifier(key) && !t.isValidIdentifier(key.name)) {
+          if (!node.computed && t.isIdentifier(key) && !t.isSpecIdentifier(key.name)) {
             // default: "bar" -> "default": "bar"
             node.key = t.stringLiteral(key.name);
           }

--- a/packages/babel-plugin-transform-member-expression-literals/src/index.js
+++ b/packages/babel-plugin-transform-member-expression-literals/src/index.js
@@ -4,7 +4,7 @@ export default function ({ types: t }) {
       MemberExpression: {
         exit({ node }) {
           let prop = node.property;
-          if (node.computed && t.isLiteral(prop) && t.isValidIdentifier(prop.value)) {
+          if (node.computed && t.isLiteral(prop) && t.isSpecIdentifier(prop.value)) {
             // foo["bar"] => foo.bar
             node.property = t.identifier(prop.value);
             node.computed = false;

--- a/packages/babel-plugin-transform-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-property-literals/src/index.js
@@ -4,7 +4,7 @@ export default function ({ types: t }) {
       ObjectProperty: {
         exit({ node }) {
           let key = node.key;
-          if (t.isLiteral(key) && t.isValidIdentifier(key.value)) {
+          if (t.isLiteral(key) && t.isSpecIdentifier(key.value)) {
             // "foo": "bar" -> foo: "bar"
             node.key = t.identifier(key.value);
             node.computed = false;

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -47,7 +47,7 @@ export default function ({ types: t }) {
             key = getAttributeValue(attr);
           } else {
             let name = attr.name.name;
-            let propertyKey = t.isValidIdentifier(name) ? t.identifier(name) : t.stringLiteral(name);
+            let propertyKey = t.isSpecIdentifier(name) ? t.identifier(name) : t.stringLiteral(name);
             pushProp(props.properties, propertyKey, getAttributeValue(attr));
           }
         }

--- a/packages/babel-types/src/converters.js
+++ b/packages/babel-types/src/converters.js
@@ -147,7 +147,7 @@ export function toIdentifier(name: string): string {
     return c ? c.toUpperCase() : "";
   });
 
-  if (!t.isValidIdentifier(name)) {
+  if (!t.isSpecIdentifier(name)) {
     name = `_${name}`;
   }
 
@@ -285,7 +285,7 @@ export function valueToNode(value: any): Object {
     let props = [];
     for (let key in value) {
       let nodeKey;
-      if (t.isValidIdentifier(key)) {
+      if (t.isSpecIdentifier(key)) {
         nodeKey = t.identifier(key);
       } else {
         nodeKey = t.stringLiteral(key);

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -304,8 +304,8 @@ defineType("Identifier", {
   fields: {
     name: {
       validate(node, key, val) {
-        if (!t.isValidIdentifier(val)) {
-          // todo
+        if (!t.isSpecIdentifierName(val)) {
+          throw new TypeError(`Property "${key}" of ${node.type} failed validation with value: ${JSON.stringify(val)}. Expected true for t.isSpecIdentifierName().`);
         }
       }
     }

--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -2,6 +2,7 @@ import { getBindingIdentifiers } from "./retrievers";
 import esutils from "esutils";
 import * as t from "./index";
 import { BLOCK_SCOPED_SYMBOL } from "./constants";
+import * as util from "util";
 
 /**
  * Check if the input `node` is a binding identifier.
@@ -150,7 +151,11 @@ export function isReferenced(node: Object, parent: Object): boolean {
   return true;
 }
 
-export let isValidIdentifier = isSpecIdentifier;
+// [DEPRECATED].
+export let isValidIdentifier = util.deprecate(
+  isSpecIdentifier,
+  "babel-types: isValidIdentifier() is deprecated. Use isSpecIdentifier() instead."
+);
 
 /**
  * Is `name` an ES2015 strict mode Identifier?

--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -164,6 +164,17 @@ export function isValidIdentifier(name: string): boolean {
 }
 
 /**
+ * Is `name` an ES2015 IdentifierName?
+ */
+
+export function isSpecIdentifierName(name: string): boolean {
+  return (
+    typeof name === "string" &&
+    esutils.keyword.isIdentifierNameES6(name)
+  );
+}
+
+/**
  * Check if the input `node` is a `let` variable declaration.
  */
 

--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -150,17 +150,18 @@ export function isReferenced(node: Object, parent: Object): boolean {
   return true;
 }
 
+export let isValidIdentifier = isSpecIdentifier;
+
 /**
- * Check if the input `name` is a valid identifier name
- * and isn't a reserved word.
+ * Is `name` an ES2015 strict mode Identifier?
+ * (IdentifierName that isn't a ReservedWord.)
  */
 
-export function isValidIdentifier(name: string): boolean {
-  if (typeof name !== "string" || esutils.keyword.isReservedWordES6(name, true)) {
-    return false;
-  } else {
-    return esutils.keyword.isIdentifierNameES6(name);
-  }
+export function isSpecIdentifier(name: string): boolean {
+  return (
+    typeof name === "string" &&
+    esutils.keyword.isIdentifierES6(name, true)
+  );
 }
 
 /**

--- a/packages/babel-types/test/definitions.js
+++ b/packages/babel-types/test/definitions.js
@@ -1,0 +1,8 @@
+var t = require("../lib");
+
+Object.keys(t.VISITOR_KEYS).forEach(function (type) {
+  try {
+    require("./definitions/" + type.toLowerCase());
+  }
+  catch (e) {}
+});

--- a/packages/babel-types/test/definitions/identifier.js
+++ b/packages/babel-types/test/definitions/identifier.js
@@ -1,0 +1,25 @@
+var t = require("../../lib");
+var assert = require("assert");
+
+// Bear in mind that ast.Identifier is used to represent syntactic productions
+// that can be spec.IdentifierName (like object property keys).
+var fixtures = require("../fixtures/identifier-name");
+
+suite("Identifier", function () {
+  test("validate()", function () {
+    fixtures.forEach(function (fixture) {
+      var value = fixture[0];
+      var isValid = fixture[1];
+
+      var assertMethod = isValid ? "doesNotThrow" : "throws";
+
+      assert[assertMethod](function () {
+        t.validate(
+          {type: "Identifier"},
+          "name",
+          value
+        )
+      });
+    });
+  });
+});

--- a/packages/babel-types/test/fixtures/identifier-name.js
+++ b/packages/babel-types/test/fixtures/identifier-name.js
@@ -1,0 +1,16 @@
+// spec.IdentifierName
+// value => valid (ES2015 strict).
+module.exports = [
+  ["x", true],
+
+  ["default", true],
+
+  ["null", true],
+
+  ["true", true],
+
+  ["false", true],
+
+  // Not a lexical IdentifierName.
+  ["bound x", false]
+];

--- a/packages/babel-types/test/fixtures/identifier.js
+++ b/packages/babel-types/test/fixtures/identifier.js
@@ -1,0 +1,16 @@
+// spec.Identifier (e.g. BindingIdentifier).
+// value => valid (ES2015 strict).
+module.exports = [
+  ["x", true],
+
+  // IdentifierName, ReservedWord :: Keyword.
+  ["default", false],
+
+  // ReservedWord's
+  ["null", false],
+  ["true", false],
+  ["false", false],
+
+  // Not a lexical IdentifierName.
+  ["bound x", false]
+];

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -1,0 +1,24 @@
+var t = require("../lib");
+var assert = require("assert");
+
+suite("Validators", function () {
+  test("isValidIdentifier()", function () {
+    var fixtures = require("./fixtures/identifier");
+
+    fixtures.forEach(function (fixture) {
+      var value = fixture[0];
+      var isValid = fixture[1];
+
+      assert.equal(
+        t.isValidIdentifier(value),
+        isValid,
+        (
+          "Expected t.isValidIdentifier(" +
+          JSON.stringify(value) +
+          ") === " +
+          JSON.stringify(isValid)
+        )
+      );
+    });
+  });
+});

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -21,4 +21,24 @@ suite("Validators", function () {
       );
     });
   });
+
+  test("isSpecIdentifierName()", function () {
+    var fixtures = require("./fixtures/identifier-name");
+
+    fixtures.forEach(function (fixture) {
+      var value = fixture[0];
+      var isValid = fixture[1];
+
+      assert.equal(
+        t.isSpecIdentifierName(value),
+        isValid,
+        (
+          "Expected t.isSpecIdentifierName(" +
+          JSON.stringify(value) +
+          ") === " +
+          JSON.stringify(isValid)
+        )
+      );
+    });
+  });
 });

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -2,43 +2,49 @@ var t = require("../lib");
 var assert = require("assert");
 
 suite("Validators", function () {
-  test("isValidIdentifier()", function () {
-    var fixtures = require("./fixtures/identifier");
+  suite("Identifiers", function () {
+    var tests = [
+      {
+        method: "isValidIdentifier",
+        fixtures: "./fixtures/identifier",
+      },
 
-    fixtures.forEach(function (fixture) {
-      var value = fixture[0];
-      var isValid = fixture[1];
+      {
+        method: "isSpecIdentifier",
+        fixtures: "./fixtures/identifier",
+      },
 
-      assert.equal(
-        t.isValidIdentifier(value),
-        isValid,
-        (
-          "Expected t.isValidIdentifier(" +
-          JSON.stringify(value) +
-          ") === " +
-          JSON.stringify(isValid)
-        )
-      );
+      {
+        method: "isSpecIdentifierName",
+        fixtures: "./fixtures/identifier-name",
+      },
+    ];
+
+    tests.forEach(function (testCfg) {
+      test(testCfg.method + "()", function () {
+        var fixtures = require(testCfg.fixtures);
+
+        fixtures.forEach(function (fixture) {
+          var value = fixture[0];
+          var isValid = fixture[1];
+
+          assert.equal(
+            t[testCfg.method](value),
+            isValid,
+            (
+              "Expected t." +
+              testCfg.method +
+              "(" +
+              JSON.stringify(value) +
+              ") === " +
+              JSON.stringify(isValid)
+            )
+          );
+        });
+      });
+      // test
     });
   });
-
-  test("isSpecIdentifierName()", function () {
-    var fixtures = require("./fixtures/identifier-name");
-
-    fixtures.forEach(function (fixture) {
-      var value = fixture[0];
-      var isValid = fixture[1];
-
-      assert.equal(
-        t.isSpecIdentifierName(value),
-        isValid,
-        (
-          "Expected t.isSpecIdentifierName(" +
-          JSON.stringify(value) +
-          ") === " +
-          JSON.stringify(isValid)
-        )
-      );
-    });
-  });
+  // suite("Identifiers")
 });
+// suite("Validators")


### PR DESCRIPTION
These changes were discussed on slack /cc @hzoo @sebmck @loganfsmyth.

This is currently based on #3267.
- Made changes to validator methods in `babel-types`:
  - Add `isSpecIdentifierName()`. `spec.IdentifierName` has no direct representation (e.g. a node type) in the AST, currently.
  - Add `isSpecIdentifier()` as new name for `isValidIdentifier()`.
  - Deprecate `isValidIdentifier()` and replace its usage throughout the internals. I couldn't find a similar scenario to use as a guide. Open to a better way of doing it.
  
  I'm not married to the new names, but I'll explain my thinking. There seemed to be agreement that `isValidIdentifier` is a confusing name when you wind up with a scenario like this for a valid AST:
  
  ``` js
  // true
  node.type === "Identifier" &&
  
  // false
  t.isValidIdentifier(node.name)
  ```
  
  I'm not really a fan of having `Valid` in the name, so I didn't include it. I think it's implied (especially with `Spec` in the name for context) because it doesn't really make sense that you'd have `isSomething(x) === true`, but `x` isn't a "valid" `something`. Also, this is defined in a file with other functions that are validators and don't have `Valid` in the name. I think it only had that in the first place because `isIdentifier()` is already taken by the node type (I believe).
  
  I included `Spec` in the names to communicate that these are validating spec compliance that's not implicit in the AST types. I think the new name helps communicate that the addtional call is there because there's not a 1:1 mapping between `ast.Identifier` and `spec.Identifier`:
  
  ``` js
  // true
  node.type === "Identifier" &&
  
  // false
  t.isSpecIdentifier(node.name)
  ```
  
  The thought crossed my mind of namespacing these kind of validators in a property, like `t.spec.isIdentifierName()`.
  
  `isValidBindingIdentifier()` was mentioned in the slack discussion, but I'm suggesting `isSpecIdentifier` instead (instead of even `isBindingIdentifier`) because `spec.BindingIdentifier` is variable -- sometimes it includes `yield`. When it doesn't (e.g. in `spec.FunctionExpression`), it's the same as `spec.Identifier`. Open to suggestions on how to handle that, if it even needs to be. E.g. a `t.isSpecBindingIdentifier(name: string, yield: boolean)`. Or perhaps validation related to that can be done within the path system, if necessary.
- Implement validation for `Identifier` builder `name` key using `isSpecIdentifierName()`. I think this is as much validation as can be done there since `ast.Identifier` is used to represent both `spec.Identifier` and `spec.IdentifierName`. Doing more, context-sensitive, validation via the path system was discussed. I haven't done anything re: that.
