### PR TITLE
Preset for env/targets

### DIFF
--- a/packages/babel-preset-env/.npmignore
+++ b/packages/babel-preset-env/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+node_modules

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -1,0 +1,49 @@
+# babel-preset-env
+
+> Babel preset for all envs.
+
+## Install
+
+```sh
+$ npm install --save-dev babel-preset-env
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "presets": ["env"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel script.js --presets env
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  presets: ["env"]
+});
+```
+
+## Options
+
+* `loose` - Enable "loose" transformations for any plugins in this preset that allow them (Disabled by default).
+
+```
+{
+  presets: [
+    ["env", {
+      chrome: 49
+    }]
+  ]
+}
+```

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "babel-preset-env",
+  "version": "6.7.7",
+  "description": "A Babel preset for each environment.",
+  "author": "Henry Zhu <hi@henryzoo.com>",
+  "homepage": "https://babeljs.io/",
+  "license": "MIT",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-env",
+  "main": "lib/index.js",
+  "dependencies": {
+    "babel-plugin-check-es2015-constants": "^6.3.13",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+    "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+    "babel-plugin-transform-es2015-block-scoping": "^6.6.0",
+    "babel-plugin-transform-es2015-classes": "^6.6.0",
+    "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-destructuring": "^6.6.0",
+    "babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
+    "babel-plugin-transform-es2015-for-of": "^6.6.0",
+    "babel-plugin-transform-es2015-function-name": "^6.3.13",
+    "babel-plugin-transform-es2015-literals": "^6.3.13",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
+    "babel-plugin-transform-es2015-object-super": "^6.3.13",
+    "babel-plugin-transform-es2015-parameters": "^6.6.0",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-spread": "^6.3.13",
+    "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+    "babel-plugin-transform-es2015-template-literals": "^6.6.0",
+    "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
+    "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+    "babel-plugin-transform-regenerator": "^6.6.0"
+  },
+  "devDependencies": {
+    "babel-helper-transform-fixture-test-runner": "^6.3.13",
+    "babel-runtime": "^5.0.0"
+  }
+}
+

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -1,0 +1,181 @@
+export const plugins = [
+  "es3-member-expression-literals",
+  "es3-property-literals",
+
+  "es5-property-mutators",
+
+  "transform-es2015-arrow-functions",
+  "transform-es2015-block-scoped-functions",
+  "transform-es2015-block-scoping",
+  "transform-es2015-classes",
+  "transform-es2015-computed-properties",
+  "check-es2015-constants",
+  "transform-es2015-destructuring",
+  "transform-es2015-for-of",
+  "transform-es2015-function-name",
+  "transform-es2015-literals",
+  "transform-es2015-object-super",
+  "transform-es2015-parameters",
+  "transform-es2015-shorthand-properties",
+  "transform-es2015-spread",
+  "transform-es2015-sticky-regex",
+  "transform-es2015-template-literals",
+  "transform-es2015-typeof-symbol",
+  "transform-es2015-unicode-regex",
+
+  "transform-regenerator",
+];
+
+// modules?
+export const modules = [
+  "es2015-modules-amd",
+  "es2015-modules-commonjs",
+  "es2015-modules-systemjs",
+  "es2015-modules-umd"
+];
+
+export const stagePlugins = [
+  "transform-async-to-generator",
+  // "transform-class-constructor-call", proposal is removed
+  "transform-class-properties",
+  "transform-transform-decorators-legacy", // legacy plugin
+  "transform-do-expressions",
+  "transform-exponentiation-operator",
+  "transform-export-extensions",
+  "transform-function-bind",
+  "transform-object-rest-spread",
+  "syntax-trailing-function-commas"
+];
+
+export default function(opts) {
+  let loose = false;
+  if (opts !== undefined){
+    if (opts.loose !== undefined) loose = opts.loose;
+  }
+
+  if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
+
+}
+
+export const environments = {
+  android: {
+    44: {
+
+    },
+    50: {
+
+    },
+    51: {
+
+    },
+  },
+  chrome: {
+    48: {
+
+    },
+    49: {
+
+    },
+    50: {
+
+    },
+    51: {
+
+    },
+    52: {
+
+    },
+  },
+  edge: {
+    12: {
+
+    },
+    13: {
+
+    },
+    14: {
+
+    },
+  },
+  firefox: {
+    43: {
+
+    },
+    44: {
+
+    },
+    45: {
+
+    },
+    46: {
+
+    },
+    47: {
+
+    },
+    48: {
+
+    },
+  },
+  ie: {
+    8: {
+
+    },
+    9: {
+
+    },
+    10: {
+
+    },
+    11: {
+
+    },
+  },
+  ios: {
+    7: {
+
+    },
+    8: {
+
+    },
+    9: {
+
+    },
+  },
+  node: {
+    "0.10": {
+
+    },
+    "0.12": {
+
+    },
+    4: {
+
+    },
+    5: {
+
+    },
+    6: {
+
+    },
+  },
+  phantom: {
+    1: {
+
+    },
+    2: {
+
+    }
+  },
+  safari: {
+    7: {
+
+    },
+    8: {
+
+    },
+    9: {
+
+    },
+  }
+};

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -1,9 +1,16 @@
+<<<<<<< HEAD:packages/babel-preset-es2015/src/index.js
 module.exports = function(context, opts) {
   const moduleTypes = ["commonjs", "amd", "umd", "systemjs"];
   let loose = false;
   let modules = "commonjs";
 
   if (opts !== undefined) {
+=======
+module.exports = function(opts){
+  let loose = false;
+  let modules = true;
+  if (opts !== undefined){
+>>>>>>> 56a3ede... babel-preset-env:packages/babel-preset-es2015/index.js
     if (opts.loose !== undefined) loose = opts.loose;
     if (opts.modules !== undefined) modules = opts.modules;
   }


### PR DESCRIPTION
#### Mostly for a discussion (no implementation atm)

> This will most likely be maintained by the community (moved into another repo). I'm just doing this off of #3331 to get preset options. Also no actual implementation yet (need data).

Basic idea to be able to specify an environment/s so that babel wouldn't transform what is already implemented natively.

This can be useful given that the latest browsers/node have implemented a good amount of es2015 already unlike a few years ago, and there are currently numerous presets for each environment (babel-preset-node5, babel-preset-modern, etc). We are at the point where you might not need the es2015 preset at all (and we would like to see an automated solution).

### TL;DR

```js
{
  presets: [
    ["targets", {
      chrome: 50,
      node: 5
    }]
  ]
}
```

Also this isn't about dynamically doing this at runtime but just a similar configuration where an environment is mapped to a set of plugins beforehand.

EDIT: Another recent discussion https://gist.github.com/addyosmani/bb6e2939f943226e68e87396c4931040

Previous Discussions:
- [T272](http://phabricator.babeljs.io/T272): Blacklist presets (created Dec 2014)
- [T631](https://phabricator.babeljs.io/T631): Generate blacklist based on targets
- [T2842](https://phabricator.babeljs.io/T2842): environment awareness
- and others: [T462](http://phabricator.babeljs.io/T462), [T686](http://phabricator.babeljs.io/T686), [T1918](http://phabricator.babeljs.io/T1918)
- [zloirock/core-js#188](https://github.com/zloirock/core-js/issues/188) different build for core-js that could be applied for `babel-plugin-transform-runtime` or polyfill based on environment.

Some other articles
- https://glebbahmutov.com/blog/javascript-needs-compile-step/
- https://glebbahmutov.com/blog/precompiled-javascript/
- https://medium.com/@kasajian/progressive-transpilation-def5da34282e#.veudqrkyx

## How do we get the data?
Many people will probably think of using something like https://github.com/kangax/compat-table/. This would be great will we could use these resources and just create a mapping to transforms. Looking at https://github.com/Fyrd/caniuse it looks like it defers to kangax's table for es2015.

> I don't think we can just run a single test since that doesn't actually mean the environment supports the whole feature/transform.

It could just be a list and we update it when necessary (with community input/help).

## How do you specify this in Babel?

### Targets
Could be a builtin config value like `targets/environments`:

Like what buble is doing: https://gitlab.com/Rich-Harris/buble/blob/master/src/support.js

```js
// .babelrc
{
  // format here isn't too important for the discussion but the idea is being able to declare targets/environments
  "targets": [
    "chrome50",
    "node5"
  ]
}
```

Targets would specify plugins that are implemented already and could act like a blacklist against the plugins passed in.

### Preset (most likely option)

> https://github.com/babel/babel/blob/preset-env/packages/babel-preset-env/src/index.js in this PR although it doesn't do anything or has an data right now.

This would depend on something like logan's pr: [#3331](https://github.com/babel/babel/pull/3331) which allows passing options to presets.

Even if this isn't a builtin feature like a targets key in `.babelrc`, it could at least be a preset with options that allow you to specify the environments you support.

We don't have to do this only for es2015 since some stage-x features are also in development. Could do another option if users want to test in a browser that has a feature behind a flag.

```js
// .babelrc
{
  presets: [
    ["env", {
      loose: true. // allow passing other options down?
      chrome: 50,
      node: 5,
    }]
  ]
}
```

### Other?