### PR TITLE
node-env-inline – Use default value when NODE_ENV is undefined

### DIFF
--- a/packages/babel-plugin-transform-node-env-inline/README.md
+++ b/packages/babel-plugin-transform-node-env-inline/README.md
@@ -35,9 +35,19 @@ $ npm install babel-plugin-transform-node-env-inline
 
 **.babelrc**
 
-```json
+```js
+// without options
 {
   "plugins": ["transform-node-env-inline"]
+}
+
+// with options
+{
+  "plugins": [
+    ["transform-node-env-inline", {
+      "default": "development"
+    }]
+  ]
 }
 ```
 

--- a/packages/babel-plugin-transform-node-env-inline/src/index.js
+++ b/packages/babel-plugin-transform-node-env-inline/src/index.js
@@ -1,9 +1,9 @@
 export default function ({ types: t }) {
   return {
     visitor: {
-      MemberExpression(path) {
+      MemberExpression(path, state) {
         if (path.matchesPattern("process.env.NODE_ENV")) {
-          path.replaceWith(t.valueToNode(process.env.NODE_ENV));
+          path.replaceWith(t.valueToNode(process.env.NODE_ENV || state.opts.default));
 
           if (path.parentPath.isBinaryExpression()) {
             let evaluated = path.parentPath.evaluate();


### PR DESCRIPTION
Many folks (myself included) typically like to treat an undefined NODE_ENV as equivalent to `development`. So I added support for a `default` option to be used as a fallback when NODE_ENV is undefined. 

I hope this is the right place to submit plugin pull requests. Let me know if there's anything missing.