### PR TITLE
Add type fields for parameter decorators

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -311,6 +311,9 @@ defineType("Identifier", {
           // todo
         }
       }
+    },
+    decorators: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
     }
   }
 });
@@ -544,6 +547,9 @@ defineType("RestElement", {
   fields: {
     argument: {
       validate: assertNodeType("LVal")
+    },
+    decorators: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
     }
   }
 });

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -17,6 +17,9 @@ defineType("AssignmentPattern", {
     },
     right: {
       validate: assertNodeType("Expression")
+    },
+    decorators: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
     }
   }
 });
@@ -27,6 +30,9 @@ defineType("ArrayPattern", {
   fields: {
     elements: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
+    },
+    decorators: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
     }
   }
 });
@@ -285,6 +291,9 @@ defineType("ObjectPattern", {
   fields: {
     properties: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("RestProperty", "Property")))
+    },
+    decorators: {
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
     }
   }
 });


### PR DESCRIPTION
Adding [type fields for parameter decorators](https://github.com/babel/babylon/pull/12#issuecomment-202667661) that are going to be introduced to babylon.