### PR TITLE
Make sure input to path.{dir,base}name is a string

### DIFF
--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -16,7 +16,7 @@ module.exports = function (commander, filenames, opts) {
 
   let buildResult = function () {
     let map = new sourceMap.SourceMapGenerator({
-      file: path.basename(commander.outFile) || "stdout",
+      file: path.basename(commander.outFile || "") || "stdout",
       sourceRoot: opts.sourceRoot
     });
 

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -309,7 +309,7 @@ export default class OptionManager {
         options: presetOpts,
         alias: presetLoc,
         loc: presetLoc,
-        dirname: path.dirname(presetLoc)
+        dirname: path.dirname(presetLoc || "")
       });
     });
   }


### PR DESCRIPTION
Since nodejs/node@08085c49b6e, which will be part of Node.js v6.0, functions from the `path` core module (like `dirname`) will require their input to be a string.

Currently, at some points in the code they might be called with `undefined`; This patch adds `… || ""` so that the input is always a string.

For `path.dirname` in the babel-core file, this does not change behaviour, since `path.dirname(undefined) === path.dirname("") === "."` (where the first expression is only defined for Node.js ≤ v5.x).

For `path.basename`, this changes the return value, since `path.basename(undefined) === "undefined"` (on Node.js ≤ v5.x), but `path.basename("") === ""`. However, it seems reasonable to assume that, due to the trailing expression in `path.basename(…) || "stdout"`, the current behaviour is not actually the intended one.

There are possibly more places in the code base where similar changes may be neccessary; However, these suffice to make the tests pass and un-break the build of at least one external project when using the current Node.js master branch.