### PR TITLE
Fix T6712, stop class method names conflicting with const and let declarations

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-T6712/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-T6712/actual.js
@@ -1,0 +1,11 @@
+class A{
+  foo(){
+    const foo = 42
+  }
+}
+
+class B{
+  foo(){
+    let foo = 42
+  }
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-T6712/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-T6712/expected.js
@@ -1,0 +1,33 @@
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var A = function () {
+  function A() {
+    _classCallCheck(this, A);
+  }
+
+  _createClass(A, [{
+    key: "foo",
+    value: function foo() {
+      var foo = 42;
+    }
+  }]);
+
+  return A;
+}();
+
+var B = function () {
+  function B() {
+    _classCallCheck(this, B);
+  }
+
+  _createClass(B, [{
+    key: "foo",
+    value: function foo() {
+      var foo = 42;
+    }
+  }]);
+
+  return B;
+}();

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-T6712/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-T6712/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-block-scoping", "transform-es2015-classes", "check-es2015-constants"]
+}

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -364,7 +364,8 @@ export default class Scope {
     let duplicate = false;
 
     // don't allow duplicate bindings to exist alongside
-    if (!duplicate) duplicate = kind === "let" || local.kind === "let" || local.kind === "const" || local.kind === "module";
+    // unless binding is let and inside a class method of the same identifier
+    if (!duplicate) duplicate = (kind === "let" && local.kind !== "local") || local.kind === "let" || local.kind === "const" || local.kind === "module";
 
     // don't allow a local of param with a kind of let
     if (!duplicate) duplicate = local.kind === "param" && (kind === "let" || kind === "const");
@@ -514,6 +515,8 @@ export default class Scope {
           if (local.identifier === id) continue;
 
           this.checkBlockScopedCollisions(local, kind, name, id);
+          // if no duplicates were found, set existing binding to null
+          local = null
         }
 
         parent.references[name] = true;


### PR DESCRIPTION
Tentative fix + regression test for https://phabricator.babeljs.io/T6712

The block scope collision check now checks if the previous binding was of type 'local' (which I assume means the name of the current scope's function), it lets the new let binding go through.

Also, if no duplicates were found (and an exception was not thrown), it sets the 'existing' binding to null so as to not register a constant violation in binding.js. I am least happy about this bit, as I am not sure whether that should be dealt with in a more explicit way - feels like a hack and I'm possibly trampling over valid behaviour.

Opinions?