### PR TITLE
Self host on babel6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ publish:
 bootstrap:
 	npm install
 	./node_modules/.bin/lerna bootstrap
+	# remove all existing babel-runtimes and use the top-level babel-runtime
+	rm -rf packages/*/node_modules/babel-runtime
 	make build
 	cd packages/babel-runtime; \
 	node scripts/build-dist.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "async": "^1.5.0",
     "babel-core": "^6.3.17",
     "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-plugin-transform-class-properties": "^6.6.0",
+    "babel-plugin-transform-flow-strip-types": "^6.3.13",
     "babel-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.0.0",
@@ -41,8 +43,12 @@
     "uglify-js": "^2.4.16"
   },
   "babel": {
-    "presets": ["es2015", "react", "stage-0"],
-    "plugins": ["transform-runtime"],
+    "presets": ["stage-0", "es2015"],
+    "plugins": [
+        "transform-runtime",
+        "transform-class-properties",
+        "transform-flow-strip-types"
+    ],
     "ignore": [
       "packages/babel-cli/src/babel-plugin/templates"
     ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "license": "MIT",
   "devDependencies": {
     "async": "^1.5.0",
-    "babel": "5.8.21",
+    "babel-core": "^6.3.17",
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-runtime": "^6.0.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-0": "^6.0.0",
     "browserify": "^11.2.0",
     "bundle-collapser": "^1.2.1",
     "chai": "^2.2.0",
@@ -14,7 +18,7 @@
     "kcheck": "^2.0.0",
     "fs-readdir-recursive": "^0.1.2",
     "gulp": "^3.9.0",
-    "gulp-babel": "^5.3.0",
+    "gulp-babel": "^6.0.0",
     "gulp-newer": "^1.0.0",
     "gulp-plumber": "^1.0.1",
     "gulp-util": "^3.0.7",
@@ -37,26 +41,15 @@
     "uglify-js": "^2.4.16"
   },
   "babel": {
+    "presets": ["es2015", "react", "stage-0"],
+    "plugins": ["transform-runtime"],
     "ignore": [
       "packages/babel-cli/src/babel-plugin/templates"
-    ],
-    "stage": 0,
-    "loose": [
-      "all"
-    ],
-    "blacklist": [
-      "es6.tailCall"
-    ],
-    "optional": [
-      "flow",
-      "optimisation.flow.forOf",
-      "runtime"
     ],
     "env": {
       "test": {
         "auxiliaryCommentBefore": "istanbul ignore next"
       }
-    },
-    "breakConfig": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.3.13",
     "babel-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-0": "^6.0.0",
     "browserify": "^11.2.0",
     "bundle-collapser": "^1.2.1",
@@ -43,7 +44,7 @@
     "uglify-js": "^2.4.16"
   },
   "babel": {
-    "presets": ["stage-0", "es2015"],
+    "presets": ["stage-0", "es2015-loose"],
     "plugins": [
         "transform-runtime",
         "transform-class-properties",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,10 @@
   "babel": {
     "presets": ["stage-0", "es2015-loose"],
     "plugins": [
-        "transform-runtime",
-        "transform-class-properties",
-        "transform-flow-strip-types"
-    ],
-    "ignore": [
-      "packages/babel-cli/src/babel-plugin/templates"
+      "./scripts/add-module-exports",
+      "transform-runtime",
+      "transform-class-properties",
+      "transform-flow-strip-types"
     ],
     "env": {
       "test": {

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -10,7 +10,7 @@
     "babel-core": "^6.7.7",
     "babel-register": "^6.6.5",
     "babel-polyfill": "^6.6.0",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "bin-version-check": "^2.1.0",
     "chalk": "1.1.1",
     "commander": "^2.8.1",

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "chalk": "^1.1.0",
     "esutils": "^2.0.2",
     "js-tokens": "^1.0.2"

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -29,7 +29,7 @@
     "babel-helpers": "^6.6.0",
     "babel-messages": "^6.7.2",
     "babel-template": "^6.7.0",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-register": "^6.7.2",
     "babel-traverse": "^6.7.6",
     "babel-types": "^6.7.7",

--- a/packages/babel-core/src/api/browser.js
+++ b/packages/babel-core/src/api/browser.js
@@ -2,7 +2,25 @@
 /* eslint no-new-func: 0 */
 
 import { transform } from "./node";
