### PR TITLE
Add `declare type` and `declare interface` Flow syntax support to 6.x

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -36,6 +36,11 @@ export function DeclareFunction(node: Object) {
   this.semicolon();
 }
 
+export function DeclareInterface(node: Object) {
+  this.push("declare ");
+  this.InterfaceDeclaration(node);
+}
+
 export function DeclareModule(node: Object) {
   this.push("declare module ");
   this.print(node.id, node);

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -43,6 +43,11 @@ export function DeclareModule(node: Object) {
   this.print(node.body, node);
 }
 
+export function DeclareTypeAlias(node: Object) {
+  this.push("declare ");
+  this.TypeAlias(node);
+}
+
 export function DeclareVariable(node: Object) {
   this.push("declare var ");
   this.print(node.id, node);

--- a/packages/babel-generator/test/fixtures/flow/declare-statements/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/declare-statements/actual.js
@@ -12,3 +12,5 @@ declare class A { static () : number }
 declare class A mixins B<T>, C {}
 declare type A = string
 declare type T<U> = { [k:string]: U }
+declare interface I { foo: string }
+declare interface I<T> { foo: T }

--- a/packages/babel-generator/test/fixtures/flow/declare-statements/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/declare-statements/actual.js
@@ -10,3 +10,5 @@ declare class A { static foo(): number; static x : string }
 declare class A { static [ indexer: number]: string }
 declare class A { static () : number }
 declare class A mixins B<T>, C {}
+declare type A = string
+declare type T<U> = { [k:string]: U }

--- a/packages/babel-generator/test/fixtures/flow/declare-statements/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/declare-statements/expected.js
@@ -10,3 +10,5 @@ declare class A { static foo(): number; static x: string; }
 declare class A { static [indexer: number]: string }
 declare class A { static (): number }
 declare class A mixins B<T>, C {}
+declare type A = string;
+declare type T<U> = { [k: string]: U };

--- a/packages/babel-generator/test/fixtures/flow/declare-statements/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/declare-statements/expected.js
@@ -12,3 +12,5 @@ declare class A { static (): number }
 declare class A mixins B<T>, C {}
 declare type A = string;
 declare type T<U> = { [k: string]: U };
+declare interface I { foo: string }
+declare interface I<T> { foo: T }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/actual.js
@@ -12,3 +12,5 @@ declare class A { static () : number }
 declare class A mixins B<T>, C {}
 declare type A = string
 declare type T<U> = { [k:string]: U }
+declare interface I { foo: string }
+declare interface I<T> { foo: T }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/actual.js
@@ -10,3 +10,5 @@ declare class A { static foo(): number; static x : string }
 declare class A { static [ indexer: number]: string }
 declare class A { static () : number }
 declare class A mixins B<T>, C {}
+declare type A = string
+declare type T<U> = { [k:string]: U }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/expected.js
@@ -12,3 +12,5 @@
 /*:: declare class A mixins B<T>, C {}*/
 /*:: declare type A = string*/
 /*:: declare type T<U> = { [k:string]: U }*/
+/*:: declare interface I { foo: string }*/
+/*:: declare interface I<T> { foo: T }*/

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/declare-statements/expected.js
@@ -10,3 +10,5 @@
 /*:: declare class A { static [ indexer: number]: string }*/
 /*:: declare class A { static () : number }*/
 /*:: declare class A mixins B<T>, C {}*/
+/*:: declare type A = string*/
+/*:: declare type T<U> = { [k:string]: U }*/

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declare-statements/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declare-statements/actual.js
@@ -12,3 +12,5 @@ declare class A { static () : number }
 declare class A mixins B<T>, C {}
 declare type A = string
 declare type T<U> = { [k:string]: U }
+declare interface I { foo: string }
+declare interface I<T> { foo: T }

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declare-statements/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declare-statements/actual.js
@@ -10,3 +10,5 @@ declare class A { static foo(): number; static x : string }
 declare class A { static [ indexer: number]: string }
 declare class A { static () : number }
 declare class A mixins B<T>, C {}
+declare type A = string
+declare type T<U> = { [k:string]: U }

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -74,6 +74,14 @@ defineType("DeclareModule", {
   }
 });
 
+defineType("DeclareTypeAlias", {
+  visitor: ["id", "typeParameters", "right"],
+  aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
+  fields: {
+    // todo
+  }
+});
+
 defineType("DeclareVariable", {
   visitor: ["id"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -66,6 +66,14 @@ defineType("DeclareFunction", {
   }
 });
 
+defineType("DeclareInterface", {
+  visitor: ["id", "typeParameters", "extends", "body"],
+  aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
+  fields: {
+    // todo
+  }
+});
+
 defineType("DeclareModule", {
   visitor: ["id", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -60,6 +60,8 @@ pp.flowParseDeclare = function (node) {
     return this.flowParseDeclareModule(node);
   } else if (this.isContextual("type")) {
     return this.flowParseDeclareTypeAlias(node);
+  } else if (this.isContextual("interface")) {
+    return this.flowParseDeclareInterface(node);
   } else {
     this.unexpected();
   }
@@ -103,6 +105,12 @@ pp.flowParseDeclareTypeAlias = function (node) {
   this.flowParseTypeAlias(node);
   return this.finishNode(node, "DeclareTypeAlias");
 };
+
+pp.flowParseDeclareInterface = function (node) {
+  this.next();
+  this.flowParseInterfaceish(node);
+  return this.finishNode(node, "DeclareInterface");
+}
 
 
 // Interfaces

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -58,6 +58,8 @@ pp.flowParseDeclare = function (node) {
     return this.flowParseDeclareVariable(node);
   } else if (this.isContextual("module")) {
     return this.flowParseDeclareModule(node);
+  } else if (this.isContextual("type")) {
+    return this.flowParseDeclareTypeAlias(node);
   } else {
     this.unexpected();
   }
@@ -94,6 +96,12 @@ pp.flowParseDeclareModule = function (node) {
 
   this.finishNode(bodyNode, "BlockStatement");
   return this.finishNode(node, "DeclareModule");
+};
+
+pp.flowParseDeclareTypeAlias = function (node) {
+  this.next();
+  this.flowParseTypeAlias(node);
+  return this.finishNode(node, "DeclareTypeAlias");
 };
 
 

--- a/packages/babylon/test/fixtures/flow/declare-statements/14/actual.js
+++ b/packages/babylon/test/fixtures/flow/declare-statements/14/actual.js
@@ -1,0 +1,2 @@
+declare type A = string;
+declare type T<U> = { [k:string]: U };

--- a/packages/babylon/test/fixtures/flow/declare-statements/14/expected.json
+++ b/packages/babylon/test/fixtures/flow/declare-statements/14/expected.json
@@ -1,0 +1,242 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 63,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 38
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 63,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 38
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareTypeAlias",
+        "start": 0,
+        "end": 24,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 13,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 13
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "StringTypeAnnotation",
+          "start": 17,
+          "end": 23,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 23
+            }
+          }
+        }
+      },
+      {
+        "type": "DeclareTypeAlias",
+        "start": 25,
+        "end": 63,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 38
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 38,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 13
+            },
+            "end": {
+              "line": 2,
+              "column": 14
+            }
+          },
+          "name": "T"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 39,
+          "end": 42,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 14
+            },
+            "end": {
+              "line": 2,
+              "column": 17
+            }
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "start": 40,
+              "end": 41,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 15
+                },
+                "end": {
+                  "line": 2,
+                  "column": 16
+                }
+              },
+              "name": "U"
+            }
+          ]
+        },
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 45,
+          "end": 62,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 20
+            },
+            "end": {
+              "line": 2,
+              "column": 37
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [
+            {
+              "type": "ObjectTypeIndexer",
+              "start": 47,
+              "end": 60,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 22
+                },
+                "end": {
+                  "line": 2,
+                  "column": 35
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 48,
+                "end": 49,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 24
+                  }
+                },
+                "name": "k"
+              },
+              "key": {
+                "type": "StringTypeAnnotation",
+                "start": 50,
+                "end": 56,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 31
+                  }
+                }
+              },
+              "value": {
+                "type": "GenericTypeAnnotation",
+                "start": 59,
+                "end": 60,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 34
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 35
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 59,
+                  "end": 60,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 34
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 35
+                    }
+                  },
+                  "name": "U"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/flow/declare-statements/15/actual.js
+++ b/packages/babylon/test/fixtures/flow/declare-statements/15/actual.js
@@ -1,0 +1,2 @@
+declare interface I { foo: string }
+declare interface I<T> { foo: T }

