### PR TITLE
Make buildExportAll generate pure ES5 code.

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
@@ -4,17 +4,15 @@ define(["exports", "foo"], function (exports, _foo) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-
-  for (let _key in _foo) {
-    if (_key === "default") continue;
-    Object.defineProperty(exports, _key, {
+  Object.keys(_foo).forEach(function (key) {
+    if (key === "default") return;
+    Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {
-        return _foo[_key];
+        return _foo[key];
       }
     });
-  }
-
+  });
   Object.defineProperty(exports, "foo", {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -32,16 +32,15 @@ let buildExportsAssignment = template(`
 `);
 
 let buildExportAll = template(`
-  for (let KEY in OBJECT) {
-    if (KEY === "default") continue;
-
-    Object.defineProperty(exports, KEY, {
+  Object.keys(OBJECT).forEach(function (key) {
+    if (key === "default") return;
+    Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {
-        return OBJECT[KEY];
+        return OBJECT[key];
       }
     });
-  }
+  });
 `);
 
 const THIS_BREAK_KEYS = ["FunctionExpression", "FunctionDeclaration", "ClassProperty", "ClassMethod", "ObjectMethod"];
@@ -335,7 +334,6 @@ export default function () {
               }
             } else if (path.isExportAllDeclaration()) {
               topNodes.push(buildExportAll({
-                KEY: path.scope.generateUidIdentifier("key"),
                 OBJECT: addRequire(path.node.source.value, path.node._blockHoist)
               }));
               path.remove();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
@@ -6,16 +6,15 @@ Object.defineProperty(exports, "__esModule", {
 
 var _foo = require("foo");
 
-for (let _key in _foo) {
-  if (_key === "default") continue;
-  Object.defineProperty(exports, _key, {
+Object.keys(_foo).forEach(function (key) {
+  if (key === "default") return;
+  Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {
-      return _foo[_key];
+      return _foo[key];
     }
   });
-}
-
+});
 Object.defineProperty(exports, "foo", {
   enumerable: true,
   get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
@@ -6,21 +6,15 @@ Object.defineProperty(exports, "__esModule", {
 
 var _bar = require('bar');
 
-var _loop = function (_key2) {
-  if (_key2 === "default") return 'continue';
-  Object.defineProperty(exports, _key2, {
+Object.keys(_bar).forEach(function (key) {
+  if (key === "default") return;
+  Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {
-      return _bar[_key2];
+      return _bar[key];
     }
   });
-};
-
-for (var _key2 in _bar) {
-  var _ret = _loop(_key2);
-
-  if (_ret === 'continue') continue;
-}
+});
 
 var _foo = require('foo');
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
@@ -6,18 +6,12 @@ Object.defineProperty(exports, "__esModule", {
 
 var _mod = require('mod');
 
-var _loop = function (_key2) {
-  if (_key2 === "default") return 'continue';
-  Object.defineProperty(exports, _key2, {
+Object.keys(_mod).forEach(function (key) {
+  if (key === "default") return;
+  Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {
-      return _mod[_key2];
+      return _mod[key];
     }
   });
-};
-
-for (var _key2 in _mod) {
-  var _ret = _loop(_key2);
-
-  if (_ret === 'continue') continue;
-}
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
@@ -16,17 +16,15 @@
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-
-  for (let _key in _foo) {
-    if (_key === "default") continue;
-    Object.defineProperty(exports, _key, {
+  Object.keys(_foo).forEach(function (key) {
+    if (key === "default") return;
+    Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {
-        return _foo[_key];
+        return _foo[key];
       }
     });
-  }
-
+  });
   Object.defineProperty(exports, "foo", {
     enumerable: true,
     get: function () {


### PR DESCRIPTION
The untransformed `let` keyword causes problems for older parsers. I understand using `let` instead of `var` ensures each getter function has its own binding for the `KEY` variable, but the same can be accomplished (with less code) using a `.forEach` callback function, and this way there's no need to worry about generating a unique name for the `key` variable.