-export * from "./node";
+export {
+  File,
+  options,
+  buildExternalHelpers,
+  template,
+  version,
+  util,
+  messages,
+  types,
+  traverse,
+  OptionManager,
+  Plugin,
+  Pipeline,
+  analyse,
+  transform,
+  transformFromAst,
+  transformFile,
+  transformFileSync
+} from "./node";
 
 export function run(code: string, opts: Object = {}): any {
   return new Function(transform(code, opts).code)();

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "babel-messages": "^6.7.2",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.7.7",
     "detect-indent": "^3.0.1",
     "is-integer": "^1.0.4",

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-traverse": "^6.6.5",
     "babel-types": "^6.6.5"
   }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-helper-explode-assignable-expression": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5"
   }
 }

--- a/packages/babel-helper-builder-conditional-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-conditional-assignment-operator-visitor/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-helper-explode-assignable-expression": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5"
   }
 }

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5",
     "esutils": "^2.0.0",
     "lodash": "^3.10.0"

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-traverse": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5",
     "babel-helper-hoist-variables": "^6.6.5"
   }

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "lodash": "^3.10.0",
     "babel-types": "^6.6.5",
     "babel-helper-function-name": "^6.6.0"

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-traverse": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5"
   }
 }

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-traverse": "^6.6.5",
     "babel-types": "^6.6.5",
     "babel-helper-bindify-decorators": "^6.6.5"

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "lodash": "^3.10.0",
     "path-exists": "^1.0.0",
     "trim-right": "^1.0.1",

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.0",
     "babel-traverse": "^6.6.0",
     "babel-helper-get-function-arity": "^6.3.13",

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5"
   }
 }

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5"
   }
 }

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.0"
   }
 }

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-helper-transform-fixture-test-runner": "^6.3.13"
   }
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "lodash": "^3.10.0",
     "babel-types": "^6.6.5"
   }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-template": "^6.7.0",
     "babel-types": "^6.7.0",
     "babel-traverse": "^6.7.0",

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-helper-optimise-call-expression": "^6.6.0",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-traverse": "^6.7.0",
     "babel-messages": "^6.6.5",
     "babel-template": "^6.7.0",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-register": "^6.6.5",
     "babel-core": "^6.6.5",
     "babel-polyfill": "^6.3.13",

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helpers",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-template": "^6.6.0"
   }
 }

--- a/packages/babel-messages/package.json
+++ b/packages/babel-messages/package.json
@@ -8,6 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-messages",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   }
 }

--- a/packages/babel-plugin-check-es2015-constants/package.json
+++ b/packages/babel-plugin-check-es2015-constants/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-async-functions/package.json
+++ b/packages/babel-plugin-syntax-async-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-class-constructor-call/package.json
+++ b/packages/babel-plugin-syntax-class-constructor-call/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-exponentiation-operator/package.json
+++ b/packages/babel-plugin-syntax-exponentiation-operator/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-export-extensions/package.json
+++ b/packages/babel-plugin-syntax-export-extensions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-syntax-trailing-function-commas/package.json
+++ b/packages/babel-plugin-syntax-trailing-function-commas/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-async-functions/package.json
+++ b/packages/babel-plugin-transform-async-functions/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-async-functions": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-helper-remap-async-to-generator": "^6.7.0",
     "babel-plugin-syntax-async-functions": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-async-to-module-method/package.json
+++ b/packages/babel-plugin-transform-async-to-module-method/package.json
@@ -12,7 +12,7 @@
     "babel-plugin-syntax-async-functions": "^6.3.13",
     "babel-helper-remap-async-to-generator": "^6.7.0",
     "babel-types": "^6.7.0",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-class-constructor-call/package.json
