### PR TITLE
WithStatements can have statements as bodies

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -704,7 +704,7 @@ defineType("WithStatement", {
       object: assertNodeType("Expression")
     },
     body: {
-      validate: assertNodeType("BlockStatement")
+      validate: assertNodeType("BlockStatement", "Statement")
     }
   }
 });


### PR DESCRIPTION
For example try: `with({x: 1}) console.log(x);`