### PR TITLE
Don't preferGlobal on the `babel` package.

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel",
-  "preferGlobal": true,
   "bin": {
     "babel": "./cli.js",
     "babel-node": "./cli.js",


### PR DESCRIPTION
Also missed a spot here.