### PR TITLE
Fix: Arrow functions with trailing comma + return type are throwing an error when parsing

### DIFF
--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -528,7 +528,7 @@ pp.parseParenExpression = function () {
   return val;
 };
 
-pp.parseParenAndDistinguishExpression = function (startPos, startLoc, canBeArrow, isAsync) {
+pp.parseParenAndDistinguishExpression = function (startPos, startLoc, canBeArrow, isAsync, allowOptionalCommaStart) {
   startPos = startPos || this.state.start;
   startLoc = startLoc || this.state.startLoc;
 
@@ -578,7 +578,7 @@ pp.parseParenAndDistinguishExpression = function (startPos, startLoc, canBeArrow
       this.unexpected(this.state.lastTokStart);
     }
   }
-  if (optionalCommaStart) this.unexpected(optionalCommaStart);
+  if (optionalCommaStart && !allowOptionalCommaStart) this.unexpected(optionalCommaStart);
   if (spreadStart) this.unexpected(spreadStart);
   if (refShorthandDefaultPos.start) this.unexpected(refShorthandDefaultPos.start);
 

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -1030,7 +1030,7 @@ export default function (instance) {
         return this.parseArrowExpression(node, [], isAsync);
       } else {
         // let foo = (foo): number => {};
-        let node = inner.call(this, startPos, startLoc, canBeArrow, isAsync);
+        let node = inner.call(this, startPos, startLoc, canBeArrow, isAsync, this.hasPlugin("trailingFunctionCommas"));
 
         if (this.match(tt.colon)) {
           let state = this.state.clone();

--- a/packages/babylon/test/fixtures/flow/trailing-function-commas-type/1/actual.js
+++ b/packages/babylon/test/fixtures/flow/trailing-function-commas-type/1/actual.js
@@ -1,0 +1,1 @@
+( props: SomeType, ) : ReturnType => ( 3 );

--- a/packages/babylon/test/fixtures/flow/trailing-function-commas-type/1/expected.json
+++ b/packages/babylon/test/fixtures/flow/trailing-function-commas-type/1/expected.json
@@ -1,0 +1,202 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 43,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 43
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 43,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 43
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 43,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 43
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 42,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 42
+            }
+          },
+          "id": null,
+          "generator": false,
+          "expression": true,
+          "async": false,
+          "params": [
+            {
+              "type": "Identifier",
+              "start": 2,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 2
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              },
+              "name": "props",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 7,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 17
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "start": 9,
+                  "end": 17,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 17
+                    }
+                  },
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start": 9,
+                    "end": 17,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 17
+                      }
+                    },
+                    "name": "SomeType"
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "NumericLiteral",
+            "start": 39,
+            "end": 40,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 39
+              },
+              "end": {
+                "line": 1,
+                "column": 40
+              }
+            },
+            "extra": {
+              "rawValue": 3,
+              "raw": "3",
+              "parenthesized": true,
+              "parenStart": 37
+            },
+            "value": 3
+          },
+          "returnType": {
+            "type": "TypeAnnotation",
+            "start": 21,
+            "end": 33,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 21
+              },
+              "end": {
+                "line": 1,
+                "column": 33
+              }
+            },
+            "typeAnnotation": {
+              "type": "GenericTypeAnnotation",
+              "start": 23,
+              "end": 33,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 23
+                },
+                "end": {
+                  "line": 1,
+                  "column": 33
+                }
+              },
+              "typeParameters": null,
+              "id": {
+                "type": "Identifier",
+                "start": 23,
+                "end": 33,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 33
+                  }
+                },
+                "name": "ReturnType"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/flow/trailing-function-commas-type/options.json
+++ b/packages/babylon/test/fixtures/flow/trailing-function-commas-type/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow", "asyncFunctions", "trailingFunctionCommas"]
+}


### PR DESCRIPTION
See https://phabricator.babeljs.io/T7052.


A few things to highlight and I would love to get feedback on for review:

- Where should the tests be placed? The error only occurs when using the `flow` and `trailingFunctionCommas`. I am therefore not sure if the tests should be placed under `babylon` or under `babel-plugin-syntax-trailing-function-commas` (or anywhere else)?

- To make the parsing work I've added a new parameter to `parseParenAndDistinguishExpression`, which is toggled from the `flow` plugin in case `trailingFunctionCommas` is enabled. This is a bit unpleasant because now `trailingFunctionCommas` influences the `flow` plugin. I tried to come up with a way to avoid this new dependency but failed doing so. Is this a problem - and if, is there a better solution?