### PR TITLE
Now babel searches presets relative the script path (process.argv[1]).

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -243,7 +243,7 @@ export default class OptionManager {
   mergePresets(presets: Array<string | Object>, dirname: string) {
     for (let val of presets) {
       if (typeof val === "string") {
-        let presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+        let presetLoc = resolve(`babel-preset-${val}`, process.argv[1]) || resolve(val, process.argv[1]);
         if (presetLoc) {
           let presetOpts = require(presetLoc);
           this.mergeOptions(presetOpts, presetLoc, presetLoc, path.dirname(presetLoc));


### PR DESCRIPTION
I had a problem when tried compile files outside the project dir. When I did so, I have an error: "Couldn't find preset es2015"