### PR TITLE
For...of strict iterator init check

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1169/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1169/expected.js
@@ -18,7 +18,7 @@ function foo() {
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return) {
+      if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
         _iterator.return();
       }
     } finally {

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/hoisting/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/hoisting/expected.js
@@ -24,7 +24,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -34,7 +34,7 @@ export default function ({ messages, template, types: t }) {
       ITERATOR_ERROR_KEY = err;
     } finally {
       try {
-        if (!ITERATOR_COMPLETION && ITERATOR_KEY.return) {
+        if (!ITERATOR_COMPLETION && ITERATOR_KEY && ITERATOR_KEY.return) {
           ITERATOR_KEY.return();
         }
       } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/identifier/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/identifier/expected.js
@@ -11,7 +11,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/ignore-cases/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/ignore-cases/expected.js
@@ -16,7 +16,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/let/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/let/expected.js
@@ -11,7 +11,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/member-expression/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/member-expression/expected.js
@@ -11,7 +11,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/multiple/expected.js
@@ -11,7 +11,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {
@@ -34,7 +34,7 @@ try {
   _iteratorError2 = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion2 && _iterator2.return) {
+    if (!_iteratorNormalCompletion2 && _iterator2 && _iterator2.return) {
       _iterator2.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/nested-label-for-of/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/nested-label-for-of/expected.js
@@ -20,7 +20,7 @@ try {
       _iteratorError2 = err;
     } finally {
       try {
-        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+        if (!_iteratorNormalCompletion2 && _iterator2 && _iterator2.return) {
           _iterator2.return();
         }
       } finally {
@@ -35,7 +35,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/var/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/spec/var/expected.js
@@ -11,7 +11,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -168,7 +168,7 @@ function forOf() {
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return) {
+      if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
         _iterator.return();
       }
     } finally {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/es6-for-of/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/es6-for-of/expected.js
@@ -12,7 +12,7 @@ try {
   _iteratorError = err;
 } finally {
   try {
-    if (!_iteratorNormalCompletion && _iterator.return) {
+    if (!_iteratorNormalCompletion && _iterator && _iterator.return) {
       _iterator.return();
     }
   } finally {


### PR DESCRIPTION
See: https://phabricator.babeljs.io/T7310

checks that `_iterator` was assigned before dereferencing `_iterator.return` (malformed iterator functions could potentially throw exception).
