### PR TITLE
Make plugin instantiation unobservable

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -30,6 +30,20 @@ function exists(filename) {
   }
 }
 
+let requireCache = {};
+
+function requireFromCache(loc) {
+  let obj = requireCache[loc];
+  if (obj) return obj;
+
+  obj = require(loc);
+
+  // remove it from the require cache so it's not observable
+  delete require.cache[loc];
+
+  return requireCache[loc] = obj;
+}
+
 type PluginObject = {
   pre?: Function;
   post?: Function;
@@ -129,7 +143,7 @@ export default class OptionManager {
       if (typeof plugin === "string") {
         let pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname);
         if (pluginLoc) {
-          plugin = require(pluginLoc);
+          plugin = requireFromCache(pluginLoc);
         } else {
           throw new ReferenceError(messages.get("pluginUnknown", plugin, loc, i, dirname));
         }
@@ -281,7 +295,7 @@ export default class OptionManager {
       if (typeof val === "string") {
         let presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
         if (presetLoc) {
-          let val = require(presetLoc);
+          let val = requireFromCache(presetLoc);
           onResolve && onResolve(val, presetLoc);
           return val;
         } else {

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -15,7 +15,7 @@ export default class Plugin extends Store {
 
     this.initialized = false;
     this.raw         = assign({}, plugin);
-    this.key         = key;
+    //this.key         = key;
 
     this.manipulateOptions = this.take("manipulateOptions");
     this.post              = this.take("post");


### PR DESCRIPTION
Not to be merged unless it becomes problematic/common. Dunno if this will work, haven't tested it.