### PR TITLE
Improves likelihood of the compilation cache saving if the process is not cleanly exited

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -85,6 +85,7 @@ function compile(filename) {
   if (cache) {
     cache[cacheKey] = result;
     result.mtime = mtime(filename);
+    registerCache.save();
   }
 
   maps[filename] = result.map;


### PR DESCRIPTION
node.js in babel-runtime now queues a save whenever the cache is modified.
cache.js debounces these notifications saving at next tick as needed.

On our server the increase in cache hits takes startup time from 6+ seconds to < 1 second.  The benefits will only be for process' that don't cleanly exit (`via process.on('exit')`).
