### PR TITLE
Correct type annotation for `shouldPrintComment`

### DIFF
--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -34,7 +34,7 @@ export class CodeGenerator extends Printer {
   }
 
   format: {
-    shouldPrintComment: boolean;
+    shouldPrintComment: (comment: string) => boolean;
     retainLines: boolean;
     comments: boolean;
     auxiliaryCommentBefore: string;


### PR DESCRIPTION
I think this is supposed to be a `Function` that returns a `boolean`.

See example usage, [here](https://github.com/babel/babel/blob/d2e7e6a54d4551f46996a4fef6558b2c9fffade3/packages/babel-generator/src/printer.js#L239).