### PR TITLE
Give specific error messages for babel 5 options that were removed in…

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -13,6 +13,7 @@ import cloneDeep from "lodash/lang/cloneDeep";
 import clone from "lodash/lang/clone";
 import merge from "../../../helpers/merge";
 import config from "./config";
+import removed from "./removed";
 import path from "path";
 import fs from "fs";
 
@@ -222,7 +223,13 @@ export default class OptionManager {
 
       // check for an unknown option
       if (!option && this.log) {
-        this.log.error(`Unknown option: ${alias}.${key}`, ReferenceError);
+        let pluginOptsInfo = "Check out http://babeljs.io/docs/usage/options/ for more info";
+
+        if (removed[key]) {
+          this.log.error(`Using removed Babel 5 option: ${alias}.${key} - ${removed[key].message}`, ReferenceError);
+        } else {
+          this.log.error(`Unknown option: ${alias}.${key}. ${pluginOptsInfo}`, ReferenceError);
+        }
       }
     }
 

--- a/packages/babel-core/src/transformation/file/options/removed.js
+++ b/packages/babel-core/src/transformation/file/options/removed.js
@@ -1,0 +1,52 @@
+/* eslint max-len: 0 */
+
+module.exports = {
+  "auxiliaryComment": {
+    "message": "Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`"
+  },
+  "blacklist": {
+    "message": "Put the specific transforms you want in the `plugins` option"
+  },
+  "breakConfig": {
+    "message": "This is not a necessary option in Babel 6"
+  },
+  "experimental": {
+    "message": "Put the specific transforms you want in the `plugins` option"
+  },
+  "externalHelpers": {
+    "message": "Use the `external-helpers` plugin instead. Check out http://babeljs.io/docs/plugins/external-helpers/"
+  },
+  "extra": {
+    "message": ""
+  },
+  "jsxPragma": {
+    "message": "use the `pragma` option in the `react-jsx` plugin . Check out http://babeljs.io/docs/plugins/transform-react-jsx/"
+  },
+  // "keepModuleIdExtensions": {
+  //   "message": ""
+  // },
+  "loose": {
+    "message": "Specify the `loose` option for the relevant plugin you are using or use a preset that sets the option."
+  },
+  "metadataUsedHelpers": {
+    "message": "Not required anymore as this is enabled by default"
+  },
+  "modules": {
+    "message": "Use the corresponding module transform plugin in the `plugins` option. Check out http://babeljs.io/docs/plugins/#modules",
+  },
+  "nonStandard": {
+    "message": "Use the `react-jsx` and `flow-strip-types` plugins to support JSX and Flow. Also check out the react preset http://babeljs.io/docs/plugins/preset-react/",
+  },
+  "optional": {
+    "message": "Put the specific transforms you want in the `plugins` option"
+  },
+  "sourceMapName": {
+    "message": "Use the `sourceMapTarget` option"
+  },
+  "stage": {
+    "message": "Check out the corresponding stage-x presets http://babeljs.io/docs/plugins/#presets"
+  },
+  "whitelist": {
+    "message": "Put the specific transforms you want in the `plugins` option"
+  }
+};

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var OptionManager = require("../lib/transformation/file/options/option-manager");
+var Logger = require("../lib/transformation/file/logger");
 
 suite("option-manager", function () {
   suite("memoisePluginContainer", function () {
@@ -14,6 +15,32 @@ suite("option-manager", function () {
           );
         },
         /Babel 5 plugin is being run with Babel 6/
+      );
+    })
+  });
+
+  suite("mergeOptions", function () {
+    test("throws for removed babel 5 options", function() {
+      return assert.throws(
+        function () {
+          var opt = new OptionManager(new Logger(null, "unknown"));
+          opt.init({
+            'randomOption': true
+          });
+        },
+        /Unknown option: base.randomOption/
+      );
+    })
+    test("throws for removed babel 5 options", function() {
+      return assert.throws(
+        function () {
+          var opt = new OptionManager(new Logger(null, "unknown"));
+          opt.init({
+            'auxiliaryComment': true,
+            'blacklist': true
+          });
+        },
+        /Using removed Babel 5 option: base.auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`/
       );
     })
   });


### PR DESCRIPTION
… babel 6

Similar in idea to https://github.com/babel/babel/pull/3362

And maybe we should add a link to for any unknown option? http://babeljs.io/docs/usage/options/

Previously:

For an unknown option:
`ReferenceError: [BABEL] unknown: Unknown option: base.randomOption`

After:
For an unknown option:
`ReferenceError: [BABEL] unknown: Unknown option: base.randomOption. Check out http://babeljs.io/docs/usage/options/ for more info`

For a babel 5 option that was removed in babel 6:
```ReferenceError: [BABEL] unknown: Using removed Babel 5 option: base.auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter````