### PR TITLE
Refactor space insertion and remove some unneeded function options

### DIFF
--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -26,6 +26,7 @@ export default class Buffer {
       column: null,
       filename: null,
     };
+    this._endsWithWord = false;
   }
 
   printedCommentStarts: Object;
@@ -139,7 +140,10 @@ export default class Buffer {
    */
 
   word(str: string) {
+    if (this._endsWithWord) this.push(" ");
+
     this.push(str);
+    this._endsWithWord = true;
   }
 
   /**
@@ -325,6 +329,9 @@ export default class Buffer {
     this.position.push(str);
     this.buf += str;
     this.last = str[str.length - 1];
+
+    // Clear any state-tracking flags that may have been set.
+    this._endsWithWord = false;
   }
 
   /**

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -213,8 +213,7 @@ export default class Buffer {
     }
 
     this.removeLast(" ");
-    this._removeSpacesAfterLastNewline();
-    this.push(repeat("\n", i), true /* noIndent */);
+    this.push(repeat("\n", i));
   }
 
   /**
@@ -271,10 +270,10 @@ export default class Buffer {
    * Push a string to the buffer, maintaining indentation and newlines.
    */
 
-  push(str: string, noIndent?: boolean) {
-    if (!this.format.compact && this._indent && !noIndent && str !== "\n") {
+  push(str: string) {
+    if (!this.format.compact && this._indent && str[0] !== "\n") {
       // we've got a newline before us so prepend on the indentation
-      if (this.endsWith("\n")) this.push(this.getIndent(), true /* noIndent */);
+      if (this.endsWith("\n")) str = this.getIndent() + str;
     }
 
     // see startTerminatorless() instance method
@@ -290,7 +289,7 @@ export default class Buffer {
 
         if (cha === "\n" || cha === "/") {
           // we're going to break this terminator expression so we need to add a parentheses
-          this.push("(", true /* noIndent */);
+          str = "(" + str;
           this.indent();
           parenPushNewlineState.printed = true;
         }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -151,6 +151,16 @@ export default class Buffer {
    */
 
   token(str: string) {
+    // space is mandatory to avoid outputting <!--
+    // http://javascript.spec.whatwg.org/#comment-syntax
+    if ((str === "--" && this.last === "!") ||
+
+      // Need spaces for operators of the same kind to avoid: `a+++b`
+      (str[0] === "+" && this.last === "+") ||
+      (str[0] === "-" && this.last === "-")) {
+      this.push(" ");
+    }
+
     this.push(str);
   }
 

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -213,7 +213,10 @@ export default class Buffer {
     }
 
     this.removeLast(" ");
-    this.push(repeat("\n", i));
+    this._removeSpacesAfterLastNewline();
+    for (let j = 0; j < i; j++) {
+      this.push("\n");
+    }
   }
 
   /**

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -98,7 +98,7 @@ export default class Buffer {
    */
 
   semicolon() {
-    this.push(";");
+    this.token(";");
   }
 
   /**
@@ -110,7 +110,7 @@ export default class Buffer {
     if (this.format.minified && !this._lastPrintedIsEmptyStatement) {
       this._removeLast(";");
     }
-    this.push("}");
+    this.token("}");
   }
 
   /**
@@ -118,7 +118,7 @@ export default class Buffer {
    */
 
   keyword(name: string) {
-    this.push(name);
+    this.word(name);
     this.space();
   }
 
@@ -133,6 +133,23 @@ export default class Buffer {
       this.push(" ");
     }
   }
+
+  /**
+   * Writes a token that can't be safely parsed without taking whitespace into account.
+   */
+
+  word(str: string) {
+    this.push(str);
+  }
+
+  /**
+   * Writes a simple token.
+   */
+
+  token(str: string) {
+    this.push(str);
+  }
+
 
   /**
    * Remove the last character.
@@ -180,7 +197,7 @@ export default class Buffer {
     if (state.printed) {
       this.dedent();
       this.newline();
-      this.push(")");
+      this.token(")");
     }
   }
 

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -131,13 +131,13 @@ export default class Buffer {
   }
 
   /**
-   * Add a space to the buffer unless it is compact (override with force).
+   * Add a space to the buffer unless it is compact.
    */
 
-  space(force?: boolean) {
-    if (!force && this.format.compact) return;
+  space() {
+    if (this.format.compact) return;
 
-    if (force || this.buf && !this.isLast(" ") && !this.isLast("\n")) {
+    if (this.buf && !this.isLast(" ") && !this.isLast("\n")) {
       this.push(" ");
     }
   }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -129,7 +129,7 @@ export default class Buffer {
   space() {
     if (this.format.compact) return;
 
-    if (this.buf && !this.isLast(" ") && !this.isLast("\n")) {
+    if (this.buf && !this.endsWith(" ") && !this.endsWith("\n")) {
       this.push(" ");
     }
   }
@@ -144,7 +144,7 @@ export default class Buffer {
   }
 
   _removeLast(cha: string) {
-    if (!this._isLast(cha)) return;
+    if (!this.endsWith(cha)) return;
     this.buf = this.buf.slice(0, -1);
     this.last = this.buf[this.buf.length - 1];
     this.position.unshift(cha);
@@ -280,7 +280,7 @@ export default class Buffer {
       str = str.replace(/\n/g, `\n${indent}`);
 
       // we've got a newline before us so prepend on the indentation
-      if (this.isLast("\n")) this._push(indent);
+      if (this.endsWith("\n")) this._push(indent);
     }
 
     this._push(str);
@@ -327,6 +327,8 @@ export default class Buffer {
    */
 
   endsWith(str: string): boolean {
+    if (Array.isArray(str)) return str.some((s) => this.endsWith(s));
+
     if (str.length === 1) {
       return this.last === str;
     } else {
@@ -334,22 +336,4 @@ export default class Buffer {
     }
   }
 
-  /**
-   * Test if a character is last in the buffer.
-   */
-
-  isLast(cha: string): boolean {
-    if (this.format.compact) return false;
-    return this._isLast(cha);
-  }
-
-  _isLast(cha: string): boolean {
-    let last = this.last;
-
-    if (Array.isArray(cha)) {
-      return cha.indexOf(last) >= 0;
-    } else {
-      return cha === last;
-    }
-  }
 }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -102,14 +102,6 @@ export default class Buffer {
   }
 
   /**
-   * Ensure last character is a semicolon.
-   */
-
-  ensureSemicolon() {
-    if (!this.isLast(";")) this.semicolon();
-  }
-
-  /**
    * Add a right brace to the buffer.
    */
 

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -224,8 +224,10 @@ export default class Buffer {
   _removeSpacesAfterLastNewline() {
     let lastNewlineIndex = this.buf.lastIndexOf("\n");
     if (lastNewlineIndex >= 0 && this.get().length <= lastNewlineIndex) {
+      let toRemove = this.buf.slice(lastNewlineIndex + 1);
       this.buf = this.buf.substring(0, lastNewlineIndex + 1);
       this.last = "\n";
+      this.position.unshift(toRemove);
     }
   }
 

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -44,7 +44,7 @@ export default class Buffer {
     // catch up to this nodes newline if we're behind
     if (node.loc && this.format.retainLines && this.buf) {
       while (this.position.line < node.loc.start.line) {
-        this._push("\n");
+        this.push("\n");
       }
     }
   }
@@ -214,7 +214,7 @@ export default class Buffer {
 
     this.removeLast(" ");
     this._removeSpacesAfterLastNewline();
-    this._push(repeat("\n", i));
+    this.push(repeat("\n", i), true /* noIndent */);
   }
 
   /**
@@ -280,17 +280,9 @@ export default class Buffer {
       str = str.replace(/\n/g, `\n${indent}`);
 
       // we've got a newline before us so prepend on the indentation
-      if (this.endsWith("\n")) this._push(indent);
+      if (this.endsWith("\n")) this.push(indent, true /* noIndent */);
     }
 
-    this._push(str);
-  }
-
-  /**
-   * Push a string to the buffer.
-   */
-
-  _push(str: string): void {
     // see startTerminatorless() instance method
     let parenPushNewlineState = this.parenPushNewlineState;
     if (parenPushNewlineState) {
@@ -304,7 +296,7 @@ export default class Buffer {
 
         if (cha === "\n" || cha === "/") {
           // we're going to break this terminator expression so we need to add a parentheses
-          this._push("(");
+          this.push("(", true /* noIndent */);
           this.indent();
           parenPushNewlineState.printed = true;
         }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -249,6 +249,8 @@ export default class Buffer {
    */
 
   withSource(prop: string, loc: Location, cb: () => void) {
+    if (!this.opts.sourceMaps) return cb();
+
     // Use the call stack to manage a stack of "source location" data.
     let originalLine = this._sourcePosition.line;
     let originalColumn = this._sourcePosition.column;
@@ -310,7 +312,7 @@ export default class Buffer {
     }
 
     // If there the line is ending, adding a new mapping marker is redundant
-    if (str[0] !== "\n") this.map.mark(this._sourcePosition);
+    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this._sourcePosition);
 
     //
     this.position.push(str);

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -273,14 +273,8 @@ export default class Buffer {
 
   push(str: string, noIndent?: boolean) {
     if (!this.format.compact && this._indent && !noIndent && str !== "\n") {
-      // we have an indent level and we aren't pushing a newline
-      let indent = this.getIndent();
-
-      // replace all newlines with newlines with the indentation
-      str = str.replace(/\n/g, `\n${indent}`);
-
       // we've got a newline before us so prepend on the indentation
-      if (this.endsWith("\n")) this.push(indent, true /* noIndent */);
+      if (this.endsWith("\n")) this.push(this.getIndent(), true /* noIndent */);
     }
 
     // see startTerminatorless() instance method

--- a/packages/babel-generator/src/generators/base.js
+++ b/packages/babel-generator/src/generators/base.js
@@ -12,7 +12,7 @@ export function Program(node: Object) {
 }
 
 export function BlockStatement(node: Object) {
-  this.push("{");
+  this.token("{");
   this.printInnerComments(node);
   if (node.body.length) {
     this.newline();
@@ -27,7 +27,7 @@ export function BlockStatement(node: Object) {
     this.rightBrace();
   } else {
     this.source("end", node.loc);
-    this.push("}");
+    this.token("}");
   }
 }
 

--- a/packages/babel-generator/src/generators/base.js
+++ b/packages/babel-generator/src/generators/base.js
@@ -38,6 +38,4 @@ export function Directive(node: Object) {
   this.semicolon();
 }
 
-export function DirectiveLiteral(node: Object) {
-  this.push(this._stringLiteral(node.value));
-}
+export { StringLiteral as DirectiveLiteral } from "./types";

--- a/packages/babel-generator/src/generators/classes.js
+++ b/packages/babel-generator/src/generators/classes.js
@@ -1,5 +1,5 @@
 export function ClassDeclaration(node: Object) {
-  this.printJoin(node.decorators, node, { separator: "" });
+  this.printJoin(node.decorators, node);
   this.push("class");
 
   if (node.id) {
@@ -17,7 +17,7 @@ export function ClassDeclaration(node: Object) {
 
   if (node.implements) {
     this.push(" implements ");
-    this.printJoin(node.implements, node, { separator: ", " });
+    this.printList(node.implements, node);
   }
 
   this.space();
@@ -43,7 +43,7 @@ export function ClassBody(node: Object) {
 }
 
 export function ClassProperty(node: Object) {
-  this.printJoin(node.decorators, node, { separator: "" });
+  this.printJoin(node.decorators, node);
 
   if (node.static) this.push("static ");
   this.print(node.key, node);
@@ -58,7 +58,7 @@ export function ClassProperty(node: Object) {
 }
 
 export function ClassMethod(node: Object) {
-  this.printJoin(node.decorators, node, { separator: "" });
+  this.printJoin(node.decorators, node);
 
   if (node.static) {
     this.push("static ");

--- a/packages/babel-generator/src/generators/classes.js
+++ b/packages/babel-generator/src/generators/classes.js
@@ -10,13 +10,17 @@ export function ClassDeclaration(node: Object) {
   this.print(node.typeParameters, node);
 
   if (node.superClass) {
-    this.push(" extends ");
+    this.push(" ");
+    this.push("extends");
+    this.push(" ");
     this.print(node.superClass, node);
     this.print(node.superTypeParameters, node);
   }
 
   if (node.implements) {
-    this.push(" implements ");
+    this.push(" ");
+    this.push("implements");
+    this.push(" ");
     this.printList(node.implements, node);
   }
 
@@ -45,7 +49,10 @@ export function ClassBody(node: Object) {
 export function ClassProperty(node: Object) {
   this.printJoin(node.decorators, node);
 
-  if (node.static) this.push("static ");
+  if (node.static) {
+    this.push("static");
+    this.push(" ");
+  }
   this.print(node.key, node);
   this.print(node.typeAnnotation, node);
   if (node.value) {
@@ -61,11 +68,13 @@ export function ClassMethod(node: Object) {
   this.printJoin(node.decorators, node);
 
   if (node.static) {
-    this.push("static ");
+    this.push("static");
+    this.push(" ");
   }
 
   if (node.kind === "constructorCall") {
-    this.push("call ");
+    this.push("call");
+    this.push(" ");
   }
 
   this._method(node);

--- a/packages/babel-generator/src/generators/classes.js
+++ b/packages/babel-generator/src/generators/classes.js
@@ -3,24 +3,24 @@ export function ClassDeclaration(node: Object) {
   this.word("class");
 
   if (node.id) {
-    this.push(" ");
+    this.space();
     this.print(node.id, node);
   }
 
   this.print(node.typeParameters, node);
 
   if (node.superClass) {
-    this.push(" ");
+    this.space();
     this.word("extends");
-    this.push(" ");
+    this.space();
     this.print(node.superClass, node);
     this.print(node.superTypeParameters, node);
   }
 
   if (node.implements) {
-    this.push(" ");
+    this.space();
     this.word("implements");
-    this.push(" ");
+    this.space();
     this.printList(node.implements, node);
   }
 
@@ -51,7 +51,7 @@ export function ClassProperty(node: Object) {
 
   if (node.static) {
     this.word("static");
-    this.push(" ");
+    this.space();
   }
   this.print(node.key, node);
   this.print(node.typeAnnotation, node);
@@ -69,12 +69,12 @@ export function ClassMethod(node: Object) {
 
   if (node.static) {
     this.word("static");
-    this.push(" ");
+    this.space();
   }
 
   if (node.kind === "constructorCall") {
     this.word("call");
-    this.push(" ");
+    this.space();
   }
 
   this._method(node);

--- a/packages/babel-generator/src/generators/classes.js
+++ b/packages/babel-generator/src/generators/classes.js
@@ -1,6 +1,6 @@
 export function ClassDeclaration(node: Object) {
   this.printJoin(node.decorators, node);
-  this.push("class");
+  this.word("class");
 
   if (node.id) {
     this.push(" ");
@@ -11,7 +11,7 @@ export function ClassDeclaration(node: Object) {
 
   if (node.superClass) {
     this.push(" ");
-    this.push("extends");
+    this.word("extends");
     this.push(" ");
     this.print(node.superClass, node);
     this.print(node.superTypeParameters, node);
@@ -19,7 +19,7 @@ export function ClassDeclaration(node: Object) {
 
   if (node.implements) {
     this.push(" ");
-    this.push("implements");
+    this.word("implements");
     this.push(" ");
     this.printList(node.implements, node);
   }
@@ -31,10 +31,10 @@ export function ClassDeclaration(node: Object) {
 export { ClassDeclaration as ClassExpression };
 
 export function ClassBody(node: Object) {
-  this.push("{");
+  this.token("{");
   this.printInnerComments(node);
   if (node.body.length === 0) {
-    this.push("}");
+    this.token("}");
   } else {
     this.newline();
 
@@ -50,14 +50,14 @@ export function ClassProperty(node: Object) {
   this.printJoin(node.decorators, node);
 
   if (node.static) {
-    this.push("static");
+    this.word("static");
     this.push(" ");
   }
   this.print(node.key, node);
   this.print(node.typeAnnotation, node);
   if (node.value) {
     this.space();
-    this.push("=");
+    this.token("=");
     this.space();
     this.print(node.value, node);
   }
@@ -68,12 +68,12 @@ export function ClassMethod(node: Object) {
   this.printJoin(node.decorators, node);
 
   if (node.static) {
-    this.push("static");
+    this.word("static");
     this.push(" ");
   }
 
   if (node.kind === "constructorCall") {
-    this.push("call");
+    this.word("call");
     this.push(" ");
   }
 

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -61,7 +61,8 @@ export function ConditionalExpression(node: Object) {
 }
 
 export function NewExpression(node: Object, parent: Object) {
-  this.push("new ");
+  this.push("new");
+  this.push(" ");
   this.print(node.callee, node);
   if (node.arguments.length === 0 && this.format.minified &&
       !t.isCallExpression(parent, { callee: node }) &&
@@ -92,7 +93,8 @@ export function Decorator(node: Object) {
 }
 
 function commaSeparatorNewline() {
-  this.push(",\n");
+  this.push(",");
+  this.push("\n");
 }
 
 export function CallExpression(node: Object) {

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -21,47 +21,51 @@ export function UnaryExpression(node: Object) {
     needsSpace = false;
   }
 
-  this.push(node.operator);
+  if (node.operator === "void" || node.operator === "delete" || node.operator === "typeof") {
+    this.word(node.operator);
+  } else {
+    this.token(node.operator);
+  }
   if (needsSpace) this.push(" ");
   this.print(node.argument, node);
 }
 
 export function DoExpression(node: Object) {
-  this.push("do");
+  this.word("do");
   this.space();
   this.print(node.body, node);
 }
 
 export function ParenthesizedExpression(node: Object) {
-  this.push("(");
+  this.token("(");
   this.print(node.expression, node);
-  this.push(")");
+  this.token(")");
 }
 
 export function UpdateExpression(node: Object) {
   if (node.prefix) {
-    this.push(node.operator);
+    this.token(node.operator);
     this.print(node.argument, node);
   } else {
     this.print(node.argument, node);
-    this.push(node.operator);
+    this.token(node.operator);
   }
 }
 
 export function ConditionalExpression(node: Object) {
   this.print(node.test, node);
   this.space();
-  this.push("?");
+  this.token("?");
   this.space();
   this.print(node.consequent, node);
   this.space();
-  this.push(":");
+  this.token(":");
   this.space();
   this.print(node.alternate, node);
 }
 
 export function NewExpression(node: Object, parent: Object) {
-  this.push("new");
+  this.word("new");
   this.push(" ");
   this.print(node.callee, node);
   if (node.arguments.length === 0 && this.format.minified &&
@@ -69,9 +73,9 @@ export function NewExpression(node: Object, parent: Object) {
       !t.isMemberExpression(parent) &&
       !t.isNewExpression(parent)) return;
 
-  this.push("(");
+  this.token("(");
   this.printList(node.arguments, node);
-  this.push(")");
+  this.token(")");
 }
 
 export function SequenceExpression(node: Object) {
@@ -79,21 +83,21 @@ export function SequenceExpression(node: Object) {
 }
 
 export function ThisExpression() {
-  this.push("this");
+  this.word("this");
 }
 
 export function Super() {
-  this.push("super");
+  this.word("super");
 }
 
 export function Decorator(node: Object) {
-  this.push("@");
+  this.token("@");
   this.print(node.expression, node);
   this.newline();
 }
 
 function commaSeparatorNewline() {
-  this.push(",");
+  this.token(",");
   this.push("\n");
 }
 
@@ -101,7 +105,7 @@ export function CallExpression(node: Object) {
   this.print(node.callee, node);
   if (node.loc) this.printAuxAfterComment();
 
-  this.push("(");
+  this.token("(");
 
   let isPrettyCall = node._prettyCall && !this.format.retainLines && !this.format.compact;
 
@@ -119,15 +123,15 @@ export function CallExpression(node: Object) {
     this.dedent();
   }
 
-  this.push(")");
+  this.token(")");
 }
 
 function buildYieldAwait(keyword: string) {
   return function (node: Object) {
-    this.push(keyword);
+    this.word(keyword);
 
     if (node.delegate) {
-      this.push("*");
+      this.token("*");
     }
 
     if (node.argument) {
@@ -155,7 +159,7 @@ export function ExpressionStatement(node: Object) {
 export function AssignmentPattern(node: Object) {
   this.print(node.left, node);
   this.space();
-  this.push("=");
+  this.token("=");
   this.space();
   this.print(node.right, node);
 }
@@ -167,7 +171,7 @@ export function AssignmentExpression(node: Object, parent: Object) {
                !n.needsParens(node, parent);
 
   if (parens) {
-    this.push("(");
+    this.token("(");
   }
 
   this.print(node.left, node);
@@ -175,7 +179,11 @@ export function AssignmentExpression(node: Object, parent: Object) {
   let spaces = !this.format.compact || node.operator === "in" || node.operator === "instanceof";
   if (spaces) this.push(" ");
 
-  this.push(node.operator);
+  if (node.operator === "in" || node.operator === "instanceof") {
+    this.word(node.operator);
+  } else {
+    this.token(node.operator);
+  }
 
   if (!spaces) {
     // space is mandatory to avoid outputting <!--
@@ -197,13 +205,13 @@ export function AssignmentExpression(node: Object, parent: Object) {
   this.print(node.right, node);
 
   if (parens) {
-    this.push(")");
+    this.token(")");
   }
 }
 
 export function BindExpression(node: Object) {
   this.print(node.object, node);
-  this.push("::");
+  this.token("::");
   this.print(node.callee, node);
 }
 
@@ -225,9 +233,9 @@ export function MemberExpression(node: Object) {
   }
 
   if (computed) {
-    this.push("[");
+    this.token("[");
     this.print(node.property, node);
-    this.push("]");
+    this.token("]");
   } else {
     if (t.isNumericLiteral(node.object)) {
       let val = this.getPossibleRaw(node.object) || node.object.value;
@@ -236,18 +244,18 @@ export function MemberExpression(node: Object) {
         !SCIENTIFIC_NOTATION.test(val) &&
         !ZERO_DECIMAL_INTEGER.test(val) &&
         !this.endsWith(".")) {
-        this.push(".");
+        this.token(".");
       }
     }
 
-    this.push(".");
+    this.token(".");
     this.print(node.property, node);
   }
 }
 
 export function MetaProperty(node: Object) {
   this.print(node.meta, node);
-  this.push(".");
+  this.token(".");
   this.print(node.property, node);
 }
 

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -10,23 +10,13 @@ const ZERO_DECIMAL_INTEGER = /\.0+$/;
 const NON_DECIMAL_LITERAL = /^0[box]/;
 
 export function UnaryExpression(node: Object) {
-  let needsSpace = /[a-z]$/.test(node.operator);
-  let arg = node.argument;
-
-  if (t.isUpdateExpression(arg) || t.isUnaryExpression(arg)) {
-    needsSpace = true;
-  }
-
-  if (t.isUnaryExpression(arg) && arg.operator === "!") {
-    needsSpace = false;
-  }
-
   if (node.operator === "void" || node.operator === "delete" || node.operator === "typeof") {
     this.word(node.operator);
+    this.space();
   } else {
     this.token(node.operator);
   }
-  if (needsSpace) this.push(" ");
+
   this.print(node.argument, node);
 }
 
@@ -176,31 +166,13 @@ export function AssignmentExpression(node: Object, parent: Object) {
 
   this.print(node.left, node);
 
-  let spaces = !this.format.compact || node.operator === "in" || node.operator === "instanceof";
-  if (spaces) this.push(" ");
-
+  this.space();
   if (node.operator === "in" || node.operator === "instanceof") {
     this.word(node.operator);
   } else {
     this.token(node.operator);
   }
-
-  if (!spaces) {
-    // space is mandatory to avoid outputting <!--
-    // http://javascript.spec.whatwg.org/#comment-syntax
-    spaces = node.operator === "<" &&
-             t.isUnaryExpression(node.right, { prefix: true, operator: "!" }) &&
-             t.isUnaryExpression(node.right.argument, { prefix: true, operator: "--" });
-
-    // Need spaces for operators of the same kind to avoid: `a+++b`
-    if (!spaces) {
-      let right = getLeftMost(node.right);
-      spaces = t.isUnaryExpression(right, { prefix: true, operator: node.operator }) ||
-               t.isUpdateExpression(right, { prefix: true, operator: node.operator + node.operator });
-    }
-  }
-
-  if (spaces) this.push(" ");
+  this.space();
 
   this.print(node.right, node);
 
@@ -257,11 +229,4 @@ export function MetaProperty(node: Object) {
   this.print(node.meta, node);
   this.token(".");
   this.print(node.property, node);
-}
-
-function getLeftMost(binaryExpr) {
-  if (!t.isBinaryExpression(binaryExpr)) {
-    return binaryExpr;
-  }
-  return getLeftMost(binaryExpr.left);
 }

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -56,7 +56,7 @@ export function ConditionalExpression(node: Object) {
 
 export function NewExpression(node: Object, parent: Object) {
   this.word("new");
-  this.push(" ");
+  this.space();
   this.print(node.callee, node);
   if (node.arguments.length === 0 && this.format.minified &&
       !t.isCallExpression(parent, { callee: node }) &&
@@ -125,7 +125,7 @@ function buildYieldAwait(keyword: string) {
     }
 
     if (node.argument) {
-      this.push(" ");
+      this.space();
       let terminatorState = this.startTerminatorless();
       this.print(node.argument, node);
       this.endTerminatorless(terminatorState);

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -91,6 +91,10 @@ export function Decorator(node: Object) {
   this.newline();
 }
 
+function commaSeparatorNewline() {
+  this.push(",\n");
+}
+
 export function CallExpression(node: Object) {
   this.print(node.callee, node);
   if (node.loc) this.printAuxAfterComment();
@@ -101,7 +105,7 @@ export function CallExpression(node: Object) {
 
   let separator;
   if (isPrettyCall) {
-    separator = ",\n";
+    separator = commaSeparatorNewline;
     this.newline();
     this.indent();
   }

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -112,11 +112,11 @@ export function _interfaceish(node: Object) {
   this.print(node.typeParameters, node);
   if (node.extends.length) {
     this.push(" extends ");
-    this.printJoin(node.extends, node, { separator: ", " });
+    this.printList(node.extends, node);
   }
   if (node.mixins && node.mixins.length) {
     this.push(" mixins ");
-    this.printJoin(node.mixins, node, { separator: ", " });
+    this.printList(node.mixins, node);
   }
   this.space();
   this.print(node.body, node);
@@ -159,7 +159,7 @@ export function ThisTypeAnnotation() {
 
 export function TupleTypeAnnotation(node: Object) {
   this.push("[");
-  this.printJoin(node.types, node, { separator: ", " });
+  this.printList(node.types, node);
   this.push("]");
 }
 
@@ -209,8 +209,7 @@ export function TypeParameter(node: Object) {
 
 export function TypeParameterInstantiation(node: Object) {
   this.push("<");
-  this.printJoin(node.params, node, {
-    separator: ", ",
+  this.printList(node.params, node, {
     iterator: (node: Object) => {
       this.print(node.typeAnnotation, node);
     }
@@ -228,7 +227,6 @@ export function ObjectTypeAnnotation(node: Object) {
     this.space();
 
     this.printJoin(props, node, {
-      separator: false,
       indent: true,
       iterator: () => {
         if (props.length !== 1) {

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -3,39 +3,39 @@
 import * as t from "babel-types";
 
 export function AnyTypeAnnotation() {
-  this.push("any");
+  this.word("any");
 }
 
 export function ArrayTypeAnnotation(node: Object) {
   this.print(node.elementType, node);
-  this.push("[");
-  this.push("]");
+  this.token("[");
+  this.token("]");
 }
 
 export function BooleanTypeAnnotation() {
-  this.push("bool");
+  this.word("bool");
 }
 
 export function BooleanLiteralTypeAnnotation(node: Object) {
-  this.push(node.value ? "true" : "false");
+  this.word(node.value ? "true" : "false");
 }
 
 export function NullLiteralTypeAnnotation() {
-  this.push("null");
+  this.word("null");
 }
 
 export function DeclareClass(node: Object) {
-  this.push("declare");
+  this.word("declare");
   this.push(" ");
-  this.push("class");
+  this.word("class");
   this.push(" ");
   this._interfaceish(node);
 }
 
 export function DeclareFunction(node: Object) {
-  this.push("declare");
+  this.word("declare");
   this.push(" ");
-  this.push("function");
+  this.word("function");
   this.push(" ");
   this.print(node.id, node);
   this.print(node.id.typeAnnotation.typeAnnotation, node);
@@ -43,15 +43,15 @@ export function DeclareFunction(node: Object) {
 }
 
 export function DeclareInterface(node: Object) {
-  this.push("declare");
+  this.word("declare");
   this.push(" ");
   this.InterfaceDeclaration(node);
 }
 
 export function DeclareModule(node: Object) {
-  this.push("declare");
+  this.word("declare");
   this.push(" ");
-  this.push("module");
+  this.word("module");
   this.push(" ");
   this.print(node.id, node);
   this.space();
@@ -59,15 +59,15 @@ export function DeclareModule(node: Object) {
 }
 
 export function DeclareTypeAlias(node: Object) {
-  this.push("declare");
+  this.word("declare");
   this.push(" ");
   this.TypeAlias(node);
 }
 
 export function DeclareVariable(node: Object) {
-  this.push("declare");
+  this.word("declare");
   this.push(" ");
-  this.push("var");
+  this.word("var");
   this.push(" ");
   this.print(node.id, node);
   this.print(node.id.typeAnnotation, node);
@@ -75,31 +75,31 @@ export function DeclareVariable(node: Object) {
 }
 
 export function ExistentialTypeParam() {
-  this.push("*");
+  this.token("*");
 }
 
 export function FunctionTypeAnnotation(node: Object, parent: Object) {
   this.print(node.typeParameters, node);
-  this.push("(");
+  this.token("(");
   this.printList(node.params, node);
 
   if (node.rest) {
     if (node.params.length) {
-      this.push(",");
+      this.token(",");
       this.space();
     }
-    this.push("...");
+    this.token("...");
     this.print(node.rest, node);
   }
 
-  this.push(")");
+  this.token(")");
 
   // this node type is overloaded, not sure why but it makes it EXTREMELY annoying
   if (parent.type === "ObjectTypeProperty" || parent.type === "ObjectTypeCallProperty" || parent.type === "DeclareFunction") {
-    this.push(":");
+    this.token(":");
   } else {
     this.space();
-    this.push("=>");
+    this.token("=>");
   }
 
   this.space();
@@ -108,8 +108,8 @@ export function FunctionTypeAnnotation(node: Object, parent: Object) {
 
 export function FunctionTypeParam(node: Object) {
   this.print(node.name, node);
-  if (node.optional) this.push("?");
-  this.push(":");
+  if (node.optional) this.token("?");
+  this.token(":");
   this.space();
   this.print(node.typeAnnotation, node);
 }
@@ -126,13 +126,13 @@ export function _interfaceish(node: Object) {
   this.print(node.typeParameters, node);
   if (node.extends.length) {
     this.push(" ");
-    this.push("extends");
+    this.word("extends");
     this.push(" ");
     this.printList(node.extends, node);
   }
   if (node.mixins && node.mixins.length) {
     this.push(" ");
-    this.push("mixins");
+    this.word("mixins");
     this.push(" ");
     this.printList(node.mixins, node);
   }
@@ -141,14 +141,14 @@ export function _interfaceish(node: Object) {
 }
 
 export function InterfaceDeclaration(node: Object) {
-  this.push("interface");
+  this.word("interface");
   this.push(" ");
   this._interfaceish(node);
 }
 
 function andSeparator() {
   this.push(" ");
-  this.push("&");
+  this.token("&");
   this.push(" ");
 }
 
@@ -157,11 +157,11 @@ export function IntersectionTypeAnnotation(node: Object) {
 }
 
 export function MixedTypeAnnotation() {
-  this.push("mixed");
+  this.word("mixed");
 }
 
 export function NullableTypeAnnotation(node: Object) {
-  this.push("?");
+  this.token("?");
   this.print(node.typeAnnotation, node);
 }
 
@@ -171,56 +171,56 @@ export {
 } from "./types";
 
 export function NumberTypeAnnotation() {
-  this.push("number");
+  this.word("number");
 }
 
 export function StringTypeAnnotation() {
-  this.push("string");
+  this.word("string");
 }
 
 export function ThisTypeAnnotation() {
-  this.push("this");
+  this.word("this");
 }
 
 export function TupleTypeAnnotation(node: Object) {
-  this.push("[");
+  this.token("[");
   this.printList(node.types, node);
-  this.push("]");
+  this.token("]");
 }
 
 export function TypeofTypeAnnotation(node: Object) {
-  this.push("typeof");
+  this.word("typeof");
   this.push(" ");
   this.print(node.argument, node);
 }
 
 export function TypeAlias(node: Object) {
-  this.push("type");
+  this.word("type");
   this.push(" ");
   this.print(node.id, node);
   this.print(node.typeParameters, node);
   this.space();
-  this.push("=");
+  this.token("=");
   this.space();
   this.print(node.right, node);
   this.semicolon();
 }
 
 export function TypeAnnotation(node: Object) {
-  this.push(":");
+  this.token(":");
   this.space();
-  if (node.optional) this.push("?");
+  if (node.optional) this.token("?");
   this.print(node.typeAnnotation, node);
 }
 
 export function TypeParameter(node: Object) {
   if (node.variance === "plus") {
-    this.push("+");
+    this.token("+");
   } else if (node.variance === "minus") {
-    this.push("-");
+    this.token("-");
   }
 
-  this.push(node.name);
+  this.word(node.name);
 
   if (node.bound) {
     this.print(node.bound, node);
@@ -228,26 +228,26 @@ export function TypeParameter(node: Object) {
 
   if (node.default) {
     this.space();
-    this.push("=");
+    this.token("=");
     this.space();
     this.print(node.default, node);
   }
 }
 
 export function TypeParameterInstantiation(node: Object) {
-  this.push("<");
+  this.token("<");
   this.printList(node.params, node, {
     iterator: (node: Object) => {
       this.print(node.typeAnnotation, node);
     }
   });
-  this.push(">");
+  this.token(">");
 }
 
 export { TypeParameterInstantiation as TypeParameterDeclaration };
 
 export function ObjectTypeAnnotation(node: Object) {
-  this.push("{");
+  this.token("{");
   let props = node.properties.concat(node.callProperties, node.indexers);
 
   if (props.length) {
@@ -266,12 +266,12 @@ export function ObjectTypeAnnotation(node: Object) {
     this.space();
   }
 
-  this.push("}");
+  this.token("}");
 }
 
 export function ObjectTypeCallProperty(node: Object) {
   if (node.static) {
-    this.push("static");
+    this.word("static");
     this.push(" ");
   }
   this.print(node.value, node);
@@ -279,29 +279,29 @@ export function ObjectTypeCallProperty(node: Object) {
 
 export function ObjectTypeIndexer(node: Object) {
   if (node.static) {
-    this.push("static");
+    this.word("static");
     this.push(" ");
   }
-  this.push("[");
+  this.token("[");
   this.print(node.id, node);
-  this.push(":");
+  this.token(":");
   this.space();
   this.print(node.key, node);
-  this.push("]");
-  this.push(":");
+  this.token("]");
+  this.token(":");
   this.space();
   this.print(node.value, node);
 }
 
 export function ObjectTypeProperty(node: Object) {
   if (node.static) {
-    this.push("static");
+    this.word("static");
     this.push(" ");
   }
   this.print(node.key, node);
-  if (node.optional) this.push("?");
+  if (node.optional) this.token("?");
   if (!t.isFunctionTypeAnnotation(node.value)) {
-    this.push(":");
+    this.token(":");
     this.space();
   }
   this.print(node.value, node);
@@ -309,13 +309,13 @@ export function ObjectTypeProperty(node: Object) {
 
 export function QualifiedTypeIdentifier(node: Object) {
   this.print(node.qualification, node);
-  this.push(".");
+  this.token(".");
   this.print(node.id, node);
 }
 
 function orSeparator() {
   this.push(" ");
-  this.push("|");
+  this.token("|");
   this.push(" ");
 }
 
@@ -324,12 +324,12 @@ export function UnionTypeAnnotation(node: Object) {
 }
 
 export function TypeCastExpression(node: Object) {
-  this.push("(");
+  this.token("(");
   this.print(node.expression, node);
   this.print(node.typeAnnotation, node);
-  this.push(")");
+  this.token(")");
 }
 
 export function VoidTypeAnnotation() {
-  this.push("void");
+  this.word("void");
 }

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -26,17 +26,17 @@ export function NullLiteralTypeAnnotation() {
 
 export function DeclareClass(node: Object) {
   this.word("declare");
-  this.push(" ");
+  this.space();
   this.word("class");
-  this.push(" ");
+  this.space();
   this._interfaceish(node);
 }
 
 export function DeclareFunction(node: Object) {
   this.word("declare");
-  this.push(" ");
+  this.space();
   this.word("function");
-  this.push(" ");
+  this.space();
   this.print(node.id, node);
   this.print(node.id.typeAnnotation.typeAnnotation, node);
   this.semicolon();
@@ -44,15 +44,15 @@ export function DeclareFunction(node: Object) {
 
 export function DeclareInterface(node: Object) {
   this.word("declare");
-  this.push(" ");
+  this.space();
   this.InterfaceDeclaration(node);
 }
 
 export function DeclareModule(node: Object) {
   this.word("declare");
-  this.push(" ");
+  this.space();
   this.word("module");
-  this.push(" ");
+  this.space();
   this.print(node.id, node);
   this.space();
   this.print(node.body, node);
@@ -60,15 +60,15 @@ export function DeclareModule(node: Object) {
 
 export function DeclareTypeAlias(node: Object) {
   this.word("declare");
-  this.push(" ");
+  this.space();
   this.TypeAlias(node);
 }
 
 export function DeclareVariable(node: Object) {
   this.word("declare");
-  this.push(" ");
+  this.space();
   this.word("var");
-  this.push(" ");
+  this.space();
   this.print(node.id, node);
   this.print(node.id.typeAnnotation, node);
   this.semicolon();
@@ -125,15 +125,15 @@ export function _interfaceish(node: Object) {
   this.print(node.id, node);
   this.print(node.typeParameters, node);
   if (node.extends.length) {
-    this.push(" ");
+    this.space();
     this.word("extends");
-    this.push(" ");
+    this.space();
     this.printList(node.extends, node);
   }
   if (node.mixins && node.mixins.length) {
-    this.push(" ");
+    this.space();
     this.word("mixins");
-    this.push(" ");
+    this.space();
     this.printList(node.mixins, node);
   }
   this.space();
@@ -142,14 +142,14 @@ export function _interfaceish(node: Object) {
 
 export function InterfaceDeclaration(node: Object) {
   this.word("interface");
-  this.push(" ");
+  this.space();
   this._interfaceish(node);
 }
 
 function andSeparator() {
-  this.push(" ");
+  this.space();
   this.token("&");
-  this.push(" ");
+  this.space();
 }
 
 export function IntersectionTypeAnnotation(node: Object) {
@@ -190,13 +190,13 @@ export function TupleTypeAnnotation(node: Object) {
 
 export function TypeofTypeAnnotation(node: Object) {
   this.word("typeof");
-  this.push(" ");
+  this.space();
   this.print(node.argument, node);
 }
 
 export function TypeAlias(node: Object) {
   this.word("type");
-  this.push(" ");
+  this.space();
   this.print(node.id, node);
   this.print(node.typeParameters, node);
   this.space();
@@ -272,7 +272,7 @@ export function ObjectTypeAnnotation(node: Object) {
 export function ObjectTypeCallProperty(node: Object) {
   if (node.static) {
     this.word("static");
-    this.push(" ");
+    this.space();
   }
   this.print(node.value, node);
 }
@@ -280,7 +280,7 @@ export function ObjectTypeCallProperty(node: Object) {
 export function ObjectTypeIndexer(node: Object) {
   if (node.static) {
     this.word("static");
-    this.push(" ");
+    this.space();
   }
   this.token("[");
   this.print(node.id, node);
@@ -296,7 +296,7 @@ export function ObjectTypeIndexer(node: Object) {
 export function ObjectTypeProperty(node: Object) {
   if (node.static) {
     this.word("static");
-    this.push(" ");
+    this.space();
   }
   this.print(node.key, node);
   if (node.optional) this.token("?");
@@ -314,9 +314,9 @@ export function QualifiedTypeIdentifier(node: Object) {
 }
 
 function orSeparator() {
-  this.push(" ");
+  this.space();
   this.token("|");
-  this.push(" ");
+  this.space();
 }
 
 export function UnionTypeAnnotation(node: Object) {

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -25,36 +25,50 @@ export function NullLiteralTypeAnnotation() {
 }
 
 export function DeclareClass(node: Object) {
-  this.push("declare class ");
+  this.push("declare");
+  this.push(" ");
+  this.push("class");
+  this.push(" ");
   this._interfaceish(node);
 }
 
 export function DeclareFunction(node: Object) {
-  this.push("declare function ");
+  this.push("declare");
+  this.push(" ");
+  this.push("function");
+  this.push(" ");
   this.print(node.id, node);
   this.print(node.id.typeAnnotation.typeAnnotation, node);
   this.semicolon();
 }
 
 export function DeclareInterface(node: Object) {
-  this.push("declare ");
+  this.push("declare");
+  this.push(" ");
   this.InterfaceDeclaration(node);
 }
 
 export function DeclareModule(node: Object) {
-  this.push("declare module ");
+  this.push("declare");
+  this.push(" ");
+  this.push("module");
+  this.push(" ");
   this.print(node.id, node);
   this.space();
   this.print(node.body, node);
 }
 
 export function DeclareTypeAlias(node: Object) {
-  this.push("declare ");
+  this.push("declare");
+  this.push(" ");
   this.TypeAlias(node);
 }
 
 export function DeclareVariable(node: Object) {
-  this.push("declare var ");
+  this.push("declare");
+  this.push(" ");
+  this.push("var");
+  this.push(" ");
   this.print(node.id, node);
   this.print(node.id.typeAnnotation, node);
   this.semicolon();
@@ -111,11 +125,15 @@ export function _interfaceish(node: Object) {
   this.print(node.id, node);
   this.print(node.typeParameters, node);
   if (node.extends.length) {
-    this.push(" extends ");
+    this.push(" ");
+    this.push("extends");
+    this.push(" ");
     this.printList(node.extends, node);
   }
   if (node.mixins && node.mixins.length) {
-    this.push(" mixins ");
+    this.push(" ");
+    this.push("mixins");
+    this.push(" ");
     this.printList(node.mixins, node);
   }
   this.space();
@@ -123,12 +141,15 @@ export function _interfaceish(node: Object) {
 }
 
 export function InterfaceDeclaration(node: Object) {
-  this.push("interface ");
+  this.push("interface");
+  this.push(" ");
   this._interfaceish(node);
 }
 
 function andSeparator() {
-  this.push(" & ");
+  this.push(" ");
+  this.push("&");
+  this.push(" ");
 }
 
 export function IntersectionTypeAnnotation(node: Object) {
@@ -168,12 +189,14 @@ export function TupleTypeAnnotation(node: Object) {
 }
 
 export function TypeofTypeAnnotation(node: Object) {
-  this.push("typeof ");
+  this.push("typeof");
+  this.push(" ");
   this.print(node.argument, node);
 }
 
 export function TypeAlias(node: Object) {
-  this.push("type ");
+  this.push("type");
+  this.push(" ");
   this.print(node.id, node);
   this.print(node.typeParameters, node);
   this.space();
@@ -247,12 +270,18 @@ export function ObjectTypeAnnotation(node: Object) {
 }
 
 export function ObjectTypeCallProperty(node: Object) {
-  if (node.static) this.push("static ");
+  if (node.static) {
+    this.push("static");
+    this.push(" ");
+  }
   this.print(node.value, node);
 }
 
 export function ObjectTypeIndexer(node: Object) {
-  if (node.static) this.push("static ");
+  if (node.static) {
+    this.push("static");
+    this.push(" ");
+  }
   this.push("[");
   this.print(node.id, node);
   this.push(":");
@@ -265,7 +294,10 @@ export function ObjectTypeIndexer(node: Object) {
 }
 
 export function ObjectTypeProperty(node: Object) {
-  if (node.static) this.push("static ");
+  if (node.static) {
+    this.push("static");
+    this.push(" ");
+  }
   this.print(node.key, node);
   if (node.optional) this.push("?");
   if (!t.isFunctionTypeAnnotation(node.value)) {
@@ -282,7 +314,9 @@ export function QualifiedTypeIdentifier(node: Object) {
 }
 
 function orSeparator() {
-  this.push(" | ");
+  this.push(" ");
+  this.push("|");
+  this.push(" ");
 }
 
 export function UnionTypeAnnotation(node: Object) {

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -140,14 +140,13 @@ export function NullableTypeAnnotation(node: Object) {
   this.print(node.typeAnnotation, node);
 }
 
-export { NumericLiteral as NumericLiteralTypeAnnotation } from "./types";
+export {
+  NumericLiteral as NumericLiteralTypeAnnotation,
+  StringLiteral as StringLiteralTypeAnnotation,
+} from "./types";
 
 export function NumberTypeAnnotation() {
   this.push("number");
-}
-
-export function StringLiteralTypeAnnotation(node: Object) {
-  this.push(this._stringLiteral(node.value));
 }
 
 export function StringTypeAnnotation() {

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -127,8 +127,12 @@ export function InterfaceDeclaration(node: Object) {
   this._interfaceish(node);
 }
 
+function andSeparator() {
+  this.push(" & ");
+}
+
 export function IntersectionTypeAnnotation(node: Object) {
-  this.printJoin(node.types, node, { separator: " & " });
+  this.printJoin(node.types, node, { separator: andSeparator });
 }
 
 export function MixedTypeAnnotation() {
@@ -277,8 +281,12 @@ export function QualifiedTypeIdentifier(node: Object) {
   this.print(node.id, node);
 }
 
+function orSeparator() {
+  this.push(" | ");
+}
+
 export function UnionTypeAnnotation(node: Object) {
-  this.printJoin(node.types, node, { separator: " | " });
+  this.printJoin(node.types, node, { separator: orSeparator });
 }
 
 export function TypeCastExpression(node: Object) {

--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -23,7 +23,8 @@ export function JSXMemberExpression(node: Object) {
 }
 
 export function JSXSpreadAttribute(node: Object) {
-  this.push("{...");
+  this.push("{");
+  this.push("...");
   this.print(node.argument, node);
   this.push("}");
 }
@@ -63,7 +64,12 @@ export function JSXOpeningElement(node: Object) {
     this.push(" ");
     this.printJoin(node.attributes, node, { separator: spaceSeparator });
   }
-  this.push(node.selfClosing ? " />" : ">");
+  if (node.selfClosing) {
+    this.push(" ");
+    this.push("/>");
+  } else {
+    this.push(">");
+  }
 }
 
 export function JSXClosingElement(node: Object) {

--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -54,18 +54,18 @@ export function JSXElement(node: Object) {
 }
 
 function spaceSeparator() {
-  this.push(" ");
+  this.space();
 }
 
 export function JSXOpeningElement(node: Object) {
   this.token("<");
   this.print(node.name, node);
   if (node.attributes.length > 0) {
-    this.push(" ");
+    this.space();
     this.printJoin(node.attributes, node, { separator: spaceSeparator });
   }
   if (node.selfClosing) {
-    this.push(" ");
+    this.space();
     this.token("/>");
   } else {
     this.token(">");

--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -1,42 +1,42 @@
 export function JSXAttribute(node: Object) {
   this.print(node.name, node);
   if (node.value) {
-    this.push("=");
+    this.token("=");
     this.print(node.value, node);
   }
 }
 
 export function JSXIdentifier(node: Object) {
-  this.push(node.name);
+  this.word(node.name);
 }
 
 export function JSXNamespacedName(node: Object) {
   this.print(node.namespace, node);
-  this.push(":");
+  this.token(":");
   this.print(node.name, node);
 }
 
 export function JSXMemberExpression(node: Object) {
   this.print(node.object, node);
-  this.push(".");
+  this.token(".");
   this.print(node.property, node);
 }
 
 export function JSXSpreadAttribute(node: Object) {
-  this.push("{");
-  this.push("...");
+  this.token("{");
+  this.token("...");
   this.print(node.argument, node);
-  this.push("}");
+  this.token("}");
 }
 
 export function JSXExpressionContainer(node: Object) {
-  this.push("{");
+  this.token("{");
   this.print(node.expression, node);
-  this.push("}");
+  this.token("}");
 }
 
 export function JSXText(node: Object) {
-  this.push(node.value);
+  this.token(node.value);
 }
 
 export function JSXElement(node: Object) {
@@ -58,7 +58,7 @@ function spaceSeparator() {
 }
 
 export function JSXOpeningElement(node: Object) {
-  this.push("<");
+  this.token("<");
   this.print(node.name, node);
   if (node.attributes.length > 0) {
     this.push(" ");
@@ -66,16 +66,16 @@ export function JSXOpeningElement(node: Object) {
   }
   if (node.selfClosing) {
     this.push(" ");
-    this.push("/>");
+    this.token("/>");
   } else {
-    this.push(">");
+    this.token(">");
   }
 }
 
 export function JSXClosingElement(node: Object) {
-  this.push("</");
+  this.token("</");
   this.print(node.name, node);
-  this.push(">");
+  this.token(">");
 }
 
 export function JSXEmptyExpression() {}

--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -52,12 +52,16 @@ export function JSXElement(node: Object) {
   this.print(node.closingElement, node);
 }
 
+function spaceSeparator() {
+  this.push(" ");
+}
+
 export function JSXOpeningElement(node: Object) {
   this.push("<");
   this.print(node.name, node);
   if (node.attributes.length > 0) {
     this.push(" ");
-    this.printJoin(node.attributes, node, { separator: " " });
+    this.printJoin(node.attributes, node, { separator: spaceSeparator });
   }
   this.push(node.selfClosing ? " />" : ">");
 }

--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -35,7 +35,7 @@ export function JSXExpressionContainer(node: Object) {
 }
 
 export function JSXText(node: Object) {
-  this.push(node.value, true);
+  this.push(node.value);
 }
 
 export function JSXElement(node: Object) {

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -28,12 +28,12 @@ export function _method(node: Object) {
 
   if (kind === "get" || kind === "set") {
     this.word(kind);
-    this.push(" ");
+    this.space();
   }
 
   if (node.async) {
     this.word("async");
-    this.push(" ");
+    this.space();
   }
 
   if (node.computed) {
@@ -52,13 +52,13 @@ export function _method(node: Object) {
 export function FunctionExpression(node: Object) {
   if (node.async) {
     this.word("async");
-    this.push(" ");
+    this.space();
   }
   this.word("function");
   if (node.generator) this.token("*");
 
   if (node.id) {
-    this.push(" ");
+    this.space();
     this.print(node.id, node);
   } else {
     this.space();
@@ -74,7 +74,7 @@ export { FunctionExpression as FunctionDeclaration };
 export function ArrowFunctionExpression(node: Object) {
   if (node.async) {
     this.word("async");
-    this.push(" ");
+    this.space();
   }
 
   if (node.params.length === 1 && t.isIdentifier(node.params[0])) {
@@ -83,9 +83,9 @@ export function ArrowFunctionExpression(node: Object) {
     this._params(node);
   }
 
-  this.push(" ");
+  this.space();
   this.token("=>");
-  this.push(" ");
+  this.space();
 
   this.print(node.body, node);
 }

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -2,14 +2,14 @@ import * as t from "babel-types";
 
 export function _params(node: Object) {
   this.print(node.typeParameters, node);
-  this.push("(");
+  this.token("(");
   this.printList(node.params, node, {
     iterator: (node) => {
-      if (node.optional) this.push("?");
+      if (node.optional) this.token("?");
       this.print(node.typeAnnotation, node);
     }
   });
-  this.push(")");
+  this.token(")");
 
   if (node.returnType) {
     this.print(node.returnType, node);
@@ -22,24 +22,24 @@ export function _method(node: Object) {
 
   if (kind === "method" || kind === "init") {
     if (node.generator) {
-      this.push("*");
+      this.token("*");
     }
   }
 
   if (kind === "get" || kind === "set") {
-    this.push(kind);
+    this.word(kind);
     this.push(" ");
   }
 
   if (node.async) {
-    this.push("async");
+    this.word("async");
     this.push(" ");
   }
 
   if (node.computed) {
-    this.push("[");
+    this.token("[");
     this.print(key, node);
-    this.push("]");
+    this.token("]");
   } else {
     this.print(key, node);
   }
@@ -51,11 +51,11 @@ export function _method(node: Object) {
 
 export function FunctionExpression(node: Object) {
   if (node.async) {
-    this.push("async");
+    this.word("async");
     this.push(" ");
   }
-  this.push("function");
-  if (node.generator) this.push("*");
+  this.word("function");
+  if (node.generator) this.token("*");
 
   if (node.id) {
     this.push(" ");
@@ -73,7 +73,7 @@ export { FunctionExpression as FunctionDeclaration };
 
 export function ArrowFunctionExpression(node: Object) {
   if (node.async) {
-    this.push("async");
+    this.word("async");
     this.push(" ");
   }
 
@@ -84,7 +84,7 @@ export function ArrowFunctionExpression(node: Object) {
   }
 
   this.push(" ");
-  this.push("=>");
+  this.token("=>");
   this.push(" ");
 
   this.print(node.body, node);

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -27,10 +27,14 @@ export function _method(node: Object) {
   }
 
   if (kind === "get" || kind === "set") {
-    this.push(kind + " ");
+    this.push(kind);
+    this.push(" ");
   }
 
-  if (node.async) this.push("async ");
+  if (node.async) {
+    this.push("async");
+    this.push(" ");
+  }
 
   if (node.computed) {
     this.push("[");
@@ -46,7 +50,10 @@ export function _method(node: Object) {
 }
 
 export function FunctionExpression(node: Object) {
-  if (node.async) this.push("async ");
+  if (node.async) {
+    this.push("async");
+    this.push(" ");
+  }
   this.push("function");
   if (node.generator) this.push("*");
 
@@ -65,7 +72,10 @@ export function FunctionExpression(node: Object) {
 export { FunctionExpression as FunctionDeclaration };
 
 export function ArrowFunctionExpression(node: Object) {
-  if (node.async) this.push("async ");
+  if (node.async) {
+    this.push("async");
+    this.push(" ");
+  }
 
   if (node.params.length === 1 && t.isIdentifier(node.params[0])) {
     this.print(node.params[0], node);
@@ -73,7 +83,9 @@ export function ArrowFunctionExpression(node: Object) {
     this._params(node);
   }
 
-  this.push(" => ");
+  this.push(" ");
+  this.push("=>");
+  this.push(" ");
 
   this.print(node.body, node);
 }

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -4,7 +4,7 @@ export function ImportSpecifier(node: Object) {
   this.print(node.imported, node);
   if (node.local && node.local.name !== node.imported.name) {
     this.push(" ");
-    this.push("as");
+    this.word("as");
     this.push(" ");
     this.print(node.local, node);
   }
@@ -22,47 +22,47 @@ export function ExportSpecifier(node: Object) {
   this.print(node.local, node);
   if (node.exported && node.local.name !== node.exported.name) {
     this.push(" ");
-    this.push("as");
+    this.word("as");
     this.push(" ");
     this.print(node.exported, node);
   }
 }
 
 export function ExportNamespaceSpecifier(node: Object) {
-  this.push("*");
+  this.token("*");
   this.push(" ");
-  this.push("as");
+  this.word("as");
   this.push(" ");
   this.print(node.exported, node);
 }
 
 export function ExportAllDeclaration(node: Object) {
-  this.push("export");
+  this.word("export");
   this.push(" ");
-  this.push("*");
+  this.token("*");
   if (node.exported) {
     this.push(" ");
-    this.push("as");
+    this.word("as");
     this.push(" ");
     this.print(node.exported, node);
   }
   this.push(" ");
-  this.push("from");
+  this.word("from");
   this.push(" ");
   this.print(node.source, node);
   this.semicolon();
 }
 
 export function ExportNamedDeclaration() {
-  this.push("export");
+  this.word("export");
   this.push(" ");
   ExportDeclaration.apply(this, arguments);
 }
 
 export function ExportDefaultDeclaration() {
-  this.push("export");
+  this.word("export");
   this.push(" ");
-  this.push("default");
+  this.word("default");
   this.push(" ");
   ExportDeclaration.apply(this, arguments);
 }
@@ -74,7 +74,7 @@ function ExportDeclaration(node: Object) {
     if (!t.isStatement(declar)) this.semicolon();
   } else {
     if (node.exportKind === "type") {
-      this.push("type");
+      this.word("type");
       this.push(" ");
     }
 
@@ -88,7 +88,7 @@ function ExportDeclaration(node: Object) {
         hasSpecial = true;
         this.print(specifiers.shift(), node);
         if (specifiers.length) {
-          this.push(",");
+          this.token(",");
           this.push(" ");
         }
       } else {
@@ -97,18 +97,18 @@ function ExportDeclaration(node: Object) {
     }
 
     if (specifiers.length || (!specifiers.length && !hasSpecial)) {
-      this.push("{");
+      this.token("{");
       if (specifiers.length) {
         this.space();
         this.printList(specifiers, node);
         this.space();
       }
-      this.push("}");
+      this.token("}");
     }
 
     if (node.source) {
       this.push(" ");
-      this.push("from");
+      this.word("from");
       this.push(" ");
       this.print(node.source, node);
     }
@@ -118,11 +118,11 @@ function ExportDeclaration(node: Object) {
 }
 
 export function ImportDeclaration(node: Object) {
-  this.push("import");
+  this.word("import");
   this.push(" ");
 
   if (node.importKind === "type" || node.importKind === "typeof") {
-    this.push(node.importKind);
+    this.word(node.importKind);
     this.push(" ");
   }
 
@@ -134,7 +134,7 @@ export function ImportDeclaration(node: Object) {
       if (t.isImportDefaultSpecifier(first) || t.isImportNamespaceSpecifier(first)) {
         this.print(specifiers.shift(), node);
         if (specifiers.length) {
-          this.push(",");
+          this.token(",");
           this.push(" ");
         }
       } else {
@@ -143,15 +143,15 @@ export function ImportDeclaration(node: Object) {
     }
 
     if (specifiers.length) {
-      this.push("{");
+      this.token("{");
       this.space();
       this.printList(specifiers, node);
       this.space();
-      this.push("}");
+      this.token("}");
     }
 
     this.push(" ");
-    this.push("from");
+    this.word("from");
     this.push(" ");
   }
 
@@ -160,9 +160,9 @@ export function ImportDeclaration(node: Object) {
 }
 
 export function ImportNamespaceSpecifier(node: Object) {
-  this.push("*");
+  this.token("*");
   this.push(" ");
-  this.push("as");
+  this.word("as");
   this.push(" ");
   this.print(node.local, node);
 }

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -3,9 +3,9 @@ import * as t from "babel-types";
 export function ImportSpecifier(node: Object) {
   this.print(node.imported, node);
   if (node.local && node.local.name !== node.imported.name) {
-    this.push(" ");
+    this.space();
     this.word("as");
-    this.push(" ");
+    this.space();
     this.print(node.local, node);
   }
 }
@@ -21,49 +21,49 @@ export function ExportDefaultSpecifier(node: Object) {
 export function ExportSpecifier(node: Object) {
   this.print(node.local, node);
   if (node.exported && node.local.name !== node.exported.name) {
-    this.push(" ");
+    this.space();
     this.word("as");
-    this.push(" ");
+    this.space();
     this.print(node.exported, node);
   }
 }
 
 export function ExportNamespaceSpecifier(node: Object) {
   this.token("*");
-  this.push(" ");
+  this.space();
   this.word("as");
-  this.push(" ");
+  this.space();
   this.print(node.exported, node);
 }
 
 export function ExportAllDeclaration(node: Object) {
   this.word("export");
-  this.push(" ");
+  this.space();
   this.token("*");
   if (node.exported) {
-    this.push(" ");
+    this.space();
     this.word("as");
-    this.push(" ");
+    this.space();
     this.print(node.exported, node);
   }
-  this.push(" ");
+  this.space();
   this.word("from");
-  this.push(" ");
+  this.space();
   this.print(node.source, node);
   this.semicolon();
 }
 
 export function ExportNamedDeclaration() {
   this.word("export");
-  this.push(" ");
+  this.space();
   ExportDeclaration.apply(this, arguments);
 }
 
 export function ExportDefaultDeclaration() {
   this.word("export");
-  this.push(" ");
+  this.space();
   this.word("default");
-  this.push(" ");
+  this.space();
   ExportDeclaration.apply(this, arguments);
 }
 
@@ -75,7 +75,7 @@ function ExportDeclaration(node: Object) {
   } else {
     if (node.exportKind === "type") {
       this.word("type");
-      this.push(" ");
+      this.space();
     }
 
     let specifiers = node.specifiers.slice(0);
@@ -89,7 +89,7 @@ function ExportDeclaration(node: Object) {
         this.print(specifiers.shift(), node);
         if (specifiers.length) {
           this.token(",");
-          this.push(" ");
+          this.space();
         }
       } else {
         break;
@@ -107,9 +107,9 @@ function ExportDeclaration(node: Object) {
     }
 
     if (node.source) {
-      this.push(" ");
+      this.space();
       this.word("from");
-      this.push(" ");
+      this.space();
       this.print(node.source, node);
     }
 
@@ -119,11 +119,11 @@ function ExportDeclaration(node: Object) {
 
 export function ImportDeclaration(node: Object) {
   this.word("import");
-  this.push(" ");
+  this.space();
 
   if (node.importKind === "type" || node.importKind === "typeof") {
     this.word(node.importKind);
-    this.push(" ");
+    this.space();
   }
 
   let specifiers = node.specifiers.slice(0);
@@ -135,7 +135,7 @@ export function ImportDeclaration(node: Object) {
         this.print(specifiers.shift(), node);
         if (specifiers.length) {
           this.token(",");
-          this.push(" ");
+          this.space();
         }
       } else {
         break;
@@ -150,9 +150,9 @@ export function ImportDeclaration(node: Object) {
       this.token("}");
     }
 
-    this.push(" ");
+    this.space();
     this.word("from");
-    this.push(" ");
+    this.space();
   }
 
   this.print(node.source, node);
@@ -161,8 +161,8 @@ export function ImportDeclaration(node: Object) {
 
 export function ImportNamespaceSpecifier(node: Object) {
   this.token("*");
-  this.push(" ");
+  this.space();
   this.word("as");
-  this.push(" ");
+  this.space();
   this.print(node.local, node);
 }

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -81,7 +81,7 @@ function ExportDeclaration(node: Object) {
       this.push("{");
       if (specifiers.length) {
         this.space();
-        this.printJoin(specifiers, node, { separator: ", " });
+        this.printList(specifiers, node);
         this.space();
       }
       this.push("}");
@@ -121,7 +121,7 @@ export function ImportDeclaration(node: Object) {
     if (specifiers.length) {
       this.push("{");
       this.space();
-      this.printJoin(specifiers, node, { separator: ", " });
+      this.printList(specifiers, node);
       this.space();
       this.push("}");
     }

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -3,7 +3,9 @@ import * as t from "babel-types";
 export function ImportSpecifier(node: Object) {
   this.print(node.imported, node);
   if (node.local && node.local.name !== node.imported.name) {
-    this.push(" as ");
+    this.push(" ");
+    this.push("as");
+    this.push(" ");
     this.print(node.local, node);
   }
 }
@@ -19,34 +21,49 @@ export function ExportDefaultSpecifier(node: Object) {
 export function ExportSpecifier(node: Object) {
   this.print(node.local, node);
   if (node.exported && node.local.name !== node.exported.name) {
-    this.push(" as ");
+    this.push(" ");
+    this.push("as");
+    this.push(" ");
     this.print(node.exported, node);
   }
 }
 
 export function ExportNamespaceSpecifier(node: Object) {
-  this.push("* as ");
+  this.push("*");
+  this.push(" ");
+  this.push("as");
+  this.push(" ");
   this.print(node.exported, node);
 }
 
 export function ExportAllDeclaration(node: Object) {
-  this.push("export *");
+  this.push("export");
+  this.push(" ");
+  this.push("*");
   if (node.exported) {
-    this.push(" as ");
+    this.push(" ");
+    this.push("as");
+    this.push(" ");
     this.print(node.exported, node);
   }
-  this.push(" from ");
+  this.push(" ");
+  this.push("from");
+  this.push(" ");
   this.print(node.source, node);
   this.semicolon();
 }
 
 export function ExportNamedDeclaration() {
-  this.push("export ");
+  this.push("export");
+  this.push(" ");
   ExportDeclaration.apply(this, arguments);
 }
 
 export function ExportDefaultDeclaration() {
-  this.push("export default ");
+  this.push("export");
+  this.push(" ");
+  this.push("default");
+  this.push(" ");
   ExportDeclaration.apply(this, arguments);
 }
 
@@ -57,7 +74,8 @@ function ExportDeclaration(node: Object) {
     if (!t.isStatement(declar)) this.semicolon();
   } else {
     if (node.exportKind === "type") {
-      this.push("type ");
+      this.push("type");
+      this.push(" ");
     }
 
     let specifiers = node.specifiers.slice(0);
@@ -70,7 +88,8 @@ function ExportDeclaration(node: Object) {
         hasSpecial = true;
         this.print(specifiers.shift(), node);
         if (specifiers.length) {
-          this.push(", ");
+          this.push(",");
+          this.push(" ");
         }
       } else {
         break;
@@ -88,7 +107,9 @@ function ExportDeclaration(node: Object) {
     }
 
     if (node.source) {
-      this.push(" from ");
+      this.push(" ");
+      this.push("from");
+      this.push(" ");
       this.print(node.source, node);
     }
 
@@ -97,10 +118,12 @@ function ExportDeclaration(node: Object) {
 }
 
 export function ImportDeclaration(node: Object) {
-  this.push("import ");
+  this.push("import");
+  this.push(" ");
 
   if (node.importKind === "type" || node.importKind === "typeof") {
-    this.push(node.importKind + " ");
+    this.push(node.importKind);
+    this.push(" ");
   }
 
   let specifiers = node.specifiers.slice(0);
@@ -111,7 +134,8 @@ export function ImportDeclaration(node: Object) {
       if (t.isImportDefaultSpecifier(first) || t.isImportNamespaceSpecifier(first)) {
         this.print(specifiers.shift(), node);
         if (specifiers.length) {
-          this.push(", ");
+          this.push(",");
+          this.push(" ");
         }
       } else {
         break;
@@ -126,7 +150,9 @@ export function ImportDeclaration(node: Object) {
       this.push("}");
     }
 
-    this.push(" from ");
+    this.push(" ");
+    this.push("from");
+    this.push(" ");
   }
 
   this.print(node.source, node);
@@ -134,6 +160,9 @@ export function ImportDeclaration(node: Object) {
 }
 
 export function ImportNamespaceSpecifier(node: Object) {
-  this.push("* as ");
+  this.push("*");
+  this.push(" ");
+  this.push("as");
+  this.push(" ");
   this.print(node.local, node);
 }

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -54,7 +54,7 @@ function ExportDeclaration(node: Object) {
   if (node.declaration) {
     let declar = node.declaration;
     this.print(declar, node);
-    if (t.isStatement(declar) || t.isFunction(declar) || t.isClass(declar)) return;
+    if (!(t.isStatement(declar) || t.isFunction(declar) || t.isClass(declar))) this.semicolon();
   } else {
     if (node.exportKind === "type") {
       this.push("type ");
@@ -91,9 +91,9 @@ function ExportDeclaration(node: Object) {
       this.push(" from ");
       this.print(node.source, node);
     }
-  }
 
-  this.ensureSemicolon();
+    this.semicolon();
+  }
 }
 
 export function ImportDeclaration(node: Object) {

--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -54,7 +54,7 @@ function ExportDeclaration(node: Object) {
   if (node.declaration) {
     let declar = node.declaration;
     this.print(declar, node);
-    if (!(t.isStatement(declar) || t.isFunction(declar) || t.isClass(declar))) this.semicolon();
+    if (!t.isStatement(declar)) this.semicolon();
   } else {
     if (node.exportKind === "type") {
       this.push("type ");

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -33,7 +33,7 @@ export function IfStatement(node: Object) {
   if (node.alternate) {
     if (this.endsWith("}")) this.space();
     this.word("else");
-    this.push(" ");
+    this.space();
     this.printAndIndentOnComments(node.alternate, node);
   }
 }
@@ -81,9 +81,9 @@ let buildForXStatement = function (op) {
     this.keyword("for");
     this.token("(");
     this.print(node.left, node);
-    this.push(" ");
+    this.space();
     this.word(op);
-    this.push(" ");
+    this.space();
     this.print(node.right, node);
     this.token(")");
     this.printBlock(node);
@@ -95,7 +95,7 @@ export let ForOfStatement = buildForXStatement("of");
 
 export function DoWhileStatement(node: Object) {
   this.word("do");
-  this.push(" ");
+  this.space();
   this.print(node.body, node);
   this.space();
   this.keyword("while");
@@ -130,7 +130,7 @@ export let ThrowStatement    = buildLabelStatement("throw", "argument");
 export function LabeledStatement(node: Object) {
   this.print(node.label, node);
   this.token(":");
-  this.push(" ");
+  this.space();
   this.print(node.body, node);
 }
 
@@ -151,7 +151,7 @@ export function TryStatement(node: Object) {
   if (node.finalizer) {
     this.space();
     this.word("finally");
-    this.push(" ");
+    this.space();
     this.print(node.finalizer, node);
   }
 }
@@ -186,7 +186,7 @@ export function SwitchStatement(node: Object) {
 export function SwitchCase(node: Object) {
   if (node.test) {
     this.word("case");
-    this.push(" ");
+    this.space();
     this.print(node.test, node);
     this.token(":");
   } else {
@@ -221,7 +221,7 @@ function constDeclarationIdent() {
 
 export function VariableDeclaration(node: Object, parent: Object) {
   this.word(node.kind);
-  this.push(" ");
+  this.space();
 
   let hasInits = false;
   // don't add whitespace to loop heads

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -100,7 +100,8 @@ export function DoWhileStatement(node: Object) {
   this.keyword("while");
   this.push("(");
   this.print(node.test, node);
-  this.push(");");
+  this.push(")");
+  this.semicolon();
 }
 
 function buildLabelStatement(prefix, key = "label") {
@@ -200,7 +201,8 @@ export function SwitchCase(node: Object) {
 }
 
 export function DebuggerStatement() {
-  this.push("debugger;");
+  this.push("debugger");
+  this.semicolon();
 }
 
 export function VariableDeclaration(node: Object, parent: Object) {

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -1,4 +1,3 @@
-import repeat from "lodash/repeat";
 import * as t from "babel-types";
 
 const NON_ALPHABETIC_UNARY_OPERATORS = t.UPDATE_OPERATORS.concat(t.NUMBER_UNARY_OPERATORS).concat(["!"]);
@@ -205,6 +204,16 @@ export function DebuggerStatement() {
   this.semicolon();
 }
 
+function variableDeclarationIdent() {
+  // "let " or "var " indentation.
+  this.push(",\n    ");
+}
+
+function constDeclarationIdent() {
+  // "const " indentation.
+  this.push(",\n      ");
+}
+
 export function VariableDeclaration(node: Object, parent: Object) {
   this.push(node.kind + " ");
 
@@ -231,14 +240,14 @@ export function VariableDeclaration(node: Object, parent: Object) {
   //       bar = "foo";
   //
 
-  let sep;
+  let separator;
   if (!this.format.compact && !this.format.concise && hasInits && !this.format.retainLines) {
-    sep = `,\n${repeat(" ", node.kind.length + 1)}`;
+    separator = node.kind === "const" ? constDeclarationIdent : variableDeclarationIdent;
   }
 
   //
 
-  this.printList(node.declarations, node, { separator: sep });
+  this.printList(node.declarations, node, { separator });
 
   if (t.isFor(parent)) {
     // don't give semicolons to these nodes since they'll be inserted in the parent generator

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -206,12 +206,14 @@ export function DebuggerStatement() {
 
 function variableDeclarationIdent() {
   // "let " or "var " indentation.
-  this.push(",\n    ");
+  this.push(",\n");
+  this.push("    ");
 }
 
 function constDeclarationIdent() {
   // "const " indentation.
-  this.push(",\n      ");
+  this.push(",\n");
+  this.push("      ");
 }
 
 export function VariableDeclaration(node: Object, parent: Object) {

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -34,7 +34,7 @@ export function IfStatement(node: Object) {
   }
 
   if (node.alternate) {
-    if (this.isLast("}")) this.space();
+    if (this.endsWith("}")) this.space();
     this.push("else ");
     this.printAndIndentOnComments(node.alternate, node);
   }

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -4,22 +4,22 @@ const NON_ALPHABETIC_UNARY_OPERATORS = t.UPDATE_OPERATORS.concat(t.NUMBER_UNARY_
 
 export function WithStatement(node: Object) {
   this.keyword("with");
-  this.push("(");
+  this.token("(");
   this.print(node.object, node);
-  this.push(")");
+  this.token(")");
   this.printBlock(node);
 }
 
 export function IfStatement(node: Object) {
   this.keyword("if");
-  this.push("(");
+  this.token("(");
   this.print(node.test, node);
-  this.push(")");
+  this.token(")");
   this.space();
 
   let needsBlock = node.alternate && t.isIfStatement(getLastStatement(node.consequent));
   if (needsBlock) {
-    this.push("{");
+    this.token("{");
     this.newline();
     this.indent();
   }
@@ -29,12 +29,12 @@ export function IfStatement(node: Object) {
   if (needsBlock) {
     this.dedent();
     this.newline();
-    this.push("}");
+    this.token("}");
   }
 
   if (node.alternate) {
     if (this.endsWith("}")) this.space();
-    this.push("else");
+    this.word("else");
     this.push(" ");
     this.printAndIndentOnComments(node.alternate, node);
   }
@@ -48,46 +48,46 @@ function getLastStatement(statement) {
 
 export function ForStatement(node: Object) {
   this.keyword("for");
-  this.push("(");
+  this.token("(");
 
   this._inForStatementInitCounter++;
   this.print(node.init, node);
   this._inForStatementInitCounter--;
-  this.push(";");
+  this.token(";");
 
   if (node.test) {
     this.space();
     this.print(node.test, node);
   }
-  this.push(";");
+  this.token(";");
 
   if (node.update) {
     this.space();
     this.print(node.update, node);
   }
 
-  this.push(")");
+  this.token(")");
   this.printBlock(node);
 }
 
 export function WhileStatement(node: Object) {
   this.keyword("while");
-  this.push("(");
+  this.token("(");
   this.print(node.test, node);
-  this.push(")");
+  this.token(")");
   this.printBlock(node);
 }
 
 let buildForXStatement = function (op) {
   return function (node: Object) {
     this.keyword("for");
-    this.push("(");
+    this.token("(");
     this.print(node.left, node);
     this.push(" ");
-    this.push(op);
+    this.word(op);
     this.push(" ");
     this.print(node.right, node);
-    this.push(")");
+    this.token(")");
     this.printBlock(node);
   };
 };
@@ -96,20 +96,20 @@ export let ForInStatement = buildForXStatement("in");
 export let ForOfStatement = buildForXStatement("of");
 
 export function DoWhileStatement(node: Object) {
-  this.push("do");
+  this.word("do");
   this.push(" ");
   this.print(node.body, node);
   this.space();
   this.keyword("while");
-  this.push("(");
+  this.token("(");
   this.print(node.test, node);
-  this.push(")");
+  this.token(")");
   this.semicolon();
 }
 
 function buildLabelStatement(prefix, key = "label") {
   return function (node: Object) {
-    this.push(prefix);
+    this.word(prefix);
 
     let label = node[key];
     if (label) {
@@ -136,7 +136,7 @@ export let ThrowStatement    = buildLabelStatement("throw", "argument");
 
 export function LabeledStatement(node: Object) {
   this.print(node.label, node);
-  this.push(":");
+  this.token(":");
   this.push(" ");
   this.print(node.body, node);
 }
@@ -157,7 +157,7 @@ export function TryStatement(node: Object) {
 
   if (node.finalizer) {
     this.space();
-    this.push("finally");
+    this.word("finally");
     this.push(" ");
     this.print(node.finalizer, node);
   }
@@ -165,20 +165,20 @@ export function TryStatement(node: Object) {
 
 export function CatchClause(node: Object) {
   this.keyword("catch");
-  this.push("(");
+  this.token("(");
   this.print(node.param, node);
-  this.push(")");
+  this.token(")");
   this.space();
   this.print(node.body, node);
 }
 
 export function SwitchStatement(node: Object) {
   this.keyword("switch");
-  this.push("(");
+  this.token("(");
   this.print(node.discriminant, node);
-  this.push(")");
+  this.token(")");
   this.space();
-  this.push("{");
+  this.token("{");
 
   this.printSequence(node.cases, node, {
     indent: true,
@@ -187,18 +187,18 @@ export function SwitchStatement(node: Object) {
     }
   });
 
-  this.push("}");
+  this.token("}");
 }
 
 export function SwitchCase(node: Object) {
   if (node.test) {
-    this.push("case");
+    this.word("case");
     this.push(" ");
     this.print(node.test, node);
-    this.push(":");
+    this.token(":");
   } else {
-    this.push("default");
-    this.push(":");
+    this.word("default");
+    this.token(":");
   }
 
   if (node.consequent.length) {
@@ -208,26 +208,26 @@ export function SwitchCase(node: Object) {
 }
 
 export function DebuggerStatement() {
-  this.push("debugger");
+  this.word("debugger");
   this.semicolon();
 }
 
 function variableDeclarationIdent() {
   // "let " or "var " indentation.
-  this.push(",");
+  this.token(",");
   this.push("\n");
   for (let i = 0; i < 4; i++) this.push(" ");
 }
 
 function constDeclarationIdent() {
   // "const " indentation.
-  this.push(",");
+  this.token(",");
   this.push("\n");
   for (let i = 0; i < 6; i++) this.push(" ");
 }
 
 export function VariableDeclaration(node: Object, parent: Object) {
-  this.push(node.kind);
+  this.word(node.kind);
   this.push(" ");
 
   let hasInits = false;
@@ -275,7 +275,7 @@ export function VariableDeclarator(node: Object) {
   this.print(node.id.typeAnnotation, node);
   if (node.init) {
     this.space();
-    this.push("=");
+    this.token("=");
     this.space();
     this.print(node.init, node);
   }

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -1,7 +1,5 @@
 import * as t from "babel-types";
 
-const NON_ALPHABETIC_UNARY_OPERATORS = t.UPDATE_OPERATORS.concat(t.NUMBER_UNARY_OPERATORS).concat(["!"]);
-
 export function WithStatement(node: Object) {
   this.keyword("with");
   this.token("(");
@@ -113,12 +111,7 @@ function buildLabelStatement(prefix, key = "label") {
 
     let label = node[key];
     if (label) {
-      if (!(this.format.minified && ((t.isUnaryExpression(label, { prefix: true }) ||
-                                      t.isUpdateExpression(label, { prefix: true })) &&
-                                     NON_ALPHABETIC_UNARY_OPERATORS.indexOf(label.operator) > -1))) {
-        this.push(" ");
-
-      }
+      this.space();
 
       let terminatorState = this.startTerminatorless();
       this.print(label, node);

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -34,7 +34,8 @@ export function IfStatement(node: Object) {
 
   if (node.alternate) {
     if (this.endsWith("}")) this.space();
-    this.push("else ");
+    this.push("else");
+    this.push(" ");
     this.printAndIndentOnComments(node.alternate, node);
   }
 }
@@ -82,7 +83,9 @@ let buildForXStatement = function (op) {
     this.keyword("for");
     this.push("(");
     this.print(node.left, node);
-    this.push(` ${op} `);
+    this.push(" ");
+    this.push(op);
+    this.push(" ");
     this.print(node.right, node);
     this.push(")");
     this.printBlock(node);
@@ -93,7 +96,8 @@ export let ForInStatement = buildForXStatement("in");
 export let ForOfStatement = buildForXStatement("of");
 
 export function DoWhileStatement(node: Object) {
-  this.push("do ");
+  this.push("do");
+  this.push(" ");
   this.print(node.body, node);
   this.space();
   this.keyword("while");
@@ -132,7 +136,8 @@ export let ThrowStatement    = buildLabelStatement("throw", "argument");
 
 export function LabeledStatement(node: Object) {
   this.print(node.label, node);
-  this.push(": ");
+  this.push(":");
+  this.push(" ");
   this.print(node.body, node);
 }
 
@@ -152,7 +157,8 @@ export function TryStatement(node: Object) {
 
   if (node.finalizer) {
     this.space();
-    this.push("finally ");
+    this.push("finally");
+    this.push(" ");
     this.print(node.finalizer, node);
   }
 }
@@ -186,11 +192,13 @@ export function SwitchStatement(node: Object) {
 
 export function SwitchCase(node: Object) {
   if (node.test) {
-    this.push("case ");
+    this.push("case");
+    this.push(" ");
     this.print(node.test, node);
     this.push(":");
   } else {
-    this.push("default:");
+    this.push("default");
+    this.push(":");
   }
 
   if (node.consequent.length) {
@@ -206,18 +214,21 @@ export function DebuggerStatement() {
 
 function variableDeclarationIdent() {
   // "let " or "var " indentation.
-  this.push(",\n");
-  this.push("    ");
+  this.push(",");
+  this.push("\n");
+  for (let i = 0; i < 4; i++) this.push(" ");
 }
 
 function constDeclarationIdent() {
   // "const " indentation.
-  this.push(",\n");
-  this.push("      ");
+  this.push(",");
+  this.push("\n");
+  for (let i = 0; i < 6; i++) this.push(" ");
 }
 
 export function VariableDeclaration(node: Object, parent: Object) {
-  this.push(node.kind + " ");
+  this.push(node.kind);
+  this.push(" ");
 
   let hasInits = false;
   // don't add whitespace to loop heads

--- a/packages/babel-generator/src/generators/template-literals.js
+++ b/packages/babel-generator/src/generators/template-literals.js
@@ -3,24 +3,25 @@ export function TaggedTemplateExpression(node: Object) {
   this.print(node.quasi, node);
 }
 
-export function TemplateElement(node: Object) {
-  this.push(node.value.raw, true/* noIndent */);
+export function TemplateElement(node: Object, parent: Object) {
+  const isFirst = parent.quasis[0] === node;
+  const isLast = parent.quasis[parent.quasis.length - 1] === node;
+
+  let value = (isFirst ? "`" : "}") + node.value.raw + (isLast ? "`" : "${");
+
+  if (!isFirst) this.push(" ");
+  this.push(value);
+  if (!isLast) this.push(" ");
 }
 
 export function TemplateLiteral(node: Object) {
-  this.push("`");
-
   let quasis = node.quasis;
 
   for (let i = 0; i < quasis.length; i++) {
     this.print(quasis[i], node);
 
     if (i + 1 < quasis.length) {
-      this.push("${ ", true /* noIndent */);
       this.print(node.expressions[i], node);
-      this.push(" }");
     }
   }
-
-  this.push("`", true /* noIndent */);
 }

--- a/packages/babel-generator/src/generators/template-literals.js
+++ b/packages/babel-generator/src/generators/template-literals.js
@@ -9,9 +9,9 @@ export function TemplateElement(node: Object, parent: Object) {
 
   let value = (isFirst ? "`" : "}") + node.value.raw + (isLast ? "`" : "${");
 
-  if (!isFirst) this.push(" ");
+  if (!isFirst) this.space();
   this.token(value);
-  if (!isLast) this.push(" ");
+  if (!isLast) this.space();
 }
 
 export function TemplateLiteral(node: Object) {

--- a/packages/babel-generator/src/generators/template-literals.js
+++ b/packages/babel-generator/src/generators/template-literals.js
@@ -10,7 +10,7 @@ export function TemplateElement(node: Object, parent: Object) {
   let value = (isFirst ? "`" : "}") + node.value.raw + (isLast ? "`" : "${");
 
   if (!isFirst) this.push(" ");
-  this.push(value);
+  this.token(value);
   if (!isLast) this.push(" ");
 }
 

--- a/packages/babel-generator/src/generators/template-literals.js
+++ b/packages/babel-generator/src/generators/template-literals.js
@@ -4,7 +4,7 @@ export function TaggedTemplateExpression(node: Object) {
 }
 
 export function TemplateElement(node: Object) {
-  this._push(node.value.raw);
+  this.push(node.value.raw, true/* noIndent */);
 }
 
 export function TemplateLiteral(node: Object) {
@@ -16,11 +16,11 @@ export function TemplateLiteral(node: Object) {
     this.print(quasis[i], node);
 
     if (i + 1 < quasis.length) {
-      this._push("${ ");
+      this.push("${ ", true /* noIndent */);
       this.print(node.expressions[i], node);
       this.push(" }");
     }
   }
 
-  this._push("`");
+  this.push("`", true /* noIndent */);
 }

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -10,17 +10,17 @@ export function Identifier(node: Object) {
   // the next major.
   if (node.variance) {
     if (node.variance === "plus") {
-      this.push("+");
+      this.token("+");
     } else if (node.variance === "minus") {
-      this.push("-");
+      this.token("-");
     }
   }
 
-  this.push(node.name);
+  this.word(node.name);
 }
 
 export function RestElement(node: Object) {
-  this.push("...");
+  this.token("...");
   this.print(node.argument, node);
 }
 
@@ -33,7 +33,7 @@ export {
 export function ObjectExpression(node: Object) {
   let props = node.properties;
 
-  this.push("{");
+  this.token("{");
   this.printInnerComments(node);
 
   if (props.length) {
@@ -42,7 +42,7 @@ export function ObjectExpression(node: Object) {
     this.space();
   }
 
-  this.push("}");
+  this.token("}");
 }
 
 export { ObjectExpression as ObjectPattern };
@@ -56,9 +56,9 @@ export function ObjectProperty(node: Object) {
   this.printJoin(node.decorators, node);
 
   if (node.computed) {
-    this.push("[");
+    this.token("[");
     this.print(node.key, node);
-    this.push("]");
+    this.token("]");
   } else {
     // print `({ foo: foo = 5 } = {})` as `({ foo = 5 } = {});`
     if (t.isAssignmentPattern(node.value) && t.isIdentifier(node.key) && node.key.name === node.value.left.name) {
@@ -77,7 +77,7 @@ export function ObjectProperty(node: Object) {
     }
   }
 
-  this.push(":");
+  this.token(":");
   this.space();
   this.print(node.value, node);
 }
@@ -86,7 +86,7 @@ export function ArrayExpression(node: Object) {
   let elems = node.elements;
   let len   = elems.length;
 
-  this.push("[");
+  this.token("[");
   this.printInnerComments(node);
 
   for (let i = 0; i < elems.length; i++) {
@@ -94,48 +94,48 @@ export function ArrayExpression(node: Object) {
     if (elem) {
       if (i > 0) this.space();
       this.print(elem, node);
-      if (i < len - 1) this.push(",");
+      if (i < len - 1) this.token(",");
     } else {
       // If the array expression ends with a hole, that hole
       // will be ignored by the interpreter, but if it ends with
       // two (or more) holes, we need to write out two (or more)
       // commas so that the resulting code is interpreted with
       // both (all) of the holes.
-      this.push(",");
+      this.token(",");
     }
   }
 
-  this.push("]");
+  this.token("]");
 }
 
 export { ArrayExpression as ArrayPattern };
 
 export function RegExpLiteral(node: Object) {
-  this.push(`/${node.pattern}/${node.flags}`);
+  this.word(`/${node.pattern}/${node.flags}`);
 }
 
 export function BooleanLiteral(node: Object) {
-  this.push(node.value ? "true" : "false");
+  this.word(node.value ? "true" : "false");
 }
 
 export function NullLiteral() {
-  this.push("null");
+  this.word("null");
 }
 
 export function NumericLiteral(node: Object) {
   let raw = this.getPossibleRaw(node);
   if (raw != null) {
-    this.push(raw);
+    this.word(raw);
     return;
   }
 
-  this.push(node.value + "");
+  this.word(node.value + "");
 }
 
 export function StringLiteral(node: Object, parent: Object) {
   let raw = this.getPossibleRaw(node);
   if (raw != null) {
-    this.push(raw);
+    this.token(raw);
     return;
   }
 
@@ -160,5 +160,5 @@ export function StringLiteral(node: Object, parent: Object) {
     val = `'${val}'`;
   }
 
-  return this.push(val);
+  return this.token(val);
 }

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -123,15 +123,27 @@ export function NullLiteral() {
 }
 
 export function NumericLiteral(node: Object) {
+  let raw = this.getPossibleRaw(node);
+  if (raw != null) {
+    // Write an empty string to add indentation on just this first time.
+    this.push("");
+    this.push(raw, true /* noIndent */);
+    return;
+  }
+
   this.push(node.value + "");
 }
 
 export function StringLiteral(node: Object, parent: Object) {
-  this.push(this._stringLiteral(node.value, parent));
-}
+  let raw = this.getPossibleRaw(node);
+  if (raw != null) {
+    // Write an empty string to add indentation on just this first time.
+    this.push("");
+    this.push(raw, true /* noIndent */);
+    return;
+  }
 
-export function _stringLiteral(val: string, parent: Object): string {
-  val = JSON.stringify(val);
+  let val = JSON.stringify(node.value);
 
   // escape illegal js but valid json unicode characters
   val = val.replace(/[\u000A\u000D\u2028\u2029]/g, function (c) {
@@ -152,5 +164,5 @@ export function _stringLiteral(val: string, parent: Object): string {
     val = `'${val}'`;
   }
 
-  return val;
+  return this.push(val);
 }

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -48,12 +48,12 @@ export function ObjectExpression(node: Object) {
 export { ObjectExpression as ObjectPattern };
 
 export function ObjectMethod(node: Object) {
-  this.printJoin(node.decorators, node, { separator: "" });
+  this.printJoin(node.decorators, node);
   this._method(node);
 }
 
 export function ObjectProperty(node: Object) {
-  this.printJoin(node.decorators, node, { separator: "" });
+  this.printJoin(node.decorators, node);
 
   if (node.computed) {
     this.push("[");

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -125,9 +125,7 @@ export function NullLiteral() {
 export function NumericLiteral(node: Object) {
   let raw = this.getPossibleRaw(node);
   if (raw != null) {
-    // Write an empty string to add indentation on just this first time.
-    this.push("");
-    this.push(raw, true /* noIndent */);
+    this.push(raw);
     return;
   }
 
@@ -137,9 +135,7 @@ export function NumericLiteral(node: Object) {
 export function StringLiteral(node: Object, parent: Object) {
   let raw = this.getPossibleRaw(node);
   if (raw != null) {
-    // Write an empty string to add indentation on just this first time.
-    this.push("");
-    this.push(raw, true /* noIndent */);
+    this.push(raw);
     return;
   }
 

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -10,13 +10,13 @@ import Printer from "./printer";
  * user preferences, and valid output.
  */
 
-export class CodeGenerator extends Printer {
+class Generator extends Printer {
   constructor(ast, opts, code) {
     opts = opts || {};
 
     let comments = ast.comments || [];
     let tokens   = ast.tokens || [];
-    let format   = CodeGenerator.normalizeOptions(code, opts, tokens);
+    let format   = Generator.normalizeOptions(code, opts, tokens);
 
     let position = new Position;
 
@@ -66,7 +66,6 @@ export class CodeGenerator extends Printer {
    *
    * - Detects code indentation.
    * - If `opts.compact = "auto"` and the code is over 100KB, `compact` will be set to `true`.
-
    */
 
   static normalizeOptions(code, opts, tokens) {
@@ -85,7 +84,7 @@ export class CodeGenerator extends Printer {
       compact: opts.compact,
       minified: opts.minified,
       concise: opts.concise,
-      quotes: opts.quotes || CodeGenerator.findCommonStringDelimiter(code, tokens),
+      quotes: opts.quotes || Generator.findCommonStringDelimiter(code, tokens),
       indent: {
         adjustMultilineComment: true,
         style: style,
@@ -161,7 +160,23 @@ export class CodeGenerator extends Printer {
   }
 }
 
+
+/**
+ * We originally exported the Generator class above, but to make it extra clear that it is a private API,
+ * we have moved that to an internal class instance and simplified the interface to the two public methods
+ * that we wish to support.
+ */
+
+export class CodeGenerator {
+  constructor(ast, opts, code) {
+    this._generator = new Generator(ast, opts, code);
+  }
+  generate() {
+    return this._generator.generate();
+  }
+}
+
 export default function (ast: Object, opts: Object, code: string): Object {
-  let gen = new CodeGenerator(ast, opts, code);
+  let gen = new Generator(ast, opts, code);
   return gen.generate();
 }

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -287,10 +287,6 @@ export default class Printer extends Buffer {
         val = val.replace(/\n/g, `\n${repeat(" ", indent)}`);
       }
 
-      if (column === 0) {
-        val = this.getIndent() + val;
-      }
-
       // force a newline for line comments when retainLines is set in case the next printed node
       // doesn't catch up
       if ((this.format.compact || this.format.concise || this.format.retainLines) &&
@@ -299,7 +295,7 @@ export default class Printer extends Buffer {
       }
 
       //
-      this.push(val, true /* noIndent */);
+      this.push(val);
 
       // whitespace after
       this.newline(this.whitespace.getNewlinesAfter(comment));

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -287,13 +287,10 @@ export default class Printer extends Buffer {
       // whitespace before
       this.newline(this.whitespace.getNewlinesBefore(comment));
 
+      if (!this.endsWith(["[", "{"])) this.space();
+
       let column = this.position.column;
       let val    = this.generateComment(comment);
-
-      if (column && !this.endsWith(["\n", " ", "[", "{"])) {
-        this._push(" ");
-        column++;
-      }
 
       //
       if (comment.type === "CommentBlock" && this.format.indent.adjustMultilineComment) {

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -125,7 +125,7 @@ export default class Printer extends Buffer {
         }
 
         if (opts.separator && i < len - 1) {
-          this.push(opts.separator);
+          opts.separator.call(this);
         }
       }
     };
@@ -187,8 +187,7 @@ export default class Printer extends Buffer {
 
   printList(items, parent, opts = {}) {
     if (opts.separator == null) {
-      opts.separator = ",";
-      if (!this.format.compact) opts.separator += " ";
+      opts.separator = commaSeparator;
     }
 
     return this.printJoin(items, parent, opts);
@@ -314,6 +313,11 @@ export default class Printer extends Buffer {
       this.printComment(comment);
     }
   }
+}
+
+function commaSeparator() {
+  this.push(",");
+  this.space();
 }
 
 for (let generator of [

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -41,7 +41,7 @@ export default class Printer extends Buffer {
     this.printAuxBeforeComment(oldInAux);
 
     let needsParens = n.needsParens(node, parent, this._printStack);
-    if (needsParens) this.push("(");
+    if (needsParens) this.token("(");
 
     this.printLeadingComments(node, parent);
 
@@ -61,7 +61,7 @@ export default class Printer extends Buffer {
 
     this.printTrailingComments(node, parent);
 
-    if (needsParens) this.push(")");
+    if (needsParens) this.token(")");
 
     // end
     this._printStack.pop();
@@ -312,7 +312,7 @@ export default class Printer extends Buffer {
 }
 
 function commaSeparator() {
-  this.push(",");
+  this.token(",");
   this.space();
 }
 

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -300,7 +300,7 @@ export default class Printer extends Buffer {
       }
 
       //
-      this._push(val);
+      this.push(val, true /* noIndent */);
 
       // whitespace after
       this.newline(this.whitespace.getNewlinesAfter(comment));

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -53,7 +53,7 @@ export default class Printer extends Buffer {
 
     let loc = (t.isProgram(node) || t.isFile(node)) ? null : node.loc;
     this.withSource("start", loc, () => {
-      this._print(node, parent);
+      this[node.type](node, parent);
     });
 
     // Check again if any of our children may have left an aux comment on the stack
@@ -96,28 +96,12 @@ export default class Printer extends Buffer {
   }
 
   getPossibleRaw(node) {
+    if (this.format.minified) return;
+
     let extra = node.extra;
     if (extra && extra.raw != null && extra.rawValue != null && node.value === extra.rawValue) {
       return extra.raw;
     }
-  }
-
-  _print(node, parent) {
-    // In minified mode we need to produce as little bytes as needed
-    // and need to make sure that string quoting is consistent.
-    // That means we have to always reprint as opposed to getting
-    // the raw value.
-    if (!this.format.minified) {
-      let extra = this.getPossibleRaw(node);
-      if (extra) {
-        this.push("");
-        this._push(extra);
-        return;
-      }
-    }
-
-    let printMethod = this[node.type];
-    printMethod.call(this, node, parent);
   }
 
   printJoin(nodes: ?Array, parent: Object, opts = {}) {

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -290,7 +290,7 @@ export default class Printer extends Buffer {
       let column = this.position.column;
       let val    = this.generateComment(comment);
 
-      if (column && !this.isLast(["\n", " ", "[", "{"])) {
+      if (column && !this.endsWith(["\n", " ", "[", "{"])) {
         this._push(" ");
         column++;
       }

--- a/packages/babel-generator/test/fixtures/compact/assignment/expected.js
+++ b/packages/babel-generator/test/fixtures/compact/assignment/expected.js
@@ -1,1 +1,1 @@
-x=1;var {y=1}=obj;
+x=1;var{y=1}=obj;

--- a/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-and-compact-option/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-and-compact-option/expected.js
@@ -1,4 +1,4 @@
 function foo(l){
-return (
+return(
 
 l);}

--- a/packages/babel-generator/test/fixtures/minified/arrow-functions/actual.js
+++ b/packages/babel-generator/test/fixtures/minified/arrow-functions/actual.js
@@ -1,0 +1,8 @@
+var foo = (arg1, arg2) => {
+  arg1;
+  arg2;
+};
+var foo2 = (arg1, arg2) => {
+  arg1;
+};
+var foo3 = arg1 => arg1;

--- a/packages/babel-generator/test/fixtures/minified/arrow-functions/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/arrow-functions/expected.js
@@ -1,1 +1,1 @@
-var foo=(arg1,arg2) => {arg1;arg2};var foo2=(arg1,arg2) => {arg1};var foo3=arg1 => arg1;
+var foo=(arg1,arg2)=>{arg1;arg2};var foo2=(arg1,arg2)=>{arg1};var foo3=arg1=>arg1;

--- a/packages/babel-generator/test/fixtures/minified/arrow-functions/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/arrow-functions/expected.js
@@ -1,0 +1,1 @@
+var foo=(arg1,arg2) => {arg1;arg2};var foo2=(arg1,arg2) => {arg1};var foo3=arg1 => arg1;

--- a/packages/babel-generator/test/fixtures/minified/block-statements/actual.js
+++ b/packages/babel-generator/test/fixtures/minified/block-statements/actual.js
@@ -1,0 +1,12 @@
+if (true) {
+  foo;
+  bar2;
+} else {
+  foo;
+  bar2;
+}
+
+function fn () {
+  foo;
+  bar2;
+}

--- a/packages/babel-generator/test/fixtures/minified/block-statements/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/block-statements/expected.js
@@ -1,1 +1,1 @@
-if(true){foo;bar2}else {foo;bar2}function fn(){foo;bar2}
+if(true){foo;bar2}else{foo;bar2}function fn(){foo;bar2}

--- a/packages/babel-generator/test/fixtures/minified/block-statements/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/block-statements/expected.js
@@ -1,0 +1,1 @@
+if(true){foo;bar2}else {foo;bar2}function fn(){foo;bar2}

--- a/packages/babel-generator/test/fixtures/minified/modules/actual.js
+++ b/packages/babel-generator/test/fixtures/minified/modules/actual.js
@@ -1,0 +1,7 @@
+import * as foo from "foo";
+import {foo as bar, foo2 as bar2} from "foo";
+import {foo2} from "foo";
+
+export * from "foo";
+export {foo as bar} from "foo";
+export {foo} from "foo";

--- a/packages/babel-generator/test/fixtures/minified/modules/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/modules/expected.js
@@ -1,0 +1,1 @@
+import * as foo from "foo";import {foo as bar, foo2 as bar2} from "foo";import {foo2} from "foo";export * from "foo";export {foo as bar} from "foo";export {foo} from "foo";

--- a/packages/babel-generator/test/fixtures/minified/modules/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/modules/expected.js
@@ -1,1 +1,1 @@
-import * as foo from "foo";import {foo as bar,foo2 as bar2} from "foo";import {foo2} from "foo";export * from "foo";export {foo as bar} from "foo";export {foo} from "foo";
+import*as foo from"foo";import{foo as bar,foo2 as bar2}from"foo";import{foo2}from"foo";export*from"foo";export{foo as bar}from"foo";export{foo}from"foo";

--- a/packages/babel-generator/test/fixtures/minified/modules/expected.js
+++ b/packages/babel-generator/test/fixtures/minified/modules/expected.js
@@ -1,1 +1,1 @@
-import * as foo from "foo";import {foo as bar, foo2 as bar2} from "foo";import {foo2} from "foo";export * from "foo";export {foo as bar} from "foo";export {foo} from "foo";
+import * as foo from "foo";import {foo as bar,foo2 as bar2} from "foo";import {foo2} from "foo";export * from "foo";export {foo as bar} from "foo";export {foo} from "foo";

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,4 +1,5 @@
 var Whitespace = require("../lib/whitespace");
+var Printer    = require("../lib/printer");
 var generate   = require("../lib");
 var assert     = require("assert");
 var parse      = require("babylon").parse;
@@ -9,10 +10,10 @@ var _          = require("lodash");
 suite("generation", function () {
   test("completeness", function () {
     _.each(t.VISITOR_KEYS, function (keys, type) {
-      assert.ok(!!generate.CodeGenerator.prototype[type], type + " should exist");
+      assert.ok(!!Printer.prototype[type], type + " should exist");
     });
 
-    _.each(generate.CodeGenerator.prototype, function (fn, type) {
+    _.each(Printer.prototype, function (fn, type) {
       if (!/[A-Z]/.test(type[0])) return;
       assert.ok(t.VISITOR_KEYS[type], type + " should not exist");
     });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
@@ -17,4 +17,4 @@ export default (param => {
     prop1: 'prop1',
     prop2: 'prop2'
   }, _temp;
-})
+});


### PR DESCRIPTION
This is also an approximate 10-15% performance improvement because I:
* Removed the `.replace(/\n/g` for indenting every line in a token, since nothing needed it
* Now only look for "raw" properties on nodes that actually have them by moving that to StringLiteral/NumericLiteral printers.

This PR makes it so that the printer handles things at a token level, and will insert spaces between tokens automatically so the printers don't need to think about it. Each print function is them just responsible for adding spaces for readability rather than parsability, meaning our default behavior of ignoring readability for compact output can affect more places.

