### PR TITLE
Add a `moduleDirectories` parameter to be able to search for modules in more than one path.

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -187,6 +187,12 @@ module.exports = {
     type: "string"
   },
 
+  modulesDirectories: {
+    type: "list",
+    default: [],
+    description: "An array of directory names to be resolved and searched for modules."
+  },
+
   passPerPreset: {
     description: "Whether to spawn a traversal pass per a preset. By default all presets are merged.",
     type: "boolean",


### PR DESCRIPTION
Hi, 

I created this pull request to add a parameter to babel, like the parameter in webpack : https://webpack.github.io/docs/configuration.html#resolve-modulesdirectories

This parameter is used in `extends`, `plugins` and `presets` to find the corresponding modules.

This resolves a problem with npm@2 or a shrinkwrapped module (even with npm@3).

Let's say I have a `my_webpack_bundle` module which has `babel-preset-es2015` as a dependency.

`babel-preset-es2015` will be installed in `my_project/node_modules/my_webpack_bundle/babel-preset-es2015`

By default babel won't be looking in that place, it will stop at `my_project/node_modules` and all parent directories

Now, with that change and if you pas the following configuration:
```js
{
    modulesDirectories: ["node_modules/my_webpack_bundle" ]
}
```

It will resolve the modules correctly, and everyone is happy :D 