### PR TITLE
Ensure that the found context is active before pushing it.

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/actual.js
@@ -1,0 +1,6 @@
+import foo from 'foo';
+import { something } from 'bar';
+
+const anything = {};
+
+export * from 'bar';

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _bar = require('bar');
+
+var _loop = function (_key2) {
+  if (_key2 === "default") return 'continue';
+  Object.defineProperty(exports, _key2, {
+    enumerable: true,
+    get: function () {
+      return _bar[_key2];
+    }
+  });
+};
+
+for (var _key2 in _bar) {
+  var _ret = _loop(_key2);
+
+  if (_ret === 'continue') continue;
+}
+
+var _foo = require('foo');
+
+var _foo2 = _interopRequireDefault(_foo);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var anything = {};

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-es2015-block-scoping",
+    "transform-es2015-modules-commonjs"
+  ]
+}

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -47,7 +47,11 @@ export function _containerInsert(from, nodes) {
 
     if (this.context) {
       let path = this.context.create(this.parent, this.container, to, this.listKey);
-      path.pushContext(this.context);
+
+      // While this path may have a context, there is currently no guarantee that the context
+      // will be the active context, because `popContext` may leave a final context in place.
+      // We should remove this `if` and always push once T7171 has been resolved.
+      if (this.context.queue) path.pushContext(this.context);
       paths.push(path);
     } else {
       paths.push(NodePath.get({


### PR DESCRIPTION
I don't think this is the best long-term fix, but it's the best middle-ground that should fix the current issue without risking introducing others.

This fixes https://phabricator.babeljs.io/T7165

I filed https://phabricator.babeljs.io/T7171 to track a better long-term fix.