### PR TITLE
Add array type to use for-of optimization

### DIFF
--- a/packages/babel-cli/src/babel-doctor/index.js
+++ b/packages/babel-cli/src/babel-doctor/index.js
@@ -36,9 +36,9 @@ while (nodeModulesDirectories.length) {
   let loc = nodeModulesDirectories.shift();
   if (!fs.existsSync(loc)) continue;
 
-  let packagesNames: Array<string> = fs.readdirSync(loc);
+  let packagesNames = fs.readdirSync(loc);
 
-  for (let packageName of packagesNames) {
+  for (let packageName of (packagesNames: Array<string>)) {
     if (packageName[0] === ".") continue;
 
     let packageLoc = path.join(loc, packageName);
@@ -69,7 +69,7 @@ async function run() {
 
   let results = await Promise.all(promises);
 
-  for (let [success, message] of results) {
+  for (let [success, message] of (results: Array)) {
     if (!success) didError = true;
     let multiline = message.indexOf("\n") >= 0;
     if (multiline) sep();

--- a/packages/babel-cli/src/babel-doctor/rules/deduped.js
+++ b/packages/babel-cli/src/babel-doctor/rules/deduped.js
@@ -12,7 +12,7 @@ export default async function (packages) {
     foundDeps[name] = true;
   }
 
-  for (let pkg of packages) {
+  for (let pkg of (packages: Array)) {
     checkDep(pkg.name);
   }
 

--- a/packages/babel-cli/src/babel-doctor/rules/latest-packages.js
+++ b/packages/babel-cli/src/babel-doctor/rules/latest-packages.js
@@ -25,7 +25,7 @@ export default async function (packages) {
   let filteredPackages = [];
   let promises = [];
 
-  for (let pkg of packages) {
+  for (let pkg of (packages: Array)) {
     if (pkg.name.indexOf("babel-") !== 0) continue;
 
     promises.push(getInfo(pkg.name));

--- a/packages/babel-core/src/helpers/merge.js
+++ b/packages/babel-core/src/helpers/merge.js
@@ -7,7 +7,7 @@ export default function (dest?: Object, src?: Object): ?Object {
     if (b && Array.isArray(a)) {
       let newArray = b.slice(0);
 
-      for (let item of a) {
+      for (let item of (a: Array)) {
         if (newArray.indexOf(item) < 0) {
           newArray.push(item);
         }

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -184,7 +184,7 @@ export default class File extends Store {
     let currentPluginPasses = [];
 
     // init plugins!
-    for (let ref of plugins) {
+    for (let ref of (plugins: Array)) {
       let [plugin, pluginOpts] = ref; // todo: fix - can't embed in loop head because of flow bug
 
       currentPluginVisitors.push(plugin.visitor);
@@ -507,7 +507,7 @@ export default class File extends Store {
   }
 
   call(key: "pre" | "post", pluginPasses: Array<PluginPass>) {
-    for (let pass of pluginPasses) {
+    for (let pass of (pluginPasses: Array)) {
       let plugin = pass.plugin;
       let fn = plugin[key];
       if (fn) fn.call(pass, this);

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -44,7 +44,7 @@ export default class Plugin extends Store {
 
     return function (...args) {
       let val;
-      for (let fn of fns) {
+      for (let fn of (fns: Array)) {
         if (fn) {
           let ret = fn.apply(this, args);
           if (ret != null) val = ret;
@@ -83,7 +83,7 @@ export default class Plugin extends Store {
   }
 
   normaliseVisitor(visitor: Object): Object {
-    for (let key of GLOBAL_VISITOR_PROPS) {
+    for (let key of (GLOBAL_VISITOR_PROPS: Array)) {
       if (visitor[key]) {
         throw new Error("Plugins aren't allowed to specify catch-all enter/exit handlers. Please target individual nodes.");
       }

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1169/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1169/expected.js
@@ -2,30 +2,10 @@ function foo() {
   var input = ['a', 'b', 'c'];
   var output = {};
 
-  var _iteratorNormalCompletion = true;
-  var _didIteratorError = false;
-  var _iteratorError = undefined;
-
-  try {
-    for (var _iterator = input[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-      var c = _step.value;
-
-      var name = c;
-      output[name] = name;
-    }
-  } catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-  } finally {
-    try {
-      if (!_iteratorNormalCompletion && _iterator.return) {
-        _iterator.return();
-      }
-    } finally {
-      if (_didIteratorError) {
-        throw _iteratorError;
-      }
-    }
+  for (var _i = 0; _i < input.length; _i++) {
+    var c = input[_i];
+    var name = c;
+    output[name] = name;
   }
 
   return output;

--- a/packages/babel-generator/src/node/index.js
+++ b/packages/babel-generator/src/node/index.js
@@ -14,11 +14,11 @@ function expandAliases(obj) {
     } : func;
   }
 
-  for (let type of Object.keys(obj)) {
+  for (let type of (Object.keys(obj): Array)) {
 
     let aliases = t.FLIPPED_ALIAS_KEYS[type];
     if (aliases) {
-      for (let alias of aliases) {
+      for (let alias of (aliases: Array)) {
         add(alias, obj[type]);
       }
     } else {

--- a/packages/babel-plugin-transform-es2015-classes/src/lib/memoise-decorators.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/lib/memoise-decorators.js
@@ -2,7 +2,7 @@ import type { Scope } from "babel-traverse";
 import * as t from "babel-types";
 
 export default function (decorators: Array<Object>, scope: Scope): Array<Object> {
-  for (let decorator of decorators) {
+  for (let decorator of (decorators: Array)) {
     let expression = decorator.expression;
     if (!t.isMemberExpression(expression)) continue;
 

--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -92,7 +92,7 @@ export default function ({ messages, template, types: t }) {
   return {
     visitor: {
       ForOfStatement(path, state) {
-        if (path.get("right").isArrayExpression()) {
+        if (path.get("right").isArrayExpression() || path.get("right").isGenericType("Array")) {
           return path.replaceWithMultiple(_ForOfStatementArray.call(this, path, state));
         }
 

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -21,7 +21,7 @@ export function call(key): boolean {
 export function _call(fns?: Array<Function>): boolean {
   if (!fns) return false;
 
-  for (let fn of fns) {
+  for (let fn of (fns: Array)) {
     if (!fn) continue;
 
     let node = this.node;
@@ -216,7 +216,7 @@ export function requeue(pathToQueue = this) {
   // let contexts = this._getQueueContexts();
   let contexts = this.contexts;
 
-  for (let context of contexts) {
+  for (let context of (contexts: Array)) {
     context.maybeQueue(pathToQueue);
   }
 }

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -181,7 +181,7 @@ export function evaluate(): { confident: boolean; value: any } {
     if (path.isArrayExpression()) {
       let arr = [];
       let elems: Array<NodePath> = path.get("elements");
-      for (let elem of elems) {
+      for (let elem of (elems: Array)) {
         elem = elem.evaluate();
 
         if (elem.confident) {

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -323,7 +323,7 @@ export function _guessExecutionStatusRelativeToDifferentFunctions(targetFuncPare
   let referencePaths: Array<NodePath> = binding.referencePaths;
 
   // verify that all of the references are calls
-  for (let path of referencePaths) {
+  for (let path of (referencePaths: Array)) {
     if (path.key !== "callee" || !path.parentPath.isCallExpression()) {
       return;
     }
@@ -332,7 +332,7 @@ export function _guessExecutionStatusRelativeToDifferentFunctions(targetFuncPare
   let allStatus;
 
   // verify that all the calls have the same execution status
-  for (let path of referencePaths) {
+  for (let path of (referencePaths: Array)) {
     // if a reference is a child of the function we're checking against then we can
     // safelty ignore it
     let childOfFunction = !!path.find((path) => path.node === targetFuncPath.node);

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -66,11 +66,11 @@ export function _containerInsert(from, nodes) {
 
   let contexts = this._getQueueContexts();
 
-  for (let path of paths) {
+  for (let path of (paths: Array)) {
     path.setScope();
     path.debug(() => "Inserted.");
 
-    for (let context of contexts) {
+    for (let context of (contexts: Array)) {
       context.maybeQueue(path, true);
     }
   }

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -207,7 +207,7 @@ export function replaceExpressionWithStatements(nodes: Array<Object>) {
 
     // add implicit returns to all ending expression statements
     let completionRecords: Array<NodePath> = this.get("callee").getCompletionRecords();
-    for (let path of completionRecords) {
+    for (let path of (completionRecords: Array)) {
       if (!path.isExpressionStatement()) continue;
 
       let loop = path.findParent((path) => path.isLoop());

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -26,7 +26,7 @@ let _crawlCallsCount = 0;
 function getCache(path, parentScope, self) {
   let scopes: Array<Scope> = scopeCache.get(path.node) || [];
 
-  for (let scope of scopes) {
+  for (let scope of (scopes: Array)) {
     if (scope.parent === parentScope && scope.path === path) return scope;
   }
 
@@ -473,7 +473,7 @@ export default class Scope {
 
     if (path.isVariableDeclaration()) {
       let declarators: Array<NodePath> = path.get("declarations");
-      for (let declar of declarators) {
+      for (let declar of (declarators: Array)) {
         this.registerBinding(kind, declar);
       }
       return;
@@ -555,7 +555,7 @@ export default class Scope {
       if (node.superClass && !this.isPure(node.superClass, constantsOnly)) return false;
       return this.isPure(node.body, constantsOnly);
     } else if (t.isClassBody(node)) {
-      for (let method of node.body) {
+      for (let method of (node.body: Array)) {
         if (!this.isPure(method, constantsOnly)) return false;
       }
       return true;
@@ -668,7 +668,7 @@ export default class Scope {
 
     if (path.isFunction()) {
       let params: Array<NodePath> = path.get("params");
-      for (let param of params) {
+      for (let param of (params: Array)) {
         this.registerBinding("param", param);
       }
     }
@@ -695,7 +695,7 @@ export default class Scope {
     this.crawling = false;
 
     // register assignments
-    for (let path of state.assignments) {
+    for (let path of (state.assignments: Array)) {
       // register undeclared bindings as globals
       let ids = path.getBindingIdentifiers();
       let programParent;
@@ -711,7 +711,7 @@ export default class Scope {
     }
 
     // register references
-    for (let ref of state.references) {
+    for (let ref of (state.references: Array)) {
       let binding = ref.scope.getBinding(ref.node.name);
       if (binding) {
         binding.reference(ref);
@@ -721,7 +721,7 @@ export default class Scope {
     }
 
     // register constant violations
-    for (let path of state.constantViolations) {
+    for (let path of (state.constantViolations: Array)) {
       path.scope.registerConstantViolation(path);
     }
   }

--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -48,7 +48,7 @@ export function assertNodeType(...types: Array<string>): Function {
   function validate(node, key, val) {
     let valid = false;
 
-    for (let type of types) {
+    for (let type of (types: Array)) {
       if (t.is(type, val)) {
         valid = true;
         break;
@@ -72,7 +72,7 @@ export function assertNodeOrValueType(...types: Array<string>): Function {
   function validate(node, key, val) {
     let valid = false;
 
-    for (let type of types) {
+    for (let type of (types: Array)) {
       if (getType(val) === type || t.is(type, val)) {
         valid = true;
         break;
@@ -108,7 +108,7 @@ export function assertValueType(type: string): Function {
 
 export function chain(...fns: Array<Function>): Function {
   function validate(...args) {
-    for (let fn of fns) {
+    for (let fn of (fns: Array)) {
       fn(...args);
     }
   }


### PR DESCRIPTION
Just noticed while working on https://github.com/babel/babel/pull/3438.

change is to add the righthand check from babel 5 (unless that isn't safe and checking ArrayExpression is what we want)

`if (path.get("right").isArrayExpression() || path.get("right").isGenericType("Array")) {`

so 

`for (let packageName of (packagesNames: Array)) {` will be optimized as a loop rather than just 
`for (let packageName of [1,2,3]) {`

Or do we already have better type information (since a lot of the times, the type is already defined above)?

Although Logan pointed out this won't give us much on Babel itself given we are using loose mode already.