### PR TITLE
Queue regeneratorRuntime so it is transformed before Program#exit

### DIFF
--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/actual.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/actual.js
@@ -1,0 +1,3 @@
+Object.keys({});
+
+function * fn(){}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/expected.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var _regenerator = require("babel-runtime/regenerator");
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _keys = require("babel-runtime/core-js/object/keys");
+
+var _keys2 = _interopRequireDefault(_keys);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var _marked = [fn].map(_regenerator2.default.mark);
+
+(0, _keys2.default)({});
+
+function fn() {
+  return _regenerator2.default.wrap(function fn$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+        case "end":
+          return _context.stop();
+      }
+    }
+  }, _marked[0], this);
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-regenerator", "transform-runtime"]
+}

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -46,6 +46,7 @@ export function _containerInsert(from, nodes) {
 
     if (this.context) {
       let path = this.context.create(this.parent, this.container, to, this.listKey);
+      path.pushContext(this.context);
       paths.push(path);
     } else {
       paths.push(NodePath.get({


### PR DESCRIPTION
When inserting nodes around a given path, ensure that the newly created paths also inherit the same context, so that new paths behave the same as an or real parsed code would.