### PR TITLE
Fix buildExportAll to account for commonjs/amd

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -33,7 +33,7 @@ let buildExportsAssignment = template(`
 
 let buildExportAll = template(`
   Object.keys(OBJECT).forEach(function (key) {
-    if (key === "default") return;
+    if (key === "default" || key === "__esModule") return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {


### PR DESCRIPTION
If the re-exported module was generated with Babel and it is a commonjs or amd module and so is the current module, this will result in an attempt to redefine the __esModule property, which throws a runtime error.