### PR TITLE
Fix shadow function processing for async functions

### DIFF
--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -19,7 +19,7 @@ function shouldShadow(path, shadowPath) {
   if (path.is("_forceShadow")) {
     return true;
   } else {
-    return shadowPath && !shadowPath.isArrowFunctionExpression();
+    return shadowPath;
   }
 }
 
@@ -39,7 +39,7 @@ function remap(path, key, create) {
 
     if (path.isProgram()) {
       return true;
-    } else if (path.isFunction()) {
+    } else if (path.isFunction() && !path.isArrowFunctionExpression()) {
       if (shadowFunction) {
         return path === shadowFunction || path.node === shadowFunction.node;
       } else {

--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -29,6 +29,7 @@ function remap(path, key, create) {
   if (!shouldShadow(path, shadowPath)) return;
 
   let shadowFunction = path.node._shadowedFunctionLiteral;
+
   let currentFunction;
   let passedShadowFunction = false;
 
@@ -55,6 +56,13 @@ function remap(path, key, create) {
 
     return false;
   });
+
+  if (shadowFunction && fnPath.isProgram() && !shadowFunction.isProgram()){
+    // If the shadow wasn't found, take the closest function as a backup.
+    // This is a bit of a hack, but it will allow the parameter transforms to work properly
+    // without introducing yet another shadow-controlling flag.
+    fnPath = path.findParent((p) => p.isProgram() || p.isFunction());
+  }
 
   // no point in realiasing if we're in this function
   if (fnPath === currentFunction) return;

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -6,7 +6,7 @@ import template from "babel-template";
 import * as t from "babel-types";
 
 let buildWrapper = template(`
-  (function () {
+  (() => {
     var ref = FUNCTION;
     return function NAME(PARAMS) {
       return ref.apply(this, arguments);
@@ -15,21 +15,12 @@ let buildWrapper = template(`
 `);
 
 let namedBuildWrapper = template(`
-  (function () {
+  (() => {
     var ref = FUNCTION;
     function NAME(PARAMS) {
       return ref.apply(this, arguments);
     }
     return NAME;
-  })
-`);
-
-let arrowBuildWrapper =  template(`
-  (() => {
-    var ref = FUNCTION, _this = this;
-    return function(PARAMS) {
-      return ref.apply(_this, arguments);
-    };
   })
 `);
 
@@ -69,19 +60,12 @@ function plainFunction(path: NodePath, callId: Object) {
 
   if (path.isArrowFunctionExpression()) {
     path.arrowFunctionToShadowed();
-    wrapper = arrowBuildWrapper;
   } else if (!isDeclaration && asyncFnId) {
     wrapper = namedBuildWrapper;
   }
 
   node.async = false;
   node.generator = true;
-  // Either the wrapped generator is invoked with `.apply(this, arguments)` or it has no params,
-  // so it should capture `arguments`
-  if (node.shadow) {
-    // node.shadow may be `true` or an object
-    node.shadow = Object.assign({}, node.shadow, { arguments: false });
-  }
 
   node.id = null;
 

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -20,11 +20,7 @@ function isMemberExpressionSuper(node) {
 }
 
 let visitor = {
-  "ObjectMethod|ClassMethod"(path) {
-    path.skip();
-  },
-
-  "FunctionDeclaration|FunctionExpression"(path) {
+  Function(path) {
     if (!path.inShadow("this")) {
       path.skip();
     }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
@@ -2,17 +2,15 @@ let TestClass = {
   name: "John Doe",
 
   testMethodFailure() {
+    var _this = this;
+
     return new Promise((() => {
-      var _this2 = this;
-
       var ref = babelHelpers.asyncToGenerator(function* (resolve) {
-        console.log(_this2);
+        console.log(_this);
         setTimeout(resolve, 1000);
-      }),
-          _this = this;
-
+      });
       return function (_x) {
-        return ref.apply(_this, arguments);
+        return ref.apply(this, arguments);
       };
     })());
   }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/actual.js
@@ -1,11 +1,13 @@
-async function s(x) {
+async function s(x, ...args) {
   let t = async (y, a) => {
-    let r = async (z, b) =>  {
+    let r = async (z, b, ...innerArgs) =>  {
       await z;
+      console.log(this, innerArgs, arguments);
       return this.x;
     }
     await r();
 
+    console.log(this, args, arguments);
     return this.g(r);
   }
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
@@ -1,17 +1,15 @@
 let s = function () {
   var ref = babelHelpers.asyncToGenerator(function* (x) {
-    let t = (() => {
-      var _this3 = this;
+    var _this2 = this;
 
+    let t = (() => {
       var ref = babelHelpers.asyncToGenerator(function* (y, a) {
         let r = (() => {
-          var _this2 = this;
-
           var ref = babelHelpers.asyncToGenerator(function* (z, b) {
             yield z;
             return _this2.x;
           }),
-              _this = this;
+              _this = _this2;
 
           return function r(_x4, _x5) {
             return ref.apply(_this, arguments);
@@ -19,10 +17,9 @@ let s = function () {
         })();
         yield r();
 
-        return _this3.g(r);
+        return _this2.g(r);
       }),
           _this = this;
-
       return function t(_x2, _x3) {
         return ref.apply(_this, arguments);
       };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
@@ -1,27 +1,24 @@
-let s = function () {
+let s = (() => {
   var ref = babelHelpers.asyncToGenerator(function* (x) {
-    var _this2 = this;
+    var _this = this;
 
     let t = (() => {
       var ref = babelHelpers.asyncToGenerator(function* (y, a) {
         let r = (() => {
           var ref = babelHelpers.asyncToGenerator(function* (z, b) {
             yield z;
-            return _this2.x;
-          }),
-              _this = _this2;
-
+            return _this.x;
+          });
           return function r(_x4, _x5) {
-            return ref.apply(_this, arguments);
+            return ref.apply(this, arguments);
           };
         })();
         yield r();
 
-        return _this2.g(r);
-      }),
-          _this = this;
+        return _this.g(r);
+      });
       return function t(_x2, _x3) {
-        return ref.apply(_this, arguments);
+        return ref.apply(this, arguments);
       };
     })();
 
@@ -31,4 +28,4 @@ let s = function () {
   return function s(_x) {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
@@ -1,12 +1,22 @@
 let s = (() => {
   var ref = babelHelpers.asyncToGenerator(function* (x) {
-    var _this = this;
+    var _this = this,
+        _arguments = arguments;
+
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
 
     let t = (() => {
       var ref = babelHelpers.asyncToGenerator(function* (y, a) {
         let r = (() => {
           var ref = babelHelpers.asyncToGenerator(function* (z, b) {
+            for (var _len2 = arguments.length, innerArgs = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+              innerArgs[_key2 - 2] = arguments[_key2];
+            }
+
             yield z;
+            console.log(_this, innerArgs, _arguments);
             return _this.x;
           });
           return function r(_x4, _x5) {
@@ -15,6 +25,7 @@ let s = (() => {
         })();
         yield r();
 
+        console.log(_this, args, _arguments);
         return _this.g(r);
       });
       return function t(_x2, _x3) {

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/expected.js
@@ -1,8 +1,8 @@
-var foo = function () {
+var foo = (() => {
   var ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
   return function foo() {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
@@ -1,4 +1,4 @@
-var foo = function () {
+var foo = (() => {
   var ref = babelHelpers.asyncToGenerator(function* () {
     console.log(bar);
   });
@@ -8,4 +8,4 @@ var foo = function () {
   }
 
   return bar;
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/options.json
@@ -1,3 +1,7 @@
 {
-  "plugins": ["external-helpers", "transform-async-to-generator"]
+  "plugins": [
+    "external-helpers",
+    "transform-es2015-parameters",
+    "transform-async-to-generator"
+  ]
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/expected.js
@@ -1,6 +1,6 @@
-let foo = function () {
+let foo = (() => {
   var ref = babelHelpers.asyncToGenerator(function* (bar) {});
   return function foo(_x) {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
@@ -1,8 +1,8 @@
-let foo = function () {
+let foo = (() => {
   var ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
   return function foo() {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -5,12 +5,12 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.foo = undefined;
 
-let foo = exports.foo = function () {
+let foo = exports.foo = (() => {
   var ref = babelHelpers.asyncToGenerator(function* () {});
   return function foo() {
     return ref.apply(this, arguments);
   };
-}();
+})();
 
 var _bar = require('bar');
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
@@ -4,9 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-let foo = exports.foo = function () {
+let foo = exports.foo = (() => {
   var ref = babelHelpers.asyncToGenerator(function* () {});
   return function foo() {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T6882/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T6882/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "transform-es2015-block-scoping",
+    "transform-es2015-arrow-functions",
+    "transform-regenerator"
+  ]
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/actual.js
@@ -1,0 +1,33 @@
+class Test{
+  static async method1() {
+    console.log(this);
+
+    setTimeout(async () => {
+      console.log(this);
+    });
+  }
+
+  static async method2() {
+    console.log(this);
+
+    setTimeout(async (arg) => {
+      console.log(this);
+    });
+  }
+
+  async method1() {
+    console.log(this);
+
+    setTimeout(async () => {
+      console.log(this);
+    });
+  }
+
+  async method2() {
+    console.log(this);
+
+    setTimeout(async (arg) => {
+      console.log(this);
+    });
+  }
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
@@ -1,0 +1,61 @@
+class Test {
+  static method1() {
+    var _this = this;
+
+    return babelHelpers.asyncToGenerator(function* () {
+      console.log(_this);
+
+      setTimeout(babelHelpers.asyncToGenerator(function* () {
+        console.log(_this);
+      }));
+    })();
+  }
+
+  static method2() {
+    var _this2 = this;
+
+    return babelHelpers.asyncToGenerator(function* () {
+      console.log(_this2);
+
+      setTimeout((() => {
+        var ref = babelHelpers.asyncToGenerator(function* (arg) {
+          console.log(_this2);
+        }),
+            _this = _this2;
+        return function (_x) {
+          return ref.apply(_this, arguments);
+        };
+      })());
+    })();
+  }
+
+  method1() {
+    var _this3 = this;
+
+    return babelHelpers.asyncToGenerator(function* () {
+      console.log(_this3);
+
+      setTimeout(babelHelpers.asyncToGenerator(function* () {
+        console.log(_this3);
+      }));
+    })();
+  }
+
+  method2() {
+    var _this4 = this;
+
+    return babelHelpers.asyncToGenerator(function* () {
+      console.log(_this4);
+
+      setTimeout((() => {
+        var ref = babelHelpers.asyncToGenerator(function* (arg) {
+          console.log(_this4);
+        }),
+            _this = _this4;
+        return function (_x2) {
+          return ref.apply(_this, arguments);
+        };
+      })());
+    })();
+  }
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
@@ -20,10 +20,9 @@ class Test {
       setTimeout((() => {
         var ref = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this2);
-        }),
-            _this = _this2;
+        });
         return function (_x) {
-          return ref.apply(_this, arguments);
+          return ref.apply(this, arguments);
         };
       })());
     })();
@@ -50,10 +49,9 @@ class Test {
       setTimeout((() => {
         var ref = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this4);
-        }),
-            _this = _this4;
+        });
         return function (_x2) {
-          return ref.apply(_this, arguments);
+          return ref.apply(this, arguments);
         };
       })());
     })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": ["external-helpers", "transform-es2015-block-scoping", "transform-regenerator", "transform-async-to-generator"]
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator"
+  ]
 }

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/expression/expected.js
@@ -1,5 +1,5 @@
 import { coroutine as _coroutine } from "bluebird";
-var foo = function () {
+var foo = (() => {
   var ref = _coroutine(function* () {
     var wat = yield bar();
   });
@@ -7,4 +7,4 @@ var foo = function () {
   return function foo() {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/named-expression/expected.js
@@ -1,5 +1,5 @@
 import { coroutine as _coroutine } from "bluebird";
-var foo = function () {
+var foo = (() => {
   var ref = _coroutine(function* () {
     console.log(bar);
   });
@@ -9,4 +9,4 @@ var foo = function () {
   }
 
   return bar;
-}();
+})();

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/statement/expected.js
@@ -1,6 +1,6 @@
 import { coroutine as _coroutine } from "bluebird";
 
-let foo = function () {
+let foo = (() => {
   var ref = _coroutine(function* () {
     var wat = yield bar();
   });
@@ -8,4 +8,4 @@ let foo = function () {
   return function foo() {
     return ref.apply(this, arguments);
   };
-}();
+})();

--- a/packages/babel-traverse/src/path/ancestry.js
+++ b/packages/babel-traverse/src/path/ancestry.js
@@ -213,7 +213,11 @@ export function inType() {
  * - _forceShadow - If truthy, this specific identifier will be bound in the closest
  *    Function that is not flagged "shadow", or the Program.
  * - _shadowedFunctionLiteral - When set to a NodePath, this specific identifier will be bound
- *    to this NodePath/Node or the Program.
+ *    to this NodePath/Node or the Program. If this path is not found relative to the
+ *    starting location path, the closest function will be used.
+ *
+ * Please Note, these flags are for private internal use only and should be avoided.
+ * Only "shadow" is a public property that other transforms may manipulate.
  */
 
 export function inShadow(key?) {

--- a/packages/babel-traverse/src/path/ancestry.js
+++ b/packages/babel-traverse/src/path/ancestry.js
@@ -220,14 +220,15 @@ export function inShadow(key?) {
   let parentFn = this.isFunction() ? this : this.findParent((p) => p.isFunction());
   if (!parentFn) return;
 
-  let shadow = parentFn.node.shadow;
-  if (shadow) {
+  if (parentFn.isFunctionExpression() || parentFn.isFunctionDeclaration()) {
+    let shadow = parentFn.node.shadow;
+
     // this is because sometimes we may have a `shadow` value of:
     //
     //   { this: false }
     //
     // we need to catch this case if `inShadow` has been passed a `key`
-    if (!key || shadow[key] !== false) {
+    if (shadow && (!key || shadow[key] !== false)) {
       return parentFn;
     }
   } else if (parentFn.isArrowFunctionExpression()) {


### PR DESCRIPTION
This reverts and re-implements some of the work done in https://github.com/babel/babel/pull/3336 because while that fixed the rest params, it broke the ability to use `arguments` in your own code, since it would resolve to the arrow function rather than the outer function.

Also fixed https://phabricator.babeljs.io/T7108

Will squash if people feel like it, but I'd love to keep this split up to it's easier to follow. Not sure what the policy is specifically for non-work-in-progress commits. 