### PR TITLE
Fix spread to work with super method calls

### DIFF
--- a/packages/babel-plugin-transform-es2015-spread/src/index.js
+++ b/packages/babel-plugin-transform-es2015-spread/src/index.js
@@ -101,6 +101,10 @@ export default function ({ types: t }) {
           node.callee = t.memberExpression(node.callee, t.identifier("apply"));
         }
 
+        if (t.isSuper(contextLiteral)) {
+          contextLiteral = t.thisExpression();
+        }
+
         node.arguments.unshift(contextLiteral);
       },
 

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/actual.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/actual.js
@@ -1,0 +1,5 @@
+class Foo {
+	bar() {
+		super.bar(arg1, arg2, ...args);
+	}
+}

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/expected.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/expected.js
@@ -1,0 +1,5 @@
+class Foo {
+	bar() {
+		super.bar.apply(this, [arg1, arg2].concat(babelHelpers.toConsumableArray(args)));
+	}
+}

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-single-arg/actual.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-single-arg/actual.js
@@ -1,0 +1,5 @@
+class Foo {
+	bar() {
+		super.bar(...args);
+	}
+}

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-single-arg/expected.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-single-arg/expected.js
@@ -1,0 +1,5 @@
+class Foo {
+	bar() {
+		super.bar.apply(this, babelHelpers.toConsumableArray(args));
+	}
+}


### PR DESCRIPTION
Fixes an issue when using spread with `super` keyword.
```javascript
class Foo {
	method(...args) {
		console.log(...args);
	}
}

class Bar extends Foo {
	method(...args) {
		super.method(...args);
	}
}

var b = new Bar();

b.method(1,2,3);
```
In the above code, the line
```javascript
super.method(...args);
```
was transpiled to
```javascript
super.method.apply(super, babelHelpers.toConsumableArray(args));
```
and since a separate `super` can not be used to reference anything, the transpiled code gives a syntax error when run.

This was fixed by changing the `thisArg` of `apply(..)` to be `this`, so the above line will transpile to
```javascript
super.method.apply(this, babelHelpers.toConsumableArray(args));
```