### PR TITLE
Support shadowing super() and super.* - fixes T6895

### DIFF
--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -23,7 +23,7 @@ function shouldShadow(path, shadowPath) {
   }
 }
 
-function remap(path, key, create) {
+function getShadowBindingRoot(path, key){
   // ensure that we're shadowed
   let shadowPath = path.inShadow(key);
   if (!shouldShadow(path, shadowPath)) return;
@@ -70,6 +70,13 @@ function remap(path, key, create) {
   // If the only functions that were encountered are arrow functions, skip remapping the
   // binding since arrow function syntax already does that.
   if (!passedShadowFunction) return;
+
+  return fnPath;
+}
+
+function remap(path, key, create) {
+  let fnPath = getShadowBindingRoot(path, key);
+  if (!fnPath) return;
 
   let cached = fnPath.getData(key);
   if (cached) return path.replaceWith(cached);

--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -1,8 +1,43 @@
 import Plugin from "../plugin";
 import * as t from "babel-types";
 
+const isSuperMember = (path) => path.isMemberExpression() && path.get("object").isSuper();
+
 export default new Plugin({
   visitor: {
+    UpdateExpression(path){
+      if (!isSuperMember(path.get("argument")) || !getShadowBindingRoot(path, "this")) return;
+
+      // Convert the update to assignments.
+      decomposeUpdateExpression(path);
+    },
+
+    CallExpression(path){
+      if (!isSuperMember(path.get("callee")) || !getShadowBindingRoot(path, "this")) return;
+
+      // super.foo(a, b, c); => super.foo.call(this, a, b, c);
+      path.node.callee = t.memberExpression(path.node.callee, t.identifier("call"));
+      path.node.arguments.unshift(t.thisExpression());
+    },
+
+    AssignmentExpression(path){
+      if (!isSuperMember(path.get("left")) || !getShadowBindingRoot(path, "this")) return;
+
+      // Convert things like "+=" and such to simple assignment.
+      decomposeUpdateAssignment(path);
+
+      // super.foo = 4; => superSet("foo", 4);
+      remapSuperSet(path);
+    },
+
+    MemberExpression(path){
+      if (!isSuperMember(path) || !getShadowBindingRoot(path, "this")) return;
+      if (path.parentPath.isAssignmentExpression({left: path.node})) return;
+
+      // var foo = super.foo; => var foo = superGet("foo");
+      remapSuperGet(path);
+    },
+
     ThisExpression(path) {
       remap(path, "this", () => t.thisExpression());
     },
@@ -88,4 +123,126 @@ function remap(path, key, create) {
   fnPath.scope.push({ id, init });
 
   return path.replaceWith(id);
+}
+
+/**
+ * Given an member expression for a super property, convert it to a call to a function that
+ * calls super in the correct scope,
+ */
+function remapSuperGet(path){
+  let fnPath = getShadowBindingRoot(path, "this");
+  if (!fnPath) return;
+
+  let id = fnPath.getData("super-get");
+  if (!id){
+    // Ensure that there is a "var _superGet = (prop) => super[prop];" helper.
+    id = path.scope.generateUidIdentifier("super-get");
+    fnPath.setData("super-get", id);
+
+    fnPath.scope.push({ id, init: t.arrowFunctionExpression([t.identifier("prop")],
+      t.memberExpression(t.super(), t.identifier("prop"), true)) });
+  }
+
+  assertNotCircular(path, id);
+
+  return path.replaceWith(t.callExpression(id,
+    [path.node.computed ? path.node.property : t.stringLiteral(path.node.property.name)]));
+}
+
+/**
+ * Given an assignment expression for a super property, convert it to a call to a function that
+ * calls super in the correct scope,
+ */
+function remapSuperSet(path){
+  let fnPath = getShadowBindingRoot(path, "this");
+  if (!fnPath) return;
+
+  let id = fnPath.getData("super-set");
+  if (!id){
+    // Ensure that there is a "var _superSet = (prop, val) => super[prop] = val;" helper.
+    id = path.scope.generateUidIdentifier("super-set");
+    fnPath.setData("super-set", id);
+
+    fnPath.scope.push({ id, init: t.arrowFunctionExpression(
+      [t.identifier("prop"), t.identifier("val")], t.assignmentExpression("=",
+      t.memberExpression(t.super(), t.identifier("prop"), true), t.identifier("val"))) });
+  }
+
+  assertNotCircular(path, id);
+
+  let {left, right} = path.node;
+
+  return path.replaceWith(t.callExpression(id, [
+    left.computed ? left.property : t.stringLiteral(left.property.name), right]));
+}
+
+/**
+ * Given an UpdateExpression, decompose and replace it with one or more AssignmentExpressions.
+ */
+function decomposeUpdateExpression(path){
+  const expr = path.get("argument");
+
+  // ++super.foo => super.foo += 1;
+  if (path.is("prefix")){
+    path.replaceWith(t.assignmentExpression(path.node.operator.slice(0, 1) + "=",
+      expr.node, t.numericLiteral(1)));
+    return;
+  }
+
+  // super.foo-- => _ref = super.foo, super.foo = _ref + 1, _ref;
+  const result = expr.scope.maybeGenerateMemoised(expr.node);
+
+  const secondary = t.memberExpression(expr.node.object, expr.node.property, expr.node.computed);
+  if (expr.is("computed")){
+    const id = expr.scope.maybeGenerateMemoised(expr.get("property"));
+    if (id){
+      expr.node.property = t.assignmentExpression("=", id, expr.node.property);
+      secondary.property = id;
+    }
+  }
+
+  path.replaceWithMultiple([
+    t.assignmentExpression("=", result, expr.node),
+    t.assignmentExpression("=", secondary, t.binaryExpression("+", result, t.numericLiteral(1))),
+    result
+  ]);
+}
+
+/**
+ * Given an AssignmentExpression, ensure that it is a simple "=" assignment, not a more complex
+ * one like "+=" or "/=".
+ */
+function decomposeUpdateAssignment(path){
+  // super.foo += bar => super.foo = super.foo + "bar";
+  if (path.node.operator === "=") return;
+
+  const expr = path.get("left");
+
+  const secondary = t.memberExpression(expr.node.object, expr.node.property, expr.node.computed);
+  if (expr.is("computed")){
+    const id = expr.scope.maybeGenerateMemoised(expr.get("property"));
+    if (id){
+      expr.node.property = t.assignmentExpression("=", id, expr.node.property);
+      secondary.property = id;
+    }
+  }
+
+  path.node.right = t.binaryExpression(path.node.operator.slice(0, 1), secondary, path.node.right);
+  path.node.operator = "=";
+}
+
+/**
+ * If someone has enabled the arrow function transform, we can't properly insert the super getter
+ * and setter functions, since they would also be transformed.
+ *
+ * We could get around this by actually transforming the super expressions the same way the class
+ * transform does it, but it's easier for now to consider that a disallowed edge-case.
+ */
+function assertNotCircular(path, id){
+  const binding = path.scope.getBinding(id.name);
+
+  if (binding && path.findParent((parent) => parent === binding.path)){
+    throw path.buildCodeFrameError("'super.*' property usage inside arrow functions is not " +
+      "supported with native classes and transpiled arrows.");
+  }
 }

--- a/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/actual.js
@@ -1,0 +1,62 @@
+class Child extends Parent {
+
+  params(){
+    var fn = () => {
+      super.params(a, b, c, d);
+
+      super.params++;
+      ++super.params;
+      super.params--;
+      --super.params;
+      super.params += 4;
+      super.params /= 4;
+      super.params %= 4;
+
+      super[a + b] = c;
+    };
+    var fn2 = (arg1 = 4) => {
+      super.params(a, b, c, d);
+
+      super.params++;
+      ++super.params;
+      super.params--;
+      --super.params;
+      super.params += 4;
+      super.params /= 4;
+      super.params %= 4;
+
+      super[a + b] = c;
+    }
+  }
+
+  asyncFn(){
+    var fn = () => {
+      super.params(a, b, c, d);
+
+      super.params++;
+      ++super.params;
+      super.params--;
+      --super.params;
+      super.params += 4;
+      super.params /= 4;
+      super.params %= 4;
+
+      super[a + b] = c;
+    };
+    var fn2 = async () => {
+      super.params(a, b, c, d);
+
+      super.params++;
+      ++super.params;
+      super.params--;
+      --super.params;
+      super.params += 4;
+      super.params /= 4;
+      super.params %= 4;
+
+      super[a + b] = c;
+    }
+  }
+
+
+}

--- a/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/actual.js
@@ -1,5 +1,10 @@
 class Child extends Parent {
 
+  constructor(){
+    var foo = (arg = 1) => super(arg, 2, 3, 4, 5);
+    foo();
+  }
+
   params(){
     var fn = () => {
       super.params(a, b, c, d);

--- a/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/expected.js
@@ -1,5 +1,15 @@
 class Child extends Parent {
 
+  constructor() {
+    var _superCall = (_x2, _x3, _x4, _x5, _x6) => super(_x2, _x3, _x4, _x5, _x6);
+
+    var foo = function () {
+      let arg = arguments.length <= 0 || arguments[0] === undefined ? 1 : arguments[0];
+      return _superCall(arg, 2, 3, 4, 5);
+    };
+    foo();
+  }
+
   params() {
     var _superGet = prop => super[prop],
         _this = this,

--- a/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/expected.js
@@ -1,0 +1,92 @@
+class Child extends Parent {
+
+  params() {
+    var _superGet = prop => super[prop],
+        _this = this,
+        _superSet = (prop, val) => super[prop] = val;
+
+    var fn = () => {
+      super.params(a, b, c, d);
+
+      super.params++;
+      ++super.params;
+      super.params--;
+      --super.params;
+      super.params += 4;
+      super.params /= 4;
+      super.params %= 4;
+
+      super[a + b] = c;
+    };
+    var fn2 = function () {
+      var _params, _params2;
+
+      let arg1 = arguments.length <= 0 || arguments[0] === undefined ? 4 : arguments[0];
+
+      _superGet("params").call(_this, a, b, c, d);
+
+      _params = _superGet("params")
+
+      _superSet("params", _params + 1)
+
+      _superSet("params", _superGet("params") + 1);
+      _params2 = _superGet("params")
+
+      _superSet("params", _params2 + 1)
+
+      _superSet("params", _superGet("params") - 1);
+      _superSet("params", _superGet("params") + 4);
+      _superSet("params", _superGet("params") / 4);
+      _superSet("params", _superGet("params") % 4);
+
+      _superSet(a + b, c);
+    };
+  }
+
+  asyncFn() {
+    var _superGet2 = prop => super[prop],
+        _this2 = this,
+        _superSet2 = (prop, val) => super[prop] = val;
+
+    var fn = () => {
+      super.params(a, b, c, d);
+
+      super.params++;
+      ++super.params;
+      super.params--;
+      --super.params;
+      super.params += 4;
+      super.params /= 4;
+      super.params %= 4;
+
+      super[a + b] = c;
+    };
+    var fn2 = (() => {
+      var ref = babelHelpers.asyncToGenerator(function* () {
+        var _params3, _params4;
+
+        _superGet2("params").call(_this2, a, b, c, d);
+
+        _params3 = _superGet2("params")
+
+        _superSet2("params", _params3 + 1)
+
+        _superSet2("params", _superGet2("params") + 1);
+        _params4 = _superGet2("params")
+
+        _superSet2("params", _params4 + 1)
+
+        _superSet2("params", _superGet2("params") - 1);
+        _superSet2("params", _superGet2("params") + 4);
+        _superSet2("params", _superGet2("params") / 4);
+        _superSet2("params", _superGet2("params") % 4);
+
+        _superSet2(a + b, c);
+      });
+      return function fn2() {
+        return ref.apply(this, arguments);
+      };
+    })();
+  }
+
+}

--- a/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/options.json
+++ b/packages/babel-core/test/fixtures/transformation/shadow-functions/super-shadow/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-es2015-parameters",
+    "transform-async-to-generator"
+  ]
+}


### PR DESCRIPTION
This'll conflict with https://github.com/babel/babel/pull/3422 but posting for review since it'll be an easy conflict to fix.