### PR TITLE
Support passing options to presets.

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -320,21 +320,40 @@ export default class OptionManager {
    */
   resolvePresets(presets: Array<string | Object>, dirname: string, onResolve?) {
     return presets.map((val) => {
-      if (typeof val === "string") {
-        let presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
-        if (presetLoc) {
-          let val = require(presetLoc);
-          onResolve && onResolve(val, presetLoc);
-          return val;
-        } else {
-          throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ${JSON.stringify(dirname)}`);
+      let options;
+      if (Array.isArray(val)) {
+        if (val.length > 2) {
+          throw new Error(`Unexpected extra options ${JSON.stringify(val.slice(2))} many ` +
+            "options passed to preset.");
         }
-      } else if (typeof val === "object") {
-        onResolve && onResolve(val);
-        return val;
-      } else {
+
+        [val, options] = val;
+      }
+
+      let presetLoc;
+      if (typeof val === "string") {
+        presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+        if (!presetLoc) {
+          throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ` +
+            JSON.stringify(dirname));
+        }
+
+        val = require(presetLoc);
+      }
+
+      if (typeof val !== "function" && options !== undefined) {
+        throw new Error(`Options ${JSON.stringify(options)} passed to ` +
+          (presetLoc || "a preset") + " which does not accept options.");
+      }
+
+      if (typeof val === "function") val = val(context, options);
+
+      if (typeof val !== "object") {
         throw new Error(`Unsupported preset format: ${val}.`);
       }
+
+      onResolve && onResolve(val);
+      return val;
     });
   }
 

--- a/packages/babel-preset-es2015/README.md
+++ b/packages/babel-preset-es2015/README.md
@@ -23,7 +23,7 @@ $ npm install --save-dev babel-preset-es2015
 ### Via CLI
 
 ```sh
-$ babel script.js --presets es2015 
+$ babel script.js --presets es2015
 ```
 
 ### Via Node API
@@ -32,4 +32,17 @@ $ babel script.js --presets es2015
 require("babel-core").transform("code", {
   presets: ["es2015"]
 });
