### PR TITLE
docs: babel-template is an implementation of quasiquotes.

### DIFF
--- a/packages/babel-template/README.md
+++ b/packages/babel-template/README.md
@@ -2,6 +2,8 @@
 
 > Generate an AST from a string template.
 
+In computer science, this is known as an implementation of quasiquotes.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
LISP, Haskell, Scala, Scheme, Boo & many others respect this term for a string literal of code being interpreted into AST. Babel should clearly identify that it too has quasi-quotes capabilities.