### PR TITLE
Defer to the built-in `typeof` if support for  symbols exists.

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -4,9 +4,9 @@ let helpers = {};
 export default helpers;
 
 helpers.typeof = template(`
-  (function (obj) {
-    return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj;
-  });
+  (typeof Symbol === "function" && typeof Symbol.iterator === "symbol")
+    ? function (obj) { return typeof obj; }
+    : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 `);
 
 helpers.jsx = template(`


### PR DESCRIPTION
This PR addresses https://phabricator.babeljs.io/T6875 by deferring to the built-in `typeof` operator if support for symbols exists.

