### PR TITLE
Parenthize "in" in for-loop init, even when init has nested for-loop

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -156,7 +156,7 @@ export function AssignmentPattern(node: Object) {
 export function AssignmentExpression(node: Object, parent: Object) {
   // Somewhere inside a for statement `init` node but doesn't usually
   // needs a paren except for `in` expressions: `for (a in b ? a : b;;)`
-  let parens = this._inForStatementInit && node.operator === "in" &&
+  let parens = this._inForStatementInitCounter && node.operator === "in" &&
                !n.needsParens(node, parent);
 
   if (parens) {

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -52,9 +52,9 @@ export function ForStatement(node: Object) {
   this.keyword("for");
   this.push("(");
 
-  this._inForStatementInit = true;
+  this._inForStatementInitCounter++;
   this.print(node.init, node);
-  this._inForStatementInit = false;
+  this._inForStatementInitCounter--;
   this.push(";");
 
   if (node.test) {

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -28,6 +28,7 @@ export class CodeGenerator extends Printer {
     this.format   = format;
     this.opts     = opts;
     this.ast      = ast;
+    this._inForStatementInitCounter = 0;
 
     this.whitespace = new Whitespace(tokens);
     this.map        = new SourceMap(position, opts, code);

--- a/packages/babel-generator/test/fixtures/edgecase/for-loop-in/actual.js
+++ b/packages/babel-generator/test/fixtures/edgecase/for-loop-in/actual.js
@@ -1,1 +1,2 @@
 for ((a in b) ? a : b; i;);
+for (function(){for(;;);} && (a in b);;);

--- a/packages/babel-generator/test/fixtures/edgecase/for-loop-in/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/for-loop-in/expected.js
@@ -1,1 +1,4 @@
 for ((a in b) ? a : b; i;);
+for (function () {
+  for (;;);
+} && (a in b);;);


### PR DESCRIPTION
When transpiling the following valid JS:

```JS
for (function(){for(;;);} && (a in b);;);
```

Babel returned the following invalid JS:

```JS
for (function () {
  for (;;);
} && a in b;;);
```

Note the dropped parens around the `in` expression. This results in a syntax error.

This happened because Babel's code generator kept track of whether it was in a for-loop init with a single boolean (see 6caaf680248ad339a9b61c11d48b7b974d7187ee). Exiting a for-loop init toggled this variable to false. So exiting the *nested* for-loop's init made the code generator think it wasn't in *any* for-loop init, even though it was still in the enclosing one. Since it didn't think it was in a for-loop init, it didn't bother to wrap the `in` expression in parens. 

This was fixed by changing `this._inForStatementInit` from a boolean to a counter. The counter starts at `0`. Every time we enter a for-loop init, we increment the counter. Every time we exit a for-loop init, we decrement the counter. When it comes to for-loop init nesting, if we've exited as many as we've entered, we get back to `0`, and we know that we're not in a for-loop init. If we've exited fewer than we've entered, the counter is positive, so we know that we're still in a for-loop init, and we wrap `in` expressions in parens.