### PR TITLE
Fix ignoring previous strict mode after twice "use strict"

### DIFF
--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -464,7 +464,7 @@ pp.parseBlockBody = function (node, allowDirectives, topLevel, end) {
       let directive = this.stmtToDirective(stmt);
       node.directives.push(directive);
 
-      if (directive.value.value === "use strict") {
+      if (oldStrict === undefined && directive.value.value === "use strict") {
         oldStrict = this.state.strict;
         this.setStrict(true);
 

--- a/packages/babylon/test/fixtures/core/uncategorised/543/actual.js
+++ b/packages/babylon/test/fixtures/core/uncategorised/543/actual.js
@@ -1,0 +1,6 @@
+var fn = function () {
+  "use strict";
+  "use strict";
+};
+
+0100;

--- a/packages/babylon/test/fixtures/core/uncategorised/543/expected.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/543/expected.json
@@ -1,0 +1,225 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 64,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 5
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 64,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 5
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 57,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 56,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 4,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 6,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 6
+                }
+              },
+              "name": "fn"
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 9,
+              "end": 56,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 4,
+                  "column": 1
+                }
+              },
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 21,
+                "end": 56,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 1
+                  }
+                },
+                "body": [],
+                "directives": [
+                  {
+                    "type": "Directive",
+                    "start": 25,
+                    "end": 38,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 15
+                      }
+                    },
+                    "value": {
+                      "type": "DirectiveLiteral",
+                      "start": 25,
+                      "end": 37,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 14
+                        }
+                      },
+                      "value": "use strict",
+                      "extra": {
+                        "raw": "\"use strict\"",
+                        "rawValue": "use strict"
+                      }
+                    }
+                  },
+                  {
+                    "type": "Directive",
+                    "start": 41,
+                    "end": 54,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 15
+                      }
+                    },
+                    "value": {
+                      "type": "DirectiveLiteral",
+                      "start": 41,
+                      "end": 53,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 14
+                        }
+                      },
+                      "value": "use strict",
+                      "extra": {
+                        "raw": "\"use strict\"",
+                        "rawValue": "use strict"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "kind": "var"
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 59,
+        "end": 64,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 5
+          }
+        },
+        "expression": {
+          "type": "NumericLiteral",
+          "start": 59,
+          "end": 63,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 0
+            },
+            "end": {
+              "line": 6,
+              "column": 4
+            }
+          },
+          "extra": {
+            "rawValue": 64,
+            "raw": "0100"
+          },
+          "value": 64
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
For example:

```javascript
var foo = function () {
  "use strict";
  "use strict";
  // there is inside of strict mode,
  // so `0123` (octal number) occurs a syntax error.
};
// there is outside of strict mode,
0123; // so left is valid syntax.
// however:
//   SyntaxError: Invalid number (8:0)
```

I fixed it and add the test case.