### PR TITLE
Travis CI: Switch from deprecated `stable` NodeJS to latest 4.x.x & 5.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
   - node_modules
 
 node_js:
- - stable
- - "4.0"
+ - "5"
+ - "4"
  - iojs
  - "0.10"
  - "0.12"


### PR DESCRIPTION
• `stable` is deprecated, see https://github.com/creationix/nvm#usage
• Switch from `4.0` to `4` to use the latest v4.x.x LTS branch (4.3.0 is currently the latest)
• Switch from `stable` to `5` to use the latest v5.x.x "stable" branch (5.6.0 is currently the latest)