### PR TITLE
Test that __esModule flag isn't overwritten on re-export

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
@@ -15,6 +15,7 @@
     "babel-plugin"
   ],
   "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.3.13"
+    "babel-helper-plugin-test-runner": "^6.3.13",
+    "babel-core": "^6.0.0"
   }
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
@@ -1,0 +1,37 @@
+var assert = require("assert");
+var babel = require("babel-core");
+var vm = require("vm");
+
+test("Re-export doesn't overwrite __esModule flag", function () {
+  var code = 'export * from "./dep";';
+  var depStub = {
+    __esModule: false,
+  };
+
+  var context = {
+    module: {
+      exports: {}
+    },
+    require: function (id) {
+      if (id === "./dep") return depStub;
+      return require(id);
+    },
+  };
+  context.exports = context.module.exports;
+
+  code = babel.transform(code, {
+    "plugins": [
+      [require("../"), {loose: true}],
+    ],
+    "ast": false,
+  }).code;
+
+  vm.runInNewContext(code, context);
+
+  // exports.__esModule shouldn't be overwritten.
+  assert.equal(
+    context.exports.__esModule,
+    true,
+    "Expected exports.__esModule === true"
+  );
+});


### PR DESCRIPTION
This is a WIP test for #3427. This is how I think we should test this behavior. Existing fixtures in this and other module plugins also need to be updated to account for the change, if those fixtures are still useful.

I thought that the build scripts, then lerna, symlinked together packages in the repo, but I'm not seeing that? Is this the right way to depend on `babel-core` to access it for use in the test?