### PR TITLE
Add conditional assignment plugin

### DIFF
--- a/packages/babel-plugin-syntax-conditional-assignment/.npmignore
+++ b/packages/babel-plugin-syntax-conditional-assignment/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+*.log
+src

--- a/packages/babel-plugin-syntax-conditional-assignment/README.md
+++ b/packages/babel-plugin-syntax-conditional-assignment/README.md
@@ -1,0 +1,35 @@
+# babel-plugin-syntax-conditional-assignment
+
+Allow parsing of the conditional assignment operator.
+
+## Installation
+
+```sh
+$ npm install babel-plugin-syntax-conditional-assignment
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["syntax-conditional-assignment"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins syntax-conditional-assignment script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["syntax-conditional-assignment"]
+});
+```

--- a/packages/babel-plugin-syntax-conditional-assignment/package.json
+++ b/packages/babel-plugin-syntax-conditional-assignment/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "babel-plugin-syntax-conditional-assignment",
+  "version": "6.8.0",
+  "description": "Allow parsing of the conditional assignment operator",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-conditional-assignment",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "babel-runtime": "^6.0.0"
+  },
+  "devDependencies": {
+    "babel-helper-plugin-test-runner": "^6.8.0"
+  }
+}

--- a/packages/babel-plugin-syntax-conditional-assignment/src/index.js
+++ b/packages/babel-plugin-syntax-conditional-assignment/src/index.js
@@ -1,0 +1,7 @@
+export default function () {
+  return {
+    manipulateOptions(opts, parserOpts) {
+      parserOpts.plugins.push("conditionalAssignment");
+    }
+  };
+}

--- a/packages/babel-plugin-transform-conditional-assignment/README.md
+++ b/packages/babel-plugin-transform-conditional-assignment/README.md
@@ -1,0 +1,72 @@
+# babel-plugin-transform-conditional-assignment
+
+Compile ES2017 conditional assignment to ES5.  Conditonal assignment a stage 0
+strawman proposal conditional assignment operator, also called an "or equals"
+operator(`||=`).  Using or equals in
+
+```
+foo ||= val
+```
+
+is the semantic equivalent of
+
+```
+if (!foo) {
+  foo = val
+}
+```
+
+More examples
+
+```
+let foo
+foo ||= 'foo'
+foo === 'foo'
+// evaluates to true
+```
+
+```
+    let bar = 'other value'
+    bar ||= 'bar'
+    bar === 'bar'
+    // evaluates to false
+```
+
+```
+    let baz = ''
+    baz ||= undefined
+    baz === undefined
+    // evaluates to true
+```
+
+## Installation
+
+```sh
+$ npm install babel-plugin-transform-conditional-assignment
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["transform-conditional-assignment"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins transform-conditional-assignment script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-conditional-assignment"]
+});
+```

--- a/packages/babel-plugin-transform-conditional-assignment/fixtures/expression/actual.js
+++ b/packages/babel-plugin-transform-conditional-assignment/fixtures/expression/actual.js
@@ -1,0 +1,2 @@
+let foo;
+foo ||= "foo";

--- a/packages/babel-plugin-transform-conditional-assignment/fixtures/expression/expected.js
+++ b/packages/babel-plugin-transform-conditional-assignment/fixtures/expression/expected.js
@@ -1,0 +1,2 @@
+let foo;
+foo ? foo = "foo" : undefined;

--- a/packages/babel-plugin-transform-conditional-assignment/fixtures/options.json
+++ b/packages/babel-plugin-transform-conditional-assignment/fixtures/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["transform-conditional-assignment"] }

--- a/packages/babel-plugin-transform-conditional-assignment/package.json
+++ b/packages/babel-plugin-transform-conditional-assignment/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "babel-plugin-transform-conditional-assignment",
+  "version": "6.8.0",
+  "description": "Compile ES2017 conditional assignment to ES5",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-conditional-assignment",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "babel-plugin-syntax-conditional-assignment": "^6.8.0",
+    "babel-runtime": "^6.0.0"
+  },
+  "devDependencies": {
+    "babel-helper-plugin-test-runner": "^6.8.0"
+  }
+}

--- a/packages/babel-plugin-transform-conditional-assignment/src/index.js
+++ b/packages/babel-plugin-transform-conditional-assignment/src/index.js
@@ -1,0 +1,16 @@
+export default function ({ types: t }) {
+  return {
+    visitor: {
+      BinaryExpression(path) {
+        if (path.node.operator !== "||=") {
+          return;
+        }
+        path.replaceWith(
+          t.conditionalExpression(
+            t.identifier("!" + path.node.left.name),
+            t.assignmentExpression("=", path.node.left, path.node.right),
+            t.identifier("undefined")));
+      }
+    }
+  };
+}


### PR DESCRIPTION
Adds a conditional assignment operator

```
let foo;
foo ||= 'foo';
foo === 'foo'; // true

let foo = 'foo';
foo ||= 'bar';
foo === 'foo'; // true
```

I'm not really sure how close this PR is to being ready to pull?  I may need to add something to `babel-types`, and probably update the documentation.  There's an associated babylon pr.