### PR TITLE
add `indent` option

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -195,9 +195,9 @@ module.exports = {
   },
   
   indent: {
-    description: "the number of space use to indent the code.",
-    type: "number",
-    default: 2,
+    description: "the string use to indent the code.",
+    type: "string",
+    default: "",
     hidden: true,
   },
 };

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -195,7 +195,7 @@ module.exports = {
   },
   
   indent: {
-    description: "the number use to indent the code.",
+    description: "the number of space use to indent the code.",
     type: "number",
     default: 2,
     hidden: true,

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -193,4 +193,11 @@ module.exports = {
     default: false,
     hidden: true,
   },
+  
+  indent: {
+    description: "the number use to indent the code.",
+    type: "number",
+    default: 2,
+    hidden: true,
+  },
 };

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -70,8 +70,8 @@ export class CodeGenerator extends Printer {
    */
 
   static normalizeOptions(code, opts, tokens) {
-    let style = "  ";
-    if (code) {
+    let style = opts.indent || "  ";
+    if (!opts.indent && code) {
       let indent = detectIndent(code).indent;
       if (indent && indent !== " ") style = indent;
     }


### PR DESCRIPTION
the `detect-indent` work error when the count of block comment lines are more the the code.

eg:

```
/**
 * a block comment
 *
 */
function code() {
    the indent code;
}
```

this will return 1 space instead  of 4 space.
