### PR TITLE
Add failing tests case for 6.4 rest.length issue

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/actual.js
@@ -1,0 +1,10 @@
+var t = function (f, ...items) {
+  items[0];
+  items[items.length - 1];
+};
+
+function t(f, ...items) {
+  items;
+  items[0];
+  items[items.length - 1];
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
@@ -1,0 +1,14 @@
+var t = function (f) {
+  arguments[0];
+  arguments[arguments.length - 1];
+};
+
+function t(f) {
+  for (var _len = arguments.length, items = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    items[_key - 1] = arguments[_key];
+  }
+
+  items;
+  items[0];
+  items[items.length - 1];
+}


### PR DESCRIPTION
Failing test for https://phabricator.babeljs.io/T6928

```
  1) babel-plugin-transform-es2015-parameters/parameters rest length:

      babel/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/actual.js !== babel/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
      + expected - actual

       var t = function (f) {
      +  arguments[0];
      +  arguments[arguments.length - 1];
      -  arguments.length <= 1 ? undefined : arguments[1];
      -  arguments.length <= NaN ? undefined : arguments[NaN];
       };

       function t(f) {
         for (var _len = arguments.length, items = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
```