### PR TITLE
Expose `--extends` option to babel cli

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -86,7 +86,7 @@ module.exports = {
 
   extends: {
     type: "string",
-    hidden: true
+    description: "a path to an .babelrc file to extend"
   },
 
   comments: {


### PR DESCRIPTION
Babel [extends option](https://babeljs.io/docs/usage/options/) is hidden to babel-cli.

It makes it impossible to extend babel configuration from cli. Is there a reason for this?

In case noting prevents it, this enables `--extends`.