### PR TITLE
PR for T6903 - fixing System source maps

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-default/expected.js
@@ -13,11 +13,8 @@ define(["exports"], function (exports) {
   exports.default = [];
   exports.default = foo;
   exports.default = class {};
-
   function foo() {}
-
   class Foo {}
-
   exports.default = Foo;
   exports.default = foo;
 

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-variable/expected.js
@@ -8,17 +8,12 @@ define(["exports"], function (exports) {
   var foo = exports.foo = 1;
   var foo = exports.foo = 1,
       bar = exports.bar = 2;
-
   var foo2 = exports.foo2 = function () {};
-
   var foo3 = exports.foo3 = undefined;
   let foo4 = exports.foo4 = 2;
   let foo5 = exports.foo5 = undefined;
   const foo6 = exports.foo6 = 3;
-
   function foo7() {}
-
   class foo8 {}
-
   exports.foo8 = foo8;
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/hoist-function-exports/expected.js
@@ -6,7 +6,6 @@ define(["exports", "./evens"], function (exports, _evens) {
   });
   exports.isOdd = undefined;
   exports.nextOdd = nextOdd;
-
   function nextOdd(n) {
     return (0, _evens.isEven)(n) ? n + 1 : n + 2;
   }

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-glob/expected.js
@@ -2,5 +2,7 @@ define(["foo"], function (_foo) {
   "use strict";
 
   var foo = babelHelpers.interopRequireWildcard(_foo);
+
+
   foo;
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/overview/expected.js
@@ -8,7 +8,10 @@ define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (exports, 
   var foo2 = babelHelpers.interopRequireWildcard(_foo);
   exports.test = test;
   var test2 = exports.test2 = 5;
+
   exports.default = test;
+
+
   foo2.default;
   foo2;
   _foo.bar;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/remap/expected.js
@@ -16,12 +16,17 @@ define(["exports"], function (exports) {
 
   var a = 2;
   exports.a = a;
+
   exports.a = a = 3;
+
   var b = 2;
   exports.c = b;
+
   exports.c = b = 3;
+
   var d = 3;
   exports.e = d;
   exports.f = d;
+
   exports.f = exports.e = d = 4;
 });

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
@@ -10,7 +10,6 @@ System.register([], function (_export, _context) {
       _export("test", test);
 
       _export("test", test = 5);
-
       _export("test", test++);
 
       (function () {

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-default/expected.js
@@ -25,11 +25,8 @@
   exports.default = [];
   exports.default = foo;
   exports.default = class {};
-
   function foo() {}
-
   class Foo {}
-
   exports.default = Foo;
   exports.default = foo;
 

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-variable/expected.js
@@ -20,17 +20,12 @@
   var foo = exports.foo = 1;
   var foo = exports.foo = 1,
       bar = exports.bar = 2;
-
   var foo2 = exports.foo2 = function () {};
-
   var foo3 = exports.foo3 = undefined;
   let foo4 = exports.foo4 = 2;
   let foo5 = exports.foo5 = undefined;
   const foo6 = exports.foo6 = 3;
-
   function foo7() {}
-
   class foo8 {}
-
   exports.foo8 = foo8;
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/hoist-function-exports/expected.js
@@ -18,7 +18,6 @@
   });
   exports.isOdd = undefined;
   exports.nextOdd = nextOdd;
-
   function nextOdd(n) {
     return (0, _evens.isEven)(n) ? n + 1 : n + 2;
   }

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-glob/expected.js
@@ -14,5 +14,7 @@
   "use strict";
 
   var foo = babelHelpers.interopRequireWildcard(_foo);
+
+
   foo;
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/overview/expected.js
@@ -20,7 +20,10 @@
   var foo2 = babelHelpers.interopRequireWildcard(_foo);
   exports.test = test;
   var test2 = exports.test2 = 5;
+
   exports.default = test;
+
+
   _foo.bar;
   _foo.foo;
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/remap/expected.js
@@ -28,12 +28,17 @@
 
   var a = 2;
   exports.a = a;
+
   exports.a = a = 3;
+
   var b = 2;
   exports.c = b;
+
   exports.c = b = 3;
+
   var d = 3;
   exports.e = d;
   exports.f = d;
+
   exports.f = exports.e = d = 4;
 });

--- a/packages/babel-template/src/index.js
+++ b/packages/babel-template/src/index.js
@@ -99,6 +99,7 @@ let templateVisitor = {
   },
 
   exit({ node }) {
-    traverse.clearNode(node);
+    if (!node.loc)
+      traverse.clearNode(node);
   }
 };


### PR DESCRIPTION
As discussed at https://twitter.com/sebmck/status/695005180413272065, this ensures that source map data is not stripped from the System module format when using the template system to create the output.