### PR TITLE
Remove unneeded dependencies from babel-generator

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -15,11 +15,8 @@
     "babel-runtime": "^5.0.0",
     "babel-types": "^6.7.2",
     "detect-indent": "^3.0.1",
-    "is-integer": "^1.0.4",
     "lodash": "^3.10.1",
-    "repeating": "^1.1.3",
-    "source-map": "^0.5.0",
-    "trim-right": "^1.0.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "babel-helper-fixtures": "^6.6.5",

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,6 +1,6 @@
 import type Position from "./position";
-import repeating from "repeating";
-import trimRight from "trim-right";
+import repeat from "lodash/string/repeat";
+import trimRight from "lodash/string/trimRight";
 
 /**
  * Buffer for collecting generated output.
@@ -58,7 +58,7 @@ export default class Buffer {
     if (this.format.compact || this.format.concise) {
       return "";
     } else {
-      return repeating(this.format.indent.style, this._indent);
+      return repeat(this.format.indent.style, this._indent);
     }
   }
 
@@ -215,7 +215,7 @@ export default class Buffer {
 
     this.removeLast(" ");
     this._removeSpacesAfterLastNewline();
-    this._push(repeating("\n", i));
+    this._push(repeat("\n", i));
   }
 
   /**

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -1,6 +1,5 @@
 /* eslint max-len: 0 */
 
-import isInteger from "is-integer";
 import isNumber from "lodash/lang/isNumber";
 import * as t from "babel-types";
 import * as n from "../node";
@@ -225,7 +224,7 @@ export function MemberExpression(node: Object) {
   } else {
     if (t.isNumericLiteral(node.object)) {
       let val = this.getPossibleRaw(node.object) || node.object.value;
-      if (isInteger(+val) &&
+      if (Number.isInteger(+val) &&
         !NON_DECIMAL_LITERAL.test(val) &&
         !SCIENTIFIC_NOTATION.test(val) &&
         !ZERO_DECIMAL_INTEGER.test(val) &&

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -1,4 +1,4 @@
-import repeating from "repeating";
+import repeat from "lodash/string/repeat";
 import * as t from "babel-types";
 
 const NON_ALPHABETIC_UNARY_OPERATORS = t.UPDATE_OPERATORS.concat(t.NUMBER_UNARY_OPERATORS).concat(["!"]);
@@ -231,7 +231,7 @@ export function VariableDeclaration(node: Object, parent: Object) {
 
   let sep;
   if (!this.format.compact && !this.format.concise && hasInits && !this.format.retainLines) {
-    sep = `,\n${repeating(" ", node.kind.length + 1)}`;
+    sep = `,\n${repeat(" ", node.kind.length + 1)}`;
   }
 
   //

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 
-import repeating from "repeating";
+import repeat from "lodash/string/repeat";
 import Buffer from "./buffer";
 import * as n from "./node";
 import * as t from "babel-types";
@@ -290,7 +290,7 @@ export default class Printer extends Buffer {
       }
 
       let indent = Math.max(this.indentSize(), column);
-      val = val.replace(/\n/g, `\n${repeating(" ", indent)}`);
+      val = val.replace(/\n/g, `\n${repeat(" ", indent)}`);
     }
 
     if (column === 0) {


### PR DESCRIPTION
I've updated babel-generator to replace the packages `is-integer`, `repeating`, `trim-right` with `Number.isInteger`, `_.repeat` and `_.trimRight` respectively.

Lodash is already a dependency so this adds nothing new.