### PR TITLE
babel-register: read .babelrc file for only/ignore/extensions/cache options

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -27,11 +27,12 @@ sourceMapSupport.install({
 
 registerCache.load();
 let cache = registerCache.get();
+let babelrcOpts = new OptionManager().init({});
 
 let transformOpts = {};
 
-let ignore;
-let only;
+let ignore = babelrcOpts.ignore;
+let only = babelrcOpts.only;
 
 let oldHandlers   = {};
 let maps          = {};


### PR DESCRIPTION
Currently the .babelrc file is only used once a file as been chosen for transpiling, this adds in the optionsManager when parsing the passed in options to allow settings in .babelrc to be used when choosing files.
