### PR TITLE
override the only and ignore options when babelrc has only or ignore configures

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -68,6 +68,9 @@ function compile(filename) {
     }
   }
 
+  if (!only && opts.only != null) only = util.arrayify(opts.only, util.regexify);
+  if (!ignore && opts.ignore != null) ignore = util.arrayify(opts.ignore, util.regexify);
+
   if (!result) {
     result = babel.transformFileSync(filename, extend(opts, {
       // Do not process config files since has already been done with the OptionManager


### PR DESCRIPTION
`package.json`

```json
{
    "babel": {
        "only": [
           "server.js",
           "config/*.js",
           "app/**/*.js",
           "node_modules/transwarp/src/*.js",
           "node_modules/transwarp-postgres/src/*.js"
        ]
    }
}
```