### PR TITLE
Show a better error when trying to use a babel 5 plugin

### DIFF
--- a/packages/babel-core/src/api/node.js
+++ b/packages/babel-core/src/api/node.js
@@ -26,6 +26,10 @@ export { traverse };
 import OptionManager from "../transformation/file/options/option-manager";
 export { OptionManager };
 
+export function Plugin(alias) {
+  throw new Error(`The (${alias}) Babel 5 plugin is being run with Babel 6.`);
+}
+
 //
 
 import Pipeline from "../transformation/pipeline";

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,0 +1,20 @@
+var assert = require("assert");
+var OptionManager = require("../lib/transformation/file/options/option-manager");
+
+suite("option-manager", function () {
+  suite("memoisePluginContainer", function () {
+    test("throws for babel 5 plugin", function() {
+      return assert.throws(
+        function () {
+          OptionManager.memoisePluginContainer(
+            function (ref) {
+              var Plugin = ref.Plugin;
+              return new Plugin("object-assign", {});
+            }
+          );
+        },
+        /Babel 5 plugin is being run with Babel 6/
+      );
+    })
+  });
+});


### PR DESCRIPTION
Since there's a good amount of "babel Plugin is not a function"