### PR TITLE
Fix export specifier validator.

### DIFF
--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -154,7 +154,7 @@ defineType("ExportSpecifier", {
     local: {
       validate: assertNodeType("Identifier")
     },
-    imported: {
+    exported: {
       validate: assertNodeType("Identifier")
     }
   }


### PR DESCRIPTION
Just noticed this didn't match up with the fields names properly so it was never running. Probably just copy/pasted from ImportSpecifier and not updated properly.