### PR TITLE
Stop traversing when target type is found

### DIFF
--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -104,7 +104,7 @@ traverse.removeProperties = function (tree) {
 function hasBlacklistedType(path, state) {
   if (path.node.type === state.type) {
     state.has = true;
-    path.skip();
+    path.stop();
   }
 }
 


### PR DESCRIPTION
It looks it should be `stop` rather than `skip`. 