### PR TITLE
Fix: invalid codegen for non decimal numeric literals in MemberExpression

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -8,6 +8,7 @@ import * as n from "../node";
 
 const SCIENTIFIC_NOTATION = /e/i;
 const ZERO_DECIMAL_INTEGER = /\.0+$/;
+const NON_DECIMAL_LITERAL = /^0[box]/;
 
 export function UnaryExpression(node: Object) {
   let needsSpace = /[a-z]$/.test(node.operator);
@@ -225,7 +226,11 @@ export function MemberExpression(node: Object) {
   } else {
     if (t.isNumericLiteral(node.object)) {
       let val = this.getPossibleRaw(node.object) || node.object.value;
-      if (isInteger(+val) && !SCIENTIFIC_NOTATION.test(val) && !ZERO_DECIMAL_INTEGER.test(val) && !this.endsWith(".")) {
+      if (isInteger(+val) &&
+        !NON_DECIMAL_LITERAL.test(val) &&
+        !SCIENTIFIC_NOTATION.test(val) &&
+        !ZERO_DECIMAL_INTEGER.test(val) &&
+        !this.endsWith(".")) {
         this.push(".");
       }
     }

--- a/packages/babel-generator/test/fixtures/edgecase/member-expression-numeric-literals/actual.js
+++ b/packages/babel-generator/test/fixtures/edgecase/member-expression-numeric-literals/actual.js
@@ -1,0 +1,5 @@
+1..toString;
+2..toString();
+0x1F7.toString();
+0b111110111.toString();
+0o767.toString();

--- a/packages/babel-generator/test/fixtures/edgecase/member-expression-numeric-literals/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/member-expression-numeric-literals/expected.js
@@ -1,0 +1,5 @@
+1..toString;
+2..toString();
+0x1F7.toString();
+0b111110111.toString();
+0o767.toString();


### PR DESCRIPTION
Similar to https://github.com/babel/babel/pull/3170

Bug: `(0xFFFF).toString() ---> 0xFFFF..toString()`

cc @tolmasky