### PR TITLE
babel-regenerator-runtime license field

### DIFF
--- a/packages/babel-regenerator-runtime/package.json
+++ b/packages/babel-regenerator-runtime/package.json
@@ -6,5 +6,5 @@
   "homepage": "https://github.com/babel/babel/tree/master/packages/babel-regenerator-runtime",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-regenerator-runtime",
   "main": "runtime.js",
-  "license": "BSD"
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
The License field contains now a valid SPDX-Expression instead of simple `BSD`:

[License File](https://github.com/babel/babel/blob/master/packages/babel-regenerator-runtime/LICENSE)