### PR TITLE
Fix sourcemap generation for ES2015 modules

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -184,7 +184,9 @@ export default function () {
 
             // Copy location from the original import statement for sourcemap
             // generation.
-            varDecl.loc = imports[source].loc;
+            if (imports[source]) {
+              varDecl.loc = imports[source].loc;
+            }
 
             if (typeof blockHoist === "number" && blockHoist > 0) {
               varDecl._blockHoist = blockHoist;
@@ -338,9 +340,11 @@ export default function () {
                 path.replaceWithMultiple(nodes);
               }
             } else if (path.isExportAllDeclaration()) {
-              topNodes.push(buildExportAll({
+              let exportNode = buildExportAll({
                 OBJECT: addRequire(path.node.source.value, path.node._blockHoist)
-              }));
+              });
+              exportNode.loc = path.node.loc;
+              topNodes.push(exportNode);
               path.remove();
             }
           }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -182,6 +182,10 @@ export default function () {
               ).expression)
             ]);
 
+            // Copy location from the original import statement for sourcemap
+            // generation.
+            varDecl.loc = imports[source].loc;
+
             if (typeof blockHoist === "number" && blockHoist > 0) {
               varDecl._blockHoist = blockHoist;
             }
@@ -215,7 +219,8 @@ export default function () {
               let key = path.node.source.value;
               let importsEntry = imports[key] || {
                 specifiers: [],
-                maxBlockHoist: 0
+                maxBlockHoist: 0,
+                loc: path.node.loc,
               };
 
               importsEntry.specifiers.push(...path.node.specifiers);
@@ -405,7 +410,9 @@ export default function () {
               }
             } else {
               // bare import
-              topNodes.push(buildRequire(t.stringLiteral(source)));
+              let requireNode = buildRequire(t.stringLiteral(source));
+              requireNode.loc = imports[source].loc;
+              topNodes.push(requireNode);
             }
           }
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
@@ -4,26 +4,28 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.test = undefined;
+/*after*/
+/*before*/require("foo"); /*after*/
 
-require("foo");
+/*before*/require("foo-bar"); /*after*/
 
-require("foo-bar");
+/*before*/require("./directory/foo-bar"); /*after*/
 
-require("./directory/foo-bar");
+var /*before*/_foo = require("foo2") /*after*/;
 
-var _foo = require("foo2");
-
+/*before*/
 var _foo2 = babelHelpers.interopRequireDefault(_foo);
 
-var _foo3 = require("foo3");
+/*after*/
+var /*before*/_foo3 = require("foo3") /*after*/;
 
-var /*after*/foo2 = babelHelpers.interopRequireWildcard(_foo3);
-/*before*/
-var _foo4 = require("foo4");
+/*before*/var /*after*/foo2 = babelHelpers.interopRequireWildcard(_foo3);
 
-var _foo5 = require("foo5");
+var /*before*/_foo4 = require("foo4") /*after*/;
 
-exports. /*after*/test = test;
+var /*before*/_foo5 = require("foo5") /*after*/;
+
+/*before*/exports. /*after*/test = test;
 var test = /*before*/exports. /*after*/test = 5;
 
 /*before*/(0, _foo4.bar) /*after*/( /*before*/_foo2.default /*after*/, /*before*/_foo5.foo /*after*/);

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/exec.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/exec.js
@@ -7,7 +7,12 @@ var tests = [
   'import {bar2, baz} from "foo";',
   'import {bar as baz2} from "foo";',
   'import {bar as baz3, xyz} from "foo";',
+  'import bar, * as bar2 from "foo";',
+  'import bar, {bar2, bar3 as bar4} from "foo";',
 
+  'export var a;',
+  'export default function(){};',
+  'export default function f(){};',
   'export default 42;',
   'export {foo};',
   'export { foo as default };',

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/exec.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/exec.js
@@ -1,0 +1,24 @@
+var tests = [
+  'import "foo";',
+  'import foo from "foo";',
+  'import {default as foo2} from "foo";',
+  'import * as foo from "foo";',
+  'import {bar} from "foo";',
+  'import {bar2, baz} from "foo";',
+  'import {bar as baz2} from "foo";',
+  'import {bar as baz3, xyz} from "foo";',
+];
+
+tests.forEach(function (code) {
+  var res = transform(code, {
+    sourceMap: true,
+    plugins: opts.plugins
+  });
+
+  // Should create mapping
+  assert.notEqual(
+    res.map.mappings,
+    '',
+    'expected to generate sourcemap for: ' + code
+  );
+});

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/exec.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/exec.js
@@ -7,6 +7,13 @@ var tests = [
   'import {bar2, baz} from "foo";',
   'import {bar as baz2} from "foo";',
   'import {bar as baz3, xyz} from "foo";',
+
+  'export default 42;',
+  'export {foo};',
+  'export { foo as default };',
+  'export * from "foo";',
+  'export {foo} from "foo";',
+  'export {default as foo} from "foo";',
 ];
 
 tests.forEach(function (code) {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/source-map/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-modules-commonjs"]
+}


### PR DESCRIPTION
In most transforms we're changing nodes as part of some original parent node. However, in the es2015 module transform we inject nodes directly in the program body. These nodes have no `loc` property which makes them generate no sourcemaps at all.

We fix this by copying the location property from the original import or export statement to the generated node.

A side effect of that is that auxiliary comments don't work exactly like before on this transform. They instead of wrapping the entire generated code they wrap at a more granule level. Which I think is fine.
 
https://phabricator.babeljs.io/T6949