### PR TITLE
Fixes T2299: Prevent REPL from printing implicit 'use strict'

### DIFF
--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -38,7 +38,7 @@ register({
 
 //
 
-let replPlugin = () => ({
+let replPlugin = ({ types: t }) => ({
   visitor: {
     ModuleDeclaration(path) {
       throw path.buildCodeFrameError("Modules aren't supported in the REPL");
@@ -47,6 +47,14 @@ let replPlugin = () => ({
     VariableDeclaration(path) {
       if (path.node.kind !== "var") {
         throw path.buildCodeFrameError("Only `var` variables are supported in the REPL");
+      }
+    },
+
+    Directive(path) {
+      if (_.isUndefined(path.node.loc)) {
+        // If the executed code doesn't evaluate to a value,
+        // prevent implicit strict mode from printing 'use strict'.
+        path.parent.body.unshift(t.expressionStatement(t.identifier("undefined")));
       }
     }
   }

--- a/packages/babel-cli/test/fixtures/babel-node/no-strict/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/no-strict/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--eval","--print", "var a = 1;"],
+  "stdout": "undefined"
+}


### PR DESCRIPTION
Currently `babel-node` prints `'use strict'` if the evaluated code does not return a value.
```js
$ babel-node
> var a = 1;
'use strict'
> 'use strict';
'use strict'
> 'use strict';var b = 1;
'use strict'
```
```js
$ node
> var a = 1;
undefined
> 'use strict';
'use strict'
> 'use strict';var b = 1;
'use strict'
```
This PR adds a plugin into the REPL which checks if a strict mode directive was implicitly inserted by Babel. If it is, the plugin adds an `undefined;` statement after it, preventing the `'use strict'` from being printed. We can tell if a strict mode directive was implicit by checking its `loc` property which doesn't exist for implicit directives.

These modifications cause the output of `babel-node` to equal the output of `node`.