### PR TITLE
Adds repository field to babel-plugin-transform-regenerator

### DIFF
--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -4,6 +4,7 @@
   "description": "Explode async and generator functions into a state machine.",
   "version": "6.5.2",
   "homepage": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-es2015-block-scoping": "^6.3.13",


### PR DESCRIPTION
Without that, our build output is polluted with warning:
```
npm WARN package.json babel-plugin-transform-regenerator@6.5.2 No repository field.
```