### PR TITLE
Skip adding __source if it already exists

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/with-source/exec.js
+++ b/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/with-source/exec.js
@@ -1,0 +1,8 @@
+var actual = transform(
+  'var x = <sometag __source="custom" />;',
+  Object.assign({}, opts, { filename: '/fake/path/mock.js' })
+).code;
+
+var expected = 'var x = <sometag __source="custom" />;';
+
+assert.equal(actual, expected);


### PR DESCRIPTION
`jsx-source` used to blindly add `__source` to elements without checking if it already exists. When applied more than once or when user has `__source` property defined on their own, this results in a syntax error ("SyntaxError: Attempted to redefine property '__source'.")