### PR TITLE
Added defense codes to prevent breaking async/await statements at IE8.

### DIFF
--- a/packages/babel-regenerator-runtime/runtime.js
+++ b/packages/babel-regenerator-runtime/runtime.js
@@ -34,8 +34,9 @@
   runtime = global.regeneratorRuntime = inModule ? module.exports : {};
 
   function wrap(innerFn, outerFn, self, tryLocsList) {
-    // If outerFn provided, then outerFn.prototype instanceof Generator.
-    var generator = Object.create((outerFn || Generator).prototype);
+    // If outerFn provided and outerFn.prototype is a Generator, then outerFn.prototype instanceof Generator.
+    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+    var generator = Object.create(protoGenerator.prototype);
     var context = new Context(tryLocsList || []);
 
     // The ._invoke method unifies the implementations of the .next,


### PR DESCRIPTION
Added defense codes to prevent breaking async/await statements at the IE8 caused by the outerFn.
Related issue: https://phabricator.babeljs.io/T7028.