### PR TITLE
Add breakConfig option to babel's own babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
       "test": {
         "auxiliaryCommentBefore": "istanbul ignore next"
       }
-    }
+    },
+    "breakConfig": true
   }
 }


### PR DESCRIPTION
The lack of this option is causing `make bootstrap` to fail when I run it on my local clone of babel (which I have as a git submodule inside a repo that includes a Babel 6 config). I keep getting "Unknown option" errors because it's trying to inherit from my Babel 6 config.