### PR TITLE
Clarify description of `comments` config.

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -92,7 +92,7 @@ module.exports = {
   comments: {
     type: "boolean",
     default: true,
-    description: "strip/output comments in generated output (on by default)"
+    description: "write comments to generated output (true by default)"
   },
 
   shouldPrintComment: {


### PR DESCRIPTION
It doesn't mean anything for “strip/output” to be “on.”