### PR TITLE
Fix Misspelling

### DIFF
--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -92,7 +92,7 @@ export default class NodePath {
         path = null;
       } else {
         // badly deserialised probably
-        throw new Error("We found a path that isn't a NodePath instance. Possiblly due to bad serialisation.");
+        throw new Error("We found a path that isn't a NodePath instance. Possibly due to bad serialisation.");
       }
     }
 


### PR DESCRIPTION
I noticed this misspelling while using the [repl](http://babeljs.io/repl).

<img width="1386" alt="screen shot 2016-03-16 at 10 20 13 pm" src="https://cloud.githubusercontent.com/assets/164506/13837132/52a32ef2-ebc5-11e5-8722-f10841557774.png">


Thanks for Babel!