+++ b/packages/babel-plugin-transform-class-constructor-call/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-template": "^6.6.5",
     "babel-plugin-syntax-class-constructor-call": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-class-properties/package.json
+++ b/packages/babel-plugin-transform-class-properties/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-class-properties": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-decorators/package.json
+++ b/packages/babel-plugin-transform-decorators/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-syntax-decorators": "^6.3.13",
     "babel-helper-explode-class": "^6.6.5",
     "babel-template": "^6.6.5",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-do-expressions/package.json
+++ b/packages/babel-plugin-transform-do-expressions/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-do-expressions": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-es2015-block-scoped-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-block-scoping/package.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/package.json
@@ -10,7 +10,7 @@
     "babel-types": "^6.7.0",
     "babel-template": "^6.7.0",
     "lodash": "^3.10.0",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-classes/package.json
+++ b/packages/babel-plugin-transform-es2015-classes/package.json
@@ -13,7 +13,7 @@
     "babel-traverse": "^6.6.5",
     "babel-helper-define-map": "^6.6.5",
     "babel-messages": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.7.7"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-es2015-computed-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-computed-properties/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-helper-define-map": "^6.6.5",
     "babel-template": "^6.6.5",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-destructuring/package.json
+++ b/packages/babel-plugin-transform-es2015-destructuring/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-es2015-duplicate-keys/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.4"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es2015-for-of/package.json
+++ b/packages/babel-plugin-transform-es2015-for-of/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-function-name/package.json
+++ b/packages/babel-plugin-transform-es2015-function-name/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-helper-function-name": "^6.4.0",
     "babel-types": "^6.4.0",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-instanceof/package.json
+++ b/packages/babel-plugin-transform-es2015-instanceof/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-literals/package.json
+++ b/packages/babel-plugin-transform-es2015-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-modules-amd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.6.5",
     "babel-template": "^6.6.5",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-types": "^6.7.7",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-template": "^6.7.0",
     "babel-plugin-transform-strict-mode": "^6.6.5"
   },

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "babel-template": "^6.6.5",
     "babel-helper-hoist-variables": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-plugin-transform-strict-mode": "^6.6.5"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-es2015-modules-umd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "babel-plugin-transform-es2015-modules-amd": "^6.6.5",
     "babel-template": "^6.6.5",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-object-super/package.json
+++ b/packages/babel-plugin-transform-es2015-object-super/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-replace-supers": "^6.6.5",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-parameters/package.json
+++ b/packages/babel-plugin-transform-es2015-parameters/package.json
@@ -11,7 +11,7 @@
     "babel-helper-get-function-arity": "^6.6.5",
     "babel-template": "^6.7.0",
     "babel-types": "^6.7.0",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-types": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-spread/package.json
+++ b/packages/babel-plugin-transform-es2015-spread/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-es2015-sticky-regex/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-helper-regex": "^6.3.13",
     "babel-types": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-template-literals/package.json
+++ b/packages/babel-plugin-transform-es2015-template-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es2015-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-regex": "^6.3.13",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "regexpu-core": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es3-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-es3-member-expression-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es3-property-literals/package.json
+++ b/packages/babel-plugin-transform-es3-property-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-es5-property-mutators/package.json
+++ b/packages/babel-plugin-transform-es5-property-mutators/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-define-map": "^6.6.5",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-eval/package.json
+++ b/packages/babel-plugin-transform-eval/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-plugin-syntax-exponentiation-operator": "^6.3.13",
     "babel-helper-builder-binary-assignment-operator-visitor": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-export-extensions/package.json
