### PR TITLE
Expand the regression tests for T2765.

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/actual.js
@@ -3,3 +3,11 @@ function f() {
     this;
   };
 };
+
+class Class {
+  async m() {
+    var c = async (b) => {
+      this
+    }
+  }
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/expected.js
@@ -10,3 +10,20 @@ function f() {
     };
   }();
 };
+
+class Class {
+  m() {
+    var _this2 = this;
+
+    return babelHelpers.asyncToGenerator(function* () {
+      var c = function () {
+        var ref = babelHelpers.asyncToGenerator(function* (b) {
+          _this2;
+        });
+        return function c(_x) {
+          return ref.apply(this, arguments);
+        };
+      }();
+    })();
+  }
+}


### PR DESCRIPTION
Just pulling in another test from https://phabricator.babeljs.io/T2765 since someone asked about it.