### PR TITLE
create new lexical env inside switch statement blocks, fixes #T7324

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch/actual.js
@@ -1,11 +1,27 @@
 let a = true;
 let b = false;
+class e {}
+function f() {}
 
 switch (a) {
   case true:
     let c = 2;
+    let foo = true;
     break;
   case false:
     let d = 3;
+    foo = false;
     break;
+}
+
+switch (true) {
+  case true:
+    let a = false;
+    let b = true;
+    let c = 4;
+    let d = 5;
+
+  case false:
+    class e {}
+    function f() {}
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch/expected.js
@@ -1,11 +1,29 @@
 var a = true;
 var b = false;
+class e {}
+function f() {}
 
 switch (a) {
   case true:
     var c = 2;
+    var foo = true;
     break;
   case false:
     var d = 3;
+    foo = false;
     break;
+}
+
+switch (true) {
+  case true:
+    var _a = false;
+    var _b = true;
+    var _c = 4;
+    var _d = 5;
+
+  case false:
+    class _e {}
+
+    var _f = function () {};
+
 }


### PR DESCRIPTION
As described in https://phabricator.babeljs.io/T7324, this would have been a lot easier I think if the AST supported [`CaseBlock` from the spec](http://www.ecma-international.org/ecma-262/6.0/#sec-switch-statement), so instead we sort of have to fudge that `SwitchStatement` is a block.

It's also possible I'm totally missing a much cleaner solution.