### PR TITLE
Fix T7183: Object accessors after computed property were broken

### DIFF
--- a/packages/babel-plugin-transform-es2015-computed-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/src/index.js
@@ -27,9 +27,9 @@ export default function ({ types: t, template }) {
   }
 
   function pushMutatorDefine({ objId, body, getMutatorId, scope }, prop) {
-    let key = prop.key;
+    let key = !prop.computed && t.isIdentifier(prop.key) ? t.stringLiteral(prop.key.name) : prop.key;
 
-    let maybeMemoise = scope.maybeGenerateMemoised(prop.key);
+    let maybeMemoise = scope.maybeGenerateMemoised(key);
     if (maybeMemoise) {
       body.push(t.expressionStatement(t.assignmentExpression("=", maybeMemoise, key)));
       key = maybeMemoise;

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/accessors/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/accessors/actual.js
@@ -1,0 +1,14 @@
+var obj = {
+  get [foobar]() {
+    return "foobar";
+  },
+  set [foobar](x) {
+    console.log(x);
+  },
+  get test() {
+    return "regular getter after computed property";
+  },
+  set "test"(x) {
+    console.log(x);
+  }
+};

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/accessors/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/accessors/expected.js
@@ -1,0 +1,11 @@
+var _foobar, _foobar2, _test, _test2, _obj, _mutatorMap;
+
+var obj = (_obj = {}, _foobar = foobar, _mutatorMap = {}, _mutatorMap[_foobar] = _mutatorMap[_foobar] || {}, _mutatorMap[_foobar].get = function () {
+  return "foobar";
+}, _foobar2 = foobar, _mutatorMap[_foobar2] = _mutatorMap[_foobar2] || {}, _mutatorMap[_foobar2].set = function (x) {
+  console.log(x);
+}, _test = "test", _mutatorMap[_test] = _mutatorMap[_test] || {}, _mutatorMap[_test].get = function () {
+  return "regular getter after computed property";
+}, _test2 = "test", _mutatorMap[_test2] = _mutatorMap[_test2] || {}, _mutatorMap[_test2].set = function (x) {
+  console.log(x);
+}, babelHelpers.defineEnumerableProperties(_obj, _mutatorMap), _obj);

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/method/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/method/actual.js
@@ -1,5 +1,8 @@
 var obj = {
   [foobar]() {
     return "foobar";
+  },
+  test() {
+    return "regular method after computed property";
   }
 };

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/method/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/method/expected.js
@@ -2,4 +2,6 @@ var _obj;
 
 var obj = (_obj = {}, _obj[foobar] = function () {
   return "foobar";
+}, _obj.test = function () {
+  return "regular method after computed property";
 }, _obj);

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/accessors/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/accessors/actual.js
@@ -1,0 +1,14 @@
+var obj = {
+  get [foobar]() {
+    return "foobar";
+  },
+  set [foobar](x) {
+    console.log(x);
+  },
+  get test() {
+    return "regular getter after computed property";
+  },
+  set "test"(x) {
+    console.log(x);
+  }
+};

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/accessors/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/accessors/expected.js
@@ -1,0 +1,11 @@
+var _foobar, _foobar2, _test, _test2, _obj, _mutatorMap;
+
+var obj = (_obj = {}, _foobar = foobar, _mutatorMap = {}, _mutatorMap[_foobar] = _mutatorMap[_foobar] || {}, _mutatorMap[_foobar].get = function () {
+  return "foobar";
+}, _foobar2 = foobar, _mutatorMap[_foobar2] = _mutatorMap[_foobar2] || {}, _mutatorMap[_foobar2].set = function (x) {
+  console.log(x);
+}, _test = "test", _mutatorMap[_test] = _mutatorMap[_test] || {}, _mutatorMap[_test].get = function () {
+  return "regular getter after computed property";
+}, _test2 = "test", _mutatorMap[_test2] = _mutatorMap[_test2] || {}, _mutatorMap[_test2].set = function (x) {
+  console.log(x);
+}, babelHelpers.defineEnumerableProperties(_obj, _mutatorMap), _obj);

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/method/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/method/actual.js
@@ -1,5 +1,8 @@
 var obj = {
   [foobar]() {
     return "foobar";
+  },
+  test() {
+    return "regular method after computed property";
   }
 };

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/method/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/method/expected.js
@@ -1,3 +1,7 @@
-var obj = babelHelpers.defineProperty({}, foobar, function () {
+var _obj;
+
+var obj = (_obj = {}, babelHelpers.defineProperty(_obj, foobar, function () {
   return "foobar";
-});
+}), babelHelpers.defineProperty(_obj, "test", function () {
+  return "regular method after computed property";
+}), _obj);


### PR DESCRIPTION
[T7183](https://phabricator.babeljs.io/T7183): Regular non-quoted object accessors after computed properties in an object literal resulted in broken code.

I've added some tests for the issue, made an existing test a little more exhaustive.

Someone will need to double-check my logic. I'm not very familiar with this code.