### PR TITLE
Add a debounce delay so switching branches rebuilds.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -45,7 +45,7 @@ gulp.task("build", function () {
 });
 
 gulp.task("watch", ["build"], function (callback) {
-  watch(scripts, function () {
+  watch(scripts, {debounceDelay: 200}, function () {
     gulp.start("build");
   });
 });


### PR DESCRIPTION
I tend to squash/rebase often, and Gulp generally doesn't rebuild properly without a bit of a delay.