### PR TITLE
check if we can revert gcc additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,6 @@ node_js:
  - iojs
  - "0.12"
 
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-
 script: make test-ci
 
 notifications:


### PR DESCRIPTION
I added this before since node 4/5 were failing - just wanted to check if we could remove