### PR TITLE
[transform-inline-environment-variables] Option to provide / override locally

### DIFF
--- a/packages/babel-plugin-transform-inline-environment-variables/src/index.js
+++ b/packages/babel-plugin-transform-inline-environment-variables/src/index.js
@@ -1,11 +1,13 @@
 export default function ({ types: t }) {
   return {
     visitor: {
-      MemberExpression(path) {
+      MemberExpression(path, state) {
         if (path.get("object").matchesPattern("process.env")) {
           let key = path.toComputedKey();
           if (t.isStringLiteral(key)) {
-            path.replaceWith(t.valueToNode(process.env[key.value]));
+            let name = key.value;
+            let value = (state.opts.env && name in state.opts.env) ? state.opts.env[name] : process.env[name];
+            path.replaceWith(t.valueToNode(value));
           }
         }
       }


### PR DESCRIPTION
The purpose of this PR is to provide a way for the [`transform-inline-environment-variables` plugin](https://github.com/jordansexton/babel/tree/master/packages/babel-plugin-transform-inline-environment-variables) to inject variables that aren't in `process.env` or are conditional depending on the build target platform, device, etc. This is especially valuable when running babel with gulp, or with the React Native packager and its [myriad caching issues](https://github.com/facebook/react-native/search?q=packager+cache&type=Issues&utf8=%E2%9C%93).

_This is a work in progress and request for comment: I plan to incorporate feedback and add tests if needed._