### PR TITLE
fix issue on IE8 and bellow

### DIFF
--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -32,8 +32,8 @@ export default function ({ messages, template, types: t }) {
       ITERATOR_ERROR_KEY = err;
     } finally {
       try {
-        if (!ITERATOR_COMPLETION && ITERATOR_KEY.return) {
-          ITERATOR_KEY.return();
+        if (!ITERATOR_COMPLETION && ITERATOR_KEY["return"]) {
+          ITERATOR_KEY["return"]();
         }
       } finally {
         if (ITERATOR_HAD_ERROR_KEY) {


### PR DESCRIPTION
It throws on IE8 and below if the access property name is a reserved keyword in the `dot-style` way. So changing to the 'bracket-style' to avoid that.