### PR TITLE
test: add a failing test case for t6922

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -49,6 +49,8 @@
   "devDependencies": {
     "babel-helper-fixtures": "^6.3.13",
     "babel-helper-transform-fixture-test-runner": "^6.3.13",
-    "babel-polyfill": "^6.3.13"
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-polyfill": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13"
   }
 }

--- a/packages/babel-core/test/fixtures/transformation/t6922/case/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/t6922/case/exec.js
@@ -1,0 +1,6 @@
+export default function *() {
+  // inclusion of the following line causes a failure
+  Object.keys({foo: 'bar', bar: 'foo'});
+
+  yield 'foo'
+}

--- a/packages/babel-core/test/fixtures/transformation/t6922/options.json
+++ b/packages/babel-core/test/fixtures/transformation/t6922/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-runtime"]
+}


### PR DESCRIPTION
https://phabricator.babeljs.io/T6922

all my packages broke with the latest update. this is currently blocking me. here's a test case from the issue mentioned above: https://github.com/jamestalmage/__babel-T6922.

i matched the test case exactly, but i'm going to dig deeper into the source code to test this w/o `babel-register` because it's so damn slow

if anyone knows where the issue is, i can try fixing it too.