### PR TITLE
Improve the error messaging for using the wrong CLI script.

### DIFF
--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
 
-console.error("The CLI has been moved into the package `babel-cli`. See http://babeljs.io/docs/usage/cli/");
+console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
+  "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +
+  "\n" +
+  "    npm uninstall babel\n" +
+  "    npm install babel-cli\n" +
+  "\n" +
+  "See http://babeljs.io/docs/usage/cli/ for setup instructions.");
 process.exit(1);


### PR DESCRIPTION
Prompted by http://stackoverflow.com/questions/35248903/how-to-compile-and-run-an-es6-file-with-node-when-using-babel6/35249152#35249152