### PR TITLE
[hotfix][T7006] Arrow functions don't have arguments bound

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -16,8 +16,10 @@ let buildWrapper = template(`
 
 let arrowBuildWrapper =  template(`
   (() => {
-    var ref = FUNCTION;
-    return (PARAMS) => ref.apply(this, arguments);
+    var ref = FUNCTION, _this = this;
+    return function(PARAMS) {
+      return ref.apply(_this, arguments);
+    };
   })
 `);
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
@@ -3,13 +3,17 @@ let TestClass = {
 
   testMethodFailure() {
     return new Promise((() => {
-      var _this = this;
+      var _this2 = this;
 
       var ref = babelHelpers.asyncToGenerator(function* (resolve) {
-        console.log(_this);
+        console.log(_this2);
         setTimeout(resolve, 1000);
-      });
-      return _x => ref.apply(this, arguments);
+      }),
+          _this = this;
+
+      return function (_x) {
+        return ref.apply(_this, arguments);
+      };
     })());
   }
 };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/actual.js
@@ -1,13 +1,14 @@
 async function s(x) {
-  let t = async (y) => {
-    let r = async (z) =>  {
+  let t = async (y, a) => {
+    let r = async (z, b) =>  {
       await z;
       return this.x;
     }
-    await r;
+    await r();
 
     return this.g(r);
   }
-  await t;
+
+  await t();
   return this.h(t);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
@@ -1,25 +1,34 @@
 let s = function () {
   var ref = babelHelpers.asyncToGenerator(function* (x) {
     let t = (() => {
-      var _this2 = this;
+      var _this3 = this;
 
-      var ref = babelHelpers.asyncToGenerator(function* (y) {
+      var ref = babelHelpers.asyncToGenerator(function* (y, a) {
         let r = (() => {
-          var _this = this;
+          var _this2 = this;
 
-          var ref = babelHelpers.asyncToGenerator(function* (z) {
+          var ref = babelHelpers.asyncToGenerator(function* (z, b) {
             yield z;
-            return _this.x;
-          });
-          return _x3 => ref.apply(this, arguments);
-        })();
-        yield r;
+            return _this2.x;
+          }),
+              _this = this;
 
-        return _this2.g(r);
-      });
-      return _x2 => ref.apply(this, arguments);
+          return function r(_x4, _x5) {
+            return ref.apply(_this, arguments);
+          };
+        })();
+        yield r();
+
+        return _this3.g(r);
+      }),
+          _this = this;
+
+      return function t(_x2, _x3) {
+        return ref.apply(_this, arguments);
+      };
     })();
-    yield t;
+
+    yield t();
     return this.h(t);
   });
   return function s(_x) {


### PR DESCRIPTION
We introduced a fix that special-cased arrow functions in the async transform to fix `this` references. However, this introduced a problem because we are using `arguments` in an arrow function which is not bound. This fixes the problem by using a regular function and explicitly referencing the previous scope's this.

