### PR TITLE
Adds npmpath option

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -193,4 +193,10 @@ module.exports = {
     default: false,
     hidden: true,
   },
+
+  npmpath: {
+    type: "npmpath",
+    description: "path to use when resolving presets and plugins",
+    shorthand: "p"
+  },
 };

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -174,7 +174,7 @@ export default class OptionManager {
     this.mergeOptions({
       options: opts,
       alias: loc,
-      dirname: path.dirname(loc)
+      dirname: opts.npmpath || path.dirname(loc)
     });
     this.resolvedConfigs.push(loc);
 
@@ -302,7 +302,7 @@ export default class OptionManager {
         options: presetOpts,
         alias: presetLoc,
         loc: presetLoc,
-        dirname: path.dirname(presetLoc)
+        dirname: presetOpts.npmpath || path.dirname(presetLoc)
       });
     });
   }
@@ -412,7 +412,7 @@ export default class OptionManager {
     this.mergeOptions({
       options: opts,
       alias: "base",
-      dirname: filename && path.dirname(filename)
+      dirname: opts.npmpath || (filename && path.dirname(filename))
     });
 
     // normalise


### PR DESCRIPTION
I am working on a project that simply hides and takes over all transpiling process. (detailed information: https://github.com/eserozvataf/sey)

Since one of my requirements is keeping project folder clean, I needed to call presets from my binary's node_modules directory instead of project folder's node_modules directory. (https://github.com/eserozvataf/sey/blob/development/src/tasks/babel.js#L11)

So I needed to add one optional config directive to determine which node_modules directory is going to be used on resolving presets and plugins.