### PR TITLE
Can we add 'opts.indentStyle' to allow customization of output indentation?

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -170,6 +170,11 @@ module.exports = {
     hidden: true
   },
 
+  indentStyle: {
+    type: "string",
+    description: "override the default indentation style detection with a custom indentation string"
+  },
+
   moduleRoot: {
     type: "filename",
     description: "optional prefix for the AMD module formatter that will be prepend to the filename on module definitions"

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -71,7 +71,8 @@ export class CodeGenerator extends Printer {
 
   static normalizeOptions(code, opts, tokens) {
     let style = "  ";
-    if (code && typeof code === "string") {
+    let hasIndentStyle = typeof opts.indentStyle === "string" && opts.indentStyle;
+    if ((code && typeof code === "string") && !hasIndentStyle) {
       let indent = detectIndent(code).indent;
       if (indent && indent !== " ") style = indent;
     }
@@ -88,7 +89,7 @@ export class CodeGenerator extends Printer {
       quotes: opts.quotes || CodeGenerator.findCommonStringDelimiter(code, tokens),
       indent: {
         adjustMultilineComment: true,
-        style: style,
+        style: hasIndentStyle ? opts.indentStyle : style,
         base: 0
       }
     };


### PR DESCRIPTION
As the title states, added support for a new 'indentStyle' string option to the main 'opts' parameter passed to 'babel-core' transform().  I'd be happy to changing the 'indentStyle' name if there's any suggestions. 
This falls better in line with how the rest of the options in babel-generator\src\index.js can be set via the 'opts' parameter except for the indent. 
