### PR TITLE
Add support for leading pipes in Flow type alias RHS syntax

### DIFF
--- a/packages/babel-generator/test/fixtures/flow/type-alias/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-alias/actual.js
@@ -2,3 +2,13 @@ type FBID = number;
 type Foo<T> = Bar<T>;
 type Maybe<T> = _Maybe<T, *>;
 export type Foo = number;
+
+type union =
+ | {type: "A"}
+ | {type: "B"}
+;
+
+type overloads =
+  & ((x: string) => number)
+  & ((x: number) => string)
+;

--- a/packages/babel-generator/test/fixtures/flow/type-alias/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-alias/expected.js
@@ -2,3 +2,7 @@ type FBID = number;
 type Foo<T> = Bar<T>;
 type Maybe<T> = _Maybe<T, *>;
 export type Foo = number;
+
+type union = { type: "A" } | { type: "B" };
+
+type overloads = (x: string) => number & (x: number) => string;

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/type-alias/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/type-alias/expected.js
@@ -3,3 +3,11 @@ function a() {}
 /*:: type B = {
   name: string;
 };*/
+/*:: type union =
+ | {type: "A"}
+ | {type: "B"}
+;*/
+/*:: type overloads =
+  & ((x: string) => number)
+  & ((x: number) => string)
+;*/

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-alias/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-alias/actual.js
@@ -1,3 +1,13 @@
 type FBID = number;
 type Foo<T> = Bar<T>
 export type Foo = number;
+
+type union =
+ | {type: "A"}
+ | {type: "B"}
+;
+
+type overloads =
+  & ((x: string) => number)
+  & ((x: number) => string)
+;

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -3,10 +3,15 @@ import Parser from "../parser";
 
 let pp = Parser.prototype;
 
-pp.flowParseTypeInitialiser = function (tok) {
+pp.flowParseTypeInitialiser = function (tok, allowLeadingPipeOrAnd) {
   let oldInType = this.state.inType;
   this.state.inType = true;
   this.expect(tok || tt.colon);
+  if (allowLeadingPipeOrAnd) {
+    if (this.match(tt.bitwiseAND) || this.match(tt.bitwiseOR)) {
+      this.next();
+    }
+  }
   let type = this.flowParseType();
   this.state.inType = oldInType;
   return type;
@@ -172,7 +177,10 @@ pp.flowParseTypeAlias = function (node) {
     node.typeParameters = null;
   }
 
-  node.right = this.flowParseTypeInitialiser(tt.eq);
+  node.right = this.flowParseTypeInitialiser(
+    tt.eq,
+    /*allowLeadingPipeOrAnd*/ true
+  );
   this.semicolon();
 
   return this.finishNode(node, "TypeAlias");

--- a/packages/babylon/test/fixtures/flow/type-alias/4/actual.js
+++ b/packages/babylon/test/fixtures/flow/type-alias/4/actual.js
@@ -1,9 +1,3 @@
-function a() {}
-type A = number;
-type B = {
-  name: string;
-};
-
 type union =
  | {type: "A"}
  | {type: "B"}

--- a/packages/babylon/test/fixtures/flow/type-alias/4/expected.json
+++ b/packages/babylon/test/fixtures/flow/type-alias/4/expected.json
@@ -1,0 +1,436 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 120,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 120,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 44,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 10,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 10
+            }
+          },
+          "name": "union"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "UnionTypeAnnotation",
+          "start": 16,
+          "end": 42,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 3
+            },
+            "end": {
+              "line": 3,
+              "column": 14
+            }
+          },
+          "types": [
+            {
+              "type": "ObjectTypeAnnotation",
+              "start": 16,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 3
+                },
+                "end": {
+                  "line": 2,
+                  "column": 14
+                }
+              },
+              "callProperties": [],
+              "properties": [
+                {
+                  "type": "ObjectTypeProperty",
+                  "start": 17,
+                  "end": 26,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 13
+                    }
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "start": 17,
+                    "end": 21,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 8
+                      }
+                    },
+                    "name": "type"
+                  },
+                  "value": {
+                    "type": "StringLiteralTypeAnnotation",
+                    "start": 23,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 13
+                      }
+                    },
+                    "value": "A",
+                    "extra": {
+                      "rawValue": "A",
+                      "raw": "\"A\""
+                    }
+                  },
+                  "optional": false
+                }
+              ],
+              "indexers": []
+            },
+            {
+              "type": "ObjectTypeAnnotation",
+              "start": 31,
+              "end": 42,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 3
+                },
+                "end": {
+                  "line": 3,
+                  "column": 14
+                }
+              },
+              "callProperties": [],
+              "properties": [
+                {
+                  "type": "ObjectTypeProperty",
+                  "start": 32,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 13
+                    }
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "start": 32,
+                    "end": 36,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 8
+                      }
+                    },
+                    "name": "type"
+                  },
+                  "value": {
+                    "type": "StringLiteralTypeAnnotation",
+                    "start": 38,
+                    "end": 41,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 13
+                      }
+                    },
+                    "value": "B",
+                    "extra": {
+                      "rawValue": "B",
+                      "raw": "\"B\""
+                    }
+                  },
+                  "optional": false
+                }
+              ],
+              "indexers": []
+            }
+          ]
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 46,
+        "end": 120,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 51,
+          "end": 60,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 5
+            },
+            "end": {
+              "line": 6,
+              "column": 14
+            }
+          },
+          "name": "overloads"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "IntersectionTypeAnnotation",
+          "start": 67,
+          "end": 118,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 4
+            },
+            "end": {
+              "line": 8,
+              "column": 27
+            }
+          },
+          "types": [
+            {
+              "type": "FunctionTypeAnnotation",
+              "start": 68,
+              "end": 89,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 5
+                },
+                "end": {
+                  "line": 7,
+                  "column": 26
+                }
+              },
+              "params": [
+                {
+                  "type": "FunctionTypeParam",
+                  "start": 69,
+                  "end": 78,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 6
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 15
+                    }
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "start": 69,
+                    "end": 70,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 7
+                      }
+                    },
+                    "name": "x"
+                  },
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 72,
+                    "end": 78,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 15
+                      }
+                    }
+                  }
+                }
+              ],
+              "rest": null,
+              "returnType": {
+                "type": "NumberTypeAnnotation",
+                "start": 83,
+                "end": 89,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 26
+                  }
+                }
+              },
+              "typeParameters": null
+            },
+            {
+              "type": "FunctionTypeAnnotation",
+              "start": 96,
+              "end": 117,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 5
+                },
+                "end": {
+                  "line": 8,
+                  "column": 26
+                }
+              },
+              "params": [
+                {
+                  "type": "FunctionTypeParam",
+                  "start": 97,
+                  "end": 106,
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 6
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 15
+                    }
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "start": 97,
+                    "end": 98,
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 7
+                      }
+                    },
+                    "name": "x"
+                  },
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "NumberTypeAnnotation",
+                    "start": 100,
+                    "end": 106,
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 15
+                      }
+                    }
+                  }
+                }
+              ],
+              "rest": null,
+              "returnType": {
+                "type": "StringTypeAnnotation",
+                "start": 111,
+                "end": 117,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 26
+                  }
+                }
+              },
+              "typeParameters": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
I just added syntax support to Flow for leading pipes in type aliases that are unions: https://github.com/facebook/flow/commit/7fb56ee9d87517973b4ab32f180ff968c99dded5

This adds parser support to Babel as well.

Caveat: I'm not actually sure how to run the test I wrote.... Any help here would be appreciated :)