+```
+
+## Options
+
+* `loose` - Enable "loose" transformations for any plugins in this preset that allow them (Disabled by default).
+* `modules` - Enable transformation of ES6 module syntax to CommonJS (Enabled by default).
+
+```
+{
+  presets: [
+    ["es2015", {loose: true, modules: false}]
+  ]
+}
 ```

--- a/packages/babel-preset-es2015/index.js
+++ b/packages/babel-preset-es2015/index.js
@@ -1,25 +1,70 @@
-module.exports = {
-  plugins: [
-    require("babel-plugin-transform-es2015-template-literals"),
-    require("babel-plugin-transform-es2015-literals"),
-    require("babel-plugin-transform-es2015-function-name"),
-    require("babel-plugin-transform-es2015-arrow-functions"),
-    require("babel-plugin-transform-es2015-block-scoped-functions"),
-    require("babel-plugin-transform-es2015-classes"),
-    require("babel-plugin-transform-es2015-object-super"),
-    require("babel-plugin-transform-es2015-shorthand-properties"),
-    require("babel-plugin-transform-es2015-duplicate-keys"),
-    require("babel-plugin-transform-es2015-computed-properties"),
-    require("babel-plugin-transform-es2015-for-of"),
-    require("babel-plugin-transform-es2015-sticky-regex"),
-    require("babel-plugin-transform-es2015-unicode-regex"),
-    require("babel-plugin-check-es2015-constants"),
-    require("babel-plugin-transform-es2015-spread"),
-    require("babel-plugin-transform-es2015-parameters"),
-    require("babel-plugin-transform-es2015-destructuring"),
-    require("babel-plugin-transform-es2015-block-scoping"),
-    require("babel-plugin-transform-es2015-typeof-symbol"),
-    require("babel-plugin-transform-es2015-modules-commonjs"),
-    [require("babel-plugin-transform-regenerator"), { async: false, asyncGenerators: false }],
-  ]
+module.exports = function(context, opts) {
+  /* eslint-disable no-var */
+  var loose = false;
+  var modules = true;
+  /* eslint-enable no-var */
+  if (opts !== undefined) {
+    if (opts.loose !== undefined) loose = opts.loose;
+    if (opts.modules !== undefined) modules = opts.modules;
+  }
+
+  if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
+  if (typeof modules !== "boolean") throw new Error("Preset es2015 'modules' option must be a boolean.");
+
+  return {
+    plugins: [
+      [require("babel-plugin-transform-es2015-template-literals"), {loose: loose}],
+      require("babel-plugin-transform-es2015-literals"),
+      require("babel-plugin-transform-es2015-function-name"),
+      require("babel-plugin-transform-es2015-arrow-functions"),
+      require("babel-plugin-transform-es2015-block-scoped-functions"),
+      [require("babel-plugin-transform-es2015-classes"), {loose: loose}],
+      require("babel-plugin-transform-es2015-object-super"),
+      require("babel-plugin-transform-es2015-shorthand-properties"),
+      require("babel-plugin-transform-es2015-duplicate-keys"),
+      [require("babel-plugin-transform-es2015-computed-properties"), {loose: loose}],
+      [require("babel-plugin-transform-es2015-for-of"), {loose: loose}],
+      require("babel-plugin-transform-es2015-sticky-regex"),
+      require("babel-plugin-transform-es2015-unicode-regex"),
+      require("babel-plugin-check-es2015-constants"),
+      [require("babel-plugin-transform-es2015-spread"), {loose: loose}],
+      require("babel-plugin-transform-es2015-parameters"),
+      [require("babel-plugin-transform-es2015-destructuring"), {loose: loose}],
+      require("babel-plugin-transform-es2015-block-scoping"),
+      require("babel-plugin-transform-es2015-typeof-symbol"),
+    ].concat(modules ? [
+      [require("babel-plugin-transform-es2015-modules-commonjs"), {loose: loose}],
+    ] : []).concat([
+      [require("babel-plugin-transform-regenerator"), { async: false, asyncGenerators: false }],
+    ]),
+  };
 };
+
+/**
+ * This preset was originally an object, before function-based configurable presets were introduced.
+ * For backward-compatibility with anything that may have been loading this preset and expecting
+ * it to be a simple Babel config object, we maintain the old config here.
+ */
+module.exports.plugins = [
+  require("babel-plugin-transform-es2015-template-literals"),
+  require("babel-plugin-transform-es2015-literals"),
+  require("babel-plugin-transform-es2015-function-name"),
+  require("babel-plugin-transform-es2015-arrow-functions"),
+  require("babel-plugin-transform-es2015-block-scoped-functions"),
+  require("babel-plugin-transform-es2015-classes"),
+  require("babel-plugin-transform-es2015-object-super"),
+  require("babel-plugin-transform-es2015-shorthand-properties"),
+  require("babel-plugin-transform-es2015-duplicate-keys"),
+  require("babel-plugin-transform-es2015-computed-properties"),
+  require("babel-plugin-transform-es2015-for-of"),
+  require("babel-plugin-transform-es2015-sticky-regex"),
+  require("babel-plugin-transform-es2015-unicode-regex"),
+  require("babel-plugin-check-es2015-constants"),
+  require("babel-plugin-transform-es2015-spread"),
+  require("babel-plugin-transform-es2015-parameters"),
+  require("babel-plugin-transform-es2015-destructuring"),
+  require("babel-plugin-transform-es2015-block-scoping"),
+  require("babel-plugin-transform-es2015-typeof-symbol"),
+  require("babel-plugin-transform-es2015-modules-commonjs"),
+  [require("babel-plugin-transform-regenerator"), { async: false, asyncGenerators: false }],
+];


### PR DESCRIPTION
To get the conversation started :)

Looking at the ecosystem of presets of that has grown for Babel 6 so far, this seems like it would be a welcome feature. 

* We've got a bunch of presets for different Node versions, and that'll only grow. Why not a single one with a version options?
* We've got a copy of `es2015` with `loose`
* We've got several copies of `es2015` without CommonJS

and plenty more. 