### PR TITLE
Expose plugins record to the outer world

### DIFF
--- a/packages/babylon/src/index.js
+++ b/packages/babylon/src/index.js
@@ -20,4 +20,4 @@ export function parse(input, options) {
   return new Parser(options, input).parse();
 }
 
-export { tokTypes };
+export { tokTypes, plugins };


### PR DESCRIPTION
I was experimenting with babel, and found that there is no way to declare my own babylon plugin. Both of jsx and flow plugins are hardcoded.

Even though there could be a better way to expose babylon API, the exposed plugins record will provide the ability at least to experiment with a syntax.

```js
import {plugins, tokTypes as tt} from 'babylon';
import {transform} from 'babel-core';

plugins.data = instance => {
  instance.extend('parseExpressionStatement', inner => function (node, expr) {
    this.unexpected();
  });
};

const dataSyntaxPlugin = () => ({
  manipulateOptions(_, parserOpts) {
    parserOpts.plugins.push('data');
  }
});

const result = transform(
  'data Maybe(a) = Nothing | Just(a);',
  {
    plugins: [dataSyntaxPlugin]
  }
);
```

If you want to make babylon's API public using the other way, I'd be happy to contribute. Do you have any thought on the subject?
