### PR TITLE
Fix named async FunctionExpression scoping issue.

### DIFF
--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
@@ -2,7 +2,10 @@ var foo = function () {
   var ref = babelHelpers.asyncToGenerator(function* () {
     console.log(bar);
   });
-  return function bar() {
+
+  function bar() {
     return ref.apply(this, arguments);
-  };
+  }
+
+  return bar;
 }();

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/named-expression/expected.js
@@ -4,7 +4,9 @@ var foo = function () {
     console.log(bar);
   });
 
-  return function bar() {
+  function bar() {
     return ref.apply(this, arguments);
-  };
+  }
+
+  return bar;
 }();


### PR DESCRIPTION
Fixed the issue with named function expressions. `async-to-generator/named-expression` test case is invalid - the code in `expected.js` would not run properly. Instead, `foo` would return rejected `Promise` with `ReferenceError: bar is not defined`. The problem is that the name `bar` of `FunctionExpression` is only visible inside that function, not in `foo` or `ref`.

Unfortunately I didn't find a way to create asynchronous test to demonstrate the issue without modifying underlying test runner.
The test case would be
```javascript
//import assert from 'assert';

var foo = async function bar() {
	assert.equal(foo, bar);
};

assert.equal(typeof bar, 'undefined');

foo()
	//.then(r => { console.log(r) }, e => { console.error(e instanceof Error ? e.stack : 'Error: ' + e); })
	.then(done, done);
```