### PR TITLE
Update to regexpu-core@2.0.0 for ES2016 compliance

### DIFF
--- a/packages/babel-plugin-transform-es2015-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-unicode-regex",
   "version": "6.8.0",
-  "description": "Compile ES2015 unicode regex to ES5",
+  "description": "Compile ES2015 Unicode regex to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-unicode-regex",
   "license": "MIT",
   "main": "lib/index.js",
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-helper-regex": "^6.8.0",
     "babel-runtime": "^6.0.0",
-    "regexpu-core": "^1.0.0"
+    "regexpu-core": "^2.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.8.0"


### PR DESCRIPTION
regexpu-core v2.0.0 matches the ES2016 spec. See https://github.com/mathiasbynens/regexpu-core/commit/9b10d2a597d4e56b236cae0f9aa2f21a9c6d1122.