### PR TITLE
Fix errors in parameters rest transformation [T7138]

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -60,6 +60,12 @@ let memberExpressionOptimisationVisitor = {
       let {parentPath} = path;
       let grandparentPath = parentPath.parentPath;
 
+      // ex: [rest[0]] = [rest[1]]
+      if (grandparentPath.isLVal()) {
+        state.deopted = true;
+        return;
+      }
+
       // ex: args[0]
       if (
         parentPath.isMemberExpression({ computed: true, object: node }) &&
@@ -68,7 +74,8 @@ let memberExpressionOptimisationVisitor = {
         !(
           grandparentPath.isAssignmentExpression() &&
           parentPath.node === grandparentPath.node.left
-        )
+        ) &&
+        !grandparentPath.isForInStatement()
       ) {
         // if we know that this member expression is referencing a number then
         // we can safely optimise it

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-deepest-common-ancestor-earliest-child/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-deepest-common-ancestor-earliest-child/actual.js
@@ -1,4 +1,4 @@
-// single referenes
+// single reference
 function r(...rest){
   if (noNeedToWork) return 0;
   return rest;
@@ -65,4 +65,10 @@ function runQueue(queue, ...args) {
       queue[i](...args)
     }
   }
+}
+
+function r(...rest){
+  if (noNeedToWork) return 0;
+  [rest[0]] = x;
+  return rest;
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-deepest-common-ancestor-earliest-child/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-deepest-common-ancestor-earliest-child/expected.js
@@ -1,4 +1,4 @@
-// single referenes
+// single reference
 function r() {
   if (noNeedToWork) return 0;
 
@@ -98,4 +98,20 @@ function runQueue(queue) {
       queue[i].apply(queue, args);
     }
   }
+}
+
+function r() {
+  if (noNeedToWork) return 0;
+
+  for (var _len9 = arguments.length, rest = Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
+    rest[_key9] = arguments[_key9];
+  }
+
+  var _x = x;
+
+  var _x2 = babelHelpers.slicedToArray(_x, 1);
+
+  rest[0] = _x2[0];
+
+  return rest;
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -80,3 +80,7 @@ function newExp (...rest) {
 function arrayDestructure (...rest) {
   [rest[0]] = x;
 }
+
+function forOf (...rest) {
+  for (rest[0] of this);
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -84,3 +84,11 @@ function arrayDestructure (...rest) {
 function forOf (...rest) {
   for (rest[0] of this);
 }
+
+function postfixIncrement (...rest) {
+  rest[0]++;
+}
+
+function postfixDecrement (...rest) {
+  rest[0]--;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -74,3 +74,9 @@ function method (...rest) {
 function newExp (...rest) {
   new rest[0]();
 }
+
+// In addition to swap() above because at some point someone tried checking
+// grandparent path for isArrayExpression() to deopt.
+function arrayDestructure (...rest) {
+  [rest[0]] = x;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -44,3 +44,33 @@ var b = function (foo, baz, ...bar) {
 function x (...rest) {
   rest[0] = 0;
 }
+
+function swap (...rest) {
+  [rest[0], rest[1]] = [rest[1], rest[0]];
+}
+
+function forIn (...rest) {
+  for (rest[0] in this) {
+    foo(rest[0]);
+  }
+}
+
+function inc (...rest) {
+  ++rest[0];
+}
+
+function dec (...rest) {
+  --rest[0];
+}
+
+function del (...rest) {
+  delete rest[0];
+}
+
+function method (...rest) {
+  rest[0]();
+}
+
+function newExp (...rest) {
+  new rest[0]();
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -149,3 +149,32 @@ function arrayDestructure() {
 
   rest[0] = _x[0];
 }
+
+function forOf() {
+  for (var _len17 = arguments.length, rest = Array(_len17), _key17 = 0; _key17 < _len17; _key17++) {
+    rest[_key17] = arguments[_key17];
+  }
+
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  try {
+    for (var _iterator = this[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+      rest[0] = _step.value;
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return) {
+        _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -135,3 +135,15 @@ function newExp() {
 
   new rest[0]();
 }
+
+// In addition to swap() above because at some point someone tried checking
+// grandparent path for isArrayExpression() to deopt.
+function arrayDestructure() {
+  for (var _len16 = arguments.length, rest = Array(_len16), _key16 = 0; _key16 < _len16; _key16++) {
+    rest[_key16] = arguments[_key16];
+  }
+
+  var _x = babelHelpers.slicedToArray(x, 1);
+
+  rest[0] = _x[0];
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -178,3 +178,19 @@ function forOf() {
     }
   }
 }
+
+function postfixIncrement() {
+  for (var _len18 = arguments.length, rest = Array(_len18), _key18 = 0; _key18 < _len18; _key18++) {
+    rest[_key18] = arguments[_key18];
+  }
+
+  rest[0]++;
+}
+
+function postfixDecrement() {
+  for (var _len19 = arguments.length, rest = Array(_len19), _key19 = 0; _key19 < _len19; _key19++) {
+    rest[_key19] = arguments[_key19];
+  }
+
+  rest[0]--;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -77,3 +77,21 @@ function x() {
 
   rest[0] = 0;
 }
+
+function swap() {
+  for (var _len9 = arguments.length, rest = Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
+    rest[_key9] = arguments[_key9];
+  }
+
+  [rest[0], rest[1]] = [rest[1], rest[0]];
+}
+
+function x() {
+  for (var _len10 = arguments.length, rest = Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
+    rest[_key10] = arguments[_key10];
+  }
+
+  for (rest[0] in this) {
+    foo(rest[0]);
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -95,3 +95,43 @@ function x() {
     foo(rest[0]);
   }
 }
+
+function inc() {
+  for (var _len11 = arguments.length, rest = Array(_len11), _key11 = 0; _key11 < _len11; _key11++) {
+    rest[_key11] = arguments[_key11];
+  }
+
+  ++rest[0];
+}
+
+function dec() {
+  for (var _len12 = arguments.length, rest = Array(_len12), _key12 = 0; _key12 < _len12; _key12++) {
+    rest[_key12] = arguments[_key12];
+  }
+
+  --rest[0];
+}
+
+function del() {
+  for (var _len13 = arguments.length, rest = Array(_len13), _key13 = 0; _key13 < _len13; _key13++) {
+    rest[_key13] = arguments[_key13];
+  }
+
+  delete rest[0];
+}
+
+function method() {
+  for (var _len14 = arguments.length, rest = Array(_len14), _key14 = 0; _key14 < _len14; _key14++) {
+    rest[_key14] = arguments[_key14];
+  }
+
+  rest[0]();
+}
+
+function newExp() {
+  for (var _len15 = arguments.length, rest = Array(_len15), _key15 = 0; _key15 < _len15; _key15++) {
+    rest[_key15] = arguments[_key15];
+  }
+
+  new rest[0]();
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -83,10 +83,12 @@ function swap() {
     rest[_key9] = arguments[_key9];
   }
 
-  [rest[0], rest[1]] = [rest[1], rest[0]];
+  var _ref = [rest[1], rest[0]];
+  rest[0] = _ref[0];
+  rest[1] = _ref[1];
 }
 
-function x() {
+function forIn() {
   for (var _len10 = arguments.length, rest = Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
     rest[_key10] = arguments[_key10];
   }


### PR DESCRIPTION
Fix [T7138](https://phabricator.babeljs.io/T7138). Followup to #3249 and [jmm/babel#1](https://github.com/jmm/babel/issues/1). Thanks to @benjamn for identifying and creating fixtures for more problem cases and @vhf for feedback on JS engine optimization and getting us past the errors that made compilation blow up with those new fixtures!

Hey, it looks like GitHub decided to start showing the commits in the right order at some point! :tada:

FYI, there's a bunch of other stuff I want to do to this transform to improve clarity and performance, but I didn't want to try to lump it in with these changes, so there's stuff here that's just for consistency with what's already there that I intend to change later.