### PR TITLE
Preserve whitespace in JSXExpressionContainer StringLiteral children

### DIFF
--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -63,7 +63,7 @@ export default function (opts) {
   function convertAttribute(node) {
     let value = convertAttributeValue(node.value || t.booleanLiteral(true));
 
-    if (t.isStringLiteral(value)) {
+    if (t.isStringLiteral(value) && !t.isJSXExpressionContainer(node.value)) {
       value.value = value.value.replace(/\n\s+/g, " ");
     }
 

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-mangle-expressioncontainer-attribute-values/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-mangle-expressioncontainer-attribute-values/actual.js
@@ -1,0 +1,1 @@
+<button data-value={"a value\n  with\nnewlines\n   and spaces"}>Button</button>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-mangle-expressioncontainer-attribute-values/expected.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-mangle-expressioncontainer-attribute-values/expected.js
@@ -1,0 +1,5 @@
+React.createElement(
+  "button",
+  { "data-value": "a value\n  with\nnewlines\n   and spaces" },
+  "Button"
+);


### PR DESCRIPTION
Babel currently replaces `/\n\s+/g` with `" "` in all StringLiteral JSXAttribute values, including those inside JSXExpressionContainers. This change restricts the behavior to non-JSXExpressionContainer-valued attributes. (I need this because I use attributes as lookups into a translation table, which expects whitespace to be untouched!)