### PR TITLE
Add a failing test of reassigning ...rest array elements.

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-reassignment/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-reassignment/actual.js
@@ -1,0 +1,4 @@
+function f(...args) {
+  args[0] = convert(args[0]);
+  return g(...args);
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-reassignment/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-reassignment/expected.js
@@ -1,0 +1,8 @@
+function f() {
+  for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  args[0] = convert(args[0]);
+  return g.apply(undefined, args);
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-reassignment/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-reassignment/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-es2015-parameters",
+    "transform-es2015-spread"
+  ]
+}


### PR DESCRIPTION
The AST produced from transforming `actual.js` fails to validate because the `optimiseIndexGetter` function attempts to replace the left-hand-side `args[0]` with a conditional expression, which is no longer a valid LVal.