### PR TITLE
Don't parse parenthesized string as directive

### DIFF
--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -460,7 +460,8 @@ pp.parseBlockBody = function (node, allowDirectives, topLevel, end) {
     let stmt = this.parseStatement(true, topLevel);
 
     if (allowDirectives && !parsedNonDirective &&
-        stmt.type === "ExpressionStatement" && stmt.expression.type === "StringLiteral") {
+        stmt.type === "ExpressionStatement" && stmt.expression.type === "StringLiteral" &&
+        !stmt.expression.extra.parenthesized) {
       let directive = this.stmtToDirective(stmt);
       node.directives.push(directive);
 

--- a/packages/babylon/test/fixtures/core/categorized/not-directive/actual.js
+++ b/packages/babylon/test/fixtures/core/categorized/not-directive/actual.js
@@ -1,0 +1,1 @@
+("not a directive");

--- a/packages/babylon/test/fixtures/core/categorized/not-directive/expected.json
+++ b/packages/babylon/test/fixtures/core/categorized/not-directive/expected.json
@@ -1,0 +1,71 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 20,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 20,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 20,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 20
+          }
+        },
+        "expression": {
+          "type": "StringLiteral",
+          "start": 1,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            }
+          },
+          "extra": {
+            "rawValue": "not a directive",
+            "raw": "\"not a directive\"",
+            "parenthesized": true,
+            "parenStart": 0
+          },
+          "value": "not a directive"
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
Not a directive:

```js
("use strict");
```

http://www.ecma-international.org/ecma-262/6.0/#sec-directive-prologues-and-the-use-strict-directive