### PR TITLE
Modules systemjs system global name, use strict wrapping

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-systemjs/README.md
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/README.md
@@ -12,9 +12,20 @@ $ npm install babel-plugin-transform-es2015-modules-systemjs
 
 **.babelrc**
 
-```json
+```javascript
+// without options
 {
   "plugins": ["transform-es2015-modules-systemjs"]
+}
+
+// with options
+{
+  "plugins": [
+    ["transform-es2015-modules-systemjs", {
+      // outputs SystemJS.register(...)
+      "systemGlobal": "SystemJS"
+    }]
+  ]
 }
 ```
 

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
@@ -8,8 +8,7 @@
   "dependencies": {
     "babel-template": "^6.8.0",
     "babel-helper-hoist-variables": "^6.8.0",
-    "babel-runtime": "^6.0.0",
-    "babel-plugin-transform-strict-mode": "^6.8.0"
+    "babel-runtime": "^6.0.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -4,7 +4,8 @@ import hoistVariables from "babel-helper-hoist-variables";
 import template from "babel-template";
 
 let buildTemplate = template(`
-  System.register(MODULE_NAME, [SOURCES], function (EXPORT_IDENTIFIER, CONTEXT_IDENTIFIER) {
+  SYSTEM_REGISTER(MODULE_NAME, [SOURCES], function (EXPORT_IDENTIFIER, CONTEXT_IDENTIFIER) {
+    "use strict";
     BEFORE_BODY;
     return {
       setters: [SETTERS],
@@ -51,8 +52,6 @@ export default function ({ types: t }) {
   };
 
   return {
-    inherits: require("babel-plugin-transform-strict-mode"),
-
     visitor: {
       ReferencedIdentifier(path, state) {
         if (path.node.name == "__moduleName" && !path.scope.hasBinding("__moduleName")) {
@@ -248,6 +247,7 @@ export default function ({ types: t }) {
 
           path.node.body = [
             buildTemplate({
+              SYSTEM_REGISTER: t.memberExpression(t.identifier(state.opts.systemGlobal || "System"), t.identifier("register")),
               BEFORE_BODY: beforeBody,
               MODULE_NAME: moduleName,
               SETTERS: setters,

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-default/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register([], function (_export, _context) {
+  "use strict";
+
   _export("default", function () {});
 
   _export("default", class {});

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo"], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [function (_foo) {
       var _exportObj = {};

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register([], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [],
     execute: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-variable/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register([], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [],
     execute: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/get-module-name-option/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/get-module-name-option/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register("my custom module name", [], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [],
     execute: function () {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["./evens"], function (_export, _context) {
+  "use strict";
+
   var isEven, p, a, i, j, isOdd;
   return {
     setters: [function (_evens) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-default/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo"], function (_export, _context) {
+  "use strict";
+
   var foo, foo2;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-glob/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo"], function (_export, _context) {
+  "use strict";
+
   var foo;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-mixing/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo"], function (_export, _context) {
+  "use strict";
+
   var foo, xyz;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-named/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo"], function (_export, _context) {
+  "use strict";
+
   var bar, bar2, baz, baz2, baz3, xyz;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [function (_foo) {}, function (_fooBar) {}, function (_directoryFooBar) {}],
     execute: function () {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/module-name/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register([], function (_export, _context) {
+  "use strict";
+
   var name;
   return {
     setters: [],

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/overview/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, _context) {
+  "use strict";
+
   var foo, foo2, bar, bar2, test2;
   return {
     setters: [function (_foo) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
@@ -1,6 +1,6 @@
-"use strict";
-
 System.register([], function (_export, _context) {
+  "use strict";
+
   var test, a, b, d;
   return {
     setters: [],


### PR DESCRIPTION
This PR makes two changes to the SystemJS modules format:

1. Supports an optional `opts.systemGlobal` string allowing `System.register` to eg become something like `scoped_system.register` by setting` opts.systemGlobal = 'scoped_system'`.

2. Moves the `"use strict"` declaration inside of the `System.register` declaration function. This is because System.register named modules are designed to be concatenated as a bundling format. The use strict statement needs to apply only to the interior of the individual module as other modules may not be strict in the same bundle.

Thanks for review in advance!