### PR TITLE
Honor .babelrc when considering `only`/`ignore` via `babel-register`

### DIFF
--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -20,6 +20,7 @@ program.option("-i, --ignore [globs]", "");
 program.option("-x, --extensions [extensions]", "List of extensions to hook into [.es6,.js,.es,.jsx]");
 program.option("-w, --plugins [string]", "", util.list);
 program.option("-b, --presets [string]", "", util.list);
+program.option("-r, --root [directory]", "Root of the package; used when searching for .babelrc", process.cwd())
 
 let pkg = require("../package.json");
 program.version(pkg.version);
@@ -29,6 +30,7 @@ program.parse(process.argv);
 //
 
 register({
+  root:       program.root,
   extensions: program.extensions,
   ignore:     program.ignore,
   only:       program.only,

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/.babelrc
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/.babelrc
@@ -1,0 +1,5 @@
+{
+  "ignore": [
+    "node_modules/blacklisted/*"
+  ]
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/index.js
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/index.js
@@ -1,0 +1,14 @@
+if (require('whitelisted').foo != 123) {
+  throw new Error('Expected babelrc.ignore to allow node_modules/whitelisted through');
+}
+
+try {
+  require('blacklisted');
+  throw new Error('Expected babelrc.ignore to deny node_modules/blacklisted');
+} catch (error) {
+  if (error.message != 'Unexpected reserved word') {
+    throw error;
+  }
+}
+
+console.log('✓ babelrc.ignore');

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/blacklisted/main.js
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/blacklisted/main.js
@@ -1,0 +1,1 @@
+export const foo = 123;

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/blacklisted/package.json
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/blacklisted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "blacklisted",
+  "private": true,
+  "main": "main.js"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/whitelisted/main.js
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/whitelisted/main.js
@@ -1,0 +1,1 @@
+export const foo = 123;

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/whitelisted/package.json
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/in-files/node_modules/whitelisted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "whitelisted",
+  "private": true,
+  "main": "main.js"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-ignore/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["index"],
+  "stdout": "✓ babelrc.ignore"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/.babelrc
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/.babelrc
@@ -1,0 +1,5 @@
+{
+  "only": [
+    "node_modules/whitelisted/*"
+  ]
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/index.js
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/index.js
@@ -1,0 +1,14 @@
+if (require('whitelisted').foo != 123) {
+  throw new Error('Expected babelrc.only to allow node_modules/whitelisted through');
+}
+
+try {
+  require('blacklisted');
+  throw new Error('Expected babelrc.only to deny node_modules/blacklisted');
+} catch (error) {
+  if (error.message != 'Unexpected reserved word') {
+    throw error;
+  }
+}
+
+console.log('✓ babelrc.only');

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/blacklisted/main.js
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/blacklisted/main.js
@@ -1,0 +1,1 @@
+export const foo = 123;

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/blacklisted/package.json
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/blacklisted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "blacklisted",
+  "private": true,
+  "main": "main.js"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/whitelisted/main.js
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/whitelisted/main.js
@@ -1,0 +1,1 @@
+export const foo = 123;

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/whitelisted/package.json
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/in-files/node_modules/whitelisted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "whitelisted",
+  "private": true,
+  "main": "main.js"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/babelrc-only/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/babelrc-only/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["index"],
+  "stdout": "✓ babelrc.only"
+}

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -28,7 +28,7 @@ var pluginLocs = [
 var readDir = function (loc) {
   var files = {};
   if (pathExists.sync(loc)) {
-    _.each(readdir(loc), function (filename) {
+    _.each(readdir(loc, () => true), function (filename) {
       var contents = helper.readFile(loc + "/" + filename);
       files[filename] = contents;
     });

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -8,12 +8,13 @@
   "main": "lib/node.js",
   "browser": "lib/browser.js",
   "dependencies": {
+    "babel-core": "^6.3.13",
+    "babel-runtime": "^5.0.0",
+    "caller": "^1.0.1",
     "core-js": "^1.0.0",
     "home-or-tmp": "^1.0.0",
-    "path-exists": "^1.0.0",
     "lodash": "^3.10.0",
-    "source-map-support": "^0.2.10",
-    "babel-core": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "path-exists": "^1.0.0",
+    "source-map-support": "^0.2.10"
   }
 }


### PR DESCRIPTION
Primarily, this allows for you to specify `only` & `ignore` via `.babelrc` when running `babel-node`, instead of being forced to supply them via command line flags.

Also, this adds a `--root` flag to `babel-node` for cases where you're not running it from the same directory as the package that contains the correct `.babelrc`.
