### PR TITLE
Class properties: Add path.ensureBlock for ArrowFunctionExpression

### DIFF
--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -145,6 +145,16 @@ export default function ({ types: t }) {
         }
 
         path.insertAfter(nodes);
+      },
+      ArrowFunctionExpression(path) {
+        let classExp = path.get("body");
+        if (!classExp.isClassExpression()) return;
+
+        let body = classExp.get("body");
+        let members = body.get("body");
+        if (members.some((member) => member.isClassProperty())) {
+          path.ensureBlock();
+        }
       }
     }
   };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/actual.js
@@ -1,0 +1,11 @@
+export default param =>
+  class App {
+    static props = {
+      prop1: 'prop1',
+      prop2: 'prop2'
+    }
+
+    getParam() {
+      return param;
+    }
+  }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
@@ -1,0 +1,20 @@
+export default (param => {
+  var _class, _temp;
+
+  return _temp = _class = function () {
+    function App() {
+      babelHelpers.classCallCheck(this, App);
+    }
+
+    babelHelpers.createClass(App, [{
+      key: 'getParam',
+      value: function getParam() {
+        return param;
+      }
+    }]);
+    return App;
+  }(), _class.props = {
+    prop1: 'prop1',
+    prop2: 'prop2'
+  }, _temp;
+})


### PR DESCRIPTION
Should fix https://github.com/jhen0409/babel-preset-es2015-node6/issues/3.

In the new test case, the original transform is wrong:

```js
export default (param => {
  var _class, _temp;

  return class App {

    getParam() {
      return param;
    }
  };
})

```