### PR TITLE
Pass through node-style function exports unchanged

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -241,7 +241,7 @@ helpers.interopRequireDefault = template(`
 
 helpers.interopRequireWildcard = template(`
   (function (obj) {
-    if (obj && obj.__esModule) {
+    if (obj && (obj.__esModule || typeof obj === 'function')) {
       return obj;
     } else {
       var newObj = {};


### PR DESCRIPTION
Please see discussion on https://phabricator.babeljs.io/T6929
This potentially is beneficial to Typescript users targeting ES6 and passing their code through Babel and wanting to consume legacy modules that export a function (which is out-of-spec from the POV of ES6) without having to completely re-write the Typescript definitions for that module in order to take advantage of the 'default' property that `interopRequireWildcard` and `interopRequireDefault` patch in.