### PR TITLE
Adds nonempty description to babel-traverse package.json

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-traverse",
   "version": "6.5.0",
-  "description": "",
+  "description": "babel-traverse",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",


### PR DESCRIPTION
Otherwise our build output is polluted with:
```
npm WARN package.json babel-traverse@6.5.0 No description
```