### PR TITLE
[T6891][fix][babel-plugin-transform-es2015-parameters] arguments.length optimization bugfix

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -32,3 +32,11 @@ var b = function (foo, ...bar) {
 var b = function (...bar) {
   return bar.len;
 };
+
+var b = function (foo, ...bar) {
+  return bar.length * 2;
+};
+
+var b = function (foo, baz, ...bar) {
+  return bar.length;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -61,3 +61,11 @@ var b = function () {
 
   return bar.len;
 };
+
+var b = function (foo) {
+  return (arguments.length - 1) * 2;
+};
+
+var b = function (foo, baz) {
+  return arguments.length - 2;
+};


### PR DESCRIPTION
https://github.com/babel/babel/pull/3143 optimizes rest params even if the function has more than one argument, which is wrong because the `length` property will be the full arguments length not the length of the rest variable.

For example:
```js
function foo(a, ...rest) {
  return rest.length;
}
```

Was wrongly getting transformed to:
```js
function foo(a) {
  return arguments.length;
}
```

https://phabricator.babeljs.io/T6891