### PR TITLE
inline-environment-variables – Use default values when environment variables are undefined

### DIFF
--- a/packages/babel-plugin-transform-inline-environment-variables/README.md
+++ b/packages/babel-plugin-transform-inline-environment-variables/README.md
@@ -29,9 +29,21 @@ $ npm install babel-plugin-transform-inline-environment-variables
 
 **.babelrc**
 
-```json
+```js
+// without options
 {
   "plugins": ["transform-inline-environment-variables"]
+}
+
+// with options
+{
+  "plugins": [
+    ["transform-inline-environment-variables", {
+      "defaults": {
+        "NODE_ENV": "development"
+      }
+    }]
+  ]
 }
 ```
 

--- a/packages/babel-plugin-transform-inline-environment-variables/src/index.js
+++ b/packages/babel-plugin-transform-inline-environment-variables/src/index.js
@@ -1,11 +1,13 @@
 export default function ({ types: t }) {
   return {
     visitor: {
-      MemberExpression(path) {
+      MemberExpression(path, state) {
         if (path.get("object").matchesPattern("process.env")) {
           let key = path.toComputedKey();
           if (t.isStringLiteral(key)) {
-            path.replaceWith(t.valueToNode(process.env[key.value]));
+            let {value} = key;
+            let replacement = process.env[value] || (state.opts.defaults || {})[value];
+            path.replaceWith(t.valueToNode(replacement));
           }
         }
       }


### PR DESCRIPTION
Same concept as #3471.