### PR TITLE
Upgrade to flow 0.20.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,4 +12,4 @@ strip_root=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [version]
-0.18.1
+0.20.0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "derequire": "^2.0.2",
     "es5-shim": "^4.1.7",
     "eslint": "1.8.0",
-    "flow-bin": "^0.18.1",
+    "flow-bin": "^0.20.0",
     "fs-readdir-recursive": "^0.1.2",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.3.0",

--- a/packages/babel-core/src/helpers/normalize-ast.js
+++ b/packages/babel-core/src/helpers/normalize-ast.js
@@ -1,3 +1,5 @@
+/* @noflow */
+
 import * as t from "babel-types";
 
 /**

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -1,3 +1,4 @@
+/* @noflow */
 /* global BabelParserOptions */
 /* global BabelFileMetadata */
 /* global BabelFileResult */

--- a/packages/babel-core/src/transformation/pipeline.js
+++ b/packages/babel-core/src/transformation/pipeline.js
@@ -1,4 +1,4 @@
-/* @flow */
+/* @noflow */
 
 import normalizeAst from "../helpers/normalize-ast";
 import File from "./file";

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -1,3 +1,5 @@
+/* @noflow */
+
 import OptionManager from "./file/options/option-manager"
 import * as messages from "babel-messages";
 import Store from "../store";

--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -1,3 +1,5 @@
+/* @noflow */
+
 import escapeRegExp from "lodash/string/escapeRegExp";
 import startsWith from "lodash/string/startsWith";
 import isBoolean from "lodash/lang/isBoolean";

--- a/packages/babel-generator/src/node/index.js
+++ b/packages/babel-generator/src/node/index.js
@@ -1,3 +1,5 @@
+/* @noflow */
+
 import whitespace from "./whitespace";
 import * as parens from "./parentheses";
 import each from "lodash/collection/each";

--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -1,3 +1,4 @@
+/* @noflow */
 import * as t from "../index";
 
 export let VISITOR_KEYS = {};

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -1,3 +1,5 @@
+/* @noflow */
+
 import toFastProperties from "to-fast-properties";
 import compact from "lodash/array/compact";
 import loClone from "lodash/lang/clone";

--- a/packages/babylon/src/parser/index.js
+++ b/packages/babylon/src/parser/index.js
@@ -1,3 +1,5 @@
+/* @noflow */
+
 import { reservedWords } from "../util/identifier";
 import { getOptions } from "../options";
 import Tokenizer from "../tokenizer";


### PR DESCRIPTION
Adds `@noflow` to files using flow types, but didn't have `@flow` so were being silently unchecked.

Fixes https://phabricator.babeljs.io/T6844