### PR TITLE
Fix generator with empty token list and force a newline for line comments in concise mode

### DIFF
--- a/packages/babel-generator/src/generators/base.js
+++ b/packages/babel-generator/src/generators/base.js
@@ -23,7 +23,7 @@ export function BlockStatement(node: Object) {
     if (node.directives && node.directives.length) this.newline();
 
     this.printSequence(node.body, node, { indent: true });
-    if (!this.format.retainLines) this.removeLast("\n");
+    if (!this.format.retainLines && !this.format.concise) this.removeLast("\n");
     this.rightBrace();
   } else {
     this.push("}");

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -299,7 +299,7 @@ export default class Printer extends Buffer {
 
     // force a newline for line comments when retainLines is set in case the next printed node
     // doesn't catch up
-    if ((this.format.compact || this.format.retainLines) && comment.type === "CommentLine") {
+    if ((this.format.compact || this.format.concise || this.format.retainLines) && comment.type === "CommentLine") {
       val += "\n";
     }
 

--- a/packages/babel-generator/src/whitespace.js
+++ b/packages/babel-generator/src/whitespace.js
@@ -83,11 +83,12 @@ export default class Whitespace {
    */
 
   _findToken(test: Function, start: number, end: number): number {
+    if (start >= end) return -1;
     const middle = (start + end) >>> 1;
     const match: number = test(this.tokens[middle]);
-    if (match < 0 && end > middle) {
+    if (match < 0) {
       return this._findToken(test, middle + 1, end);
-    } else if (match > 0 && start < middle) {
+    } else if (match > 0) {
       return this._findToken(test, start, middle);
     } else if (match === 0) {
       return middle;

--- a/packages/babel-generator/test/fixtures/comments/block-line-comment-with-concise-format/actual.js
+++ b/packages/babel-generator/test/fixtures/comments/block-line-comment-with-concise-format/actual.js
@@ -1,0 +1,4 @@
+{
+  print("hello");
+  // comment
+}

--- a/packages/babel-generator/test/fixtures/comments/block-line-comment-with-concise-format/expected.js
+++ b/packages/babel-generator/test/fixtures/comments/block-line-comment-with-concise-format/expected.js
@@ -1,0 +1,2 @@
+{ print("hello"); // comment
+}

--- a/packages/babel-generator/test/fixtures/comments/block-line-comment-with-concise-format/options.json
+++ b/packages/babel-generator/test/fixtures/comments/block-line-comment-with-concise-format/options.json
@@ -1,0 +1,3 @@
+{
+  "concise": true
+}

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,9 +1,10 @@
-var generate = require("../lib");
-var assert   = require("assert");
-var parse    = require("babylon").parse;
-var chai     = require("chai");
-var t        = require("babel-types");
-var _        = require("lodash");
+var Whitespace = require("../lib/whitespace");
+var generate   = require("../lib");
+var assert     = require("assert");
+var parse      = require("babylon").parse;
+var chai       = require("chai");
+var t          = require("babel-types");
+var _          = require("lodash");
 
 suite("generation", function () {
   test("completeness", function () {
@@ -41,6 +42,14 @@ suite("programmatic generation", function() {
 
     var ast = parse(generate.default(ifStatement).code);
     assert.equal(ast.program.body[0].consequent.type, 'BlockStatement');
+  });
+});
+
+
+suite("whitespace", function () {
+  test("empty token list", function () {
+    var w = new Whitespace([]);
+    assert.equal(w.getNewlinesBefore(t.stringLiteral('1')), 0);
   });
 });
 


### PR DESCRIPTION
This PR aims to fix two issues in babel-generator:

1. `generator.Whitespace` throws when an empty token list passed in
2. printer does not print a newline after line comments in concise mode

refs: https://github.com/sindresorhus/ava/issues/538