### PR TITLE
Minimise cases inside the regenerator FSM

### DIFF
--- a/packages/babel-plugin-transform-regenerator/src/emit.js
+++ b/packages/babel-plugin-transform-regenerator/src/emit.js
@@ -18,12 +18,13 @@ let hasOwn = Object.prototype.hasOwnProperty;
 
 function checkAbruptReturn(stmt, contextId) {
   // Abrupt if stmt like `return context.abrupt('return', ...);`
-  return t.isReturnStatement(stmt)
+  // or; `throw ...`
+  return t.isThrowStatement(stmt) || (t.isReturnStatement(stmt)
       && t.isCallExpression(stmt.argument)
       && stmt.argument.callee.object === contextId
       && stmt.argument.callee.property.name === "abrupt"
       && t.isLiteral(stmt.argument.arguments[0])
-      && stmt.argument.arguments[0].value === "return";
+      && stmt.argument.arguments[0].value === "return");
 }
 
 function Emitter(contextId) {

--- a/packages/babel-plugin-transform-regenerator/src/emit.js
+++ b/packages/babel-plugin-transform-regenerator/src/emit.js
@@ -16,6 +16,16 @@ import * as util from "./util";
 
 let hasOwn = Object.prototype.hasOwnProperty;
 
+function checkAbruptReturn(stmt, contextId) {
+  // Abrupt if stmt like `return context.abrupt('return', ...);`
+  return t.isReturnStatement(stmt)
+      && t.isCallExpression(stmt.argument)
+      && stmt.argument.callee.object === contextId
+      && stmt.argument.callee.property.name === "abrupt"
+      && t.isLiteral(stmt.argument.arguments[0])
+      && stmt.argument.arguments[0].value === "return";
+}
+
 function Emitter(contextId) {
   assert.ok(this instanceof Emitter);
   t.assertIdentifier(contextId);
@@ -225,6 +235,8 @@ Ep.getDispatchLoop = function() {
   // If we encounter a break, continue, or return statement in a switch
   // case, we can skip the rest of the statements until the next case.
   let alreadyEnded = false;
+  let wasAbruptReturn = false;
+  const lastListingIndex = self.listing.length - 1;
 
   self.listing.forEach(function(stmt, i) {
     if (self.marked.hasOwnProperty(i)) {
@@ -239,17 +251,23 @@ Ep.getDispatchLoop = function() {
       if (t.isCompletionStatement(stmt))
         alreadyEnded = true;
     }
+    wasAbruptReturn = i === lastListingIndex
+      && checkAbruptReturn(stmt, self.contextId);
   });
 
   // Now that we know how many statements there will be in this.listing,
   // we can finally resolve this.finalLoc.value.
   this.finalLoc.value = this.listing.length;
 
-  cases.push(
-    t.switchCase(this.finalLoc, [
-      // Intentionally fall through to the "end" case...
-    ]),
+  if (!wasAbruptReturn) {
+    cases.push(
+      t.switchCase(this.finalLoc, [
+        // Intentionally fall through to the "end" case...
+      ])
+    );
+  }
 
+  cases.push(
     // So that the runtime can jump to the final location without having
     // to know its offset, we provide the "end" case as a synonym.
     t.switchCase(t.stringLiteral("end"), [

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
@@ -20,7 +20,6 @@ function _callee() {
           x = _context.sent;
           return _context.abrupt("return", 5);
 
-        case 4:
         case "end":
           return _context.stop();
       }

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/with-throw/actual.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/with-throw/actual.js
@@ -1,0 +1,3 @@
+export default function * () {
+  throw new Error();
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/with-throw/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/with-throw/expected.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = _callee;
+
+var _marked = [_callee].map(regeneratorRuntime.mark);
+
+function _callee() {
+  return regeneratorRuntime.wrap(function _callee$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          throw new Error();
+
+        case "end":
+          return _context.stop();
+      }
+    }
+  }, _marked[0], this);
+}


### PR DESCRIPTION
(NB: Also opened against facebook/regenerator#241 )

This PR aids downstream consumers of babel-optimised code by producing a more idomatic switch statement in the regenerator FSM used for generators/async statements.

This greatly benefits code coverage tools that check for branch usage; as-is, it's not possible to cover every branch.