### PR TITLE
Fix T2929, T6796, stop leaking directives

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-specifier-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-specifier-default/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports"], function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-default/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports"], function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports", "foo"], function (exports, _foo) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-named/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports"], function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-variable/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports"], function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/get-module-name-option/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/get-module-name-option/expected.js
@@ -1,3 +1,1 @@
-"use strict";
-
 define("my custom module name", [], function () {});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/hoist-function-exports/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports", "./evens"], function (exports, _evens) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["foo"], function (_foo) {
+  "use strict";
+
   var _foo2 = babelHelpers.interopRequireDefault(_foo);
 
   _foo2.default;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-glob/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["foo"], function (_foo) {
+  "use strict";
+
   var foo = babelHelpers.interopRequireWildcard(_foo);
   foo;
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-mixing/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["foo"], function (_foo) {
+  "use strict";
+
   var _foo2 = babelHelpers.interopRequireDefault(_foo);
 
   _foo2.default;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-named/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["foo"], function (_foo) {
+  "use strict";
+
   _foo.bar;
   _foo.bar2;
   _foo.baz;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports/expected.js
@@ -1,3 +1,1 @@
-"use strict";
-
 define(["foo", "foo-bar", "./directory/foo-bar"], function () {});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/module-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/module-name/expected.js
@@ -1,5 +1,5 @@
-"use strict";
-
 define("amd/module-name/expected", [], function () {
+  "use strict";
+
   foobar();
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/overview/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (exports, _foo) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/remap/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 define(["exports"], function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-default/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports", "foo"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports, _foo) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-named/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-variable/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/get-module-name-option/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/get-module-name-option/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define("my custom module name", [], factory);

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/hoist-function-exports/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports", "./evens"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports, _evens) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["foo"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (_foo) {
+  "use strict";
+
   var _foo2 = babelHelpers.interopRequireDefault(_foo);
 
   _foo2.default;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-glob/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["foo"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (_foo) {
+  "use strict";
+
   var foo = babelHelpers.interopRequireWildcard(_foo);
   foo;
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-mixing/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["foo"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (_foo) {
+  "use strict";
+
   var _foo2 = babelHelpers.interopRequireDefault(_foo);
 
   _foo.baz;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-named/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["foo"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (_foo) {
+  "use strict";
+
   _foo.bar;
   _foo.bar2;
   _foo.baz;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["foo", "foo-bar", "./directory/foo-bar"], factory);

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define("MyLib", [], factory);
@@ -13,5 +11,7 @@
     global.MyLib = mod.exports;
   }
 })(this, function () {
+  "use strict";
+
   foobar();
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define("umd/module-name/expected", [], factory);
@@ -13,5 +11,7 @@
     global.umdModuleNameExpected = mod.exports;
   }
 })(this, function () {
+  "use strict";
+
   foobar();
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/non-default-imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/non-default-imports/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["./lib/render"], factory);

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/overview/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports", "foo", "foo-bar", "./directory/foo-bar"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports, _foo) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/remap/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports"], factory);
@@ -13,6 +11,8 @@
     global.actual = mod.exports;
   }
 })(this, function (exports) {
+  "use strict";
+
   Object.defineProperty(exports, "__esModule", {
     value: true
   });


### PR DESCRIPTION
With the AMD and UMD module wrappers, directives (namely "use strict") were not being hoisted into the factory body and were therefore leaking into the global space. This change transfers all directives into the function body so they no longer leak.

Not sure about the preferred way to link this PR to the issues, but fixes:
https://phabricator.babeljs.io/T2929
https://phabricator.babeljs.io/T6796