### PR TITLE
Clean up babylon bundle to allow it to be re-bundled - fixes T6930

### DIFF
--- a/packages/babylon/scripts/prepublish.js
+++ b/packages/babylon/scripts/prepublish.js
@@ -1,2 +1,8 @@
 require("./_util").updateMain("index.js");
-require("child_process").execSync(__dirname + "/../../../node_modules/.bin/browserify -s babylon -e " + __dirname + "/../lib/index.js -o " + __dirname + "/../index.js", { encoding: "utf8" });
+require("child_process").execSync(
+  __dirname + "/../../../node_modules/.bin/browserify " +
+  "--standalone babylon " +
+  "--entry " + __dirname + "/../lib/index.js " +
+  "--plugin bundle-collapser/plugin " +
+  "--plugin derequire/plugin " +
+  "--outfile " + __dirname + "/../index.js", { encoding: "utf8" });


### PR DESCRIPTION
* Expanded options to more readable long-form names
* Added 

        --plugin bundle-collapser/plugin
        --plugin derequire/plugin

    so the bundle is obscured and does not include `require()` calls that would be picked up if re-bundled.
