### PR TITLE
use flow instead of flow-comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,14 +45,11 @@
     "loose": [
       "all"
     ],
-    "plugins": [
-      "flow-comments"
-    ],
     "blacklist": [
-      "flow",
       "es6.tailCall"
     ],
     "optional": [
+      "flow",
       "optimisation.flow.forOf",
       "runtime"
     ],

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1130/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1130/expected.js
@@ -1,7 +1,7 @@
 function A() {
-  var a = undefined;
+  var a = void 0;
 }
 
 function B() {
-  var a = undefined;
+  var a = void 0;
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-return-undefined/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-return-undefined/expected.js
@@ -4,7 +4,7 @@
       return i;
     });
     return {
-      v: undefined
+      v: void 0
     };
   };
 

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/loop-initializer-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/loop-initializer-default/expected.js
@@ -1,5 +1,5 @@
 while (value) {
-  var foo = undefined;
+  var foo = void 0;
 
   if (bar) {
     foo = [];

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
@@ -22,8 +22,8 @@ var Foo = function (_Bar) {
 var ConstructorScoping = function ConstructorScoping() {
   babelHelpers.classCallCheck(this, ConstructorScoping);
 
-  var bar = undefined;
+  var bar = void 0;
   {
-    var _bar = undefined;
+    var _bar = void 0;
   }
 };


### PR DESCRIPTION
Ok should of looked at the issues: https://github.com/babel-plugins/babel-plugin-flow-comments/issues/21

TD;LR flow-comments has a bug in that it's removing class properties (running before class properties transform?)

```js
 buildUndefinedNode() {
    if (this.hasBinding("undefined")) {
      return t.unaryExpression("void", t.numericLiteral(0), true);
    } else {
      return t.identifier("undefined");
    }
  }
```

So `this.hasBinding("undefined")` is evaluating to true with flow but not with flow-comments

https://github.com/babel/babel/blob/92ed05640c7e244671126ab0166e29702e8c16d9/packages/babel-traverse/src/scope/index.js#L480-L486


`Scope.globals` is undefined

We are using class properties in `babel-traverse/src/scope`: https://github.com/babel/babel/blob/92ed05640c7e244671126ab0166e29702e8c16d9/packages/babel-traverse/src/scope/index.js#L194-L205

` static globals = Object.keys(globals.builtin);`

with flow-comments it is removed so Scope.globals is undefined so it causes the different test output.