### PR TITLE
Set NOT_LOCAL_BINDING on all inferred function names

### DIFF
--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -63,15 +63,6 @@ export function push(mutatorMap: Object, node: Object, kind: string, file, scope
   // infer function name
   if (scope && t.isStringLiteral(key) && (kind === "value" || kind === "initializer") && t.isFunctionExpression(value)) {
     value = nameFunction({ id: key, node: value, scope });
-
-    // Class methods don't have their name bound in the funciton body.
-    if (t.isClassMethod(node)) {
-      if (value.id) {
-        value.id[t.NOT_LOCAL_BINDING] = true;
-      } else if (t.isCallExpression(value) && t.isFunctionExpression(value.callee) && value.callee.id) {
-        value.callee.id[t.NOT_LOCAL_BINDING] = true;
-      }
-    }
   }
 
   if (value) {

--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -65,8 +65,12 @@ export function push(mutatorMap: Object, node: Object, kind: string, file, scope
     value = nameFunction({ id: key, node: value, scope });
 
     // Class methods don't have their name bound in the funciton body.
-    if (t.isClassMethod(node) && value.id) {
-      value.id[t.NOT_LOCAL_BINDING] = true;
+    if (t.isClassMethod(node)) {
+      if (value.id) {
+        value.id[t.NOT_LOCAL_BINDING] = true;
+      } else if (t.isCallExpression(value) && t.isFunctionExpression(value.callee) && value.callee.id) {
+        value.callee.id[t.NOT_LOCAL_BINDING] = true;
+      }
     }
   }
 

--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -65,8 +65,8 @@ export function push(mutatorMap: Object, node: Object, kind: string, file, scope
     value = nameFunction({ id: key, node: value, scope });
 
     // Class methods don't have their name bound in the funciton body.
-    if (t.isClassMethod(node)) {
-      value.id[t.NOT_LOCAL_BINDING] = true
+    if (t.isClassMethod(node) && value.id) {
+      value.id[t.NOT_LOCAL_BINDING] = true;
     }
   }
 

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -141,6 +141,7 @@ export default function ({ node, parent, scope, id }) {
       if (binding && binding.constant && scope.getBinding(id.name) === binding) {
         // always going to reference this method
         node.id = id;
+        node.id[t.NOT_LOCAL_BINDING] = true;
         return;
       }
     }
@@ -162,6 +163,11 @@ export default function ({ node, parent, scope, id }) {
 
   name = t.toBindingIdentifierName(name);
   id = t.identifier(name);
+
+  // The id shouldn't be considered a local binding to the function because
+  // we are simply trying to set the function name and not actually create
+  // a local binding.
+  id[t.NOT_LOCAL_BINDING] = true;
 
   let state = visit(node, name, scope);
   return wrap(state, node, id, scope) || node;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/actual.js
@@ -1,0 +1,8 @@
+class Foo {
+  constructor(val){
+    this._val = val;
+  }
+  foo2(){
+    return foo2(this._val);
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/expected.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var Foo = function () {
+  function Foo(val) {
+    babelHelpers.classCallCheck(this, Foo);
+
+    this._val = val;
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "foo2",
+    value: function (_foo) {
+      function foo2() {
+        return _foo.apply(this, arguments);
+      }
+
+      foo2.toString = function () {
+        return _foo.toString();
+      };
+
+      return foo2;
+    }(function () {
+      return foo2(this._val);
+    })
+  }]);
+  return Foo;
+}();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-es2015-classes",
+    "external-helpers"
+  ]
+}


### PR DESCRIPTION
Since all inferred function names (as part of the function name helper) are just to set the `function.name` value and are not actual bindings we need to set the `NOT_LOCAL_BINDING` symbol on them. 

cc @hzoo @kittens 