### PR TITLE
Allow babel presets to be objects

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -309,7 +309,7 @@ export default class OptionManager {
         options: presetOpts,
         alias: presetLoc,
         loc: presetLoc,
-        dirname: path.dirname(presetLoc)
+        dirname: presetLoc ? path.dirname(presetLoc) : path.resolve(".")
       });
     });
   }


### PR DESCRIPTION
In [electron-compile](https://github.com/electron/electron-compile), we require Babel plugins / presets ourselves before passing them to Babel (specifically at https://github.com/electron/electron-compilers/blob/master/src/js/babel.js#L63), because our module setup is a bit odd compared to standard node.js projects. 

This is afaik a supported feature, but it looks like it was broken in a recent release on latest node (node v5.10.0) - [here](https://github.com/babel/babel/compare/master...paulcbetts:fix-object-preloads?expand=1#diff-35232e36a88e5301dcb036713aec30f8L333), we specifically call the `onResolve` callback without a location parameter, yet [here](https://github.com/babel/babel/compare/master...paulcbetts:fix-object-preloads?expand=1#diff-35232e36a88e5301dcb036713aec30f8L312) we expect it to be set and call `path.dirname` on it. 