### PR TITLE
`babylon`: throw parse error if class properties do not have a semico…

### DIFF
--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/actual.js
@@ -5,5 +5,5 @@ class Child extends Parent {
 
     scopedFunctionWithThis = () => {
         this.name = {};
-    }
+    };
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/actual.js
@@ -1,7 +1,7 @@
 call(class {
-  static test = true
+  static test = true;
 });
 
 export default class {
-  static test = true
+  static test = true;
 };

--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -594,7 +594,7 @@ pp.parseClass = function (node, isStatement, optionalId) {
 };
 
 pp.isClassProperty = function () {
-  return this.match(tt.eq) || this.isLineTerminator();
+  return this.match(tt.eq) || this.match(tt.semi) || this.canInsertSemicolon();
 };
 
 pp.parseClassBody = function (node) {
@@ -746,7 +746,9 @@ pp.parseClassProperty = function (node) {
   } else {
     node.value = null;
   }
-  this.semicolon();
+  if (!this.eat(tt.semi)) {
+    this.raise(this.state.start, "A semicolon is required after a class property");
+  }
   return this.finishNode(node, "ClassProperty");
 };
 

--- a/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-with-value/actual.js
+++ b/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-with-value/actual.js
@@ -1,0 +1,3 @@
+class A {
+  asdf = 1
+}

--- a/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-with-value/options.json
+++ b/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-with-value/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "A semicolon is required after a class property (3:0)",
+  "plugins": ["classProperties"]
+}

--- a/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-without-value/actual.js
+++ b/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-without-value/actual.js
@@ -1,0 +1,3 @@
+class A {
+  asdf
+}

--- a/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-without-value/options.json
+++ b/packages/babylon/test/fixtures/experimental/class-properties/semicolons-required-without-value/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "A semicolon is required after a class property (3:0)",
+  "plugins": ["classProperties"]
+}


### PR DESCRIPTION
…lon (fixes T6873)

Fixes https://phabricator.babeljs.io/T6873.
Ref https://github.com/jeffmo/es-class-fields-and-static-properties/issues/25

not using `isLineTerminator` since it tries to eat the semicolon
```js
// TODO
pp.isLineTerminator = function () {
  return this.eat(tt.semi) || this.canInsertSemicolon();
};
```

