### PR TITLE
babel-generator: keep double quotes in StringLiteral for JSX parent

### DIFF
--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -115,11 +115,11 @@ export function NumericLiteral(node: Object) {
   this.push(node.value + "");
 }
 
-export function StringLiteral(node: Object) {
-  this.push(this._stringLiteral(node.value));
+export function StringLiteral(node: Object, parent: Object) {
+  this.push(this._stringLiteral(node.value, parent));
 }
 
-export function _stringLiteral(val: string): string {
+export function _stringLiteral(val: string, parent: Object): string {
   val = JSON.stringify(val);
 
   // escape illegal js but valid json unicode characters
@@ -127,7 +127,7 @@ export function _stringLiteral(val: string): string {
     return "\\u" + ("0000" + c.charCodeAt(0).toString(16)).slice(-4);
   });
 
-  if (this.format.quotes === "single") {
+  if (this.format.quotes === "single" && !t.isJSX(parent)) {
     // remove double quotes
     val = val.slice(1, -1);
 

--- a/packages/babel-generator/test/fixtures/auto-string/jsx/actual.js
+++ b/packages/babel-generator/test/fixtures/auto-string/jsx/actual.js
@@ -1,0 +1,9 @@
+var single = 'quotes';
+var outnumber = 'double';
+var moreSingleQuotesThanDouble = '!';
+
+React.createClass({
+  render() {
+    return <View multiple="attributes" attribute="If parent is JSX keep double quote" />;
+  }
+});

--- a/packages/babel-generator/test/fixtures/auto-string/jsx/expected.js
+++ b/packages/babel-generator/test/fixtures/auto-string/jsx/expected.js
@@ -1,0 +1,9 @@
+var single = 'quotes';
+var outnumber = 'double';
+var moreSingleQuotesThanDouble = '!';
+
+React.createClass({
+  render() {
+    return <View multiple="attributes" attribute="If parent is JSX keep double quote" />;
+  }
+});


### PR DESCRIPTION
Fixes https://phabricator.babeljs.io/T6859

Idea is to check if the parent node of the `StringLiteral` is of type JSX - although maybe we can just check `t.isJSXAttribute`?

```Diff
var quotes = '!';

React.createClass({
  render() {
+    return <View multiple="attributes" attribute="Value's got a single quote in it" />;
-    return <View multiple='attributes' attribute='Value\'s got a single quote in it' />;
  }
});
```

@steveluscher 