### PR TITLE
Add a check for parentheses for AwaitExpressions (fixes T6913)

### DIFF
--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -145,23 +145,17 @@ export function SequenceExpression(node: Object, parent: Object): boolean {
 }
 
 export function AwaitExpression(node: Object, parent: Object): boolean {
-  return t.isBinary(parent) ||
-         t.isUnaryLike(parent) ||
+  return t.isUnaryLike(parent) ||
          t.isCallExpression(parent) ||
          t.isMemberExpression(parent) ||
-         t.isNewExpression(parent) ||
-         t.isConditionalExpression(parent) ||
-         t.isAwaitExpression(parent);
+         t.isNewExpression(parent);
 }
 
 export function YieldExpression(node: Object, parent: Object): boolean {
-  return t.isBinary(parent) ||
-         t.isUnaryLike(parent) ||
+  return t.isUnaryLike(parent) ||
          t.isCallExpression(parent) ||
          t.isMemberExpression(parent) ||
-         t.isNewExpression(parent) ||
-         t.isConditionalExpression(parent) ||
-         t.isYieldExpression(parent);
+         t.isNewExpression(parent);
 }
 
 export function ClassExpression(node: Object, parent: Object): boolean {

--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -144,6 +144,16 @@ export function SequenceExpression(node: Object, parent: Object): boolean {
   return true;
 }
 
+export function AwaitExpression(node: Object, parent: Object): boolean {
+  return t.isBinary(parent) ||
+         t.isUnaryLike(parent) ||
+         t.isCallExpression(parent) ||
+         t.isMemberExpression(parent) ||
+         t.isNewExpression(parent) ||
+         t.isConditionalExpression(parent) ||
+         t.isAwaitExpression(parent);
+}
+
 export function YieldExpression(node: Object, parent: Object): boolean {
   return t.isBinary(parent) ||
          t.isUnaryLike(parent) ||

--- a/packages/babel-generator/test/fixtures/harmony-edgecase/yield-precedence/expected.js
+++ b/packages/babel-generator/test/fixtures/harmony-edgecase/yield-precedence/expected.js
@@ -4,5 +4,5 @@ function* foo() {
   var c = yield a = b;
   yield a, yield b;
   yield a = b;
-  return (yield 1) || (yield 2);
+  return yield 1 || yield 2;
 }

--- a/packages/babel-generator/test/fixtures/parentheses/await-expression/actual.js
+++ b/packages/babel-generator/test/fixtures/parentheses/await-expression/actual.js
@@ -1,0 +1,11 @@
+async function asdf() {
+  (await 1) || (await 2);
+  (await b)();
+  new (await b)();
+  true ? (await 1) : (await 2);
+  await (await 1);
+}
+
+async function a(b) {
+  (await xhr({ url: "views/test.html" })).data;
+}

--- a/packages/babel-generator/test/fixtures/parentheses/await-expression/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/await-expression/expected.js
@@ -1,9 +1,9 @@
 async function asdf() {
-  (await 1) || (await 2);
+  await 1 || await 2;
   (await b)();
   new (await b)();
-  true ? (await 1) : (await 2);
-  await (await 1);
+  true ? await 1 : await 2;
+  await await 1;
 }
 
 async function a(b) {

--- a/packages/babel-generator/test/fixtures/parentheses/await-expression/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/await-expression/expected.js
@@ -1,0 +1,11 @@
+async function asdf() {
+  (await 1) || (await 2);
+  (await b)();
+  new (await b)();
+  true ? (await 1) : (await 2);
+  await (await 1);
+}
+
+async function a(b) {
+  (await xhr({ url: "views/test.html" })).data;
+}

--- a/packages/babel-generator/test/fixtures/parentheses/yield-expression/actual.js
+++ b/packages/babel-generator/test/fixtures/parentheses/yield-expression/actual.js
@@ -1,0 +1,11 @@
+function* asdf() {
+  (yield 1) || (yield 2);
+  (yield b)();
+  new (yield b)();
+  true ? (yield 1) : (yield 2);
+  yield (yield 1);
+}
+
+function* a(b) {
+  (yield xhr({ url: "views/test.html" })).data;
+}

--- a/packages/babel-generator/test/fixtures/parentheses/yield-expression/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/yield-expression/expected.js
@@ -1,0 +1,11 @@
+function* asdf() {
+  yield 1 || yield 2;
+  (yield b)();
+  new (yield b)();
+  true ? yield 1 : yield 2;
+  yield yield 1;
+}
+
+function* a(b) {
+  (yield xhr({ url: "views/test.html" })).data;
+}


### PR DESCRIPTION
Are parentheses necessary for `ConditionalExpression` `AwaitExpression` `YieldExpression`?