### PR TITLE
Remove check for configurable property in helpers.defaults

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -135,7 +135,7 @@ helpers.defaults = template(`
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
       var value = Object.getOwnPropertyDescriptor(defaults, key);
-      if (value && value.configurable && obj[key] === undefined) {
+      if (value && obj[key] === undefined) {
         Object.defineProperty(obj, key, value);
       }
     }


### PR DESCRIPTION
Fixes [T7102](https://phabricator.babeljs.io/T7102).
Fixes https://github.com/aurelia/framework/issues/271.