### PR TITLE
[doc] Correct use of possessive case

### DIFF
--- a/doc/design/compiler-assumptions.md
+++ b/doc/design/compiler-assumptions.md
@@ -1,6 +1,6 @@
 # Compiler assumptions
 
-Babel and it's associated official transforms make some assumptions about your code. These
+Babel and its associated official transforms make some assumptions about your code. These
 assumptions are only made as they're either **impossible** to take into consideration or
 are extremely exotic.
 


### PR DESCRIPTION
Changing it's to its.