### PR TITLE
Adds repository field to babel-regenerator-runtime

### DIFF
--- a/packages/babel-regenerator-runtime/package.json
+++ b/packages/babel-regenerator-runtime/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "version": "6.5.0",
   "homepage": "https://github.com/babel/babel/tree/master/packages/babel-regenerator-runtime",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-regenerator-runtime",
   "main": "runtime.js",
   "license": "BSD"
 }


### PR DESCRIPTION
Similiar to #3370.

One of our licensing checking scripts throws warnings, as we expect npm dependencies to contain the repository field.