### PR TITLE
fix(babel-template): Fix Error in IE <= 9

### DIFF
--- a/packages/babel-template/src/index.js
+++ b/packages/babel-template/src/index.js
@@ -18,7 +18,10 @@ export default function (code: string, opts?: Object): Function {
     // error stack gets populated in IE only on throw (https://msdn.microsoft.com/en-us/library/hh699850(v=vs.94).aspx)
     throw new Error();
   } catch (error) {
-    stack = error.stack.split("\n").slice(1).join("\n");
+    if (error.stack) {
+      // error.stack does not exists in IE <= 9
+      stack = error.stack.split("\n").slice(1).join("\n");
+    }
   }
 
   let getAst = function () {


### PR DESCRIPTION
In IE <= 9 Error.prototype.stack does not exist.