### PR TITLE
UnaryExpressions are never not prefix

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -626,7 +626,7 @@ defineType("UnaryExpression", {
   builder: ["operator", "argument", "prefix"],
   fields: {
     prefix: {
-      default: false
+      default: true
     },
     argument: {
       validate: assertNodeType("Expression")


### PR DESCRIPTION
If you look at the spec https://github.com/babel/babel/blob/master/doc/ast/spec.md#unaryexpression
All unary expressions are prefix. We should deprecate this field. But for now let's just default it true.