+++ b/packages/babel-plugin-transform-export-extensions/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-export-extensions": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-plugin-syntax-flow": "^6.3.13"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-plugin-syntax-flow": "^6.3.13"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-function-bind/package.json
+++ b/packages/babel-plugin-transform-function-bind/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-function-bind": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-inline-environment-variables/package.json
+++ b/packages/babel-plugin-transform-inline-environment-variables/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-merge-sibling-variables/package.json
+++ b/packages/babel-plugin-transform-merge-sibling-variables/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-minify-booleans/package.json
+++ b/packages/babel-plugin-transform-minify-booleans/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-node-env-inline/package.json
+++ b/packages/babel-plugin-transform-node-env-inline/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -10,7 +10,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-object-rest-spread/package.json
+++ b/packages/babel-plugin-transform-object-rest-spread/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-object-rest-spread": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "lodash": "^3.9.3"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-helper-builder-react-jsx": "^6.3.13"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-plugin-syntax-jsx": "^6.3.13"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-helper-builder-react-jsx": "^6.7.5",
     "babel-plugin-syntax-jsx": "^6.3.13"
   },

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-syntax-async-functions": "^6.3.13",
     "babel-plugin-transform-es2015-for-of": "^6.6.0",
     "babel-core": "^6.6.5",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-traverse": "^6.6.5",
     "babel-types": "^6.6.5",
     "babylon": "^6.6.5",

--- a/packages/babel-plugin-transform-remove-console/package.json
+++ b/packages/babel-plugin-transform-remove-console/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-remove-debugger/package.json
+++ b/packages/babel-plugin-transform-remove-debugger/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-simplify-comparison-operators/package.json
+++ b/packages/babel-plugin-transform-simplify-comparison-operators/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.6.5"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-undefined-to-void/package.json
+++ b/packages/babel-plugin-transform-undefined-to-void/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"

