### PR TITLE
Make use of `opts.quotes` in the CodeGenerator

### DIFF
--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -84,7 +84,7 @@ export class CodeGenerator extends Printer {
       compact: opts.compact,
       minified: opts.minified,
       concise: opts.concise,
-      quotes: CodeGenerator.findCommonStringDelimiter(code, tokens),
+      quotes: opts.quotes || CodeGenerator.findCommonStringDelimiter(code, tokens),
       indent: {
         adjustMultilineComment: true,
         style: style,


### PR DESCRIPTION
I think we're meant to respect the value of `opts.quotes`, and try to infer it if none was supplied.