### PR TITLE
Add support for mixins to Babel 6.x

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -104,7 +104,7 @@ export function _interfaceish(node: Object) {
     this.push(" extends ");
     this.printJoin(node.extends, node, { separator: ", " });
   }
-  if (node.mixins.length) {
+  if (node.mixins && node.mixins.length) {
     this.push(" mixins ");
     this.printJoin(node.mixins, node, { separator: ", " });
   }

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -104,6 +104,10 @@ export function _interfaceish(node: Object) {
     this.push(" extends ");
     this.printJoin(node.extends, node, { separator: ", " });
   }
+  if (node.mixins.length) {
+    this.push(" mixins ");
+    this.printJoin(node.mixins, node, { separator: ", " });
+  }
   this.space();
   this.print(node.body, node);
 }

--- a/packages/babel-generator/test/fixtures/flow/declare-statements/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/declare-statements/actual.js
@@ -9,3 +9,4 @@ declare class A<T> extends B<T> { x: number }
 declare class A { static foo(): number; static x : string }
 declare class A { static [ indexer: number]: string }
 declare class A { static () : number }
+declare class A mixins B<T>, C {}

--- a/packages/babel-generator/test/fixtures/flow/declare-statements/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/declare-statements/expected.js
@@ -9,3 +9,4 @@ declare class A<T> extends B<T> { x: number }
 declare class A { static foo(): number; static x: string; }
 declare class A { static [indexer: number]: string }
 declare class A { static (): number }
+declare class A mixins B<T>, C {}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/actual.js
@@ -1,0 +1,12 @@
+declare var foo
+declare var foo;
+declare function foo(): void
+declare function foo(): void;
+declare function foo<T>(): void;
+declare function foo(x: number, y: string): void;
+declare class A {}
+declare class A<T> extends B<T> { x: number }
+declare class A { static foo(): number; static x : string }
+declare class A { static [ indexer: number]: string }
+declare class A { static () : number }
+declare class A mixins B<T>, C {}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/expected.js
@@ -1,0 +1,12 @@
+/*:: declare var foo*/
+/*:: declare var foo;*/
+/*:: declare function foo(): void*/
+/*:: declare function foo(): void;*/
+/*:: declare function foo<T>(): void;*/
+/*:: declare function foo(x: number, y: string): void;*/
+/*:: declare class A {}*/
+/*:: declare class A<T> extends B<T> { x: number }*/
+/*:: declare class A { static foo(): number; static x : string }*/
+/*:: declare class A { static [ indexer: number]: string }*/
+/*:: declare class A { static () : number }*/
+/*:: declare class A mixins B<T>, C {}*/

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declare-statements/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declare-statements/actual.js
@@ -9,3 +9,4 @@ declare class A<T> extends B<T> { x: number }
 declare class A { static foo(): number; static x : string }
 declare class A { static [ indexer: number]: string }
 declare class A { static () : number }
+declare class A mixins B<T>, C {}

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -64,6 +64,7 @@ defineType("ClassDeclaration", {
     "id",
     "body",
     "superClass",
+    "mixins",
     "typeParameters",
     "superTypeParameters",
     "implements",

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -109,10 +109,18 @@ pp.flowParseInterfaceish = function (node, allowStatic) {
   }
 
   node.extends = [];
+  node.mixins = [];
 
   if (this.eat(tt._extends)) {
     do {
       node.extends.push(this.flowParseInterfaceExtends());
+    } while (this.eat(tt.comma));
+  }
+
+  if (this.isContextual("mixins")) {
+    this.next();
+    do {
+      node.mixins.push(this.flowParseInterfaceExtends());
     } while (this.eat(tt.comma));
   }
 

--- a/packages/babylon/test/fixtures/flow/declare-statements/13/actual.js
+++ b/packages/babylon/test/fixtures/flow/declare-statements/13/actual.js
@@ -1,0 +1,1 @@
+declare class A mixins B<T>, C {}

--- a/packages/babylon/test/fixtures/flow/declare-statements/13/expected.json
+++ b/packages/babylon/test/fixtures/flow/declare-statements/13/expected.json
@@ -1,0 +1,199 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 33,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 33
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 33,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 33
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareClass",
+        "start": 0,
+        "end": 33,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 33
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 14,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [
+          {
+            "type": "InterfaceExtends",
+            "start": 23,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 23
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 23,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 23
+                },
+                "end": {
+                  "line": 1,
+                  "column": 24
+                }
+              },
+              "name": "B"
+            },
+            "typeParameters": {
+              "type": "TypeParameterInstantiation",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                }
+              },
+              "params": [
+                {
+                  "type": "GenericTypeAnnotation",
+                  "start": 25,
+                  "end": 26,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 26
+                    }
+                  },
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start": 25,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 26
+                      }
+                    },
+                    "name": "T"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "InterfaceExtends",
+            "start": 29,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 29
+              },
+              "end": {
+                "line": 1,
+                "column": 30
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 30
+                }
+              },
+              "name": "C"
+            },
+            "typeParameters": null
+          }
+        ],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 31,
+          "end": 33,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 31
+            },
+            "end": {
+              "line": 1,
+              "column": 33
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
If this looks good I'll backport to Babel 5.x. In particular I'm unsure if it's kosher to reuse `InterfaceExtends` as the type of `mixins` nodes. Should I create a `ClassMixins` type instead?

cc @sebmck @jeffmo 