### PR TITLE
don't double count binding references

### DIFF
--- a/packages/babel-traverse/src/scope/binding.js
+++ b/packages/babel-traverse/src/scope/binding.js
@@ -82,6 +82,9 @@ export default class Binding {
    */
 
   reference(path: NodePath) {
+    if (this.referencePaths.indexOf(path) !== -1) {
+      return;
+    }
     this.referenced = true;
     this.references++;
     this.referencePaths.push(path);


### PR DESCRIPTION
When, for example, a function is moved between from one place to another we recrawl and end up double counting any references it holds to the upper scope. This protects against that. (The same thing is done for constant violations in the `reassign` method)