### PR TITLE
Update scope info after block-scoping transform

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/actual.js
@@ -3,3 +3,9 @@ export default class Foo {
     const baz = 0;
   }
 }
+
+async function foo() {
+  async function bar() {
+    const baz = {};
+  }
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -1,19 +1,88 @@
-export default class Foo {
-  bar() {
-    var _this = this;
+"use strict";
 
-    return babelHelpers.asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-      var baz;
-      return regeneratorRuntime.wrap(function _callee$(_context) {
-        while (1) switch (_context.prev = _context.next) {
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var foo = function () {
+  var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee3() {
+    var bar = function () {
+      var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee2() {
+        var baz;
+        return regeneratorRuntime.wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                baz = {};
+
+              case 1:
+              case "end":
+                return _context2.stop();
+            }
+          }
+        }, _callee2, this);
+      }));
+
+      return function bar() {
+        return ref.apply(this, arguments);
+      };
+    }();
+
+    return regeneratorRuntime.wrap(function _callee3$(_context3) {
+      while (1) {
+        switch (_context3.prev = _context3.next) {
           case 0:
-            baz = 0;
-
-          case 1:
           case "end":
-            return _context.stop();
+            return _context3.stop();
         }
-      }, _callee, _this);
-    }))();
+      }
+    }, _callee3, this);
+  }));
+
+  return function foo() {
+    return ref.apply(this, arguments);
+  };
+}();
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { return step("next", value); }, function (err) { return step("throw", err); }); } } return step("next"); }); }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Foo = function () {
+  function Foo() {
+    _classCallCheck(this, Foo);
   }
-}
+
+  _createClass(Foo, [{
+    key: "bar",
+    value: function () {
+      var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
+        var baz;
+        return regeneratorRuntime.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                baz = 0;
+
+              case 1:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee, this);
+      }));
+
+      function bar() {
+        return ref.apply(this, arguments);
+      }
+
+      return bar;
+    }()
+  }]);
+
+  return Foo;
+}();
+
+exports.default = Foo;

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/options.json
@@ -1,3 +1,4 @@
- {
-  "plugins": ["external-helpers", "transform-async-to-generator", "transform-regenerator"]
+{
+  "plugins": ["transform-async-to-generator"],
+  "presets": ["es2015"]
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -346,12 +346,11 @@ class BlockScoping {
     let parentScope = scope.getFunctionParent();
     let letRefs = this.letReferences;
 
-    const i = 0;
     for (let key in letRefs) {
       let ref = letRefs[key];
       const binding = scope.getBinding(ref.name);
       if (!binding) continue;
-      if (binding.kind === 'let' || binding.kind === 'const') {
+      if (binding.kind === "let" || binding.kind === "const") {
         scope.removeOwnBinding(ref.name);
         parentScope.registerBinding("var", binding.path);
       }

--- a/packages/babel-traverse/src/scope/binding.js
+++ b/packages/babel-traverse/src/scope/binding.js
@@ -71,7 +71,7 @@ export default class Binding {
 
   reassign(path: Object) {
     this.constant = false;
-    if (this.constantViolations.includes(path)) {
+    if (this.constantViolations.indexOf(path) !== -1) {
       return;
     }
     this.constantViolations.push(path);

--- a/packages/babel-traverse/src/scope/binding.js
+++ b/packages/babel-traverse/src/scope/binding.js
@@ -71,6 +71,9 @@ export default class Binding {
 
   reassign(path: Object) {
     this.constant = false;
+    if (this.constantViolations.includes(path)) {
+      return;
+    }
     this.constantViolations.push(path);
   }
 


### PR DESCRIPTION
I previously tried an approach to scope bindings from var to scope but
it didn't catch all cases. This is evident in this bug:

https://phabricator.babeljs.io/T2892

Where even after transforming a const to a var we still get an error
that it's read-only.

This approach will go through and delete every existing let and const
binding and creates a new one with the kind "var"