### PR TITLE
Fix T3077 (incorrect _arguments for async arrow functions with rest params)

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -62,6 +62,12 @@ function plainFunction(path: NodePath, callId: Object) {
 
   node.async = false;
   node.generator = true;
+  // Either the wrapped generator is invoked with `.apply(this, arguments)` or it has no params,
+  // so it should capture `arguments`
+  if (node.shadow) {
+    // node.shadow may be `true` or an object
+    node.shadow = Object.assign({}, node.shadow, { arguments: false });
+  }
 
   let asyncFnId = node.id;
   node.id = null;

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/actual.js
@@ -1,0 +1,9 @@
+var concat = async (...arrs) => {
+  var x = arrs[0];
+  var y = arrs[1];
+};
+
+var x = async (...rest) => {
+  if (noNeedToWork) return 0;
+  return rest;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/expected.js
@@ -1,0 +1,23 @@
+var concat = function () {
+  var ref = babelHelpers.asyncToGenerator(function* () {
+    var x = arguments.length <= 0 ? undefined : arguments[0];
+    var y = arguments.length <= 1 ? undefined : arguments[1];
+  });
+  return function concat() {
+    return ref.apply(this, arguments);
+  };
+}();
+
+var x = function () {
+  var ref = babelHelpers.asyncToGenerator(function* () {
+    for (var _len = arguments.length, rest = Array(_len), _key = 0; _key < _len; _key++) {
+      rest[_key] = arguments[_key];
+    }
+
+    if (noNeedToWork) return 0;
+    return rest;
+  });
+  return function x() {
+    return ref.apply(this, arguments);
+  };
+}();

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-parameters", "transform-async-to-generator"]
+}


### PR DESCRIPTION
https://phabricator.babeljs.io/T3077
which is duplicated by
https://phabricator.babeljs.io/T6972

~~If I manage to figure out why this is happening, I'll add the fix to this PR.~~