### PR TITLE
Increase `parameters/rest` transform test coverage

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arguments-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arguments-deoptimisation/actual.js
@@ -1,0 +1,3 @@
+function x (...rest) {
+  arguments;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arguments-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arguments-deoptimisation/expected.js
@@ -1,0 +1,7 @@
+function x() {
+  for (var _len = arguments.length, rest = Array(_len), _key = 0; _key < _len; _key++) {
+    rest[_key] = arguments[_key];
+  }
+
+  arguments;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/actual.js
@@ -22,3 +22,8 @@ function demo1(...args) {
     return args[i+0];
   };
 }
+
+var x = (...rest) => {
+  if (noNeedToWork) return 0;
+  return rest;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
@@ -28,3 +28,12 @@ function demo1() {
     return args[i + 0];
   };
 }
+
+var x = function () {
+  for (var _len2 = arguments.length, rest = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+    rest[_key2] = arguments[_key2];
+  }
+
+  if (noNeedToWork) return 0;
+  return rest;
+};


### PR DESCRIPTION
These fixtures are passing and cover the following:

https://github.com/babel/babel/blob/add96d626d98133e26f62ec4c2aeee655bed069a/packages/babel-plugin-transform-es2015-parameters/src/rest.js#L45-L47

https://github.com/babel/babel/blob/add96d626d98133e26f62ec4c2aeee655bed069a/packages/babel-plugin-transform-es2015-parameters/src/rest.js#L198

I don't fully understand the reason for the `shadow` part, but unless someone who does knows it can be jettisoned, it should be covered.