### PR TITLE
Update README.md

### DIFF
--- a/packages/babel-generator/README.md
+++ b/packages/babel-generator/README.md
@@ -63,7 +63,6 @@ Here's an example of what that might look like:
 
 ```js
 import {parse} from 'babylon';
-import traverse from "babel-traverse";
 import generate from 'babel-generator';
 
 const a = 'var a = 1;';


### PR DESCRIPTION
`traverse` is imported but not used.