### PR TITLE
babel-cli: add --skip-initial-build option to only compile on changes when watching

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -61,7 +61,9 @@ module.exports = function (commander, filenames) {
     }
   }
 
-  _.each(filenames, handle);
+  if (!commander.skipInitialBuild) {
+    _.each(filenames, handle);
+  }
 
   if (commander.watch) {
     let chokidar = util.requireChokidar();

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -129,7 +129,10 @@ module.exports = function (commander, filenames, opts) {
   };
 
   let files = function () {
-    walk();
+
+    if (!commander.skipInitialBuild) {
+      walk();
+    }
 
     if (commander.watch) {
       let chokidar = util.requireChokidar();

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -40,6 +40,7 @@ each(options, function (option, key) {
 
 commander.option("-x, --extensions [extensions]", "List of extensions to compile when a directory has been input [.es6,.js,.es,.jsx]");
 commander.option("-w, --watch", "Recompile files on changes");
+commander.option("-s, --skip-initial-build", "Do not compile files before watching");
 commander.option("-o, --out-file [out]", "Compile all input files into a single file");
 commander.option("-d, --out-dir [out]", "Compile an input directory of modules into an output directory");
 commander.option("-D, --copy-files", "When compiling a directory copy over non-compilable files");
@@ -90,6 +91,10 @@ if (commander.watch) {
   if (!filenames.length) {
     errors.push("--watch requires filenames");
   }
+}
+
+if (commander.skipInitialBuild && !commander.watch) {
+  errors.push("--skip-initial-build requires --watch");
 }
 
 if (errors.length) {


### PR DESCRIPTION
Currently, the `-w` option would build the files, and then keep the process running, recompiling the files on changes.

Consider this 'watch' workflow:

```bash
#/usr/bin/env bash

watch () {
  # compile sources and watch for changes
  babel src -d dest -w &

  # restart server when anything in dest/ changes
  nodemon --watch dest dest/server &

  wait
}
```

This causes 2 problems:
 - Since `nodemon dest/server` can start before babel finishes compilation of
 - Nodemon would pick up every change the in `dist/` and restart the server on initialization multiple times. 

Let's compile the files before starting the watch commands:

```bash
#/usr/bin/env bash

watch () {
  # compile sources
  babel src -d dest

  # compile sources and watch for changes
  babel src -d dest -w &

  # restart server when anything in dest/ changes
  nodemon dest/server &

  wait
}
```

This solves the first problem, however now we are recompiling things twice, which causes nodemon to flap.

We can solve all that with `sleep`, but that's far from ideal.

Instead, lets introduce `--just-watch`:

```bash
#/usr/bin/env bash

watch () {
  # compile sources
  babel src -d dest

  # just watch for changes and recompile when needed
  babel src -d dest -w --just-watch &

  # restart server when anything in dest/ changes
  nodemon dest/server &

  wait
}
```

This way nodemon always starts cleanly.
