### PR TITLE
also visit ClassProperty's for rest param deopt check, fixes #T7311

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -30,7 +30,7 @@ let memberExpressionOptimisationVisitor = {
     path.skip();
   },
 
-  Function(path, state) {
+  "Function|ClassProperty": function (path, state) {
     // Detect whether any reference to rest is contained in nested functions to
     // determine if deopt is necessary.
     let oldNoOptimise = state.noOptimise;

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["external-helpers", "syntax-flow", "transform-es2015-parameters", "transform-es2015-block-scoping", "transform-es2015-spread", "transform-es2015-classes", "transform-es2015-destructuring", "transform-es2015-arrow-functions", "syntax-async-functions", "transform-es2015-for-of"]
+  "plugins": ["transform-class-properties", "external-helpers", "syntax-flow", "transform-es2015-parameters", "transform-es2015-block-scoping", "transform-es2015-spread", "transform-es2015-classes", "transform-es2015-destructuring", "transform-es2015-arrow-functions", "syntax-async-functions", "transform-es2015-for-of"]
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/actual.js
@@ -27,3 +27,10 @@ var x = (...rest) => {
   if (noNeedToWork) return 0;
   return rest;
 };
+
+var innerclassproperties = (...args) => (
+  class {
+    static args = args;
+    args = args;
+  }
+);

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-arrow-functions/expected.js
@@ -37,3 +37,16 @@ var x = function () {
   if (noNeedToWork) return 0;
   return rest;
 };
+
+var innerclassproperties = function () {
+  var _class, _temp;
+
+  for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+    args[_key3] = arguments[_key3];
+  }
+
+  return _temp = _class = function _class() {
+    babelHelpers.classCallCheck(this, _class);
+    this.args = args;
+  }, _class.args = args, _temp;
+};


### PR DESCRIPTION
Fixes cases like this:

```js
const test = (...args) => {
  class Foo {
    // these will both error with "args is not defined" even though it should be defined
    static bar = args;
    bar = args;
    
    /*
    // If you comment this out, it will now generate
    // the right code for `args` and work
    works() {
      args;
    }
    */
  }
};

console.log(test(1, 2, 3));
```