### PR TITLE
Remove Flow annotations and pragmas

### DIFF
--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint indent: 0 */
 /* eslint max-len: 0 */
 
@@ -62,7 +61,7 @@ function getTokenType(match) {
  * Highlight `text`.
  */
 
-function highlight(text: string) {
+function highlight(text) {
   return text.replace(jsTokens, function (...args) {
     let type = getTokenType(args);
     let colorize = defs[type];
@@ -78,12 +77,7 @@ function highlight(text: string) {
  * Create a code frame, adding line numbers, code highlighting, and pointing to a given position.
  */
 
-export default function (
-  rawLines: string,
-  lineNumber: number,
-  colNumber: number,
-  opts: Object = {},
-): string {
+export default function (rawLines, lineNumber, colNumber, opts = {}) {
   colNumber = Math.max(colNumber, 0);
 
   let highlighted = opts.highlightCode && chalk.supportsColor;

--- a/packages/babel-core/src/helpers/merge.js
+++ b/packages/babel-core/src/helpers/merge.js
@@ -1,8 +1,8 @@
-/* @flow */
+
 
 import merge from "lodash/object/merge";
 
-export default function (dest?: Object, src?: Object): ?Object {
+export default function (dest, src) {
   if (!dest || !src) return;
 
   return merge(dest, src, function (a, b) {

--- a/packages/babel-core/src/helpers/normalize-ast.js
+++ b/packages/babel-core/src/helpers/normalize-ast.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import * as t from "babel-types";
 
@@ -8,11 +7,7 @@ import * as t from "babel-types";
  * - Wrap `Program` node with a `File` node.
  */
 
-export default function (
-  ast: Object,
-  comments?: Array<Object>,
-  tokens?: Array<Object>,
-) {
+export default function (ast, comments, tokens) {
   if (ast) {
     if (ast.type === "Program") {
       return t.file(ast, comments || [], tokens || []);

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -1,17 +1,14 @@
 /* @noflow */
-/* global BabelParserOptions */
-/* global BabelFileMetadata */
-/* global BabelFileResult */
 /* eslint max-len: 0 */
 
 import getHelper from "babel-helpers";
 import * as metadataVisitor from "./metadata";
 import convertSourceMap from "convert-source-map";
 import OptionManager from "./options/option-manager";
-import type Pipeline from "../pipeline";
+
 import PluginPass from "../plugin-pass";
 import shebangRegex from "shebang-regex";
-import { NodePath, Hub, Scope } from "babel-traverse";
+import { NodePath, Hub } from "babel-traverse";
 import sourceMap from "source-map";
 import generate from "babel-generator";
 import codeFrame from "babel-code-frame";
@@ -43,7 +40,7 @@ let errorVisitor = {
 };
 
 export default class File extends Store {
-  constructor(opts: Object = {}, pipeline: Pipeline) {
+  constructor(opts = {}, pipeline) {
     super();
 
     this.pipeline = pipeline;
@@ -104,30 +101,9 @@ export default class File extends Store {
     this.hub = new Hub(this);
   }
 
-  static helpers: Array<string>;
-
-  pluginVisitors: Array<Object>;
-  pluginPasses: Array<PluginPass>;
-  pipeline: Pipeline;
-  parserOpts: BabelParserOptions;
-  log: Logger;
-  opts: Object;
-  dynamicImportTypes: Object;
-  dynamicImportIds: Object;
-  dynamicImports: Array<Object>;
-  declarations: Object;
-  usedHelpers: Object;
-  path: NodePath;
-  ast: Object;
-  scope: Scope;
-  metadata: BabelFileMetadata;
-  hub: Hub;
-  code: string;
-  shebang: string;
-
   getMetadata() {
     let has = false;
-    for (let node of (this.ast.program.body: Array<Object>)) {
+    for (let node of this.ast.program.body) {
       if (t.isModuleDeclaration(node)) {
         has = true;
         break;
@@ -182,7 +158,7 @@ export default class File extends Store {
       return;
     }
 
-    let plugins: Array<[PluginPass, Object]> = opts.plugins.concat(INTERNAL_PLUGINS);
+    let plugins = opts.plugins.concat(INTERNAL_PLUGINS);
     let currentPluginVisitors = [];
     let currentPluginPasses = [];
 
@@ -202,7 +178,7 @@ export default class File extends Store {
     this.pluginPasses.push(currentPluginPasses);
   }
 
-  getModuleName(): ?string {
+  getModuleName() {
     let opts = this.opts;
     if (!opts.moduleIds) {
       return null;
@@ -246,13 +222,13 @@ export default class File extends Store {
     }
   }
 
-  resolveModuleSource(source: string): string {
+  resolveModuleSource(source) {
     let resolveModuleSource = this.opts.resolveModuleSource;
     if (resolveModuleSource) source = resolveModuleSource(source, this.opts.filename);
     return source;
   }
 
-  addImport(source: string, imported: string, name?: string = imported): Object {
+  addImport(source, imported, name = imported) {
     let alias = `${source}:${imported}`;
     let id = this.dynamicImportIds[alias];
 
@@ -279,7 +255,7 @@ export default class File extends Store {
     return id;
   }
 
-  addHelper(name: string): Object {
+  addHelper(name) {
     let declar = this.declarations[name];
     if (declar) return declar;
 
@@ -318,11 +294,7 @@ export default class File extends Store {
     return uid;
   }
 
-  addTemplateObject(
-    helperName: string,
-    strings: Array<Object>,
-    raw: Object,
-  ): Object {
+  addTemplateObject(helperName, strings, raw) {
     // Generate a unique name based on the string literals so we dedupe
     // identical strings used in the program.
     let stringIds = raw.elements.map(function(string) {
@@ -346,7 +318,7 @@ export default class File extends Store {
     return uid;
   }
 
-  buildCodeFrameError(node: Object, msg: string, Error: typeof Error = SyntaxError): Error {
+  buildCodeFrameError(node, msg, Error = SyntaxError) {
     let loc = node && (node.loc || node._loc);
 
     let err = new Error(msg);
@@ -368,7 +340,7 @@ export default class File extends Store {
     return err;
   }
 
-  mergeSourceMap(map: Object) {
+  mergeSourceMap(map) {
     let inputMap = this.opts.inputSourceMap;
 
     if (inputMap) {
@@ -412,7 +384,7 @@ export default class File extends Store {
     }
   }
 
-  parse(code: string) {
+  parse(code) {
     this.log.debug("Parse start");
     let ast = parse(code, this.parserOpts);
     this.log.debug("Parse stop");
@@ -438,7 +410,7 @@ export default class File extends Store {
     this.log.debug("End set AST");
   }
 
-  transform(): BabelFileResult {
+  transform() {
     // In the "pass per preset" mode, we have grouped passes.
     // Otherwise, there is only one plain pluginPasses array.
     this.pluginPasses.forEach((pluginPasses, index) => {
@@ -452,7 +424,7 @@ export default class File extends Store {
     return this.generate();
   }
 
-  wrap(code: string, callback: Function): BabelFileResult {
+  wrap(code, callback) {
     code = code + "";
 
     try {
@@ -491,7 +463,7 @@ export default class File extends Store {
     }
   }
 
-  addCode(code: string) {
+  addCode(code) {
     code = (code || "") + "";
     code = this.parseInputSourceMap(code);
     this.code = code;
@@ -508,7 +480,7 @@ export default class File extends Store {
     return util.shouldIgnore(opts.filename, opts.ignore, opts.only);
   }
 
-  call(key: "pre" | "post", pluginPasses: Array<PluginPass>) {
+  call(key, pluginPasses) {
     for (let pass of pluginPasses) {
       let plugin = pass.plugin;
       let fn = plugin[key];
@@ -516,7 +488,7 @@ export default class File extends Store {
     }
   }
 
-  parseInputSourceMap(code: string): string {
+  parseInputSourceMap(code) {
     let opts = this.opts;
 
     if (opts.inputSourceMap !== false) {
@@ -538,7 +510,7 @@ export default class File extends Store {
     }
   }
 
-  makeResult({ code, map, ast, ignored }: BabelFileResult): BabelFileResult {
+  makeResult({ code, map, ast, ignored }) {
     let result = {
       metadata: null,
       options:  this.opts,
@@ -563,11 +535,11 @@ export default class File extends Store {
     return result;
   }
 
-  generate(): BabelFileResult {
+  generate() {
     let opts = this.opts;
     let ast  = this.ast;
 
-    let result: BabelFileResult = { ast };
+    let result = { ast };
     if (!opts.code) return this.makeResult(result);
 
     this.log.debug("Generation start");

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -1,4 +1,3 @@
-/* @noflow */
 /* eslint max-len: 0 */
 
 import getHelper from "babel-helpers";

--- a/packages/babel-core/src/transformation/file/options/index.js
+++ b/packages/babel-core/src/transformation/file/options/index.js
@@ -1,11 +1,10 @@
-/* @flow */
 
 import * as parsers from "./parsers";
 import config from "./config";
 
 export { config };
 
-export function normaliseOptions(options: Object = {}): Object {
+export function normaliseOptions(options = {}) {
   for (let key in options) {
     let val = options[key];
     if (val == null) continue;

--- a/packages/babel-core/src/transformation/file/options/parsers.js
+++ b/packages/babel-core/src/transformation/file/options/parsers.js
@@ -1,18 +1,18 @@
-/* @flow */
+
 
 import slash from "slash";
 import * as util from "../../../util";
 
 export let filename = slash;
 
-export function boolean(val: any): boolean {
+export function boolean(val) {
   return !!val;
 }
 
-export function booleanString(val: any): boolean | any {
+export function booleanString(val) {
   return util.booleanify(val);
 }
 
-export function list(val: any): Array<string> {
+export function list(val) {
   return util.list(val);
 }

--- a/packages/babel-core/src/transformation/internal-plugins/block-hoist.js
+++ b/packages/babel-core/src/transformation/internal-plugins/block-hoist.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import Plugin from "../plugin";
 import sortBy from "lodash/collection/sortBy";

--- a/packages/babel-core/src/transformation/pipeline.js
+++ b/packages/babel-core/src/transformation/pipeline.js
@@ -1,19 +1,15 @@
-/* @flow */
-/* global BabelFileResult */
-/* global BabelFileMetadata */
-
 import normalizeAst from "../helpers/normalize-ast";
 import Plugin from "./plugin";
 import File from "./file";
 
 export default class Pipeline {
-  lint(code: string, opts?: Object = {}): BabelFileResult {
+  lint(code, opts = {}) {
     opts.code = false;
     opts.mode = "lint";
     return this.transform(code, opts);
   }
 
-  pretransform(code: string, opts?: Object): BabelFileResult {
+  pretransform(code, opts) {
     let file = new File(opts, this);
     return file.wrap(code, function () {
       file.addCode(code);
@@ -22,7 +18,7 @@ export default class Pipeline {
     });
   }
 
-  transform(code: string, opts?: Object): BabelFileResult {
+  transform(code, opts) {
     let file = new File(opts, this);
     return file.wrap(code, function () {
       file.addCode(code);
@@ -31,7 +27,7 @@ export default class Pipeline {
     });
   }
 
-  analyse(code: string, opts: Object = {}, visitor?: Object): ?BabelFileMetadata {
+  analyse(code, opts = {}, visitor) {
     opts.code = false;
     if (visitor) {
       opts.plugins = opts.plugins || [];
@@ -40,7 +36,7 @@ export default class Pipeline {
     return this.transform(code, opts).metadata;
   }
 
-  transformFromAst(ast: Object, code: string, opts: Object): BabelFileResult {
+  transformFromAst(ast, code, opts) {
     ast = normalizeAst(ast);
 
     let file = new File(opts, this);

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -1,4 +1,3 @@
-/* @noflow */
 /* eslint max-len: 0 */
 
 import OptionManager from "./file/options/option-manager";

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -11,7 +11,7 @@ import clone from "lodash/lang/clone";
 const GLOBAL_VISITOR_PROPS = ["enter", "exit"];
 
 export default class Plugin extends Store {
-  constructor(plugin: Object, key?: string) {
+  constructor(plugin, key) {
     super();
 
     this.initialized = false;
@@ -24,13 +24,6 @@ export default class Plugin extends Store {
     this.visitor           = this.normaliseVisitor(clone(this.take("visitor")) || {});
   }
 
-  initialized: boolean;
-  raw: Object;
-  manipulateOptions: ?Function;
-  post: ?Function;
-  pre: ?Function;
-  visitor: Object;
-
   take(key) {
     let val = this.raw[key];
     delete this.raw[key];
@@ -41,7 +34,7 @@ export default class Plugin extends Store {
     if (!target[key]) return this[key];
     if (!this[key]) return target[key];
 
-    let fns: Array<?Function> = [target[key], this[key]];
+    let fns = [target[key], this[key]];
 
     return function (...args) {
       let val;
@@ -55,7 +48,7 @@ export default class Plugin extends Store {
     };
   }
 
-  maybeInherit(loc: string) {
+  maybeInherit(loc) {
     let inherits = this.take("inherits");
     if (!inherits) return;
 
@@ -72,7 +65,7 @@ export default class Plugin extends Store {
    * position on disk and how it was specified.
    */
 
-  init(loc: string, i: number) {
+  init(loc, i) {
     if (this.initialized) return;
     this.initialized = true;
 
@@ -83,7 +76,7 @@ export default class Plugin extends Store {
     }
   }
 
-  normaliseVisitor(visitor: Object): Object {
+  normaliseVisitor(visitor) {
     for (let key of GLOBAL_VISITOR_PROPS) {
       if (visitor[key]) {
         throw new Error("Plugins aren't allowed to specify catch-all enter/exit handlers. Please target individual nodes.");

--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import escapeRegExp from "lodash/string/escapeRegExp";
 import startsWith from "lodash/string/startsWith";
@@ -16,7 +15,7 @@ export { inherits, inspect } from "util";
  * Test if a filename ends with a compilable extension.
  */
 
-export function canCompile(filename: string, altExts?: Array<string>): boolean {
+export function canCompile(filename, altExts) {
   let exts = altExts || canCompile.EXTENSIONS;
   let ext = path.extname(filename);
   return contains(exts, ext);
@@ -32,7 +31,7 @@ canCompile.EXTENSIONS = [".js", ".jsx", ".es6", ".es"];
  * Create an array from any value, splitting strings by ",".
  */
 
-export function list(val?: string): Array<string> {
+export function list(val) {
   if (!val) {
     return [];
   } else if (Array.isArray(val)) {
@@ -48,7 +47,7 @@ export function list(val?: string): Array<string> {
  * Create a RegExp from a string, array, or regexp.
  */
 
-export function regexify(val: any): RegExp {
+export function regexify(val) {
   if (!val) {
     return new RegExp(/.^/);
   }
@@ -80,7 +79,7 @@ export function regexify(val: any): RegExp {
  * Create an array from a boolean, string, or array, mapped by and optional function.
  */
 
-export function arrayify(val: any, mapFn?: Function): Array<any> {
+export function arrayify(val, mapFn) {
   if (!val) return [];
   if (isBoolean(val)) return arrayify([val], mapFn);
   if (isString(val)) return arrayify(list(val), mapFn);
@@ -97,7 +96,7 @@ export function arrayify(val: any, mapFn?: Function): Array<any> {
  * Makes boolean-like strings into booleans.
  */
 
-export function booleanify(val: any): boolean | any {
+export function booleanify(val) {
   if (val === "true" || val == 1) {
     return true;
   }
@@ -113,11 +112,7 @@ export function booleanify(val: any): boolean | any {
  * Tests if a filename should be ignored based on "ignore" and "only" options.
  */
 
-export function shouldIgnore(
-  filename: string,
-  ignore: Array<RegExp | Function> = [],
-  only?: Array<RegExp | Function>,
-): boolean {
+export function shouldIgnore(filename, ignore = [], only) {
   filename = slash(filename);
 
   if (only) {
@@ -139,7 +134,7 @@ export function shouldIgnore(
  * Otherwise returns result of matching pattern Regex with filename.
  */
 
-function _shouldIgnore(pattern: Function | RegExp, filename: string) {
+function _shouldIgnore(pattern, filename) {
   if (typeof pattern === "function") {
     return pattern(filename);
   } else {

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,6 +1,4 @@
-/* @flow */
 
-import type Position from "./position";
 import repeating from "repeating";
 import trimRight from "trim-right";
 
@@ -9,7 +7,7 @@ import trimRight from "trim-right";
  */
 
 export default class Buffer {
-  constructor(position: Position, format: Object) {
+  constructor(position, format) {
     this.printedCommentStarts = {};
     this.parenPushNewlineState = null;
     this.position = position;
@@ -23,19 +21,11 @@ export default class Buffer {
     this.last = "";
   }
 
-  printedCommentStarts: Object;
-  parenPushNewlineState: ?Object;
-  position: Position;
-  _indent: number;
-  format: Object;
-  buf: string;
-  last: string;
-
   /**
    * Description
    */
 
-  catchUp(node: Object) {
+  catchUp(node) {
     // catch up to this nodes newline if we're behind
     if (node.loc && this.format.retainLines && this.buf) {
       while (this.position.line < node.loc.start.line) {
@@ -48,7 +38,7 @@ export default class Buffer {
    * Get the current trimmed buffer.
    */
 
-  get(): string {
+  get() {
     return trimRight(this.buf);
   }
 
@@ -56,7 +46,7 @@ export default class Buffer {
    * Get the current indent.
    */
 
-  getIndent(): string {
+  getIndent() {
     if (this.format.compact || this.format.concise) {
       return "";
     } else {
@@ -68,7 +58,7 @@ export default class Buffer {
    * Get the current indent size.
    */
 
-  indentSize(): number {
+  indentSize() {
     return this.getIndent().length;
   }
 
@@ -120,7 +110,7 @@ export default class Buffer {
    * Add a keyword to the buffer.
    */
 
-  keyword(name: string) {
+  keyword(name) {
     this.push(name);
     this.space();
   }
@@ -129,7 +119,7 @@ export default class Buffer {
    * Add a space to the buffer unless it is compact (override with force).
    */
 
-  space(force?: boolean) {
+  space(force) {
     if (!force && this.format.compact) return;
 
     if (force || this.buf && !this.isLast(" ") && !this.isLast("\n")) {
@@ -141,12 +131,12 @@ export default class Buffer {
    * Remove the last character.
    */
 
-  removeLast(cha: string) {
+  removeLast(cha) {
     if (this.format.compact) return;
     return this._removeLast(cha);
   }
 
-  _removeLast(cha: string) {
+  _removeLast(cha) {
     if (!this._isLast(cha)) return;
     this.buf = this.buf.slice(0, -1);
     this.last = this.buf[this.buf.length - 1];
@@ -169,7 +159,7 @@ export default class Buffer {
    *  `undefined` will be returned and not `foo` due to the terminator.
    */
 
-  startTerminatorless(): Object {
+  startTerminatorless() {
     return this.parenPushNewlineState = {
       printed: false
     };
@@ -179,7 +169,7 @@ export default class Buffer {
    * Print an ending parentheses if a starting one has been printed.
    */
 
-  endTerminatorless(state: Object) {
+  endTerminatorless(state) {
     if (state.printed) {
       this.dedent();
       this.newline();
@@ -192,7 +182,7 @@ export default class Buffer {
    * Strips multiple newlines if removeLast is true.
    */
 
-  newline(i?: boolean | number, removeLast?: boolean) {
+  newline(i, removeLast) {
     if (this.format.retainLines || this.format.compact) return;
 
     if (this.format.concise) {
@@ -236,7 +226,7 @@ export default class Buffer {
    * Push a string to the buffer, maintaining indentation and newlines.
    */
 
-  push(str: string, noIndent?: boolean) {
+  push(str, noIndent) {
     if (!this.format.compact && this._indent && !noIndent && str !== "\n") {
       // we have an indent level and we aren't pushing a newline
       let indent = this.getIndent();
@@ -255,7 +245,7 @@ export default class Buffer {
    * Push a string to the buffer.
    */
 
-  _push(str: string): void {
+  _push(str) {
     // see startTerminatorless() instance method
     let parenPushNewlineState = this.parenPushNewlineState;
     if (parenPushNewlineState) {
@@ -288,7 +278,7 @@ export default class Buffer {
    * Test if the buffer ends with a string.
    */
 
-  endsWith(str: string): boolean {
+  endsWith(str) {
     if (str.length === 1) {
       return this.last === str;
     } else {
@@ -300,12 +290,12 @@ export default class Buffer {
    * Test if a character is last in the buffer.
    */
 
-  isLast(cha: string): boolean {
+  isLast(cha) {
     if (this.format.compact) return false;
     return this._isLast(cha);
   }
 
-  _isLast(cha: string): boolean {
+  _isLast(cha) {
     let last = this.last;
 
     if (Array.isArray(cha)) {

--- a/packages/babel-generator/src/generators/base.js
+++ b/packages/babel-generator/src/generators/base.js
@@ -1,10 +1,9 @@
-/* @flow */
 
-export function File(node: Object) {
+export function File(node) {
   this.print(node.program, node);
 }
 
-export function Program(node: Object) {
+export function Program(node) {
   this.printInnerComments(node, false);
 
   this.printSequence(node.directives, node);
@@ -13,7 +12,7 @@ export function Program(node: Object) {
   this.printSequence(node.body, node);
 }
 
-export function BlockStatement(node: Object) {
+export function BlockStatement(node) {
   this.push("{");
   this.printInnerComments(node);
   if (node.body.length) {
@@ -32,11 +31,11 @@ export function BlockStatement(node: Object) {
 
 export function Noop() {}
 
-export function Directive(node: Object) {
+export function Directive(node) {
   this.print(node.value, node);
   this.semicolon();
 }
 
-export function DirectiveLiteral(node: Object) {
+export function DirectiveLiteral(node) {
   this.push(this._stringLiteral(node.value));
 }

--- a/packages/babel-generator/src/generators/classes.js
+++ b/packages/babel-generator/src/generators/classes.js
@@ -1,6 +1,5 @@
-/* @flow */
 
-export function ClassDeclaration(node: Object) {
+export function ClassDeclaration(node) {
   this.printJoin(node.decorators, node, { separator: "" });
   this.push("class");
 
@@ -28,7 +27,7 @@ export function ClassDeclaration(node: Object) {
 
 export { ClassDeclaration as ClassExpression };
 
-export function ClassBody(node: Object) {
+export function ClassBody(node) {
   this.push("{");
   this.printInnerComments(node);
   if (node.body.length === 0) {
@@ -44,7 +43,7 @@ export function ClassBody(node: Object) {
   }
 }
 
-export function ClassProperty(node: Object) {
+export function ClassProperty(node) {
   this.printJoin(node.decorators, node, { separator: "" });
 
   if (node.static) this.push("static ");
@@ -59,7 +58,7 @@ export function ClassProperty(node: Object) {
   this.semicolon();
 }
 
-export function ClassMethod(node: Object) {
+export function ClassMethod(node) {
   this.printJoin(node.decorators, node, { separator: "" });
 
   if (node.static) {

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint max-len: 0 */
 
 import isInteger from "is-integer";
@@ -9,7 +8,7 @@ import * as n from "../node";
 const SCIENTIFIC_NOTATION = /e/i;
 const ZERO_DECIMAL_INTEGER = /\.0+$/;
 
-export function UnaryExpression(node: Object) {
+export function UnaryExpression(node) {
   let needsSpace = /[a-z]$/.test(node.operator);
   let arg = node.argument;
 
@@ -26,19 +25,19 @@ export function UnaryExpression(node: Object) {
   this.print(node.argument, node);
 }
 
-export function DoExpression(node: Object) {
+export function DoExpression(node) {
   this.push("do");
   this.space();
   this.print(node.body, node);
 }
 
-export function ParenthesizedExpression(node: Object) {
+export function ParenthesizedExpression(node) {
   this.push("(");
   this.print(node.expression, node);
   this.push(")");
 }
 
-export function UpdateExpression(node: Object) {
+export function UpdateExpression(node) {
   if (node.prefix) {
     this.push(node.operator);
     this.print(node.argument, node);
@@ -48,7 +47,7 @@ export function UpdateExpression(node: Object) {
   }
 }
 
-export function ConditionalExpression(node: Object) {
+export function ConditionalExpression(node) {
   this.print(node.test, node);
   this.space();
   this.push("?");
@@ -60,7 +59,7 @@ export function ConditionalExpression(node: Object) {
   this.print(node.alternate, node);
 }
 
-export function NewExpression(node: Object, parent: Object) {
+export function NewExpression(node, parent) {
   this.push("new ");
   this.print(node.callee, node);
   if (node.arguments.length === 0 && this.format.minified &&
@@ -73,7 +72,7 @@ export function NewExpression(node: Object, parent: Object) {
   this.push(")");
 }
 
-export function SequenceExpression(node: Object) {
+export function SequenceExpression(node) {
   this.printList(node.expressions, node);
 }
 
@@ -85,13 +84,13 @@ export function Super() {
   this.push("super");
 }
 
-export function Decorator(node: Object) {
+export function Decorator(node) {
   this.push("@");
   this.print(node.expression, node);
   this.newline();
 }
 
-export function CallExpression(node: Object) {
+export function CallExpression(node) {
   this.print(node.callee, node);
   if (node.loc) this.printAuxAfterComment();
 
@@ -116,8 +115,8 @@ export function CallExpression(node: Object) {
   this.push(")");
 }
 
-function buildYieldAwait(keyword: string) {
-  return function (node: Object) {
+function buildYieldAwait(keyword) {
+  return function (node) {
     this.push(keyword);
 
     if (node.delegate) {
@@ -141,12 +140,12 @@ export function EmptyStatement() {
   this.semicolon();
 }
 
-export function ExpressionStatement(node: Object) {
+export function ExpressionStatement(node) {
   this.print(node.expression, node);
   this.semicolon();
 }
 
-export function AssignmentPattern(node: Object) {
+export function AssignmentPattern(node) {
   this.print(node.left, node);
   this.space();
   this.push("=");
@@ -154,7 +153,7 @@ export function AssignmentPattern(node: Object) {
   this.print(node.right, node);
 }
 
-export function AssignmentExpression(node: Object, parent: Object) {
+export function AssignmentExpression(node, parent) {
   // Somewhere inside a for statement `init` node but doesn't usually
   // needs a paren except for `in` expressions: `for (a in b ? a : b;;)`
   let parens = this._inForStatementInitCounter && node.operator === "in" &&
@@ -195,7 +194,7 @@ export function AssignmentExpression(node: Object, parent: Object) {
   }
 }
 
-export function BindExpression(node: Object) {
+export function BindExpression(node) {
   this.print(node.object, node);
   this.push("::");
   this.print(node.callee, node);
@@ -206,7 +205,7 @@ export {
   AssignmentExpression as LogicalExpression
 };
 
-export function MemberExpression(node: Object) {
+export function MemberExpression(node) {
   this.print(node.object, node);
 
   if (!node.computed && t.isMemberExpression(node.property)) {
@@ -235,7 +234,7 @@ export function MemberExpression(node: Object) {
   }
 }
 
-export function MetaProperty(node: Object) {
+export function MetaProperty(node) {
   this.print(node.meta, node);
   this.push(".");
   this.print(node.property, node);

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint max-len: 0 */
 
 import * as t from "babel-types";
@@ -7,7 +6,7 @@ export function AnyTypeAnnotation() {
   this.push("any");
 }
 
-export function ArrayTypeAnnotation(node: Object) {
+export function ArrayTypeAnnotation(node) {
   this.print(node.elementType, node);
   this.push("[");
   this.push("]");
@@ -17,7 +16,7 @@ export function BooleanTypeAnnotation() {
   this.push("bool");
 }
 
-export function BooleanLiteralTypeAnnotation(node: Object) {
+export function BooleanLiteralTypeAnnotation(node) {
   this.push(node.value ? "true" : "false");
 }
 
@@ -25,36 +24,36 @@ export function NullLiteralTypeAnnotation() {
   this.push("null");
 }
 
-export function DeclareClass(node: Object) {
+export function DeclareClass(node) {
   this.push("declare class ");
   this._interfaceish(node);
 }
 
-export function DeclareFunction(node: Object) {
+export function DeclareFunction(node) {
   this.push("declare function ");
   this.print(node.id, node);
   this.print(node.id.typeAnnotation.typeAnnotation, node);
   this.semicolon();
 }
 
-export function DeclareInterface(node: Object) {
+export function DeclareInterface(node) {
   this.push("declare ");
   this.InterfaceDeclaration(node);
 }
 
-export function DeclareModule(node: Object) {
+export function DeclareModule(node) {
   this.push("declare module ");
   this.print(node.id, node);
   this.space();
   this.print(node.body, node);
 }
 
-export function DeclareTypeAlias(node: Object) {
+export function DeclareTypeAlias(node) {
   this.push("declare ");
   this.TypeAlias(node);
 }
 
-export function DeclareVariable(node: Object) {
+export function DeclareVariable(node) {
   this.push("declare var ");
   this.print(node.id, node);
   this.print(node.id.typeAnnotation, node);
@@ -65,7 +64,7 @@ export function ExistentialTypeParam() {
   this.push("*");
 }
 
-export function FunctionTypeAnnotation(node: Object, parent: Object) {
+export function FunctionTypeAnnotation(node, parent) {
   this.print(node.typeParameters, node);
   this.push("(");
   this.printList(node.params, node);
@@ -93,7 +92,7 @@ export function FunctionTypeAnnotation(node: Object, parent: Object) {
   this.print(node.returnType, node);
 }
 
-export function FunctionTypeParam(node: Object) {
+export function FunctionTypeParam(node) {
   this.print(node.name, node);
   if (node.optional) this.push("?");
   this.push(":");
@@ -101,14 +100,14 @@ export function FunctionTypeParam(node: Object) {
   this.print(node.typeAnnotation, node);
 }
 
-export function InterfaceExtends(node: Object) {
+export function InterfaceExtends(node) {
   this.print(node.id, node);
   this.print(node.typeParameters, node);
 }
 
 export { InterfaceExtends as ClassImplements, InterfaceExtends as GenericTypeAnnotation };
 
-export function _interfaceish(node: Object) {
+export function _interfaceish(node) {
   this.print(node.id, node);
   this.print(node.typeParameters, node);
   if (node.extends.length) {
@@ -123,12 +122,12 @@ export function _interfaceish(node: Object) {
   this.print(node.body, node);
 }
 
-export function InterfaceDeclaration(node: Object) {
+export function InterfaceDeclaration(node) {
   this.push("interface ");
   this._interfaceish(node);
 }
 
-export function IntersectionTypeAnnotation(node: Object) {
+export function IntersectionTypeAnnotation(node) {
   this.printJoin(node.types, node, { separator: " & " });
 }
 
@@ -136,7 +135,7 @@ export function MixedTypeAnnotation() {
   this.push("mixed");
 }
 
-export function NullableTypeAnnotation(node: Object) {
+export function NullableTypeAnnotation(node) {
   this.push("?");
   this.print(node.typeAnnotation, node);
 }
@@ -147,7 +146,7 @@ export function NumberTypeAnnotation() {
   this.push("number");
 }
 
-export function StringLiteralTypeAnnotation(node: Object) {
+export function StringLiteralTypeAnnotation(node) {
   this.push(this._stringLiteral(node.value));
 }
 
@@ -159,18 +158,18 @@ export function ThisTypeAnnotation() {
   this.push("this");
 }
 
-export function TupleTypeAnnotation(node: Object) {
+export function TupleTypeAnnotation(node) {
   this.push("[");
   this.printJoin(node.types, node, { separator: ", " });
   this.push("]");
 }
 
-export function TypeofTypeAnnotation(node: Object) {
+export function TypeofTypeAnnotation(node) {
   this.push("typeof ");
   this.print(node.argument, node);
 }
 
-export function TypeAlias(node: Object) {
+export function TypeAlias(node) {
   this.push("type ");
   this.print(node.id, node);
   this.print(node.typeParameters, node);
@@ -181,18 +180,18 @@ export function TypeAlias(node: Object) {
   this.semicolon();
 }
 
-export function TypeAnnotation(node: Object) {
+export function TypeAnnotation(node) {
   this.push(":");
   this.space();
   if (node.optional) this.push("?");
   this.print(node.typeAnnotation, node);
 }
 
-export function TypeParameterInstantiation(node: Object) {
+export function TypeParameterInstantiation(node) {
   this.push("<");
   this.printJoin(node.params, node, {
     separator: ", ",
-    iterator: (node: Object) => {
+    iterator: (node) => {
       this.print(node.typeAnnotation, node);
     }
   });
@@ -201,7 +200,7 @@ export function TypeParameterInstantiation(node: Object) {
 
 export { TypeParameterInstantiation as TypeParameterDeclaration };
 
-export function ObjectTypeAnnotation(node: Object) {
+export function ObjectTypeAnnotation(node) {
   this.push("{");
   let props = node.properties.concat(node.callProperties, node.indexers);
 
@@ -225,12 +224,12 @@ export function ObjectTypeAnnotation(node: Object) {
   this.push("}");
 }
 
-export function ObjectTypeCallProperty(node: Object) {
+export function ObjectTypeCallProperty(node) {
   if (node.static) this.push("static ");
   this.print(node.value, node);
 }
 
-export function ObjectTypeIndexer(node: Object) {
+export function ObjectTypeIndexer(node) {
   if (node.static) this.push("static ");
   this.push("[");
   this.print(node.id, node);
@@ -243,7 +242,7 @@ export function ObjectTypeIndexer(node: Object) {
   this.print(node.value, node);
 }
 
-export function ObjectTypeProperty(node: Object) {
+export function ObjectTypeProperty(node) {
   if (node.static) this.push("static ");
   this.print(node.key, node);
   if (node.optional) this.push("?");
@@ -254,17 +253,17 @@ export function ObjectTypeProperty(node: Object) {
   this.print(node.value, node);
 }
 
-export function QualifiedTypeIdentifier(node: Object) {
+export function QualifiedTypeIdentifier(node) {
   this.print(node.qualification, node);
   this.push(".");
   this.print(node.id, node);
 }
 
-export function UnionTypeAnnotation(node: Object) {
+export function UnionTypeAnnotation(node) {
   this.printJoin(node.types, node, { separator: " | " });
 }
 
-export function TypeCastExpression(node: Object) {
+export function TypeCastExpression(node) {
   this.push("(");
   this.print(node.expression, node);
   this.print(node.typeAnnotation, node);

--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -1,6 +1,6 @@
-/* @flow */
 
-export function JSXAttribute(node: Object) {
+
+export function JSXAttribute(node) {
   this.print(node.name, node);
   if (node.value) {
     this.push("=");
@@ -8,45 +8,45 @@ export function JSXAttribute(node: Object) {
   }
 }
 
-export function JSXIdentifier(node: Object) {
+export function JSXIdentifier(node) {
   this.push(node.name);
 }
 
-export function JSXNamespacedName(node: Object) {
+export function JSXNamespacedName(node) {
   this.print(node.namespace, node);
   this.push(":");
   this.print(node.name, node);
 }
 
-export function JSXMemberExpression(node: Object) {
+export function JSXMemberExpression(node) {
   this.print(node.object, node);
   this.push(".");
   this.print(node.property, node);
 }
 
-export function JSXSpreadAttribute(node: Object) {
+export function JSXSpreadAttribute(node) {
   this.push("{...");
   this.print(node.argument, node);
   this.push("}");
 }
 
-export function JSXExpressionContainer(node: Object) {
+export function JSXExpressionContainer(node) {
   this.push("{");
   this.print(node.expression, node);
   this.push("}");
 }
 
-export function JSXText(node: Object) {
+export function JSXText(node) {
   this.push(node.value, true);
 }
 
-export function JSXElement(node: Object) {
+export function JSXElement(node) {
   let open = node.openingElement;
   this.print(open, node);
   if (open.selfClosing) return;
 
   this.indent();
-  for (let child of (node.children: Array<Object>)) {
+  for (let child of node.children) {
     this.print(child, node);
   }
   this.dedent();
@@ -54,7 +54,7 @@ export function JSXElement(node: Object) {
   this.print(node.closingElement, node);
 }
 
-export function JSXOpeningElement(node: Object) {
+export function JSXOpeningElement(node) {
   this.push("<");
   this.print(node.name, node);
   if (node.attributes.length > 0) {
@@ -64,7 +64,7 @@ export function JSXOpeningElement(node: Object) {
   this.push(node.selfClosing ? " />" : ">");
 }
 
-export function JSXClosingElement(node: Object) {
+export function JSXClosingElement(node) {
   this.push("</");
   this.print(node.name, node);
   this.push(">");

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -1,8 +1,8 @@
-/* @flow */
+
 
 import * as t from "babel-types";
 
-export function _params(node: Object) {
+export function _params(node) {
   this.print(node.typeParameters, node);
   this.push("(");
   this.printList(node.params, node, {
@@ -18,9 +18,9 @@ export function _params(node: Object) {
   }
 }
 
-export function _method(node: Object) {
+export function _method(node) {
   let kind = node.kind;
-  let key  = node.key;
+  let key = node.key;
 
   if (kind === "method" || kind === "init") {
     if (node.generator) {
@@ -47,7 +47,7 @@ export function _method(node: Object) {
   this.print(node.body, node);
 }
 
-export function FunctionExpression(node: Object) {
+export function FunctionExpression(node) {
   if (node.async) this.push("async ");
   this.push("function");
   if (node.generator) this.push("*");
@@ -66,7 +66,7 @@ export function FunctionExpression(node: Object) {
 
 export { FunctionExpression as FunctionDeclaration };
 
-export function ArrowFunctionExpression(node: Object) {
+export function ArrowFunctionExpression(node) {
   if (node.async) this.push("async ");
 
   if (node.params.length === 1 && t.isIdentifier(node.params[0])) {

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -1,8 +1,7 @@
-/* @flow */
 
 import * as t from "babel-types";
 
-export function ImportSpecifier(node: Object) {
+export function ImportSpecifier(node) {
   this.print(node.imported, node);
   if (node.local && node.local.name !== node.imported.name) {
     this.push(" as ");
@@ -10,15 +9,15 @@ export function ImportSpecifier(node: Object) {
   }
 }
 
-export function ImportDefaultSpecifier(node: Object) {
+export function ImportDefaultSpecifier(node) {
   this.print(node.local, node);
 }
 
-export function ExportDefaultSpecifier(node: Object) {
+export function ExportDefaultSpecifier(node) {
   this.print(node.exported, node);
 }
 
-export function ExportSpecifier(node: Object) {
+export function ExportSpecifier(node) {
   this.print(node.local, node);
   if (node.exported && node.local.name !== node.exported.name) {
     this.push(" as ");
@@ -26,12 +25,12 @@ export function ExportSpecifier(node: Object) {
   }
 }
 
-export function ExportNamespaceSpecifier(node: Object) {
+export function ExportNamespaceSpecifier(node) {
   this.push("* as ");
   this.print(node.exported, node);
 }
 
-export function ExportAllDeclaration(node: Object) {
+export function ExportAllDeclaration(node) {
   this.push("export *");
   if (node.exported) {
     this.push(" as ");
@@ -52,7 +51,7 @@ export function ExportDefaultDeclaration() {
   ExportDeclaration.apply(this, arguments);
 }
 
-function ExportDeclaration(node: Object) {
+function ExportDeclaration(node) {
   if (node.declaration) {
     let declar = node.declaration;
     this.print(declar, node);
@@ -98,7 +97,7 @@ function ExportDeclaration(node: Object) {
   this.ensureSemicolon();
 }
 
-export function ImportDeclaration(node: Object) {
+export function ImportDeclaration(node) {
   this.push("import ");
 
   if (node.importKind === "type" || node.importKind === "typeof") {
@@ -135,7 +134,7 @@ export function ImportDeclaration(node: Object) {
   this.semicolon();
 }
 
-export function ImportNamespaceSpecifier(node: Object) {
+export function ImportNamespaceSpecifier(node) {
   this.push("* as ");
   this.print(node.local, node);
 }

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -5,7 +5,7 @@ import * as t from "babel-types";
 
 const NON_ALPHABETIC_UNARY_OPERATORS = t.UPDATE_OPERATORS.concat(t.NUMBER_UNARY_OPERATORS).concat(["!"]);
 
-export function WithStatement(node: Object) {
+export function WithStatement(node) {
   this.keyword("with");
   this.push("(");
   this.print(node.object, node);
@@ -13,7 +13,7 @@ export function WithStatement(node: Object) {
   this.printBlock(node);
 }
 
-export function IfStatement(node: Object) {
+export function IfStatement(node) {
   this.keyword("if");
   this.push("(");
   this.print(node.test, node);
@@ -48,7 +48,7 @@ function getLastStatement(statement) {
   return getLastStatement(statement.body);
 }
 
-export function ForStatement(node: Object) {
+export function ForStatement(node) {
   this.keyword("for");
   this.push("(");
 
@@ -72,7 +72,7 @@ export function ForStatement(node: Object) {
   this.printBlock(node);
 }
 
-export function WhileStatement(node: Object) {
+export function WhileStatement(node) {
   this.keyword("while");
   this.push("(");
   this.print(node.test, node);
@@ -81,7 +81,7 @@ export function WhileStatement(node: Object) {
 }
 
 let buildForXStatement = function (op) {
-  return function (node: Object) {
+  return function (node) {
     this.keyword("for");
     this.push("(");
     this.print(node.left, node);
@@ -95,7 +95,7 @@ let buildForXStatement = function (op) {
 export let ForInStatement = buildForXStatement("in");
 export let ForOfStatement = buildForXStatement("of");
 
-export function DoWhileStatement(node: Object) {
+export function DoWhileStatement(node) {
   this.push("do ");
   this.print(node.body, node);
   this.space();
@@ -106,7 +106,7 @@ export function DoWhileStatement(node: Object) {
 }
 
 function buildLabelStatement(prefix, key = "label") {
-  return function (node: Object) {
+  return function (node) {
     this.push(prefix);
 
     let label = node[key];
@@ -132,13 +132,13 @@ export let ReturnStatement   = buildLabelStatement("return", "argument");
 export let BreakStatement    = buildLabelStatement("break");
 export let ThrowStatement    = buildLabelStatement("throw", "argument");
 
-export function LabeledStatement(node: Object) {
+export function LabeledStatement(node) {
   this.print(node.label, node);
   this.push(": ");
   this.print(node.body, node);
 }
 
-export function TryStatement(node: Object) {
+export function TryStatement(node) {
   this.keyword("try");
   this.print(node.block, node);
   this.space();
@@ -159,7 +159,7 @@ export function TryStatement(node: Object) {
   }
 }
 
-export function CatchClause(node: Object) {
+export function CatchClause(node) {
   this.keyword("catch");
   this.push("(");
   this.print(node.param, node);
@@ -168,7 +168,7 @@ export function CatchClause(node: Object) {
   this.print(node.body, node);
 }
 
-export function SwitchStatement(node: Object) {
+export function SwitchStatement(node) {
   this.keyword("switch");
   this.push("(");
   this.print(node.discriminant, node);
@@ -186,7 +186,7 @@ export function SwitchStatement(node: Object) {
   this.push("}");
 }
 
-export function SwitchCase(node: Object) {
+export function SwitchCase(node) {
   if (node.test) {
     this.push("case ");
     this.print(node.test, node);
@@ -205,13 +205,13 @@ export function DebuggerStatement() {
   this.push("debugger;");
 }
 
-export function VariableDeclaration(node: Object, parent: Object) {
+export function VariableDeclaration(node, parent) {
   this.push(node.kind + " ");
 
   let hasInits = false;
   // don't add whitespace to loop heads
   if (!t.isFor(parent)) {
-    for (let declar of (node.declarations: Array<Object>)) {
+    for (let declar of node.declarations) {
       if (declar.init) {
         // has an init so let's split it up over multiple lines
         hasInits = true;
@@ -248,7 +248,7 @@ export function VariableDeclaration(node: Object, parent: Object) {
   this.semicolon();
 }
 
-export function VariableDeclarator(node: Object) {
+export function VariableDeclarator(node) {
   this.print(node.id, node);
   this.print(node.id.typeAnnotation, node);
   if (node.init) {

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import repeating from "repeating";
 import * as t from "babel-types";
 

--- a/packages/babel-generator/src/generators/template-literals.js
+++ b/packages/babel-generator/src/generators/template-literals.js
@@ -1,15 +1,14 @@
-/* @flow */
 
-export function TaggedTemplateExpression(node: Object) {
+export function TaggedTemplateExpression(node) {
   this.print(node.tag, node);
   this.print(node.quasi, node);
 }
 
-export function TemplateElement(node: Object) {
+export function TemplateElement(node) {
   this._push(node.value.raw);
 }
 
-export function TemplateLiteral(node: Object) {
+export function TemplateLiteral(node) {
   this.push("`");
 
   let quasis = node.quasis;

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -1,14 +1,13 @@
-/* @flow */
 /* eslint max-len: 0 */
 /* eslint quotes: 0 */
 
 import * as t from "babel-types";
 
-export function Identifier(node: Object) {
+export function Identifier(node) {
   this.push(node.name);
 }
 
-export function RestElement(node: Object) {
+export function RestElement(node) {
   this.push("...");
   this.print(node.argument, node);
 }
@@ -19,7 +18,7 @@ export {
   RestElement as RestProperty,
 };
 
-export function ObjectExpression(node: Object) {
+export function ObjectExpression(node) {
   let props = node.properties;
 
   this.push("{");
@@ -36,12 +35,12 @@ export function ObjectExpression(node: Object) {
 
 export { ObjectExpression as ObjectPattern };
 
-export function ObjectMethod(node: Object) {
+export function ObjectMethod(node) {
   this.printJoin(node.decorators, node, { separator: "" });
   this._method(node);
 }
 
-export function ObjectProperty(node: Object) {
+export function ObjectProperty(node) {
   this.printJoin(node.decorators, node, { separator: "" });
 
   if (node.computed) {
@@ -71,7 +70,7 @@ export function ObjectProperty(node: Object) {
   this.print(node.value, node);
 }
 
-export function ArrayExpression(node: Object) {
+export function ArrayExpression(node) {
   let elems = node.elements;
   let len   = elems.length;
 
@@ -99,11 +98,11 @@ export function ArrayExpression(node: Object) {
 
 export { ArrayExpression as ArrayPattern };
 
-export function RegExpLiteral(node: Object) {
+export function RegExpLiteral(node) {
   this.push(`/${node.pattern}/${node.flags}`);
 }
 
-export function BooleanLiteral(node: Object) {
+export function BooleanLiteral(node) {
   this.push(node.value ? "true" : "false");
 }
 
@@ -111,15 +110,15 @@ export function NullLiteral() {
   this.push("null");
 }
 
-export function NumericLiteral(node: Object) {
+export function NumericLiteral(node) {
   this.push(node.value + "");
 }
 
-export function StringLiteral(node: Object, parent: Object) {
+export function StringLiteral(node, parent) {
   this.push(this._stringLiteral(node.value, parent));
 }
 
-export function _stringLiteral(val: string, parent: Object): string {
+export function _stringLiteral(val, parent) {
   val = JSON.stringify(val);
 
   // escape illegal js but valid json unicode characters

--- a/packages/babel-generator/src/node/index.js
+++ b/packages/babel-generator/src/node/index.js
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import whitespace from "./whitespace";
 import * as parens from "./parentheses";
 import * as t from "babel-types";

--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import * as t from "babel-types";
 
@@ -29,13 +28,13 @@ const PRECEDENCE = {
   "**": 10
 };
 
-export function NullableTypeAnnotation(node: Object, parent: Object): boolean {
+export function NullableTypeAnnotation(node, parent) {
   return t.isArrayTypeAnnotation(parent);
 }
 
 export { NullableTypeAnnotation as FunctionTypeAnnotation };
 
-export function UpdateExpression(node: Object, parent: Object): boolean {
+export function UpdateExpression(node, parent) {
   if (t.isMemberExpression(parent) && parent.object === node) {
     // (foo++).test()
     return true;
@@ -44,7 +43,7 @@ export function UpdateExpression(node: Object, parent: Object): boolean {
   return false;
 }
 
-export function ObjectExpression(node: Object, parent: Object, printStack: Array<Object>): boolean {
+export function ObjectExpression(node, parent, printStack) {
   if (t.isExpressionStatement(parent)) {
     // ({ foo: "bar" });
     return true;
@@ -53,7 +52,7 @@ export function ObjectExpression(node: Object, parent: Object, printStack: Array
   return isFirstInStatement(printStack, true);
 }
 
-export function Binary(node: Object, parent: Object): boolean {
+export function Binary(node, parent) {
   if ((t.isCallExpression(parent) || t.isNewExpression(parent)) && parent.callee === node) {
     return true;
   }
@@ -86,7 +85,7 @@ export function Binary(node: Object, parent: Object): boolean {
   return false;
 }
 
-export function BinaryExpression(node: Object, parent: Object): boolean {
+export function BinaryExpression(node, parent) {
   if (node.operator === "in") {
     // let i = (1 in []);
     if (t.isVariableDeclarator(parent)) {
@@ -102,7 +101,7 @@ export function BinaryExpression(node: Object, parent: Object): boolean {
   return false;
 }
 
-export function SequenceExpression(node: Object, parent: Object): boolean {
+export function SequenceExpression(node, parent) {
   if (t.isForStatement(parent)) {
     // Although parentheses wouldn"t hurt around sequence
     // expressions in the head of for loops, traditional style
@@ -144,7 +143,7 @@ export function SequenceExpression(node: Object, parent: Object): boolean {
   return true;
 }
 
-export function YieldExpression(node: Object, parent: Object): boolean {
+export function YieldExpression(node, parent) {
   return t.isBinary(parent) ||
          t.isUnaryLike(parent) ||
          t.isCallExpression(parent) ||
@@ -154,7 +153,7 @@ export function YieldExpression(node: Object, parent: Object): boolean {
 
 export { YieldExpression as AwaitExpression };
 
-export function ClassExpression(node: Object, parent: Object): boolean {
+export function ClassExpression(node, parent) {
   // (class {});
   if (t.isExpressionStatement(parent)) {
     return true;
@@ -168,7 +167,7 @@ export function ClassExpression(node: Object, parent: Object): boolean {
   return false;
 }
 
-export function UnaryLike(node: Object, parent: Object): boolean {
+export function UnaryLike(node, parent) {
   if (t.isMemberExpression(parent, { object: node })) {
     return true;
   }
@@ -180,7 +179,7 @@ export function UnaryLike(node: Object, parent: Object): boolean {
   return false;
 }
 
-export function FunctionExpression(node: Object, parent: Object, printStack: Array<Object>): boolean {
+export function FunctionExpression(node, parent, printStack) {
   // (function () {});
   if (t.isExpressionStatement(parent)) {
     return true;
@@ -194,7 +193,7 @@ export function FunctionExpression(node: Object, parent: Object, printStack: Arr
   return isFirstInStatement(printStack);
 }
 
-export function ArrowFunctionExpression(node: Object, parent: Object): boolean {
+export function ArrowFunctionExpression(node, parent) {
   // export default (function () {});
   if (t.isExportDeclaration(parent)) {
     return true;
@@ -207,7 +206,7 @@ export function ArrowFunctionExpression(node: Object, parent: Object): boolean {
   return UnaryLike(node, parent);
 }
 
-export function ConditionalExpression(node: Object, parent: Object): boolean {
+export function ConditionalExpression(node, parent) {
   if (t.isUnaryLike(parent)) {
     return true;
   }
@@ -223,7 +222,7 @@ export function ConditionalExpression(node: Object, parent: Object): boolean {
   return UnaryLike(node, parent);
 }
 
-export function AssignmentExpression(node: Object): boolean {
+export function AssignmentExpression(node) {
   if (t.isObjectPattern(node.left)) {
     return true;
   } else {
@@ -233,7 +232,7 @@ export function AssignmentExpression(node: Object): boolean {
 
 // Walk up the print stack to deterimine if our node can come first
 // in statement.
-function isFirstInStatement(printStack: Array<Object>, considerArrow: bool = false): boolean {
+function isFirstInStatement(printStack, considerArrow = false) {
   let i = printStack.length - 1;
   let node = printStack[i];
   i--;

--- a/packages/babel-generator/src/node/whitespace.js
+++ b/packages/babel-generator/src/node/whitespace.js
@@ -5,11 +5,6 @@ import each from "lodash/collection/each";
 import map from "lodash/collection/map";
 import * as t from "babel-types";
 
-type WhitespaceObject = {
-  before?: boolean,
-  after?: boolean
-};
-
 /**
  * Crawl a node to test if it contains a CallExpression, a Function, or a Helper.
  *
@@ -70,7 +65,7 @@ exports.nodes = {
    * Test if AssignmentExpression needs whitespace.
    */
 
-  AssignmentExpression(node: Object): ?WhitespaceObject {
+  AssignmentExpression(node) {
     let state = crawl(node.right);
     if ((state.hasCall && state.hasHelper) || state.hasFunction) {
       return {
@@ -84,7 +79,7 @@ exports.nodes = {
    * Test if SwitchCase needs whitespace.
    */
 
-  SwitchCase(node: Object, parent: Object): ?WhitespaceObject {
+  SwitchCase(node, parent) {
     return {
       before: node.consequent.length || parent.cases[0] === node
     };
@@ -94,7 +89,7 @@ exports.nodes = {
    * Test if LogicalExpression needs whitespace.
    */
 
-  LogicalExpression(node: Object): ?WhitespaceObject {
+  LogicalExpression(node) {
     if (t.isFunction(node.left) || t.isFunction(node.right)) {
       return {
         after: true
@@ -106,7 +101,7 @@ exports.nodes = {
    * Test if Literal needs whitespace.
    */
 
-  Literal(node: Object): ?WhitespaceObject {
+  Literal(node) {
     if (node.value === "use strict") {
       return {
         after: true
@@ -118,7 +113,7 @@ exports.nodes = {
    * Test if CallExpression needs whitespace.
    */
 
-  CallExpression(node: Object): ?WhitespaceObject {
+  CallExpression(node) {
     if (t.isFunction(node.callee) || isHelper(node)) {
       return {
         before: true,
@@ -131,7 +126,7 @@ exports.nodes = {
    * Test if VariableDeclaration needs whitespace.
    */
 
-  VariableDeclaration(node: Object): ?WhitespaceObject {
+  VariableDeclaration(node) {
     for (let i = 0; i < node.declarations.length; i++) {
       let declar = node.declarations[i];
 
@@ -154,7 +149,7 @@ exports.nodes = {
    * Test if IfStatement needs whitespace.
    */
 
-  IfStatement(node: Object): ?WhitespaceObject {
+  IfStatement(node) {
     if (t.isBlockStatement(node.consequent)) {
       return {
         before: true,
@@ -170,7 +165,7 @@ exports.nodes = {
 
 exports.nodes.ObjectProperty =
 exports.nodes.ObjectMethod =
-exports.nodes.SpreadProperty = function (node: Object, parent): ?WhitespaceObject {
+exports.nodes.SpreadProperty = function (node, parent) {
   if (parent.properties[0] === node) {
     return {
       before: true
@@ -188,7 +183,7 @@ exports.list = {
    * Return VariableDeclaration declarations init properties.
    */
 
-  VariableDeclaration(node: Object): Array<Object> {
+  VariableDeclaration(node) {
     return map(node.declarations, "init");
   },
 
@@ -196,7 +191,7 @@ exports.list = {
    * Return VariableDeclaration elements.
    */
 
-  ArrayExpression(node: Object): Array<Object> {
+  ArrayExpression(node) {
     return node.elements;
   },
 
@@ -204,7 +199,7 @@ exports.list = {
    * Return VariableDeclaration properties.
    */
 
-  ObjectExpression(node: Object): Array<Object> {
+  ObjectExpression(node) {
     return node.properties;
   }
 };

--- a/packages/babel-generator/src/node/whitespace.js
+++ b/packages/babel-generator/src/node/whitespace.js
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import isBoolean from "lodash/lang/isBoolean";
 import each from "lodash/collection/each";
 import map from "lodash/collection/map";

--- a/packages/babel-generator/src/position.js
+++ b/packages/babel-generator/src/position.js
@@ -1,12 +1,9 @@
-/* @flow */
 
 /**
  * Track current position in code generation.
  */
 
 export default class Position {
-  column: number;
-  line: number;
 
   constructor() {
     this.line = 1;
@@ -17,7 +14,7 @@ export default class Position {
    * Push a string to the current position, mantaining the current line and column.
    */
 
-  push(str: string): void {
+  push(str) {
     for (let i = 0; i < str.length; i++) {
       if (str[i] === "\n") {
         this.line++;
@@ -32,7 +29,7 @@ export default class Position {
    * Unshift a string from the current position, mantaining the current line and column.
    */
 
-  unshift(str: string): void {
+  unshift(str) {
     for (let i = 0; i < str.length; i++) {
       if (str[i] === "\n") {
         this.line--;

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import explode from "babel-helper-explode-assignable-expression";
 import * as t from "babel-types";
 

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
@@ -3,10 +3,7 @@
 import explode from "babel-helper-explode-assignable-expression";
 import * as t from "babel-types";
 
-export default function (opts: {
-  build: Function;
-  operator: string;
-}): Object {
+export default function (opts) {
   let visitor = {};
 
   function isAssignment(node) {

--- a/packages/babel-helper-builder-conditional-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-conditional-assignment-operator-visitor/src/index.js
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import explode from "babel-helper-explode-assignable-expression";
 import * as t from "babel-types";
 

--- a/packages/babel-helper-builder-conditional-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-conditional-assignment-operator-visitor/src/index.js
@@ -3,13 +3,7 @@
 import explode from "babel-helper-explode-assignable-expression";
 import * as t from "babel-types";
 
-export default function (
-  exports: Object,
-  opts: {
-    build: Function;
-    is: Function;
-  },
-) {
+export default function (exports, opts) {
   let buildAssignment = function (left, right) {
     return t.assignmentExpression("=", left, right);
   };

--- a/packages/babel-helper-regex/src/index.js
+++ b/packages/babel-helper-regex/src/index.js
@@ -1,13 +1,13 @@
-/* @flow */
+
 
 import pull from "lodash/array/pull";
 import * as t from "babel-types";
 
-export function is(node: Object, flag: string): boolean {
+export function is(node, flag) {
   return t.isRegExpLiteral(node) && node.flags.indexOf(flag) >= 0;
 }
 
-export function pullFlag(node: Object, flag: string) {
+export function pullFlag(node, flag) {
   let flags = node.flags.split("");
   if (node.flags.indexOf(flag) < 0) return;
   pull(flags, flag);

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -1,6 +1,4 @@
-/* @noflow */
 
-import type { NodePath } from "babel-traverse";
 import nameFunction from "babel-helper-function-name";
 import template from "babel-template";
 import * as t from "babel-types";
@@ -35,7 +33,7 @@ let awaitVisitor = {
   }
 };
 
-function classOrObjectMethod(path: NodePath, callId: Object) {
+function classOrObjectMethod(path, callId) {
   let node = path.node;
   let body = node.body;
 
@@ -51,7 +49,7 @@ function classOrObjectMethod(path: NodePath, callId: Object) {
   ];
 }
 
-function plainFunction(path: NodePath, callId: Object) {
+function plainFunction(path, callId) {
   let node = path.node;
   let wrapper = buildWrapper;
 
@@ -118,7 +116,7 @@ function plainFunction(path: NodePath, callId: Object) {
   }
 }
 
-export default function (path: NodePath, callId: Object) {
+export default function (path, callId) {
   let node = path.node;
   if (node.generator) return;
 

--- a/packages/babel-messages/src/index.js
+++ b/packages/babel-messages/src/index.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint max-len: 0 */
 
 import * as util from "util";
@@ -48,7 +47,7 @@ export const MESSAGES = {
  * Get a message with $0 placeholders replaced by arguments.
  */
 
-export function get(key: string, ...args: Array<any>): string {
+export function get(key, ...args) {
   let msg = MESSAGES[key];
   if (!msg) throw new ReferenceError(`Unknown message ${JSON.stringify(key)}`);
 
@@ -65,7 +64,7 @@ export function get(key: string, ...args: Array<any>): string {
  * Stingify arguments to be used inside messages.
  */
 
-export function parseArgs(args: Array<any>): Array<string> {
+export function parseArgs(args) {
   return args.map(function (val) {
     if (val != null && val.inspect) {
       return val.inspect();

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import deepClone from "lodash/lang/cloneDeep";
 import sourceMapSupport from "source-map-support";
@@ -129,7 +128,7 @@ function hookExtensions(_exts) {
 
 hookExtensions(util.canCompile.EXTENSIONS);
 
-export default function (opts?: Object = {}) {
+export default function (opts = {}) {
   if (opts.only != null) only = util.arrayify(opts.only, util.regexify);
   if (opts.ignore != null) ignore = util.arrayify(opts.ignore, util.regexify);
 

--- a/packages/babel-types/src/converters.js
+++ b/packages/babel-types/src/converters.js
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import isPlainObject from "lodash/lang/isPlainObject";
 import isNumber from "lodash/lang/isNumber";
 import isRegExp from "lodash/lang/isRegExp";

--- a/packages/babel-types/src/converters.js
+++ b/packages/babel-types/src/converters.js
@@ -5,10 +5,9 @@ import isNumber from "lodash/lang/isNumber";
 import isRegExp from "lodash/lang/isRegExp";
 import isString from "lodash/lang/isString";
 import traverse from "babel-traverse";
-import type { Scope } from "babel-traverse";
 import * as t from "./index";
 
-export function toComputedKey(node: Object, key: Object = node.key || node.property): Object {
+export function toComputedKey(node, key = node.key || node.property) {
   if (!node.computed) {
     if (t.isIdentifier(key)) key = t.stringLiteral(key.name);
   }
@@ -24,7 +23,7 @@ export function toComputedKey(node: Object, key: Object = node.key || node.prope
  * Expression statements are just resolved to their expression.
  */
 
-export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Object {
+export function toSequenceExpression(nodes, scope) {
   if (!nodes || !nodes.length) return;
 
   let declars = [];
@@ -43,7 +42,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
     let ensureLastUndefined = false;
     let exprs   = [];
 
-    for (let node of (nodes: Array)) {
+    for (let node of nodes) {
       if (t.isExpression(node)) {
         exprs.push(node);
       } else if (t.isExpressionStatement(node)) {
@@ -51,7 +50,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
       } else if (t.isVariableDeclaration(node)) {
         if (node.kind !== "var") return bailed = true; // bailed
 
-        for (let declar of (node.declarations: Array)) {
+        for (let declar of node.declarations) {
           let bindings = t.getBindingIdentifiers(declar);
           for (let key in bindings) {
             declars.push({
@@ -101,7 +100,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
   }
 }
 
-export function toKeyAlias(node: Object, key: Object = node.key): string {
+export function toKeyAlias(node, key = node.key) {
   let alias;
 
   if (node.kind === "method") {
@@ -135,7 +134,7 @@ toKeyAlias.increment = function () {
   }
 };
 
-export function toIdentifier(name: string): string {
+export function toIdentifier(name) {
   name = name + "";
 
   // replace all non-valid identifiers with dashes
@@ -156,7 +155,7 @@ export function toIdentifier(name: string): string {
   return name || "_";
 }
 
-export function toBindingIdentifierName(name: string): string {
+export function toBindingIdentifierName(name) {
   name = toIdentifier(name);
   if (name === "eval" || name === "arguments") name = "_" + name;
   return name;
@@ -167,7 +166,7 @@ export function toBindingIdentifierName(name: string): string {
  * @returns {Object|Boolean}
  */
 
-export function toStatement(node: Object, ignore?: boolean) {
+export function toStatement(node, ignore) {
   if (t.isStatement(node)) {
     return node;
   }
@@ -202,7 +201,7 @@ export function toStatement(node: Object, ignore?: boolean) {
   return node;
 }
 
-export function toExpression(node: Object): Object {
+export function toExpression(node) {
   if (t.isExpressionStatement(node)) {
     node = node.expression;
   }
@@ -220,7 +219,7 @@ export function toExpression(node: Object): Object {
   }
 }
 
-export function toBlock(node: Object, parent: Object): Object {
+export function toBlock(node, parent) {
   if (t.isBlockStatement(node)) {
     return node;
   }
@@ -244,7 +243,7 @@ export function toBlock(node: Object, parent: Object): Object {
   return t.blockStatement(node);
 }
 
-export function valueToNode(value: any): Object {
+export function valueToNode(value) {
   // undefined
   if (value === undefined) {
     return t.identifier("undefined");

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint max-len: 0 */
 
 import defineType, {

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import defineType, { assertNodeType } from "./index";
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import defineType from "./index";
 

--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -1,4 +1,3 @@
-/* @noflow */
 import * as t from "../index";
 
 export let VISITOR_KEYS = {};

--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -19,7 +19,7 @@ function getType(val) {
   }
 }
 
-export function assertEach(callback: Function): Function {
+export function assertEach(callback) {
   function validator(node, key, val) {
     if (!Array.isArray(val)) return;
 
@@ -31,7 +31,7 @@ export function assertEach(callback: Function): Function {
   return validator;
 }
 
-export function assertOneOf(...vals): Function {
+export function assertOneOf(...vals) {
   function validate(node, key, val) {
     if (vals.indexOf(val) < 0) {
       throw new TypeError(
@@ -45,7 +45,7 @@ export function assertOneOf(...vals): Function {
   return validate;
 }
 
-export function assertNodeType(...types: Array<string>): Function {
+export function assertNodeType(...types) {
   function validate(node, key, val) {
     let valid = false;
 
@@ -69,7 +69,7 @@ export function assertNodeType(...types: Array<string>): Function {
   return validate;
 }
 
-export function assertNodeOrValueType(...types: Array<string>): Function {
+export function assertNodeOrValueType(...types) {
   function validate(node, key, val) {
     let valid = false;
 
@@ -93,7 +93,7 @@ export function assertNodeOrValueType(...types: Array<string>): Function {
   return validate;
 }
 
-export function assertValueType(type: string): Function {
+export function assertValueType(type) {
   function validate(node, key, val) {
     let valid = getType(val) === type;
 
@@ -107,7 +107,7 @@ export function assertValueType(type: string): Function {
   return validate;
 }
 
-export function chain(...fns: Array<Function>): Function {
+export function chain(...fns) {
   function validate(...args) {
     for (let fn of fns) {
       fn(...args);
@@ -117,16 +117,7 @@ export function chain(...fns: Array<Function>): Function {
   return validate;
 }
 
-export default function defineType(
-  type: string,
-  opts: {
-    fields?: Object;
-    visitor?: Array<string>;
-    aliases?: Array<string>;
-    builder?: Array<string>;
-    inherits?: string;
-  } = {},
-) {
+export default function defineType(type, opts = {}) {
   let inherits = (opts.inherits && store[opts.inherits]) || {};
 
   opts.fields  = opts.fields || inherits.fields || {};
@@ -139,7 +130,7 @@ export default function defineType(
   }
 
   // ensure all field keys are represented in `fields`
-  for (let key of (opts.visitor.concat(opts.builder): Array<string>)) {
+  for (let key of opts.visitor.concat(opts.builder)) {
     opts.fields[key] = opts.fields[key] || {};
   }
 

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import defineType, { assertNodeType, assertValueType, chain, assertEach } from "./index";
 

--- a/packages/babel-types/src/definitions/misc.js
+++ b/packages/babel-types/src/definitions/misc.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import defineType, { assertNodeType } from "./index";
 

--- a/packages/babel-types/src/flow.js
+++ b/packages/babel-types/src/flow.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import * as t from "./index";
 
@@ -7,7 +6,7 @@ import * as t from "./index";
  * returns a `UnionTypeAnnotation` node containg them.
  */
 
-export function createUnionTypeAnnotation(types: Array<Object>) {
+export function createUnionTypeAnnotation(types) {
   let flattened  = removeTypeDuplicates(types);
 
   if (flattened.length === 1) {
@@ -21,7 +20,7 @@ export function createUnionTypeAnnotation(types: Array<Object>) {
  * Dedupe type annotations.
  */
 
-export function removeTypeDuplicates(nodes: Array<Object>): Array<Object> {
+export function removeTypeDuplicates(nodes) {
   let generics = {};
   let bases = {};
 
@@ -101,7 +100,7 @@ export function removeTypeDuplicates(nodes: Array<Object>): Array<Object> {
  * Create a type anotation based on typeof expression.
  */
 
-export function createTypeAnnotationBasedOnTypeof(type: string) {
+export function createTypeAnnotationBasedOnTypeof(type) {
   if (type === "string") {
     return t.stringTypeAnnotation();
   } else if (type === "number") {

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import toFastProperties from "to-fast-properties";
 import compact from "lodash/array/compact";
@@ -13,7 +12,7 @@ let t = exports;
  * Pass `skipAliasCheck` to force it to directly compare `node.type` with `type`.
  */
 
-function registerType(type: string) {
+function registerType(type) {
   let is = t[`is${type}`] = function (node, opts) {
     return t.is(type, node, opts);
   };
@@ -78,7 +77,7 @@ export const TYPES = Object.keys(t.VISITOR_KEYS)
  * Optionally, pass `skipAliasCheck` to directly compare `node.type` with `type`.
  */
 
-export function is(type: string, node: Object, opts?: Object): boolean {
+export function is(type, node, opts) {
   if (!node) return false;
 
   let matches = isType(node.type, type);
@@ -95,7 +94,7 @@ export function is(type: string, node: Object, opts?: Object): boolean {
  * Test if a `nodeType` is a `targetType` or if `targetType` is an alias of `nodeType`.
  */
 
-export function isType(nodeType: string, targetType: string): boolean {
+export function isType(nodeType, targetType) {
   if (nodeType === targetType) return true;
 
   let aliases: ?Array<string> = t.FLIPPED_ALIAS_KEYS[targetType];
@@ -128,7 +127,7 @@ each(t.BUILDER_KEYS, function (keys, type) {
 
     let i = 0;
 
-    for (let key of (keys: Array<string>)) {
+    for (let key of keys) {
       let field = t.NODE_FIELDS[type][key];
 
       let arg = arguments[i++];
@@ -171,7 +170,7 @@ for (let type in t.DEPRECATED_KEYS) {
  * Description
  */
 
-export function validate(node?: Object, key: string, val: any) {
+export function validate(node, key, val) {
   if (!node) return;
 
   let fields = t.NODE_FIELDS[node.type];
@@ -188,10 +187,10 @@ export function validate(node?: Object, key: string, val: any) {
  * Test if an object is shallowly equal.
  */
 
-export function shallowEqual(actual: Object, expected: Object): boolean {
+export function shallowEqual(actual, expected) {
   let keys = Object.keys(expected);
 
-  for (let key of (keys: Array<string>)) {
+  for (let key of keys) {
     if (actual[key] !== expected[key]) {
       return false;
     }
@@ -204,7 +203,7 @@ export function shallowEqual(actual: Object, expected: Object): boolean {
  * Append a node to a member expression.
  */
 
-export function appendToMemberExpression(member: Object, append: Object, computed?: boolean): Object {
+export function appendToMemberExpression(member, append, computed) {
   member.object   = t.memberExpression(member.object, member.property, member.computed);
   member.property = append;
   member.computed = !!computed;
@@ -215,7 +214,7 @@ export function appendToMemberExpression(member: Object, append: Object, compute
  * Prepend a node to a member expression.
  */
 
-export function prependToMemberExpression(member: Object, prepend: Object): Object {
+export function prependToMemberExpression(member, prepend) {
   member.object = t.memberExpression(prepend, member.object);
   return member;
 }
@@ -225,7 +224,7 @@ export function prependToMemberExpression(member: Object, prepend: Object): Obje
  * Casting it to a block if it is not.
  */
 
-export function ensureBlock(node: Object, key: string = "body"): Object {
+export function ensureBlock(node, key = "body") {
   return node[key] = t.toBlock(node[key], node);
 }
 
@@ -233,7 +232,7 @@ export function ensureBlock(node: Object, key: string = "body"): Object {
  * Create a shallow clone of a `node` excluding `_private` properties.
  */
 
-export function clone(node: Object): Object {
+export function clone(node) {
   let newNode = {};
   for (let key in node) {
     if (key[0] === "_") continue;
@@ -246,7 +245,7 @@ export function clone(node: Object): Object {
  * Create a shallow clone of a `node` excluding `_private` and location properties.
  */
 
-export function cloneWithoutLoc(node: Object): Object {
+export function cloneWithoutLoc(node) {
   let newNode = clone(node);
   delete newNode.loc;
   return newNode;
@@ -257,7 +256,7 @@ export function cloneWithoutLoc(node: Object): Object {
  * exluding `_private` properties.
  */
 
-export function cloneDeep(node: Object): Object {
+export function cloneDeep(node) {
   let newNode = {};
 
   for (let key in node) {
@@ -287,7 +286,7 @@ export function cloneDeep(node: Object): Object {
  * parsed nodes of `React.createClass` and `React["createClass"]`.
  */
 
-export function buildMatchMemberExpression(match:string, allowPartial?: boolean): Function {
+export function buildMatchMemberExpression(match, allowPartial) {
   let parts = match.split(".");
 
   return function (member) {
@@ -338,7 +337,7 @@ export function buildMatchMemberExpression(match:string, allowPartial?: boolean)
  * Remove comment properties from a node.
  */
 
-export function removeComments(node: Object): Object {
+export function removeComments(node) {
   for (let key of t.COMMENT_KEYS) {
     delete node[key];
   }
@@ -349,22 +348,22 @@ export function removeComments(node: Object): Object {
  * Inherit all unique comments from `parent` node to `child` node.
  */
 
-export function inheritsComments(child: Object, parent: Object): Object {
+export function inheritsComments(child, parent) {
   inheritTrailingComments(child, parent);
   inheritLeadingComments(child, parent);
   inheritInnerComments(child, parent);
   return child;
 }
 
-export function inheritTrailingComments(child: Object, parent: Object) {
+export function inheritTrailingComments(child, parent) {
   _inheritComments("trailingComments", child, parent);
 }
 
-export function inheritLeadingComments(child: Object, parent: Object) {
+export function inheritLeadingComments(child, parent) {
   _inheritComments("leadingComments", child, parent);
 }
 
-export function inheritInnerComments(child: Object, parent: Object) {
+export function inheritInnerComments(child, parent) {
   _inheritComments("innerComments", child, parent);
 }
 
@@ -378,11 +377,11 @@ function _inheritComments(key, child, parent) {
  * Inherit all contextual properties from `parent` node to `child` node.
  */
 
-export function inherits(child: Object, parent: Object): Object {
+export function inherits(child, parent) {
   if (!child || !parent) return child;
 
   // optionally inherit specific properties if not null
-  for (let key of (t.INHERIT_KEYS.optional: Array<string>)) {
+  for (let key of t.INHERIT_KEYS.optional) {
     if (child[key] == null) {
       child[key] = parent[key];
     }
@@ -394,7 +393,7 @@ export function inherits(child: Object, parent: Object): Object {
   }
 
   // force inherit select properties
-  for (let key of (t.INHERIT_KEYS.force: Array<string>)) {
+  for (let key of t.INHERIT_KEYS.force) {
     child[key] = parent[key];
   }
 
@@ -407,7 +406,7 @@ export function inherits(child: Object, parent: Object): Object {
  * TODO
  */
 
-export function assertNode(node?) {
+export function assertNode(node) {
   if (!isNode(node)) {
     // $FlowFixMe
     throw new TypeError("Not a valid node " + (node && node.type));
@@ -418,7 +417,7 @@ export function assertNode(node?) {
  * TODO
  */
 
-export function isNode(node?): boolean {
+export function isNode(node) {
   return !!(node && VISITOR_KEYS[node.type]);
 }
 

--- a/packages/babel-types/src/react.js
+++ b/packages/babel-types/src/react.js
@@ -1,17 +1,14 @@
-/* @flow */
+
 
 import * as t from "./index";
 
 export let isReactComponent = t.buildMatchMemberExpression("React.Component");
 
-export function isCompatTag(tagName?: string): boolean {
+export function isCompatTag(tagName) {
   return !!tagName && /^[a-z]|\-/.test(tagName);
 }
 
-function cleanJSXElementLiteralChild(
-  child: { value: string },
-  args: Array<Object>,
-) {
+function cleanJSXElementLiteralChild(child, args) {
   let lines = child.value.split(/\r\n|\n|\r/);
 
   let lastNonEmptyLine = 0;
@@ -56,7 +53,7 @@ function cleanJSXElementLiteralChild(
   if (str) args.push(t.stringLiteral(str));
 }
 
-export function buildChildren(node: Object): Array<Object> {
+export function buildChildren(node) {
   let elems = [];
 
   for (let i = 0; i < node.children.length; i++) {

--- a/packages/babel-types/src/retrievers.js
+++ b/packages/babel-types/src/retrievers.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import * as t from "./index";
 
@@ -6,11 +5,7 @@ import * as t from "./index";
  * Return a list of binding identifiers associated with the input `node`.
  */
 
-export function getBindingIdentifiers(
-  node: Object,
-  duplicates?: boolean,
-  outerOnly?: boolean
-): Object {
+export function getBindingIdentifiers(node, duplicates, outerOnly) {
   let search = [].concat(node);
   let ids    = Object.create(null);
 
@@ -107,9 +102,6 @@ getBindingIdentifiers.keys = {
   VariableDeclarator: ["id"]
 };
 
-export function getOuterBindingIdentifiers(
-  node: Object,
-  duplicates?: boolean,
-): Object {
+export function getOuterBindingIdentifiers(node, duplicates) {
   return getBindingIdentifiers(node, duplicates, true);
 }

--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint indent: 0 */
 
 import { getBindingIdentifiers } from "./retrievers";
@@ -10,7 +9,7 @@ import { BLOCK_SCOPED_SYMBOL } from "./constants";
  * Check if the input `node` is a binding identifier.
  */
 
-export function isBinding(node: Object, parent: Object): boolean {
+export function isBinding(node, parent) {
   let keys = getBindingIdentifiers.keys[parent.type];
   if (keys) {
     for (let i = 0; i < keys.length; i++) {
@@ -31,7 +30,7 @@ export function isBinding(node: Object, parent: Object): boolean {
  * Check if the input `node` is a reference to a bound variable.
  */
 
-export function isReferenced(node: Object, parent: Object): boolean {
+export function isReferenced(node, parent) {
   switch (parent.type) {
     // yes: object::NODE
     // yes: NODE::callee
@@ -74,7 +73,7 @@ export function isReferenced(node: Object, parent: Object): boolean {
     case "ArrowFunctionExpression":
     case "FunctionDeclaration":
     case "FunctionExpression":
-      for (let param of (parent.params: Array<any>)) {
+      for (let param of parent.params) {
         if (param === node) return false;
       }
 
@@ -162,7 +161,7 @@ export function isReferenced(node: Object, parent: Object): boolean {
  * and isn't a reserved word.
  */
 
-export function isValidIdentifier(name: string): boolean {
+export function isValidIdentifier(name) {
   if (typeof name !== "string" || esutils.keyword.isReservedWordES6(name, true)) {
     return false;
   } else {
@@ -174,7 +173,7 @@ export function isValidIdentifier(name: string): boolean {
  * Check if the input `node` is a `let` variable declaration.
  */
 
-export function isLet(node: Object): boolean {
+export function isLet(node) {
   return t.isVariableDeclaration(node) && (node.kind !== "var" || node[BLOCK_SCOPED_SYMBOL]);
 }
 
@@ -182,7 +181,7 @@ export function isLet(node: Object): boolean {
  * Check if the input `node` is block scoped.
  */
 
-export function isBlockScoped(node: Object): boolean {
+export function isBlockScoped(node) {
   return t.isFunctionDeclaration(node) || t.isClassDeclaration(node) || t.isLet(node);
 }
 
@@ -190,7 +189,7 @@ export function isBlockScoped(node: Object): boolean {
  * Check if the input `node` is a variable declaration.
  */
 
-export function isVar(node: Object): boolean {
+export function isVar(node) {
   return t.isVariableDeclaration(node, { kind: "var" }) && !node[BLOCK_SCOPED_SYMBOL];
 }
 
@@ -207,7 +206,7 @@ export function isSpecifierDefault(specifier: Object): boolean {
  * Check if the input `node` is a scope.
  */
 
-export function isScope(node: Object, parent: Object): boolean {
+export function isScope(node, parent) {
   if (t.isBlockStatement(node) && t.isFunction(parent, { body: node })) {
     return false;
   }
@@ -219,7 +218,7 @@ export function isScope(node: Object, parent: Object): boolean {
  * Check if the input `node` is definitely immutable.
  */
 
-export function isImmutable(node: Object): boolean {
+export function isImmutable(node) {
   if (t.isType(node.type, "Immutable")) return true;
 
   if (t.isIdentifier(node)) {

--- a/packages/babylon/src/options.js
+++ b/packages/babylon/src/options.js
@@ -1,15 +1,8 @@
-/* @flow */
 // A second optional argument can be given to further configure
 // the parser process. These options are recognized:
 
-export const defaultOptions: {
-  sourceType: string,
-  allowReturnOutsideFunction: boolean,
-  allowImportExportEverywhere: boolean,
-  allowSuperOutsideMethod: boolean,
-  plugins: Array<string>,
-  strictMode: any
-} = {
+
+export const defaultOptions = {
   // Source type ("script" or "module") for different semantics
   sourceType: "script",
   // When enabled, a return at the top level is not considered an
@@ -28,7 +21,7 @@ export const defaultOptions: {
 
 // Interpret and default an options object
 
-export function getOptions(opts?: Object): Object {
+export function getOptions(opts) {
   let options = {};
   for (let key in defaultOptions) {
     options[key] = opts && key in opts ? opts[key] : defaultOptions[key];

--- a/packages/babylon/src/parser/comments.js
+++ b/packages/babylon/src/parser/comments.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint max-len: 0 */
 
 /**
@@ -119,7 +118,7 @@ pp.processComment = function (node) {
       // result in an empty array, and if so, the array must be
       // deleted.
       node.leadingComments = this.state.leadingComments.slice(0, i);
-      if ((node.leadingComments: Array<any>).length === 0) {
+      if (node.leadingComments.length === 0) {
         node.leadingComments = null;
       }
 

--- a/packages/babylon/src/parser/index.js
+++ b/packages/babylon/src/parser/index.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import { reservedWords } from "../util/identifier";
 import { getOptions } from "../options";
@@ -7,7 +6,7 @@ import Tokenizer from "../tokenizer";
 export const plugins = {};
 
 export default class Parser extends Tokenizer {
-  constructor(options: Object, input: string) {
+  constructor(options, input) {
     options = getOptions(options);
     super(options, input);
 
@@ -23,15 +22,15 @@ export default class Parser extends Tokenizer {
     }
   }
 
-  hasPlugin(name: string): boolean {
+  hasPlugin(name) {
     return !!(this.plugins["*"] || this.plugins[name]);
   }
 
-  extend(name: string, f: Function) {
+  extend(name, f) {
     this[name] = f(this[name]);
   }
 
-  loadPlugins(plugins: Array<string>): Object {
+  loadPlugins(plugins) {
     let pluginMap = {};
 
     if (plugins.indexOf("flow") >= 0) {
@@ -52,13 +51,7 @@ export default class Parser extends Tokenizer {
     return pluginMap;
   }
 
-  parse(): {
-    type: "File",
-    program: {
-      type: "Program",
-      body: Array<Object>
-    }
-  } {
+  parse() {
     let file = this.startNode();
     let program = this.startNode();
     this.nextToken();

--- a/packages/babylon/src/parser/util.js
+++ b/packages/babylon/src/parser/util.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 import { types as tt } from "../tokenizer/types";
 import Parser from "./index";

--- a/packages/babylon/src/tokenizer/context.js
+++ b/packages/babylon/src/tokenizer/context.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 // The algorithm used to determine whether a regexp can appear at a
 // given point in the program is loosely based on sweet.js' approach.
@@ -8,27 +7,16 @@ import { types as tt } from "./types";
 import { lineBreak } from "../util/whitespace";
 
 export class TokContext {
-  constructor(
-    token: string,
-    isExpr?: boolean,
-    preserveSpace?: boolean,
-    override?: Function,
-  ) {
+  constructor(token, isExpr, preserveSpace, override) {
     this.token = token;
     this.isExpr = !!isExpr;
     this.preserveSpace = !!preserveSpace;
     this.override = override;
   }
 
-  token: string;
-  isExpr: boolean;
-  preserveSpace: boolean;
-  override: ?Function;
 }
 
-export const types: {
-  [key: string]: TokContext;
-} = {
+export const types = {
   b_stat: new TokContext("{", false),
   b_expr: new TokContext("{", true),
   b_tmpl: new TokContext("${", true),

--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -1,4 +1,3 @@
-import { isIdentifierStart, isIdentifierChar, isKeyword } from "../util/identifier";
 /* eslint max-len: 0 */
 /* eslint indent: 0 */
 

--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -1,8 +1,7 @@
-/* @noflow */
+import { isIdentifierStart, isIdentifierChar, isKeyword } from "../util/identifier";
 /* eslint max-len: 0 */
 /* eslint indent: 0 */
 
-import type { TokenType } from "./types";
 import { isIdentifierStart, isIdentifierChar, isKeyword } from "../util/identifier";
 import { types as tt, keywords as keywordTypes } from "./types";
 import { types as ct } from "./context";
@@ -23,11 +22,6 @@ export class Token {
     this.loc = new SourceLocation(state.startLoc, state.endLoc);
   }
 
-  type: TokenType;
-  value: any;
-  start: number;
-  end: number;
-  loc: SourceLocation;
 }
 
 // ## Tokenizer

--- a/packages/babylon/src/util/whitespace.js
+++ b/packages/babylon/src/util/whitespace.js
@@ -1,4 +1,3 @@
-/* @flow */
 
 // Matches a whole line break (where CRLF is considered a single
 // line break). Used to count lines.
@@ -6,7 +5,7 @@
 export const lineBreak = /\r\n?|\n|\u2028|\u2029/;
 export const lineBreakG = new RegExp(lineBreak.source, "g");
 
-export function isNewLine(code: number): boolean {
+export function isNewLine(code) {
   return code === 10 || code === 13 || code === 0x2028 || code === 0x2029;
 }
 


### PR DESCRIPTION
It pains me to do this, but currently the `@flow` files in Babel cause type errors for people using Flow in their own project with babel in their node_modules.

I considered just changing `@flow` to `@noflow`, but I noticed a few things that made me choose this route instead:

* There is no `.flowconfig` in this project. Without using Flow as part of the dev/test pipeline, it's pretty likely that more Flow errors will be introduced in the future.
* Many of the existing annotations have low value. [`Object`](http://flowtype.org/docs/quick-reference.html#the-object-type) and [`Function`](http://flowtype.org/docs/quick-reference.html#the-function-type) are pervasive, but these types are quite weak in practice.

I think that Flow could provide a ton of value to Babel. In particular, a disjoint union type representing the AST would be great. I think an effort to Flow-ify the source should restart from first principles. I'd be happy to collaborate on that effort.

Until then, it's hurting Flow/Babel users to have things the way they are.