### PR TITLE
Example of configurable preset. WIP.

### DIFF
--- a/packages/babel-preset-es2015/index.js
+++ b/packages/babel-preset-es2015/index.js
@@ -1,24 +1,11 @@
+var plugins = require("./plugins")();
+
 module.exports = {
-  plugins: [
-    require("babel-plugin-transform-es2015-template-literals"),
-    require("babel-plugin-transform-es2015-literals"),
-    require("babel-plugin-transform-es2015-function-name"),
-    require("babel-plugin-transform-es2015-arrow-functions"),
-    require("babel-plugin-transform-es2015-block-scoped-functions"),
-    require("babel-plugin-transform-es2015-classes"),
-    require("babel-plugin-transform-es2015-object-super"),
-    require("babel-plugin-transform-es2015-shorthand-properties"),
-    require("babel-plugin-transform-es2015-computed-properties"),
-    require("babel-plugin-transform-es2015-for-of"),
-    require("babel-plugin-transform-es2015-sticky-regex"),
-    require("babel-plugin-transform-es2015-unicode-regex"),
-    require("babel-plugin-check-es2015-constants"),
-    require("babel-plugin-transform-es2015-spread"),
-    require("babel-plugin-transform-es2015-parameters"),
-    require("babel-plugin-transform-es2015-destructuring"),
-    require("babel-plugin-transform-es2015-block-scoping"),
-    require("babel-plugin-transform-es2015-typeof-symbol"),
-    require("babel-plugin-transform-es2015-modules-commonjs"),
-    [require("babel-plugin-transform-regenerator"), { async: false, asyncGenerators: false }],
-  ]
+  plugins: plugins.map(function (plugin) {
+    if (Array.isArray(plugin)) {
+      plugin = [require(plugin[0]), plugin[1]];
+    }
+    else plugin = require(plugin);
+    return plugin;
+  })
 };

--- a/packages/babel-preset-es2015/plugins.js
+++ b/packages/babel-preset-es2015/plugins.js
@@ -23,11 +23,46 @@ var plugins = [
   ["babel-plugin-transform-regenerator", { async: false, asyncGenerators: false }],
 ];
 
-module.exports = function () {
-  return plugins.map(function () {
-    if (Array.isArray(plugin) {
-      plugin = [plugin[0], assign({}, plugin[1]];
+module.exports = function (opts) {
+  var loose = false;
+  var modules = true;
+  if (opts !== undefined){
+    if (opts.loose !== undefined) loose = opts.loose;
+    if (opts.modules !== undefined) modules = opts.modules;
+  }
+
+  if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
+  if (typeof modules !== "boolean") throw new Error("Preset es2015 'modules' option must be a boolean.");
+
+  var loosePlugins = [
+    "template-literals",
+    "classes",
+    "computed-properties",
+    "for-of",
+    "spread",
+    "destructuring",
+    "modules-commonjs"
+  ];
+
+  var exportedPlugins = [].concat(plugins);
+
+  if (!modules) {
+    exportedPlugins.splice(exportedPlugins.indexOf(
+      "babel-plugin-transform-es2015-modules-commonjs"
+    ), 1);
+  }
+
+  return exportedPlugins.map(function (plugin) {
+    plugin = [].concat(plugin);
+    var pluginOpts = {};
+
+    if (
+      loosePlugins.indexOf("babel-plugin-transform-es2015-" + plugin[0]) >= 0
+    ) {
+      pluginOpts.loose = loose;
     }
+
+    plugin[1] = assign(pluginOpts, plugin[1]);
     return plugin;
-  };
+  });
 };

--- a/packages/babel-preset-es2015/plugins.js
+++ b/packages/babel-preset-es2015/plugins.js
@@ -1,0 +1,33 @@
+var assign = Object.assign || whatever;
+
+var plugins = [
+  "babel-plugin-transform-es2015-template-literals",
+  "babel-plugin-transform-es2015-literals",
+  "babel-plugin-transform-es2015-function-name",
+  "babel-plugin-transform-es2015-arrow-functions",
+  "babel-plugin-transform-es2015-block-scoped-functions",
+  "babel-plugin-transform-es2015-classes",
+  "babel-plugin-transform-es2015-object-super",
+  "babel-plugin-transform-es2015-shorthand-properties",
+  "babel-plugin-transform-es2015-computed-properties",
+  "babel-plugin-transform-es2015-for-of",
+  "babel-plugin-transform-es2015-sticky-regex",
+  "babel-plugin-transform-es2015-unicode-regex",
+  "babel-plugin-check-es2015-constants",
+  "babel-plugin-transform-es2015-spread",
+  "babel-plugin-transform-es2015-parameters",
+  "babel-plugin-transform-es2015-destructuring",
+  "babel-plugin-transform-es2015-block-scoping",
+  "babel-plugin-transform-es2015-typeof-symbol",
+  "babel-plugin-transform-es2015-modules-commonjs",
+  ["babel-plugin-transform-regenerator", { async: false, asyncGenerators: false }],
+];
+
+module.exports = function () {
+  return plugins.map(function () {
+    if (Array.isArray(plugin) {
+      plugin = [plugin[0], assign({}, plugin[1]];
+    }
+    return plugin;
+  };
+};


### PR DESCRIPTION
This isn't meant to be merged. For now it's just a counterpoint to #3331.

How this would work:

`my-custom-preset.js`

```js
// Optionally pass an options hash like this:
var opts = {
  loose: true,
  modules: false,
};
var plugins = require("babel-preset-es2015/plugins")();

// Do whatever you want with plugins -- add, remove, reorder, add options,
// change options. Depending exactly how the resolution works, maybe require()
// them here.

module.exports = {plugins: plugins};
```

`.babelrc`

```json
{
  "presets": ["my-custom-preset"]
}
```

`package.json`

```json
{
  "devDependencies": {
    "babel-preset-es2015": "6.x",
    "my-custom-preset": "file:./my-custom-preset"
  }
}
```