### PR TITLE
Code generator performance improvements

### DIFF
--- a/packages/babel-generator/src/node/index.js
+++ b/packages/babel-generator/src/node/index.js
@@ -2,22 +2,42 @@ import whitespace from "./whitespace";
 import * as parens from "./parentheses";
 import * as t from "babel-types";
 
-function find(obj, node, parent, printStack) {
-  if (!obj) return;
-  let result;
+function expandAliases(obj) {
+  let newObj = {};
 
-  let types = Object.keys(obj);
-  for (let i = 0; i < types.length; i++) {
-    let type = types[i];
+  function add(type, func) {
+    let fn = newObj[type];
+    newObj[type] = fn ? function(node, parent, stack) {
+      let result = fn(node, parent, stack);
 
-    if (t.is(type, node)) {
-      let fn = obj[type];
-      result = fn(node, parent, printStack);
-      if (result != null) break;
+      return result == null ? func(node, parent, stack) : result;
+    } : func;
+  }
+
+  for (let type of Object.keys(obj)) {
+
+    let aliases = t.FLIPPED_ALIAS_KEYS[type];
+    if (aliases) {
+      for (let alias of aliases) {
+        add(alias, obj[type]);
+      }
+    } else {
+      add(type, obj[type]);
     }
   }
 
-  return result;
+  return newObj;
+}
+
+// Rather than using `t.is` on each object property, we pre-expand any type aliases
+// into concrete types so that the 'find' call below can be as fast as possible.
+let expandedParens = expandAliases(parens);
+let expandedWhitespaceNodes = expandAliases(whitespace.nodes);
+let expandedWhitespaceList = expandAliases(whitespace.list);
+
+function find(obj, node, parent, printStack) {
+  let fn = obj[node.type];
+  return fn ? fn(node, parent, printStack) : null;
 }
 
 function isOrHasCallExpression(node) {
@@ -45,10 +65,10 @@ export function needsWhitespace(node, parent, type) {
     node = node.expression;
   }
 
-  let linesInfo = find(whitespace.nodes, node, parent);
+  let linesInfo = find(expandedWhitespaceNodes, node, parent);
 
   if (!linesInfo) {
-    let items = find(whitespace.list, node, parent);
+    let items = find(expandedWhitespaceList, node, parent);
     if (items) {
       for (let i = 0; i < items.length; i++) {
         linesInfo = needsWhitespace(items[i], node, type);
@@ -75,5 +95,5 @@ export function needsParens(node, parent, printStack) {
     if (isOrHasCallExpression(node)) return true;
   }
 
-  return find(parens, node, parent, printStack);
+  return find(expandedParens, node, parent, printStack);
 }

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -211,7 +211,17 @@ export default class Printer extends Buffer {
   }
 
   _printNewline(leading, node, parent, opts) {
+    // Fast path since 'this.newline' does nothing when not tracking lines.
+    if (this.format.retainLines || this.format.compact) return;
+
     if (!opts.statement && !n.isUserWhitespacable(node, parent)) {
+      return;
+    }
+
+    // Fast path for concise since 'this.newline' just inserts a space when
+    // concise formatting is in use.
+    if (this.format.concise) {
+      this.space();
       return;
     }
 

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -182,11 +182,11 @@ export default class Printer extends Buffer {
   }
 
   printTrailingComments(node, parent) {
-    this.printComments(this.getComments("trailingComments", node, parent));
+    this.printComments(this.getComments(false, node, parent));
   }
 
   printLeadingComments(node, parent) {
-    this.printComments(this.getComments("leadingComments", node, parent));
+    this.printComments(this.getComments(true, node, parent));
   }
 
   printInnerComments(node, indent = true) {
@@ -250,8 +250,10 @@ export default class Printer extends Buffer {
     this.newline(lines);
   }
 
-  getComments(key, node) {
-    return (node && node[key]) || [];
+  getComments(leading, node) {
+    // Note, we use a boolean flag here instead of passing in the attribute name as it is faster
+    // because this is called extremely frequently.
+    return (node && (leading ? node.leadingComments : node.trailingComments)) || [];
   }
 
   shouldPrintComment(comment) {

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -96,6 +96,10 @@ export function is(type: string, node: Object, opts?: Object): boolean {
 export function isType(nodeType: string, targetType: string): boolean {
   if (nodeType === targetType) return true;
 
+  // This is a fast-path. If the test above failed, but an alias key is found, then the
+  // targetType was a primary node type, so there's no need to check the aliases.
+  if (t.ALIAS_KEYS[targetType]) return false;
+
   let aliases: ?Array<string> = t.FLIPPED_ALIAS_KEYS[targetType];
   if (aliases) {
     if (aliases[0] === nodeType) return true;


### PR DESCRIPTION
This makes everything faster, but it in particular makes things faster if you're using `compact: true`

Here's some unscientific numbers from me parsing an AST then generating code from it 100 times:

Master:

| Compact	| SourceMaps| Comments	| Time  |
| --------- | --------- | --------- | ----- |
| true		| false		| false		| 4.15s |
| true		| false		| true		| 4.11s |
| true		| true		| false		| 6.67s |
| true		| true		| true		| 6.92s |
| false		| false		| false		| 5.65s |
| false		| false		| true		| 5.64s |
| false		| true		| false		| 8.72s |
| false		| true		| true		| 8.71s |


With PR:

| Compact	| SourceMaps| Comments	| Time  |
| --------- | --------- | --------- | ----- |
| true		| false		| false		| 1.35s |
| true		| false		| true		| 1.26s |
| true		| true		| false		| 3.02s |
| true		| true		| true		| 3.23s |
| false		| false		| false		| 3.17s |
| false		| false		| true		| 3.23s |
| false		| true		| false		| 5.42s |
| false		| true		| true		| 5.32s |
