### PR TITLE
Update gcc for compiling modules in node 4/5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ node_js:
  - "0.10"
  - "0.12"
 
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
 script: make test-ci
 
 notifications:


### PR DESCRIPTION
https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements

Getting these errors in node 4/5

```
> thread-sleep@1.0.4 install /home/travis/build/babel/babel/node_modules/thread-sleep
> node-pre-gyp install --fallback-to-build
make[2]: Entering directory `/home/travis/build/babel/babel/node_modules/thread-sleep/build'
  CXX(target) Release/obj.target/thread_sleep/thread_sleep.o
In file included from ../thread_sleep.cc:10:0:
../../nan/nan.h:41:3: error: #error This version of node/NAN/v8 requires a C++11 compiler
In file included from /home/travis/.node-gyp/5.4.1/include/node/node.h:42:0,
                 from ../../nan/nan.h:45,
                 from ../thread_sleep.cc:10:
/home/travis/.node-gyp/5.4.1/include/node/v8.h:336:1: error: expected unqualified-id before ‘using’
/home/travis/.node-gyp/5.4.1/include/node/v8.h:469:1: error: expected unqualified-id before ‘using’
/home/travis/.node-gyp/5.4.1/include/node/v8.h:856:1: error: expected unqualified-id before ‘using’
In file included from ../../nan/nan.h:194:0,
                 from ../thread_sleep.cc:10:
```

Not sure which dependencies are doing this