### PR TITLE
ast/spec: add BindExpression

### DIFF
--- a/doc/ast/spec.md
+++ b/doc/ast/spec.md
@@ -71,6 +71,7 @@ These are the core Babylon AST node types.
       - [LogicalOperator](#logicaloperator)
     - [SpreadElement](#spreadelement)
     - [MemberExpression](#memberexpression)
+    - [BindExpression](#bindexpression)
   - [ConditionalExpression](#conditionalexpression)
   - [CallExpression](#callexpression)
   - [NewExpression](#newexpression)
@@ -832,6 +833,18 @@ interface MemberExpression <: Expression, Pattern {
 ```
 
 A member expression. If `computed` is `true`, the node corresponds to a computed (`a[b]`) member expression and `property` is an `Expression`. If `computed` is `false`, the node corresponds to a static (`a.b`) member expression and `property` is an `Identifier`.
+
+### BindExpression
+
+```js
+interface BindExpression <: Expression {
+    type: "BindExpression";
+    object: [ Expression | null ];
+    callee: [ Expression ]
+}
+```
+
+If `object` is `null`, then `callee` should be a `MemberExpression`.
 
 ## ConditionalExpression
 


### PR DESCRIPTION
https://github.com/babel/babel/blob/master/packages/babel-types/src/definitions/experimental.js#L16-L22

```
interface BindExpression <: Expression {
    type: "BindExpression";
    object: [ Expression | null ];
    callee: [ Expression ]
}
```

If `object` is `null`, then `callee` should be a `MemberExpression`.

object Identifier
callee Identifier

object Identifier
callee MemberExpression

object null
callee MemberExpression

object MemberExpression
callee MemberExpression

object NewExpression
callee Identifier

object CallExpression
callee Identifier