### PR TITLE
Fix T6882 (async functions are not hoisted)

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -87,6 +87,7 @@ function plainFunction(path: NodePath, callId: Object) {
         t.callExpression(container, [])
       )
     ]);
+    declar._blockHoist = true;
 
     retFunction.id = asyncFnId;
     path.replaceWith(declar);

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/actual.js
@@ -1,5 +1,3 @@
-function normalFunction() {}
-
 async function foo() {
   var wat = await bar();
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
@@ -1,5 +1,3 @@
-function normalFunction() {}
-
 let foo = function () {
   var ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -5,13 +5,13 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.foo = undefined;
 
-var _bar = require('bar');
-
-var _bar2 = babelHelpers.interopRequireDefault(_bar);
-
 let foo = exports.foo = function () {
   var ref = babelHelpers.asyncToGenerator(function* () {});
   return function foo() {
     return ref.apply(this, arguments);
   };
 }();
+
+var _bar = require('bar');
+
+var _bar2 = babelHelpers.interopRequireDefault(_bar);

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T6882/exec.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T6882/exec.js
@@ -1,0 +1,3 @@
+foo();
+
+async function foo() {}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-block-scoping", "transform-regenerator", "transform-async-to-generator"]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -399,14 +399,21 @@ export default function () {
               hoistedExportsNode = buildExportsAssignment(t.identifier(name), hoistedExportsNode).expression;
             }
 
-            topNodes.unshift(t.expressionStatement(hoistedExportsNode));
+            const node = t.expressionStatement(hoistedExportsNode);
+            node._blockHoist = 3;
+
+            topNodes.unshift(node);
           }
 
           // add __esModule declaration if this file has any exports
           if (hasExports && !strict) {
             let buildTemplate = buildExportsModuleDeclaration;
             if (this.opts.loose) buildTemplate = buildLooseExportsModuleDeclaration;
-            topNodes.unshift(buildTemplate());
+
+            const declar = buildTemplate();
+            declar._blockHoist = 3;
+
+            topNodes.unshift(declar);
           }
 
           path.unshiftContainer("body", topNodes);


### PR DESCRIPTION
https://phabricator.babeljs.io/T6882

Reverting #3097 fixes T6882, but breaks [T3085](https://phabricator.babeljs.io/T3085) and [T3026](https://phabricator.babeljs.io/T3026) (duplicates).

I don't think that the way I fixed T3085/T3026 is ideal, but I feel that it's preferable to turning off hoisting for _all_ async function declarations (à la #3097).