### PR TITLE
Failing test case for caching bugs

### DIFF
--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -2,6 +2,7 @@ import cloneDeep from "lodash/cloneDeep";
 import traverse from "../lib";
 import assert from "assert";
 import { parse } from "babylon";
+import * as t from "babel-types";
 
 describe("traverse", function() {
   const code = `
@@ -174,5 +175,32 @@ describe("traverse", function() {
     scopes2.forEach(function(p, i) {
       assert.notStrictEqual(p, scopes[i]);
     });
+  });
+
+  it("shared node leads to wrong path", function() {
+    const code = "function y() { f(); } function z() { g(); }";
+    const ast = parse(code);
+    const foo = t.memberExpression(t.identifier("foo"), t.identifier("bar"));
+
+    traverse(ast, {
+      CallExpression: function(path) {
+        path.node.callee = foo;
+      },
+    });
+
+    traverse.cache.clear();
+
+    const paths = [];
+    traverse(ast, {
+      ReferencedIdentifier: function(path) {
+        if (path.node.name !== "foo") {
+          return;
+        }
+
+        paths.push(path);
+      },
+    });
+
+    assert.notStrictEqual(paths[0], paths[1]);
   });
 });


### PR DESCRIPTION
tl;dr: Reusing nodes is leading to caching bugs. We're getting the same path/scope etc for fundamentally different paths in the tree. This can be catastrophic.

The test cases creates a member expression node that is going to be used to replace multiple call expression callee. After we do that, we clear the cache, and we traverse again to visit `Identifier`. Then the two `foo` identifiers are going to have exactly the same path, which is obviously wrong because they are different places in the AST. 
