### PR TITLE
Remove micro dependencies in favour of lodash functions for babel-generator

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -15,11 +15,8 @@
     "babel-runtime": "^6.0.0",
     "babel-types": "^6.8.0",
     "detect-indent": "^3.0.1",
-    "is-integer": "^1.0.4",
     "lodash": "^4.2.0",
-    "repeating": "^1.1.3",
-    "source-map": "^0.5.0",
-    "trim-right": "^1.0.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "babel-helper-fixtures": "^6.8.0",

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,6 +1,6 @@
 import type Position from "./position";
-import repeating from "repeating";
-import trimRight from "trim-right";
+import repeat from "lodash/repeat";
+import trimEnd from "lodash/trimEnd";
 
 /**
  * Buffer for collecting generated output.
@@ -54,7 +54,7 @@ export default class Buffer {
    */
 
   get(): string {
-    return trimRight(this.buf);
+    return trimEnd(this.buf);
   }
 
   /**
@@ -65,7 +65,7 @@ export default class Buffer {
     if (this.format.compact || this.format.concise) {
       return "";
     } else {
-      return repeating(this.format.indent.style, this._indent);
+      return repeat(this.format.indent.style, this._indent);
     }
   }
 
@@ -222,7 +222,7 @@ export default class Buffer {
 
     this.removeLast(" ");
     this._removeSpacesAfterLastNewline();
-    this._push(repeating("\n", i));
+    this._push(repeat("\n", i));
   }
 
   /**

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 
-import isInteger from "is-integer";
+import isInteger from "lodash/isInteger";
 import isNumber from "lodash/isNumber";
 import * as t from "babel-types";
 import * as n from "../node";

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -1,4 +1,4 @@
-import repeating from "repeating";
+import repeat from "lodash/repeat";
 import * as t from "babel-types";
 
 const NON_ALPHABETIC_UNARY_OPERATORS = t.UPDATE_OPERATORS.concat(t.NUMBER_UNARY_OPERATORS).concat(["!"]);
@@ -231,7 +231,7 @@ export function VariableDeclaration(node: Object, parent: Object) {
 
   let sep;
   if (!this.format.compact && !this.format.concise && hasInits && !this.format.retainLines) {
-    sep = `,\n${repeating(" ", node.kind.length + 1)}`;
+    sep = `,\n${repeat(" ", node.kind.length + 1)}`;
   }
 
   //

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 
-import repeating from "repeating";
+import repeat from "lodash/repeat";
 import Buffer from "./buffer";
 import * as n from "./node";
 import * as t from "babel-types";
@@ -304,7 +304,7 @@ export default class Printer extends Buffer {
         }
 
         let indent = Math.max(this.indentSize(), column);
-        val = val.replace(/\n/g, `\n${repeating(" ", indent)}`);
+        val = val.replace(/\n/g, `\n${repeat(" ", indent)}`);
       }
 
       if (column === 0) {


### PR DESCRIPTION
This is a revision of https://github.com/babel/babel/pull/3460, the following three modules have been replaced with their equivalent lodash 4 functions:

- `is-integer` -> `_.isInteger`
- `repeating` -> `_.repeat`
- `trim-right` -> `_.trimEnd` 