### PR TITLE
Fix T3084, `import type` was broken in react preset

### DIFF
--- a/packages/babel-plugin-syntax-flow/src/index.js
+++ b/packages/babel-plugin-syntax-flow/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push("flow");
+      if (parserOpts.plugins.indexOf("flow") === -1) {
+        parserOpts.plugins.push("flow");
+      }
     }
   };
 }


### PR DESCRIPTION
This fixes [T3084](https://phabricator.babeljs.io/T3084).

The react preset caused both the flow-strip-types and syntax-flow plugins to be used. The flow-strip-types plugin also loads the syntax-flow plugin. The syntax-flow plugin being loaded twice would
cause "flow" to be pushed to the parser options twice. Babylon doesn't expect to find it as an option twice.

An alternate fix would be to make Babylon handle "flow" being listed in its parser options twice, but I didn't look into what would be required in that.