### PR TITLE
Add test case for failing block scope

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
@@ -5,14 +5,20 @@ define(["exports", "foo"], function (exports, _foo) {
     value: true
   });
 
-  for (let _key in _foo) {
-    if (_key === "default") continue;
-    Object.defineProperty(exports, _key, {
+  var _loop = function (_key2) {
+    if (_key2 === "default") return "continue";
+    Object.defineProperty(exports, _key2, {
       enumerable: true,
       get: function () {
-        return _foo[_key];
+        return _foo[_key2];
       }
     });
+  };
+
+  for (var _key2 in _foo) {
+    var _ret = _loop(_key2);
+
+    if (_ret === "continue") continue;
   }
 
   Object.defineProperty(exports, "foo", {

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-block-scoping"]
+}


### PR DESCRIPTION
While working on #3252 I came across this issue. I tried to fix it but didn't get very far. Here's a failing test case.

```diff
$ TEST_ONLY=babel-plugin-transform-es2015-modules-amd make test-only./scripts/test.sh

․․․․․․․․․․․․․․․

14 passing (365ms)
1 failing

1) babel-plugin-transform-es2015-modules-amd/amd exports from:

/Users/casey/code/babel/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/actual.js !== /Users/casey/code/babel/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
+ expected
- actual

 "use strict";

-var _loop = function (_key2) {
-  if (_key2 === "default") return "continue";
-  Object.defineProperty(exports, _key2, {
-    enumerable: true,
-    get: function () {
-      return _foo[_key2];
-    }
-  });
-};
-
 define(["exports", "foo"], function (exports, _foo) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

+  var _loop = function (_key2) {
+    if (_key2 === "default") return "continue";
+    Object.defineProperty(exports, _key2, {
+      enumerable: true,
+      get: function () {
+        return _foo[_key2];
+      }
+    });
+  };
+
   for (var _key2 in _foo) {
     var _ret = _loop(_key2);

     if (_ret === "continue") continue;
```

The minimum plugins I was able to reproduce this with was `["external-helpers", "transform-es2015-modules-amd", "transform-es2015-block-scoping"]`. From what I can tell the block scoping transform is simply dropping the `_loop` declaration one scope too high. What's also weird is I tried to make a failing case in the block scoping tests but wasn't able to. It's only with this specific set of plugins that something goes awry.