### PR TITLE
Fix T6953,T2541 export-from statement renamed default issue

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -295,7 +295,11 @@ export default function () {
                     } else if (specifier.isExportDefaultSpecifier()) {
                       // todo
                     } else if (specifier.isExportSpecifier()) {
-                      topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(ref, specifier.node.local)));
+                      if (specifier.node.local.name === "default") {
+                        topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(t.callExpression(this.addHelper("interopRequireDefault"), [ref]), specifier.node.local)));
+                      } else {
+                        topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(ref, specifier.node.local)));
+                      }
                       nonHoistedExportNames[specifier.node.exported.name] = true;
                     }
                   }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/actual.js
@@ -4,3 +4,4 @@ export {foo, bar} from "foo";
 export {foo as bar} from "foo";
 export {foo as default} from "foo";
 export {foo as default, bar} from "foo";
+export {default as foo} from "foo";

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
@@ -58,3 +58,9 @@ Object.defineProperty(exports, "bar", {
     return _foo.bar;
   }
 });
+Object.defineProperty(exports, "foo", {
+  enumerable: true,
+  get: function () {
+    return babelHelpers.interopRequireDefault(_foo).default;
+  }
+});


### PR DESCRIPTION
> https://github.com/babel/babel/pull/3270

> This PR fixes [T6953](https://phabricator.babeljs.io/T6953),[T2541](https://phabricator.babeljs.io/T2541).

> > via [59naga/babel-plugin-add-module-exports#20](https://github.com/59naga/babel-plugin-add-module-exports/issues/20)