### PR TITLE
babel-cli: Make chokidar dependency optional

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -13,7 +13,6 @@
     "babel-runtime": "^5.0.0",
     "bin-version-check": "^2.1.0",
     "chalk": "1.1.1",
-    "chokidar": "^1.0.0",
     "commander": "^2.8.1",
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^0.1.0",
@@ -27,6 +26,9 @@
     "slash": "^1.0.0",
     "source-map": "^0.5.0",
     "v8flags": "^2.0.10"
+  },
+  "optionalDependencies": {
+    "chokidar": "^1.0.0"
   },
   "devDependencies": {
     "babel-helper-fixtures": "^6.3.13"

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -1,6 +1,5 @@
 let outputFileSync = require("output-file-sync");
 let pathExists     = require("path-exists");
-let chokidar       = require("chokidar");
 let slash          = require("slash");
 let path           = require("path");
 let util           = require("./util");
@@ -65,6 +64,8 @@ module.exports = function (commander, filenames) {
   _.each(filenames, handle);
 
   if (commander.watch) {
+    let chokidar = require("chokidar");
+
     _.each(filenames, function (dirname) {
       let watcher = chokidar.watch(dirname, {
         persistent: true,

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -64,7 +64,7 @@ module.exports = function (commander, filenames) {
   _.each(filenames, handle);
 
   if (commander.watch) {
-    let chokidar = require("chokidar");
+    let chokidar = util.requireChokidar();
 
     _.each(filenames, function (dirname) {
       let watcher = chokidar.watch(dirname, {

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -132,7 +132,7 @@ module.exports = function (commander, filenames, opts) {
     walk();
 
     if (commander.watch) {
-      let chokidar = require("chokidar");
+      let chokidar = util.requireChokidar();
       chokidar.watch(filenames, {
         persistent: true,
         ignoreInitial: true

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -1,7 +1,6 @@
 let convertSourceMap = require("convert-source-map");
 let pathExists       = require("path-exists");
 let sourceMap        = require("source-map");
-let chokidar         = require("chokidar");
 let slash            = require("slash");
 let path             = require("path");
 let util             = require("./util");
@@ -133,6 +132,7 @@ module.exports = function (commander, filenames, opts) {
     walk();
 
     if (commander.watch) {
+      let chokidar = require("chokidar");
       chokidar.watch(filenames, {
         persistent: true,
         ignoreInitial: true

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -71,3 +71,12 @@ process.on("uncaughtException", function (err) {
   console.error(toErrorStack(err));
   process.exit(1);
 });
+
+export function requireChokidar() {
+  try {
+    return require("chokidar");
+  } catch (err) {
+    console.error("The optional dependency chokidar failed to install and is required for --watch. Chokidar is likely not supported on your platform.")
+    throw err;
+  }
+}


### PR DESCRIPTION
chokidar is only need for monitoring the file system when using the `--watch` flag. Its native fsevent subdependency is sometimes problematic to install in certain deployment environments. 

chokidar will still be installed by default, so it shouldn't affect any existing behavior. But it would allow people to omit it from being installed.

See postcss-cli's chokidar integration for reference: https://github.com/postcss/postcss-cli/blob/cd3baca2d1e89ced965e646d9bc3206e0b7990be/index.js#L150, https://github.com/postcss/postcss-cli/blob/cd3baca2d1e89ced965e646d9bc3206e0b7990be/package.json#L29.