### PR TITLE
`babel-plugin-undeclared-variables-check`: False negative errors for global variables

### DIFF
--- a/packages/babel-plugin-undeclared-variables-check/src/index.js
+++ b/packages/babel-plugin-undeclared-variables-check/src/index.js
@@ -1,5 +1,20 @@
 import leven from "leven";
 
+const _global = new Function("return this")();
+
+function isGlobalVar(name) {
+  if (name in _global) {
+    return true;
+  }
+  try {
+    eval(name);
+  } catch (err) {
+    return false;
+  }
+  return true;
+}
+
+
 export default function ({ messages }) {
   return {
     visitor: {
@@ -11,7 +26,7 @@ export default function ({ messages }) {
           throw path.buildCodeFrameError(messages.get("undeclaredVariableType", node.name), ReferenceError);
         }
 
-        if (scope.hasBinding(node.name)) return;
+        if (scope.hasBinding(node.name) || isGlobalVar(node.name)) return;
 
         // get the closest declaration to offer as a suggestion
         // the variable name may have just been mistyped

--- a/packages/babel-plugin-undeclared-variables-check/test/fixtures/validation.undeclared-variable-check/declared-global-console/exec.js
+++ b/packages/babel-plugin-undeclared-variables-check/test/fixtures/validation.undeclared-variable-check/declared-global-console/exec.js
@@ -1,0 +1,1 @@
+console.log;

--- a/packages/babel-plugin-undeclared-variables-check/test/fixtures/validation.undeclared-variable-check/declared-global-exports/exec.js
+++ b/packages/babel-plugin-undeclared-variables-check/test/fixtures/validation.undeclared-variable-check/declared-global-exports/exec.js
@@ -1,0 +1,1 @@
+exports


### PR DESCRIPTION
Hello, I tried to use this plugin for project on nodejs and babel crashed on simple 'console' and 'require' in the source code.
Checking only name in _global is not enough i.e. such global variables like 'require' are skipped. Actually eval check is enough, but it is quite expensive than just check existence in _global.

Nodejs 5.3.0
Linux Ubuntu
npm 3.5.2