### PR TITLE
[babel-template][T7046]: Add optional babylon options argument.

### DIFF
--- a/packages/babel-template/src/index.js
+++ b/packages/babel-template/src/index.js
@@ -1,4 +1,5 @@
 import cloneDeep from "lodash/lang/cloneDeep";
+import assign from "lodash/object/assign";
 import has from "lodash/object/has";
 import traverse from "babel-traverse";
 import * as babylon from "babylon";
@@ -7,7 +8,7 @@ import * as t from "babel-types";
 let FROM_TEMPLATE = "_fromTemplate"; //Symbol(); // todo: probably wont get copied over
 let TEMPLATE_SKIP = Symbol();
 
-export default function (code: string): Function {
+export default function (code: string, opts?: Object): Function {
   // since we lazy parse the template, we get the current stack so we have the
   // original stack to append if it errors when parsing
   let stack;
@@ -22,10 +23,10 @@ export default function (code: string): Function {
     let ast;
 
     try {
-      ast = babylon.parse(code, {
+      ast = babylon.parse(code, assign({
         allowReturnOutsideFunction: true,
         allowSuperOutsideMethod: true
-      });
+      }, opts));
 
       ast = traverse.removeProperties(ast);
 

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -1,0 +1,16 @@
+var template  = require("../lib");
+var chai      = require("chai");
+
+suite("templating", function () {
+  test("import statement will cause parser to throw by default", function () {
+    chai.expect(function () {
+      template("import foo from 'foo'")({});
+    }).to.throw();
+  });
+
+  test("import statements are allowed with sourceType: module", function () {
+    chai.expect(function () {
+      template("import foo from 'foo'", {sourceType: 'module'})({});
+    }).not.to.throw();
+  });
+});


### PR DESCRIPTION
Reference [#T7046](https://phabricator.babeljs.io/T7046)

I would love to add a test, but there do not appear to be any for `babel-template`. I will happily add one if pointed in the right direction.