### PR TITLE
Evaluation may succeed even when not confident

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -99,11 +99,14 @@ export function evaluate(): { confident: boolean; value: any } {
         if (expr) str += String(evaluate(expr));
       }
 
-      if (confident) return str;
+      if (!confident) return;
+      return str;
     }
 
     if (path.isConditionalExpression()) {
-      if (evaluate(path.get("test"))) {
+      let testResult = evaluate(path.get("test"));
+      if (!confident) return;
+      if (testResult) {
         return evaluate(path.get("consequent"));
       } else {
         return evaluate(path.get("alternate"));
@@ -162,6 +165,7 @@ export function evaluate(): { confident: boolean; value: any } {
       }
 
       let arg = evaluate(argument);
+      if (!confident) return;
       switch (node.operator) {
         case "!": return !arg;
         case "+": return +arg;
@@ -218,7 +222,9 @@ export function evaluate(): { confident: boolean; value: any } {
 
     if (path.isBinaryExpression()) {
       let left = evaluate(path.get("left"));
+      if (!confident) return;
       let right = evaluate(path.get("right"));
+      if (!confident) return;
 
       switch (node.operator) {
         case "-": return left - right;

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -1,0 +1,26 @@
+var traverse = require("../lib").default;
+var assert = require("assert");
+var parse = require("babylon").parse;
+
+function getPath(code) {
+  var ast = parse(code);
+  var path;
+  traverse(ast, {
+    Program: function (_path) {
+      path = _path;
+      _path.stop();
+    }
+  });
+  return path;
+}
+
+suite("evaluation", function () {
+  suite("evaluateTruthy", function () {
+    test("it should work with null", function () {
+      assert.strictEqual(
+        getPath("false || a.length === 0;").get("body")[0].evaluateTruthy(),
+        false
+      );
+    });
+  });
+});

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -19,7 +19,7 @@ suite("evaluation", function () {
     test("it should work with null", function () {
       assert.strictEqual(
         getPath("false || a.length === 0;").get("body")[0].evaluateTruthy(),
-        false
+        undefined
       );
     });
   });


### PR DESCRIPTION
There are some code paths where the confidence is not checked and we proceed blindly and by some turn of events the entire expression will evaluate to truthy. The easiest way to reproduce this is to take the expression:

`false || a.length === 0;`

`a.length` evaluates to undefined with `confidence = false` however, in the binary expression code path we continue by comparing to undefined values that were meant as "no value" as opposed to "undefined type" thus succeeding. Finally, in the logical expression we hit a code path that flips the confidence given it's an or operation.