### PR TITLE
Remove repeating dependency from babel-traverse

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -16,7 +16,6 @@
     "debug": "^2.2.0",
     "globals": "^8.3.0",
     "invariant": "^2.2.0",
-    "lodash": "^4.2.0",
-    "repeating": "^1.1.3"
+    "lodash": "^4.2.0"
   }
 }

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -1,7 +1,7 @@
 /* eslint max-len: 0 */
 
 import includes from "lodash/includes";
-import repeating from "repeating";
+import repeat from "lodash/repeat";
 import Renamer from "./lib/renamer";
 import type NodePath from "../path";
 import traverse from "../index";
@@ -367,7 +367,7 @@ export default class Scope {
   }
 
   dump() {
-    let sep = repeating("-", 60);
+    let sep = repeat("-", 60);
     console.log(sep);
     let scope = this;
     do {


### PR DESCRIPTION
I've updated babel-traverse to replace the `repeating` dependency with `_.repeat`.