--- a/packages/babylon/test/fixtures/flow/declare-statements/15/expected.json
+++ b/packages/babylon/test/fixtures/flow/declare-statements/15/expected.json
@@ -1,0 +1,283 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 69,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 33
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 69,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 33
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareInterface",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 18,
+          "end": 19,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 18
+            },
+            "end": {
+              "line": 1,
+              "column": 19
+            }
+          },
+          "name": "I"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 20,
+          "end": 35,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 20
+            },
+            "end": {
+              "line": 1,
+              "column": 35
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 22,
+              "end": 33,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 22
+                },
+                "end": {
+                  "line": 1,
+                  "column": 33
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 22,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 25
+                  }
+                },
+                "name": "foo"
+              },
+              "value": {
+                "type": "StringTypeAnnotation",
+                "start": 27,
+                "end": 33,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 33
+                  }
+                }
+              },
+              "optional": false
+            }
+          ],
+          "indexers": []
+        }
+      },
+      {
+        "type": "DeclareInterface",
+        "start": 36,
+        "end": 69,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 33
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 54,
+          "end": 55,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 18
+            },
+            "end": {
+              "line": 2,
+              "column": 19
+            }
+          },
+          "name": "I"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 55,
+          "end": 58,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 19
+            },
+            "end": {
+              "line": 2,
+              "column": 22
+            }
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "start": 56,
+              "end": 57,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 20
+                },
+                "end": {
+                  "line": 2,
+                  "column": 21
+                }
+              },
+              "name": "T"
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 59,
+          "end": 69,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 23
+            },
+            "end": {
+              "line": 2,
+              "column": 33
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 61,
+              "end": 67,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 25
+                },
+                "end": {
+                  "line": 2,
+                  "column": 31
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 61,
+                "end": 64,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 28
+                  }
+                },
+                "name": "foo"
+              },
+              "value": {
+                "type": "GenericTypeAnnotation",
+                "start": 66,
+                "end": 67,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 31
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 66,
+                  "end": 67,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 31
+                    }
+                  },
+                  "name": "T"
+                }
+              },
+              "optional": false
+            }
+          ],
+          "indexers": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
If this looks good, I'll back port to 5.x