### PR TITLE
make publish: add make build in case it wasn't run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ test-ci:
 
 publish:
 	git pull --rebase
+	make build
 	make test
 	./node_modules/.bin/lerna publish
 	make clean


### PR DESCRIPTION
To prevent the publishing issue from https://github.com/babel/babel/releases/tag/v6.4.4 (since we publish the `/lib` folder and it was using locally modified stuff instead of being rebuilt)