### PR TITLE
Remove console/debugger's parent statement if it's conditional

### DIFF
--- a/packages/babel-plugin-transform-remove-console/src/index.js
+++ b/packages/babel-plugin-transform-remove-console/src/index.js
@@ -3,6 +3,8 @@ export default function () {
     visitor: {
       CallExpression(path) {
         if (path.get("callee").matchesPattern("console", true)) {
+          let parent = path.getStatementParent();
+          if (parent !== path.parentPath) parent.remove();
           path.remove();
         }
       }

--- a/packages/babel-plugin-transform-remove-debugger/src/index.js
+++ b/packages/babel-plugin-transform-remove-debugger/src/index.js
@@ -2,6 +2,8 @@ export default function () {
   return {
     visitor: {
       DebuggerStatement(path) {
+        let parent = path.getStatementParent();
+        if (parent === path.parentPath) parent.remove();
         path.remove();
       }
     }


### PR DESCRIPTION
```js
if (debug) console.log('a debug statement')
if (something == 'else') debugger
switch (...) {
  case '...':
  // ...
  default:
    debugger
}
```

the if statements will produce an error that says: statement expected but null found (because an if-statement must have a body). this PR attempts to correct that by checking to see if the path's parent is the statement's parent.

the logic took me a bit to figure out because:

 - for debugger (maybe because it's not a statement?), if the statement's parent is the debugger statement's direct parent, remove it (not totally sure about this one)
 - for console the opposite: if the statement's parent is not the path's direct parent (like an if-statement) remove it

---

I would really like to know if there is any improvement that can be made to this PR - helper methods I missed or something else?

