### PR TITLE
Revert .requeue changes made in earlier ES3 fixes.

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -258,6 +258,11 @@ export default function () {
                 }
               } else {
                 path.replaceWith(buildExportsAssignment(t.identifier("default"), declaration.node));
+
+                // Manualy re-queue `export default foo;` expressions so that the ES3 transform
+                // has an opportunity to convert them. Ideally this would happen automatically from the
+                // replaceWith above. See T7166 for more info.
+                path.parentPath.requeue(path.get("expression.left"));
               }
             } else if (path.isExportNamedDeclaration()) {
               let declaration = path.get("declaration");

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -211,7 +211,10 @@ export function setKey(key) {
 export function requeue(pathToQueue = this) {
   if (pathToQueue.removed) return;
 
-  let contexts = this._getQueueContexts();
+  // TODO(loganfsmyth): This should be switched back to queue in parent contexts
+  // automatically once T2892 and T7160 have been resolved. See T7166.
+  // let contexts = this._getQueueContexts();
+  let contexts = this.contexts;
 
   for (let context of contexts) {
     context.maybeQueue(pathToQueue);


### PR DESCRIPTION
This reverts my `.requeue` change from https://github.com/babel/babel/pull/3368 in favor of explicitly requeuing in the parent for now. I've files a task to investigate a better fix for this.