### PR TITLE
fix(function-name): workout function names across objects

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -131,9 +131,12 @@ export default function ({ node, parent, scope, id }) {
   // has an `id` so we don't need to infer one
   if (node.id) return;
 
+  let shouldRename = false;
+
   if ((t.isObjectProperty(parent) || t.isObjectMethod(parent, { kind: "method" })) && (!parent.computed || t.isLiteral(parent.key))) {
     // { foo() {} };
     id = parent.key;
+    shouldRename = true;
   } else if (t.isVariableDeclarator(parent)) {
     // let foo = function () {};
     id = parent.id;
@@ -164,7 +167,7 @@ export default function ({ node, parent, scope, id }) {
   }
 
   name = t.toBindingIdentifierName(name);
-  id = t.identifier(name);
+  id = shouldRename ? scope.generateUidIdentifier(name) : t.identifier(name);
 
   // The id shouldn't be considered a local binding to the function because
   // we are simply trying to set the function name and not actually create

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/two-objects-same-keys/actual.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/two-objects-same-keys/actual.js
@@ -1,0 +1,11 @@
+var o1 = {
+  a: function() {
+    doSomething();
+  }
+};
+
+var o2 = {
+  a: function() {
+    doSomethingElse();
+  }
+};

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/two-objects-same-keys/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/two-objects-same-keys/expected.js
@@ -1,0 +1,11 @@
+var o1 = {
+  a: function _a() {
+    doSomething();
+  }
+};
+
+var o2 = {
+  a: function _a2() {
+    doSomethingElse();
+  }
+};


### PR DESCRIPTION
Given:
```
var o1 = {
  a: function() {
    doSomething();
  }
};

var o2 = {
  a: function() {
    doSomethingElse();
  }
};
```

Babel will currently output:
```
var o1 = {
  a: function a() {
    doSomething();
  }
};

var o2 = {
  a: function a() {
    doSomethingElse();
  }
};
```

The problem is that `a` gets stepped over by whatever latter definition we may have.
This commit fixes the problem by producing the following output:
```
var o1 = {
  a: function _a() {
    doSomething();
  }
};

var o2 = {
  a: function _a2() {
    doSomethingElse();
  }
};
```

It does however change the expected behaviour and make other tests fail.
Before diving any deeper into this, would anyone know if there's any better alternative to it?
I couldn't find how to check whether the function's name was already defined in scope (I would've
thought that `path.scope.hasBinding` or `path.scope.hasOwnBiding` would work but they don't).

Thanks!
Darío