### PR TITLE
Remove the NodePath validation check

### DIFF
--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -84,18 +84,6 @@ export default class NodePath {
       }
     }
 
-    if (path && !(path instanceof NodePath)) {
-      if (path.constructor.name === "NodePath") {
-        // we're going to absolutley thrash the tree and allocate way too many node paths
-        // than is necessary but there's no way around this as the node module resolution
-        // algorithm is ridiculous
-        path = null;
-      } else {
-        // badly deserialised probably
-        throw new Error("We found a path that isn't a NodePath instance. Possibly due to bad serialisation.");
-      }
-    }
-
     if (!path) {
       path = new NodePath(hub, parent);
       paths.push(path);


### PR DESCRIPTION
`path.constructor.name === "NodePath"` is always falsy when Babel is minified, which caused https://phabricator.babeljs.io/T7198 in some cases. Now that we've moved the `_paths` cache into a WeakMap, it should be impossible to get a NodePath into the cache that isn't an instance of NodePath, so we can drop this check entirely.