### PR TITLE
Fix T6712, wrap class methods in def prop

### DIFF
--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -61,7 +61,7 @@ export function push(mutatorMap: Object, node: Object, kind: string, file, scope
   }
 
   // infer function name
-  if (scope && t.isStringLiteral(key) && (kind === "value" || kind === "initializer") && t.isFunctionExpression(value)) {
+  if (scope && t.isStringLiteral(key) && (kind === "value" || kind === "initializer") && t.isFunctionExpression(value) && !t.isClassMethod(node)) {
     value = nameFunction({ id: key, node: value, scope });
   }
 

--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -61,8 +61,8 @@ export function push(mutatorMap: Object, node: Object, kind: string, file, scope
   }
 
   // infer function name
-  if (scope && t.isStringLiteral(key) && (kind === "value" || kind === "initializer") && t.isFunctionExpression(value) && !t.isClassMethod(node)) {
-    value = nameFunction({ id: key, node: value, scope });
+  if (scope && t.isStringLiteral(key) && (kind === "value" || kind === "initializer") && t.isFunctionExpression(value)) {
+    value = nameFunction({ id: key, node: value, scope, isClassMethod: t.isClassMethod(node) });
   }
 
   if (value) {

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -75,10 +75,10 @@ function wrap(state, method, id, scope, isClassMethod) {
     }
   }
 
-  if(isClassMethod){
+  if (isClassMethod) {
     return template(`Object.defineProperty(FUNCTION, 'name', { value: '${id.name}' })`)
     .build({ FUNCTION: method }).expression;
-  }else{
+  } else {
     method.id = id;
     scope.getProgramParent().references[id.name] = true;
   }

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -76,8 +76,7 @@ function wrap(state, method, id, scope, isClassMethod) {
   }
 
   if (isClassMethod) {
-    return template(`Object.defineProperty(FUNCTION, 'name', { value: '${id.name}' })`)
-    .build({ FUNCTION: method }).expression;
+    return template(`Object.defineProperty(FUNCTION, 'name', { value: '${id.name}' })`)({ FUNCTION: method }).expression;
   } else {
     method.id = id;
     scope.getProgramParent().references[id.name] = true;


### PR DESCRIPTION
Continuation from https://github.com/babel/babel/pull/3256

The ES6 spec requires we give class methods names, but with the current way of polyfilling the class spec we can't give the function a normal name as it will bind itself to its own scope under that name, which violates the rules of the ES6 spec.

Instead, detect when we are dealing with a class method and wrap it with an Object.defineProperty to set the name. This means we give the function a name, but not a binding.

Before:

```
  _createClass(Foo, [{
    key: 'bar',
    value: function bar() {
      console.log('bar is', bar);
    }
  }]);
```

After:

```
  _createClass(Foo, [{
    key: 'bar',
    value: Object.defineProperty(function() {
      console.log('bar is', bar);
    }, 'name', { value: 'bar' })
  }]);
```

This works, and gives you the correct behaviour:

```
new Foo().bar.name //'bar'
new Foo().bar() //ReferenceError: bar is not defined
```

However I am not very happy with this implementation! I don't like the fact that I'm having to pass through 'isClassMethod' - can that be inferred from the function itself? It can be in `babel-helper-define-map` because we have access to the node, but that isn't passed down into `babel-helper-function-name`
(the class method node is turned into a function expression on line 55:
```
    value = t.functionExpression(null, node.params, node.body, node.generator, node.async);
```
so the information about how to treat it as a normal function vs a class method is lost.
If `babel-helper-function-name` needs to differentiate between different types of functions, perhaps that information should be available. I'm not sure exactly where I should be putting this logic.

I'm also not happy with the fact that the template string is sitting in the middle of the `wrap` function whereas the others are at the top of the file, but I couldn't figure out how to pass in the function name as a string. Any ideas? Am I meant to transform a string into some more AST-friendly format before handing it to the template?

Because this changes the output of all polyfilled classes, I expect this to break a lot of tests, but fixing them should be pretty straight forward.

Are there any runtime performance implications to changing the name of functions that have already been created?

What is the best solution here?