### PR TITLE
Merge config options into list after babelrc options - fixes T7079

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -401,17 +401,17 @@ export default class OptionManager {
   init(opts: Object = {}): Object {
     let filename = opts.filename;
 
+    // resolve all .babelrc files
+    if (opts.babelrc !== false) {
+      this.findConfigs(filename);
+    }
+
     // merge in base options
     this.mergeOptions({
       options: opts,
       alias: "base",
       dirname: filename && path.dirname(filename)
     });
-
-    // resolve all .babelrc files
-    if (this.options.babelrc !== false) {
-      this.findConfigs(filename);
-    }
 
     // normalise
     this.normaliseOptions(opts);

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -49,16 +49,10 @@ function mtime(filename) {
 function compile(filename) {
   let result;
 
-  let optsManager = new OptionManager;
-
   // merge in base options and resolve all the plugins and presets relative to this file
-  optsManager.mergeOptions({
-    options: deepClone(transformOpts),
-    alias: "base",
-    dirname: path.dirname(filename)
-  });
-
-  let opts = optsManager.init({ filename });
+  let opts = new OptionManager().init(extend(deepClone(transformOpts), {
+    filename
+  }));
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
 


### PR DESCRIPTION
This reverts the ordering change made in https://github.com/babel/babel/pull/3168 and fixes `babel-register` to use the OptionManager in a standard way. Feedback definitely need though, since it's not at all clear if there's a specific reason we were calling `mergeOptions` separately from `init`. That's the core cause of the `babelrc` issue in https://github.com/babel/babel/pull/3168though, since it means `babelrc` is passed in, but not available on the options passed to `init`.