### PR TITLE
Add jsxQuotes option for formatting output:

### DIFF
--- a/packages/babel-generator/README.md
+++ b/packages/babel-generator/README.md
@@ -35,6 +35,7 @@ compact                | boolean or `'auto'` | `opts.minified` | Set to `true` t
 minified               | boolean  | `false`         | Should the output be minified
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 quotes                 | `'single'` or `'double'` | autodetect based on `ast.tokens` | The type of quote to use in the output
+jsxQuotes              | `'single'` or `'double'` | autodetect based on `ast.tokens` | The type of quote to use in the output
 filename               | string   |                 | Used in warning messages
 
 Options for source maps:

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -135,10 +135,10 @@ export function _stringLiteral(val: string, parent: Object): string {
   val = val.replace(/[\u000A\u000D\u2028\u2029]/g, function (c) {
     return "\\u" + ("0000" + c.charCodeAt(0).toString(16)).slice(-4);
   });
-  
+
   const hasJSXParent = t.isJSX(parent);
 
-  if (this.format.quotes === "single" && (!hasJSXParent || (hasJSXParent && this.format.jsxQuotes !== "double")) {
+  if (this.format.quotes === "single" && (!hasJSXParent || (hasJSXParent && this.format.jsxQuotes !== "double"))) {
     // remove double quotes
     val = val.slice(1, -1);
 

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -135,8 +135,10 @@ export function _stringLiteral(val: string, parent: Object): string {
   val = val.replace(/[\u000A\u000D\u2028\u2029]/g, function (c) {
     return "\\u" + ("0000" + c.charCodeAt(0).toString(16)).slice(-4);
   });
+  
+  const hasJSXParent = t.isJSX(parent);
 
-  if (this.format.quotes === "single" && !t.isJSX(parent)) {
+  if (this.format.quotes === "single" && (!hasJSXParent || (hasJSXParent && this.format.jsxQuotes !== "double")) {
     // remove double quotes
     val = val.slice(1, -1);
 

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -75,7 +75,9 @@ export class CodeGenerator extends Printer {
       let indent = detectIndent(code).indent;
       if (indent && indent !== " ") style = indent;
     }
-
+    
+    let commonQuotes = CodeGenerator.findCommonStringDelimiter(code, tokens);
+    
     let format = {
       auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
       auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
@@ -85,7 +87,8 @@ export class CodeGenerator extends Printer {
       compact: opts.compact,
       minified: opts.minified,
       concise: opts.concise,
-      quotes: opts.quotes || CodeGenerator.findCommonStringDelimiter(code, tokens),
+      quotes: opts.quotes || commonQuotes,
+      jsxQuotes: opts.jsxQuotes || commonQuotes,
       indent: {
         adjustMultilineComment: true,
         style: style,

--- a/packages/babel-generator/test/fixtures/auto-string/jsx-single-quotes/actual.js
+++ b/packages/babel-generator/test/fixtures/auto-string/jsx-single-quotes/actual.js
@@ -1,0 +1,9 @@
+var single = 'quotes';
+var outnumber = 'double';
+var moreSingleQuotesThanDouble = '!';
+
+React.createClass({
+  render() {
+    return <View multiple="attributes" attribute="If parent is JSX keep double quote" />;
+  }
+});

--- a/packages/babel-generator/test/fixtures/auto-string/jsx-single-quotes/expected.js
+++ b/packages/babel-generator/test/fixtures/auto-string/jsx-single-quotes/expected.js
@@ -1,0 +1,9 @@
+var single = 'quotes';
+var outnumber = 'double';
+var moreSingleQuotesThanDouble = '!';
+
+React.createClass({
+  render() {
+    return <View multiple='attributes' attribute='If parent is JSX keep double quote' />;
+  }
+});

--- a/packages/babel-generator/test/fixtures/auto-string/jsx/options.json
+++ b/packages/babel-generator/test/fixtures/auto-string/jsx/options.json
@@ -1,0 +1,3 @@
+{
+  "jsxQuotes": "double"
+}


### PR DESCRIPTION
Add ability to generate JSX code with single quotes.

``` javascript
class Map {
  render() {
    return <div className='awesome'>Single quotes :)</div>
  }
}
```
