### PR TITLE
Only attempt to rename export declarations, not expressions - fixes T7215

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/T7215/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/T7215/actual.js
@@ -1,0 +1,5 @@
+export default (onClick) => ({
+    onClick: function(){
+        onClick(text);
+    },
+});

--- a/packages/babel-core/test/fixtures/transformation/misc/T7215/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/T7215/expected.js
@@ -1,0 +1,13 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+exports.default = function (_onClick) {
+    return {
+        onClick: function onClick() {
+            _onClick(text);
+        }
+    };
+};

--- a/packages/babel-core/test/fixtures/transformation/misc/T7215/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/T7215/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["external-helpers"]
+}

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -105,7 +105,7 @@ export default class Renamer {
     let { binding, oldName, newName } = this;
     let { scope, path } = binding;
 
-    let parentDeclar = path.find((path) => path.isDeclaration() || path.isFunctionExpression());
+    let parentDeclar = path.find((path) => path.isDeclaration());
     if (parentDeclar) {
       this.maybeConvertFromExportDeclaration(parentDeclar);
     }


### PR DESCRIPTION
Not sure why this was allowing function expressions, but it doesn't seem right to me.