### PR TITLE
Simplify `parameters/rest` code

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -186,11 +186,11 @@ export let visitor = {
         }
       }
       return;
-    } else {
-      state.references = state.references.concat(
-        state.candidates.map(({path}) => path)
-      );
     }
+
+    state.references = state.references.concat(
+      state.candidates.map(({path}) => path)
+    );
 
     // deopt shadowed functions as transforms like regenerator may try touch the allocation loop
     state.deopted = state.deopted || !!node.shadow;

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -242,7 +242,7 @@ export let visitor = {
       let target = path.getEarliestCommonAncestorFrom(state.references).getStatementParent();
 
       // don't perform the allocation inside a loop
-      target.findParent(function (path) {
+      target.findParent(path => {
         if (path.isLoop()) {
           target = path;
         } else {

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -242,16 +242,14 @@ export let visitor = {
       let target = path.getEarliestCommonAncestorFrom(state.references).getStatementParent();
 
       // don't perform the allocation inside a loop
-      let highestLoop;
       target.findParent(function (path) {
         if (path.isLoop()) {
-          highestLoop = path;
+          target = path;
         } else if (path.isFunction()) {
           // stop crawling up for functions
           return true;
         }
       });
-      if (highestLoop) target = highestLoop;
 
       target.insertBefore(loop);
     }

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -171,20 +171,18 @@ export let visitor = {
 
     path.traverse(memberExpressionOptimisationVisitor, state);
 
+    // There are only "shorthand" references
     if (!state.deopted && !state.references.length) {
-      // we only have shorthands and there are no other references
-      if (state.candidates.length) {
-        for (let {path, cause} of (state.candidates: Array)) {
-          switch (cause) {
-            case "indexGetter":
-              optimiseIndexGetter(path, argsId, state.offset);
-              break;
-            case "lengthGetter":
-              optimiseLengthGetter(path, argsLengthExpression, argsId, state.offset);
-              break;
-            default:
-              path.replaceWith(argsId);
-          }
+      for (let {path, cause} of (state.candidates: Array)) {
+        switch (cause) {
+          case "indexGetter":
+            optimiseIndexGetter(path, argsId, state.offset);
+            break;
+          case "lengthGetter":
+            optimiseLengthGetter(path, argsLengthExpression, argsId, state.offset);
+            break;
+          default:
+            path.replaceWith(argsId);
         }
       }
       return;

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -245,9 +245,9 @@ export let visitor = {
       target.findParent(function (path) {
         if (path.isLoop()) {
           target = path;
-        } else if (path.isFunction()) {
-          // stop crawling up for functions
-          return true;
+        } else {
+          // Stop crawling up if this is a function.
+          return path.isFunction();
         }
       });
 


### PR DESCRIPTION
Remove extraneous clutter and improve comments to make it easier to reason about, without changing any behavior.