--- a/packages/babel-plugin-undeclared-variables-check/package.json
+++ b/packages/babel-plugin-undeclared-variables-check/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "leven": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "core-js": "^2.1.0",
     "babel-regenerator-runtime": "^6.3.13",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   }
 }

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -9,7 +9,7 @@
   "browser": "lib/browser.js",
   "dependencies": {
     "babel-core": "^6.7.2",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "core-js": "^2.1.0",
     "home-or-tmp": "^1.0.0",
     "lodash": "^3.10.0",

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -11,7 +11,7 @@
     "babylon": "^6.7.0",
     "babel-traverse": "^6.7.0",
     "babel-types": "^6.7.0",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "lodash": "^3.10.1"
   }
 }

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "babel-code-frame": "^6.7.5",
     "babel-messages": "^6.7.2",
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
     "debug": "^2.2.0",

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-types",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^5.0.0",
+    "babel-runtime": "^6.0.0",
     "babel-traverse": "^6.7.2",
     "esutils": "^2.0.2",
     "lodash": "^3.10.1",

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -12,9 +12,12 @@ let t = exports;
  */
 
 function registerType(type: string) {
-  let is = t[`is${type}`] = function (node, opts) {
-    return t.is(type, node, opts);
-  };
+  let is = t[`is${type}`];
+  if (!is) {
+    is = t[`is${type}`] = function (node, opts) {
+      return t.is(type, node, opts);
+    };
+  }
 
   t[`assert${type}`] = function (node, opts) {
     opts = opts || {};

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -26,7 +26,27 @@ function registerType(type: string) {
 
 //
 
-export * from "./constants";
+export {
+  STATEMENT_OR_BLOCK_KEYS,
+  FLATTENABLE_KEYS,
+  FOR_INIT_KEYS,
+  COMMENT_KEYS,
+  LOGICAL_OPERATORS,
+  UPDATE_OPERATORS,
+  BOOLEAN_NUMBER_BINARY_OPERATORS,
+  EQUALITY_BINARY_OPERATORS,
+  COMPARISON_BINARY_OPERATORS,
+  BOOLEAN_BINARY_OPERATORS,
+  NUMBER_BINARY_OPERATORS,
+  BINARY_OPERATORS,
+  BOOLEAN_UNARY_OPERATORS,
+  NUMBER_UNARY_OPERATORS,
+  STRING_UNARY_OPERATORS,
+  UNARY_OPERATORS,
+  INHERIT_KEYS,
+  BLOCK_SCOPED_SYMBOL,
+  NOT_LOCAL_BINDING
+} from "./constants";
 
 import "./definitions/init";
 import { VISITOR_KEYS, ALIAS_KEYS, NODE_FIELDS, BUILDER_KEYS, DEPRECATED_KEYS } from "./definitions";
@@ -436,7 +456,37 @@ toFastProperties(t);
 toFastProperties(t.VISITOR_KEYS);
 
 //
-export * from "./retrievers";
-export * from "./validators";
-export * from "./converters";
-export * from "./flow";
+export {
+  getBindingIdentifiers,
+  getOuterBindingIdentifiers
+} from "./retrievers";
+
+export {
+  isBinding,
+  isReferenced,
+  isValidIdentifier,
+  isLet,
+  isBlockScoped,
+  isVar,
+  isSpecifierDefault,
+  isScope,
+  isImmutable
+} from "./validators";
+
+export {
+  toComputedKey,
+  toSequenceExpression,
+  toKeyAlias,
+  toIdentifier,
+  toBindingIdentifierName,
+  toStatement,
+  toExpression,
+  toBlock,
+  valueToNode
+} from "./converters";
+
+export {
+  createUnionTypeAnnotation,
+  removeTypeDuplicates,
+  createTypeAnnotationBasedOnTypeof
+} from "./flow";

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -3,6 +3,7 @@ import compact from "lodash/array/compact";
 import loClone from "lodash/lang/clone";
 import each from "lodash/collection/each";
 import uniq from "lodash/array/uniq";
+import traverse from "babel-traverse";
 
 let t = exports;
 
@@ -398,12 +399,6 @@ function _inheritComments(key, child, parent) {
     child[key] = uniq(compact([].concat(child[key], parent[key])));
   }
 }
-
-
-// Can't use import because of cyclic dependency between babel-traverse
-// and this module (babel-types). This require needs to appear after
-// we export the TYPES constant.
-const traverse = require("babel-traverse").default;
 
 /**
  * Inherit all contextual properties from `parent` node to `child` node.

--- a/scripts/add-module-exports.js
+++ b/scripts/add-module-exports.js
@@ -1,0 +1,47 @@
+// "add-module-exports"
+module.exports = function (babel) {
+  var t = babel.types;
+  return {
+    visitor: {
+      Program: {
+        exit: function(path) {
+          if (path.BABEL_PLUGIN_ADD_MODULE_EXPORTS) {
+            return;
+          }
+
+          var hasExportDefault = false;
+          var hasExportNamed = false;
+          var body = path.get("body");
+
+          path.get('body').forEach(function (path) {
+            if (path.isExportDefaultDeclaration()) {
+              hasExportDefault = true;
+              return;
+            }
+
+            if (path.isExportNamedDeclaration()) {
+              if (path.node.specifiers.length === 1 && path.node.specifiers[0].exported.name === "default") {
+                hasExportDefault = true;
+              } else {
+                hasExportNamed = true;
+              }
+              return;
+            }
+          });
+
+          if (hasExportDefault && !hasExportNamed) {
+            path.pushContainer("body", [
+              t.expressionStatement(t.assignmentExpression(
+                "=",
+                t.memberExpression(t.identifier("module"), t.identifier("exports")),
+                t.memberExpression(t.identifier("exports"), t.stringLiteral("default"), true)
+              ))
+            ]);
+          }
+
+          path.BABEL_PLUGIN_ADD_MODULE_EXPORTS = true;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We should do this*

The 114 files changed is mostly from the 2nd commit (https://github.com/babel/babel/pull/3438/commits/4c23b01798db0926d914eabd65e0911dfc27a3fe) - which changes all babel-runtime's in each package to be babel-runtime@6. Otherwise it should be straightforward to review