### PR TITLE
Order of arguments initialization - fixes T6809

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/destructuring.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/destructuring.js
@@ -3,8 +3,12 @@ import * as t from "babel-types";
 export let visitor = {
   Function(path) {
     let params: Array = path.get("params");
-    
-    for (let i = 0; i < params.length; i++) {
+
+    // If there's a rest param, no need to loop through it. Also, we need to
+    // hoist one more level to get `declar` at the right spot.
+    const hoistTweak = t.isRestElement(params[params.length - 1]) ? 1 : 0;
+
+    for (let i = 0; i < params.length - hoistTweak; i++) {
       let param = params[i];
       if (param.isArrayPattern() || param.isObjectPattern()) {
         let uid = path.scope.generateUidIdentifier("ref");
@@ -12,7 +16,7 @@ export let visitor = {
         let declar = t.variableDeclaration("let", [
           t.variableDeclarator(param.node, uid)
         ]);
-        declar._blockHoist = params.length - i;
+        declar._blockHoist = params.length - i - hoistTweak;
 
         path.ensureBlock();
         path.get("body").unshiftContainer("body", declar);

--- a/packages/babel-plugin-transform-es2015-parameters/src/destructuring.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/destructuring.js
@@ -6,9 +6,10 @@ export let visitor = {
 
     // If there's a rest param, no need to loop through it. Also, we need to
     // hoist one more level to get `declar` at the right spot.
-    const hoistTweak = t.isRestElement(params[params.length - 1]) ? 1 : 0;
+    let hoistTweak = t.isRestElement(params[params.length - 1]) ? 1 : 0;
+    let outputParamsLength = params.length - hoistTweak;
 
-    for (let i = 0; i < params.length - hoistTweak; i++) {
+    for (let i = 0; i < outputParamsLength; i++) {
       let param = params[i];
       if (param.isArrayPattern() || param.isObjectPattern()) {
         let uid = path.scope.generateUidIdentifier("ref");
@@ -16,7 +17,7 @@ export let visitor = {
         let declar = t.variableDeclaration("let", [
           t.variableDeclarator(param.node, uid)
         ]);
-        declar._blockHoist = params.length - i - hoistTweak;
+        declar._blockHoist = outputParamsLength - i;
 
         path.ensureBlock();
         path.get("body").unshiftContainer("body", declar);

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/destructuring-rest/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/destructuring-rest/actual.js
@@ -1,0 +1,4 @@
+// T6809
+function t(x = "default", { a, b }, ...args) {
+  console.log(x, a, b, args);
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/destructuring-rest/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/destructuring-rest/expected.js
@@ -1,0 +1,13 @@
+// T6809
+function t() {
+  var x = arguments.length <= 0 || arguments[0] === undefined ? "default" : arguments[0];
+  var _ref = arguments[1];
+  var a = _ref.a;
+  var b = _ref.b;
+
+  for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+    args[_key - 2] = arguments[_key];
+  }
+
+  console.log(x, a, b, args);
+}


### PR DESCRIPTION
When using a default param + some destructuring param + a rest param, the
initialization order of the destructured arguments was incorrect due to the
presence of the rest parameter.

```diff
function t(x = "default", { a, b }, ...args) {
  console.log(x, a, b, args);
}

// ==>

function t() {
  var x = arguments.length <= 0 || arguments[0] === undefined ? "default" : arguments[0];
+ var _ref = arguments[1];
  var a = _ref.a;
  var b = _ref.b;
- var _ref = arguments[1];

  for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
    args[_key - 2] = arguments[_key];
  }

  console.log(x, a, b, args);
}
```