### PR TITLE
Update AST spec

### DIFF
--- a/doc/ast/spec.md
+++ b/doc/ast/spec.md
@@ -141,7 +141,7 @@ interface Position {
 # Identifier
 
 ```js
-interface Identifier <: Node, Expression, Pattern {
+interface Identifier <: Expression, Pattern {
   type: "Identifier";
   name: string;
 }
@@ -150,6 +150,12 @@ interface Identifier <: Node, Expression, Pattern {
 An identifier. Note that an identifier may be an expression or a destructuring pattern.
 
 # Literals
+
+```js
+interface Literal <: Expression { }
+```
+
+A literal token. May or may not represent an expression.
 
 ## RegExpLiteral
 
@@ -928,6 +934,10 @@ interface TemplateElement <: Node {
 ```
 
 # Patterns
+
+```js
+interface Pattern <: Node { }
+```
 
 ## ObjectPattern
 


### PR DESCRIPTION
* Remove redundant `Node` reference from `Identifier` interface.
  `Expression` already inherits from `Node`. (Same change went into ESTree: https://github.com/estree/estree/pull/110.)

* Add missing interfaces: `Literal`, `Pattern`.