### PR TITLE
Replace trim-right with _.trimEnd in babel-helper-fixtures

### DIFF
--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -10,7 +10,6 @@
     "babel-runtime": "^6.0.0",
     "lodash": "^4.2.0",
     "path-exists": "^1.0.0",
-    "trim-right": "^1.0.1",
     "try-resolve": "^1.0.0"
   }
 }

--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -1,5 +1,4 @@
 import pathExists from "path-exists";
-import trimRight from "trim-right";
 import resolve from "try-resolve";
 import path from "path";
 import fs from "fs";
@@ -164,7 +163,7 @@ export function multiple(entryLoc, ignore?: Array<string>) {
 
 export function readFile(filename) {
   if (pathExists.sync(filename)) {
-    let file = trimRight(fs.readFileSync(filename, "utf8"));
+    let file = _.trimEnd(fs.readFileSync(filename, "utf8"));
     file = file.replace(/\r\n/g, "\n");
     return file;
   } else {


### PR DESCRIPTION
I've updated babel-helper-fixtures to replace the `trim-right` dependency with `_.trimEnd`.