### PR TITLE
turn transform into a simple `for` loop

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -438,13 +438,14 @@ export default class File extends Store {
   transform(): BabelFileResult {
     // In the "pass per preset" mode, we have grouped passes.
     // Otherwise, there is only one plain pluginPasses array.
-    this.pluginPasses.forEach((pluginPasses, index) => {
+    for (let i = 0; i < this.pluginPasses.length; i++) {
+      const pluginPasses = this.pluginPasses[i];
       this.call("pre", pluginPasses);
       this.log.debug("Start transform traverse");
-      traverse(this.ast, traverse.visitors.merge(this.pluginVisitors[index], pluginPasses), this.scope);
+      traverse(this.ast, traverse.visitors.merge(this.pluginVisitors[i], pluginPasses), this.scope);
       this.log.debug("End transform traverse");
       this.call("post", pluginPasses);
-    });
+    }
 
     return this.generate();
   }


### PR DESCRIPTION
I'm all for expressive code, but the transform function is HOT. Profiling my webpack build, the function accounts for ~20% of the ticks. This is verified through my webpack build times: I reduced my build from ~12 seconds to ~10 seconds.
Before:
![](http://i.imgur.com/55dzNrM.png)
After:
![](http://i.imgur.com/cBw8j77.png)

I'm not saying we should do this for every `forEach`, but a 20% reduction in build times just for changing a loop type seems like an easy win.