### PR TITLE
Add lossy traversal method type

### DIFF
--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -7,7 +7,7 @@ import traverse from "babel-traverse";
 import assign from "lodash/object/assign";
 import clone from "lodash/lang/clone";
 
-const GLOBAL_VISITOR_PROPS = ["enter", "exit"];
+const GLOBAL_VISITOR_PROPS = ["enter", "exit", "lossy"];
 
 export default class Plugin extends Store {
   constructor(plugin: Object, key?: string) {
@@ -89,7 +89,16 @@ export default class Plugin extends Store {
       }
     }
 
-    traverse.explode(visitor);
+    // set an `id` that we can use to possibly refer to this visitor if an error occurs
+    // when merging
+    visitor._id = this.key;
+
+    try {
+      traverse.explode(visitor);
+    } catch (err) {
+      err.message = `Error exploding visitor for plugin ${this.key}: ${err.message}`;
+    }
+
     return visitor;
   }
 }

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -20,29 +20,33 @@ export default function ({ types: t }) {
         path.insertAfter(t.exportDefaultDeclaration(ref));
       },
 
-      ClassDeclaration(path) {
-        let { node } = path;
+      ClassDeclaration: {
+        lossy(path) {
+          let { node } = path;
 
-        let ref = node.id || path.scope.generateUidIdentifier("class");
+          let ref = node.id || path.scope.generateUidIdentifier("class");
 
-        path.replaceWith(t.variableDeclaration("let", [
-          t.variableDeclarator(ref, t.toExpression(node))
-        ]));
+          path.replaceWith(t.variableDeclaration("let", [
+            t.variableDeclarator(ref, t.toExpression(node))
+          ]));
+        }
       },
 
-      ClassExpression(path, state) {
-        let { node } = path;
-        if (node[VISITED]) return;
+      ClassExpression: {
+        lossy(path, state) {
+          let { node } = path;
+          if (node[VISITED]) return;
 
-        let inferred = nameFunction(path);
-        if (inferred && inferred !== node) return path.replaceWith(inferred);
+          let inferred = nameFunction(path);
+          if (inferred && inferred !== node) return path.replaceWith(inferred);
 
-        node[VISITED] = true;
+          node[VISITED] = true;
 
-        let Constructor = VanillaTransformer;
-        if (state.opts.loose) Constructor = LooseTransformer;
+          let Constructor = VanillaTransformer;
+          if (state.opts.loose) Constructor = LooseTransformer;
 
-        path.replaceWith(new Constructor(path, state.file).run());
+          path.replaceWith(new Constructor(path, state.file).run());
+        }
       }
     }
   };


### PR DESCRIPTION
This adds a new type of visitor method called `lossy`. The idea behind these is that they're only necessary when a transform is **lossy** AKA information is lost due to a transform. They're specified like so:

```javsacript
({
  ClassExpression: {
    lossy(path) {}
  }
});
```

Things to note about this:

 - Only one lossy function can be specified per node type.
 - They're ran on `exit`.
 - They're always the last `exit` function.

One scenario where this became an issue is that one of the transforms they use internally for [relay](https://github.com/facebook/relay) transforms `Relay.QL` tagged template literals. This means that their transform needs to happen before the internal one.

This prevents plugins needing to specify any sort of ordering information as this lossy transforms is the largest cause of these issues.This is especially problematic when people try and write plugins that are interopable with the internal ones. This gets tricky as sometimes you need to be aware of the behaviour of the internal visitor and on what method a replacement is triggered on. This will hopefully negate a lot of that and we make the lossy methods public API that can actually be relied upon..

I've only converted the `transform-es2015-classes` plugin, I can do the rest if we decide that this is a good way to go. Also tests will follow if this is :+1:. Also I'm ambivalent to the "lossy" name so I'm open to alternate names.