### PR TITLE
More relaxed `displayName` inference

### DIFF
--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/actual.js
@@ -1,0 +1,1 @@
+foo = React.createClass({});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/expected.js
@@ -1,0 +1,3 @@
+foo = React.createClass({
+  displayName: "foo"
+});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/actual.js
@@ -1,0 +1,1 @@
+var foo = bar(React.createClass({}));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/expected.js
@@ -1,0 +1,3 @@
+var foo = bar(React.createClass({
+  displayName: "foo"
+}));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/actual.js
@@ -1,0 +1,3 @@
+({
+  foo: React.createClass({})
+});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/expected.js
@@ -1,0 +1,5 @@
+({
+  foo: React.createClass({
+    displayName: "foo"
+  })
+});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/options.json
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-react-display-name"]
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/actual.js
@@ -1,0 +1,1 @@
+var foo = React.createClass({});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/expected.js
@@ -1,0 +1,3 @@
+var foo = React.createClass({
+  displayName: "foo"
+});

--- a/packages/babel-plugin-transform-react-display-name/test/index.js
+++ b/packages/babel-plugin-transform-react-display-name/test/index.js
@@ -1,0 +1,1 @@
+require("babel-helper-plugin-test-runner")(__dirname);


### PR DESCRIPTION
Causes the `displayName` of:

```javascript
var foo = bar(React.createClass({}));
```

to be inferred as `foo` despite not being the direct parent.