### PR TITLE
feat: Add babelWD option to specify presets location

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -193,4 +193,9 @@ module.exports = {
     default: false,
     hidden: true,
   },
+
+  babelWD: {
+    description: "Location to resolve plugins and presets relative to.",
+    type: "string"
+  },
 };

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -409,6 +409,7 @@ export default class OptionManager {
 
   init(opts: Object = {}): Object {
     let filename = opts.filename;
+    let dirname = opts.babelWD || (filename && path.dirname(filename));
 
     // resolve all .babelrc files
     if (opts.babelrc !== false) {
@@ -419,7 +420,7 @@ export default class OptionManager {
     this.mergeOptions({
       options: opts,
       alias: "base",
-      dirname: filename && path.dirname(filename)
+      dirname: dirname
     });
 
     // normalise


### PR DESCRIPTION
Currently presets and plugins are resolved relative to the `filename`
option. In certain circumstances though your source code/file will be
located in a directory above where your plugins/presets are installed.

You can resolve them and pass in their resolved location but it's
cleaner to provide an option to specify a working directory for babel.

This will help fix some issues open in `babel-loader`.
