### PR TITLE
Add `export interface` Flow syntax support to Babel 6.x

### DIFF
--- a/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
@@ -98,3 +98,5 @@ import type, { foo } from "bar";
 import type * as namespace from "bar";
 export type { foo };
 export type { foo } from "bar";
+export interface foo { p: number };
+export interface foo<T> { p: T };

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
@@ -102,3 +102,5 @@ import type, { foo } from "bar";
 import type * as namespace from "bar";
 export type { foo };
 export type { foo } from "bar";
+export interface foo { p: number };
+export interface foo<T> { p: T };

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/export-type-alias/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/export-type-alias/actual.js
@@ -6,3 +6,5 @@ export type GraphQLFormattedError = {
     column: number
   }>
 };
+export interface foo { p: number }
+export interface foo<T> { p: T }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/export-type-alias/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/export-type-alias/expected.js
@@ -6,3 +6,5 @@
     column: number
   }>
 };*/
+/*:: export interface foo { p: number }*/
+/*:: export interface foo<T> { p: T }*/

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-annotations/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-annotations/actual.js
@@ -97,3 +97,5 @@ import type2, { foo3 } from "bar";
 import type * as namespace from "bar";
 export type { foo };
 export type { foo } from "bar";
+export interface foo { p: number }
+export interface foo<T> { p: T }

--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -838,7 +838,9 @@ pp.parseExportDeclaration = function () {
 
 pp.isExportDefaultSpecifier = function () {
   if (this.match(tt.name)) {
-    return this.state.value !== "type" && this.state.value !== "async";
+    return this.state.value !== "type"
+        && this.state.value !== "async"
+        && this.state.value !== "interface";
   }
 
   if (!this.match(tt._default)) {

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -687,7 +687,9 @@ export default function (instance) {
   // export type
   instance.extend("shouldParseExportDeclaration", function (inner) {
     return function () {
-      return this.isContextual("type") || inner.call(this);
+      return this.isContextual("type")
+          || this.isContextual("interface")
+          || inner.call(this);
     };
   });
 
@@ -745,6 +747,11 @@ export default function (instance) {
           // export type Foo = Bar;
           return this.flowParseTypeAlias(declarationNode);
         }
+      } else if (this.isContextual("interface")) {
+        node.exportKind = "type";
+        let declarationNode = this.startNode();
+        this.next();
+        return this.flowParseInterface(declarationNode);
       } else {
         return inner.call(this, node);
       }

--- a/packages/babylon/test/fixtures/flow/type-exports/interface/actual.js
+++ b/packages/babylon/test/fixtures/flow/type-exports/interface/actual.js
@@ -1,0 +1,2 @@
+export interface foo { p: number };
+export interface foo<T> { p: T };

--- a/packages/babylon/test/fixtures/flow/type-exports/interface/expected.json
+++ b/packages/babylon/test/fixtures/flow/type-exports/interface/expected.json
@@ -1,0 +1,349 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 69,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 33
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 69,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 33
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "specifiers": [],
+        "source": null,
+        "exportKind": "type",
+        "declaration": {
+          "type": "InterfaceDeclaration",
+          "start": 7,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 34
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 17,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 20
+              }
+            },
+            "name": "foo"
+          },
+          "typeParameters": null,
+          "extends": [],
+          "mixins": [],
+          "body": {
+            "type": "ObjectTypeAnnotation",
+            "start": 21,
+            "end": 34,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 21
+              },
+              "end": {
+                "line": 1,
+                "column": 34
+              }
+            },
+            "callProperties": [],
+            "properties": [
+              {
+                "type": "ObjectTypeProperty",
+                "start": 23,
+                "end": 32,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 32
+                  }
+                },
+                "key": {
+                  "type": "Identifier",
+                  "start": 23,
+                  "end": 24,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 24
+                    }
+                  },
+                  "name": "p"
+                },
+                "value": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 26,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 26
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 32
+                    }
+                  }
+                },
+                "optional": false
+              }
+            ],
+            "indexers": []
+          }
+        }
+      },
+      {
+        "type": "EmptyStatement",
+        "start": 34,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 34
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        }
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 36,
+        "end": 68,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 32
+          }
+        },
+        "specifiers": [],
+        "source": null,
+        "exportKind": "type",
+        "declaration": {
+          "type": "InterfaceDeclaration",
+          "start": 43,
+          "end": 68,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 7
+            },
+            "end": {
+              "line": 2,
+              "column": 32
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 53,
+            "end": 56,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 17
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            "name": "foo"
+          },
+          "typeParameters": {
+            "type": "TypeParameterDeclaration",
+            "start": 56,
+            "end": 59,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 20
+              },
+              "end": {
+                "line": 2,
+                "column": 23
+              }
+            },
+            "params": [
+              {
+                "type": "Identifier",
+                "start": 57,
+                "end": 58,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 22
+                  }
+                },
+                "name": "T"
+              }
+            ]
+          },
+          "extends": [],
+          "mixins": [],
+          "body": {
+            "type": "ObjectTypeAnnotation",
+            "start": 60,
+            "end": 68,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 24
+              },
+              "end": {
+                "line": 2,
+                "column": 32
+              }
+            },
+            "callProperties": [],
+            "properties": [
+              {
+                "type": "ObjectTypeProperty",
+                "start": 62,
+                "end": 66,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 30
+                  }
+                },
+                "key": {
+                  "type": "Identifier",
+                  "start": 62,
+                  "end": 63,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 26
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 27
+                    }
+                  },
+                  "name": "p"
+                },
+                "value": {
+                  "type": "GenericTypeAnnotation",
+                  "start": 65,
+                  "end": 66,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 30
+                    }
+                  },
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start": 65,
+                    "end": 66,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 30
+                      }
+                    },
+                    "name": "T"
+                  }
+                },
+                "optional": false
+              }
+            ],
+            "indexers": []
+          }
+        }
+      },
+      {
+        "type": "EmptyStatement",
+        "start": 68,
+        "end": 69,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 32
+          },
+          "end": {
+            "line": 2,
+            "column": 33
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
An interface export is just like a type export. In fact, it's a syntax affordance which makes the following equivalent:

```javascript
interface I_ { ... }
export type I = I_;
```

```javascript
export interface I { ... }
```

See facebook/flow#1145

Will backport to Babel 5.x if this looks good.