### PR TITLE
Simplify babel-generator/node/index.js

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -3,7 +3,7 @@
 import isInteger from "is-integer";
 import isNumber from "lodash/lang/isNumber";
 import * as t from "babel-types";
-import n from "../node";
+import * as n from "../node";
 
 const SCIENTIFIC_NOTATION = /e/i;
 const ZERO_DECIMAL_INTEGER = /\.0+$/;

--- a/packages/babel-generator/src/node/index.js
+++ b/packages/babel-generator/src/node/index.js
@@ -2,7 +2,6 @@
 
 import whitespace from "./whitespace";
 import * as parens from "./parentheses";
-import each from "lodash/collection/each";
 import * as t from "babel-types";
 
 function find(obj, node, parent, printStack) {
@@ -36,72 +35,47 @@ function isOrHasCallExpression(node) {
   }
 }
 
-export default class Node {
-  constructor(node: Object, parent: Object) {
-    this.parent = parent;
-    this.node   = node;
-  }
 
-  parent: Object;
-  node: Object;
-
-  static isUserWhitespacable(node) {
-    return t.isUserWhitespacable(node);
-  }
-
-  static needsWhitespace(node, parent, type) {
-    if (!node) return 0;
-
-    if (t.isExpressionStatement(node)) {
-      node = node.expression;
-    }
-
-    let linesInfo = find(whitespace.nodes, node, parent);
-
-    if (!linesInfo) {
-      let items = find(whitespace.list, node, parent);
-      if (items) {
-        for (let i = 0; i < items.length; i++) {
-          linesInfo = Node.needsWhitespace(items[i], node, type);
-          if (linesInfo) break;
-        }
-      }
-    }
-
-    return (linesInfo && linesInfo[type]) || 0;
-  }
-
-  static needsWhitespaceBefore(node, parent) {
-    return Node.needsWhitespace(node, parent, "before");
-  }
-
-  static needsWhitespaceAfter(node, parent) {
-    return Node.needsWhitespace(node, parent, "after");
-  }
-
-  static needsParens(node, parent, printStack) {
-    if (!parent) return false;
-
-    if (t.isNewExpression(parent) && parent.callee === node) {
-      if (isOrHasCallExpression(node)) return true;
-    }
-
-    return find(parens, node, parent, printStack);
-  }
+export function isUserWhitespacable(node) {
+  return t.isUserWhitespacable(node);
 }
 
-each(Node, function (fn, key) {
-  Node.prototype[key] = function () {
-    // Avoid leaking arguments to prevent deoptimization
-    let args = new Array(arguments.length + 2);
+export function needsWhitespace(node, parent, type) {
+  if (!node) return 0;
 
-    args[0] = this.node;
-    args[1] = this.parent;
+  if (t.isExpressionStatement(node)) {
+    node = node.expression;
+  }
 
-    for (let i = 0; i < args.length; i++) {
-      args[i + 2] = arguments[i];
+  let linesInfo = find(whitespace.nodes, node, parent);
+
+  if (!linesInfo) {
+    let items = find(whitespace.list, node, parent);
+    if (items) {
+      for (let i = 0; i < items.length; i++) {
+        linesInfo = needsWhitespace(items[i], node, type);
+        if (linesInfo) break;
+      }
     }
+  }
 
-    return Node[key].apply(null, args);
-  };
-});
+  return (linesInfo && linesInfo[type]) || 0;
+}
+
+export function needsWhitespaceBefore(node, parent) {
+  return needsWhitespace(node, parent, "before");
+}
+
+export function needsWhitespaceAfter(node, parent) {
+  return needsWhitespace(node, parent, "after");
+}
+
+export function needsParens(node, parent, printStack) {
+  if (!parent) return false;
+
+  if (t.isNewExpression(parent) && parent.callee === node) {
+    if (isOrHasCallExpression(node)) return true;
+  }
+
+  return find(parens, node, parent, printStack);
+}

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -1,6 +1,6 @@
 import repeating from "repeating";
 import Buffer from "./buffer";
-import n from "./node";
+import * as n from "./node";
 import * as t from "babel-types";
 
 export default class Printer extends Buffer {


### PR DESCRIPTION
The Node class was unused as a class, and the class was just being used as a bundle of static functions.

I noticed this while working on #3315.

Mostly indentation changes, see [diff with whitespace changes ignored](https://github.com/babel/babel/pull/3316/files?w=1)