### PR TITLE
[RFC] Pass per preset

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -8,7 +8,6 @@ import * as metadataVisitor from "./metadata";
 import convertSourceMap from "convert-source-map";
 import OptionManager from "./options/option-manager";
 import type Pipeline from "../pipeline";
-import type Plugin from "../plugin";
 import PluginPass from "../plugin-pass";
 import shebangRegex from "shebang-regex";
 import { NodePath, Hub, Scope } from "babel-traverse";
@@ -61,8 +60,21 @@ export default class File extends Store {
 
     this.pluginVisitors = [];
     this.pluginPasses = [];
-    this.pluginStack = [];
-    this.buildPlugins();
+
+    // Plugins for top-level options.
+    this.buildPluginsForOptions(this.opts);
+
+    // If we are in the "pass per preset" mode, build
+    // also plugins for each preset.
+    if (this.opts.passPerPresset) {
+      // All the "per preset" options are inherited from the main options.
+      this.perPresetOpts = [];
+      this.opts.presets.forEach(presetOpts => {
+        let perPresetOpts = Object.assign(Object.create(this.opts), presetOpts);
+        this.perPresetOpts.push(perPresetOpts);
+        this.buildPluginsForOptions(perPresetOpts);
+      });
+    }
 
     this.metadata = {
       usedHelpers: [],
@@ -95,7 +107,6 @@ export default class File extends Store {
 
   pluginVisitors: Array<Object>;
   pluginPasses: Array<PluginPass>;
-  pluginStack: Array<Plugin>;
   pipeline: Pipeline;
   parserOpts: BabelParserOptions;
   log: Logger;
@@ -165,21 +176,29 @@ export default class File extends Store {
     return opts;
   }
 
-  buildPlugins() {
-    let plugins: Array<[PluginPass, Object]> = this.opts.plugins.concat(INTERNAL_PLUGINS);
+  buildPluginsForOptions(opts) {
+    if (!Array.isArray(opts.plugins)) {
+      return;
+    }
+
+    let plugins: Array<[PluginPass, Object]> = opts.plugins.concat(INTERNAL_PLUGINS);
+    let currentPluginVisitors = [];
+    let currentPluginPasses = [];
 
     // init plugins!
     for (let ref of plugins) {
       let [plugin, pluginOpts] = ref; // todo: fix - can't embed in loop head because of flow bug
 
-      this.pluginStack.push(plugin);
-      this.pluginVisitors.push(plugin.visitor);
-      this.pluginPasses.push(new PluginPass(this, plugin, pluginOpts));
+      currentPluginVisitors.push(plugin.visitor);
+      currentPluginPasses.push(new PluginPass(this, plugin, pluginOpts));
 
       if (plugin.manipulateOptions) {
-        plugin.manipulateOptions(this.opts, this.parserOpts, this);
+        plugin.manipulateOptions(opts, this.parserOpts, this);
       }
     }
+
+    this.pluginVisitors.push(currentPluginVisitors);
+    this.pluginPasses.push(currentPluginPasses);
   }
 
   getModuleName(): ?string {
@@ -419,11 +438,16 @@ export default class File extends Store {
   }
 
   transform(): BabelFileResult {
-    this.call("pre");
-    this.log.debug(`Start transform traverse`);
-    traverse(this.ast, traverse.visitors.merge(this.pluginVisitors, this.pluginPasses), this.scope);
-    this.log.debug(`End transform traverse`);
-    this.call("post");
+    // In the "pass per preset" mode, we have grouped passes.
+    // Otherwise, there is only one plain pluginPasses array.
+    this.pluginPasses.forEach((pluginPasses, index) => {
+      this.call("pre", pluginPasses);
+      this.log.debug(`Start transform traverse`);
+      traverse(this.ast, traverse.visitors.merge(this.pluginVisitors[index], pluginPasses), this.scope);
+      this.log.debug(`End transform traverse`);
+      this.call("post", pluginPasses);
+    });
+
     return this.generate();
   }
 
@@ -483,8 +507,8 @@ export default class File extends Store {
     return util.shouldIgnore(opts.filename, opts.ignore, opts.only);
   }
 
-  call(key: "pre" | "post") {
-    for (let pass of (this.pluginPasses: Array<PluginPass>)) {
+  call(key: "pre" | "post", pluginPasses: Array<PluginPass>) {
+    for (let pass of pluginPasses) {
       let plugin = pass.plugin;
       let fn = plugin[key];
       if (fn) fn.call(pass, this);

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -66,7 +66,7 @@ export default class File extends Store {
 
     // If we are in the "pass per preset" mode, build
     // also plugins for each preset.
-    if (this.opts.passPerPresset) {
+    if (this.opts.passPerPreset) {
       // All the "per preset" options are inherited from the main options.
       this.perPresetOpts = [];
       this.opts.presets.forEach(presetOpts => {

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -185,9 +185,10 @@ module.exports = {
     type: "string"
   },
 
-  passPerPresset: {
+  passPerPreset: {
     description: "Whether to spawn a traversal pass per a preset. By default all presets are merged.",
     type: "boolean",
-    default: false
+    default: false,
+    hidden: true,
   },
 };

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -183,5 +183,11 @@ module.exports = {
   moduleId: {
     description: "specify a custom name for module ids",
     type: "string"
-  }
+  },
+
+  passPerPresset: {
+    description: "Whether to spawn a traversal pass per a preset. By default all presets are merged.",
+    type: "boolean",
+    default: false
+  },
 };

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -157,22 +157,23 @@ export default class OptionManager {
       throw err;
     }
 
-    this.mergeOptions(opts, loc, null, path.dirname(loc));
+    this.mergeOptions(opts, this.options, loc, null, path.dirname(loc));
     this.resolvedConfigs.push(loc);
 
     return !!opts;
   }
 
   /**
-   * This is called when we want to merge the input `opts` into our
-   * base options.
+   * This is called when we want to merge the input `opts` into the
+   * base options (passed as the `extendingOpts`: at top-level it's the
+   * main options, at presets level it's presets options).
    *
    *  - `alias` is used to output pretty traces back to the original source.
    *  - `loc` is used to point to the original config.
    *  - `dirname` is used to resolve plugins relative to it.
    */
 
-  mergeOptions(rawOpts?: Object, alias: string = "foreign", loc?: string, dirname?: string) {
+  mergeOptions(rawOpts?: Object, extendingOpts?: Object, alias: string = "foreign", loc?: string, dirname?: string) {
     if (!rawOpts) return;
 
     //
@@ -223,11 +224,9 @@ export default class OptionManager {
     if (opts.presets) {
       // If we're in the "pass per preset" mode, we resolve the presets
       // and keep them for further execution to calculate the options.
-      if (opts.passPerPresset) {
+      if (opts.passPerPreset) {
         opts.presets = this.resolvePresets(opts.presets, dirname, (preset, presetLoc) => {
-          if (preset.plugins) {
-            preset.plugins = OptionManager.normalisePlugins(presetLoc, dirname, preset.plugins);
-          }
+          this.mergeOptions(preset, preset, presetLoc, presetLoc, dirname);
         });
       } else {
         // Otherwise, just merge presets options into the main options.
@@ -244,11 +243,17 @@ export default class OptionManager {
       delete opts.env;
     }
 
-    // merge them into this current files options
-    merge(this.options, opts);
+    // Merge them into current extending options in case of top-level
+    // options. In case of presets, just re-assign options which are got
+    // normalized during the `mergeOptions`.
+    if (rawOpts !== extendingOpts) {
+      merge(extendingOpts, opts);
+    } else {
+      Object.assign(extendingOpts, opts);
+    }
 
     // merge in env options
-    this.mergeOptions(envOpts, `${alias}.env.${envKey}`, null, dirname);
+    this.mergeOptions(envOpts, extendingOpts, `${alias}.env.${envKey}`, null, dirname);
   }
 
   /**
@@ -259,6 +264,7 @@ export default class OptionManager {
     this.resolvePresets(presets, dirname, (presetOpts, presetLoc) => {
       this.mergeOptions(
         presetOpts,
+        this.options,
         presetLoc,
         presetLoc,
         path.dirname(presetLoc)
@@ -298,7 +304,7 @@ export default class OptionManager {
       .map((line) => line.replace(/#(.*?)$/, "").trim())
       .filter((line) => !!line);
 
-    this.mergeOptions({ ignore: lines }, loc);
+    this.mergeOptions({ ignore: lines }, this.options, loc);
   }
 
   findConfigs(loc) {
@@ -365,7 +371,7 @@ export default class OptionManager {
     }
 
     // merge in base options
-    this.mergeOptions(opts, "base", null, filename && path.dirname(filename));
+    this.mergeOptions(opts, this.options, "base", null, filename && path.dirname(filename));
 
     // normalise
     this.normaliseOptions(opts);

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -57,7 +57,7 @@ suite("api", function () {
             plugins: [
               new Plugin({
                 visitor: {
-                  Function(path) {
+                  Function: function(path) {
                     var node = path.node;
                     var scope = path.scope;
 


### PR DESCRIPTION
#### Rationale

See discussion and the issue description in [#6730: Plugins order is not respected](https://phabricator.babeljs.io/T6730).

This introduces "pass per preset" feature, spawting a new traversal for each preset in case if the `passPerPreset` is `true` (default is `false`).

This gives opportunity to define "before" and "after" presets, mimicking a similar feature from Babel 5. A rationally for this is to make plugins as short as possible, and handle only needed nodes, not dealing with "unrelated" node in order to avoid potential collisions in case if presets are merged.

#### RFC: design notes

Currently I handle only `plugins` in presets. Are there actual practical use case when a preset may define its own options, other than `plugins`? The options per preset are inherited from main options, overriding needed fields, such as `plugins`.

#### Test plan

`make test`. Will add more tests "per preset" after main review.