### PR TITLE
Fixed T7006 - Async arrow functions receive the wrong arguments

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -8,8 +8,8 @@ import * as t from "babel-types";
 let buildWrapper = template(`
   (function () {
     var ref = FUNCTION;
-    return function (PARAMS) {
-      return ref.apply(this, arguments);
+    return function (...PARAMS) {
+      return ref.apply(this, PARAMS);
     };
   })
 `);
@@ -17,7 +17,7 @@ let buildWrapper = template(`
 let arrowBuildWrapper =  template(`
   (() => {
     var ref = FUNCTION;
-    return (PARAMS) => ref.apply(this, arguments);
+    return (...PARAMS) => ref.apply(this, PARAMS);
   })
 `);
 
@@ -77,7 +77,7 @@ function plainFunction(path: NodePath, callId: Object) {
   let built = t.callExpression(callId, [node]);
   let container = wrapper({
     FUNCTION: built,
-    PARAMS: node.params.map(() => path.scope.generateUidIdentifier("x"))
+    PARAMS: path.scope.generateUidIdentifier("x")
   }).expression;
 
   let retFunction = container.body.body[1].argument;


### PR DESCRIPTION
The problem is caused because the wrapper function generated in the arrow function case is using the 'arguments' keyword when calling apply  which refers to its bound parent scope. The fix is to use an argument spread and pass that to apply instead of using the arguments keyword.