### PR TITLE
fix: assign _this to `this` when there is no Superclass - closes T7364

### DIFF
--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -92,7 +92,10 @@ function remap(path, key) {
 
   fnPath.setData(key, id);
 
-  if (key === "this" && fnPath.isMethod({kind: "constructor"})) {
+  let classPath = fnPath.findParent((p) => p.isClassDeclaration());
+  let hasSuperClass = !!(classPath && classPath.node && classPath.node.superClass);
+
+  if (key === "this" && fnPath.isMethod({kind: "constructor"}) && hasSuperClass) {
     fnPath.scope.push({ id });
 
     fnPath.traverse(superVisitor, { id });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/actual.js
@@ -1,0 +1,5 @@
+class MyClass {
+  myAsyncMethod = async () => {
+    console.log(this);
+  }
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/expected.js
@@ -1,0 +1,10 @@
+class MyClass {
+  constructor() {
+    var _this = this;
+
+    this.myAsyncMethod = babelHelpers.asyncToGenerator(function* () {
+      console.log(_this);
+    });
+  }
+
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "transform-class-properties"
+  ]
+}


### PR DESCRIPTION
The cause of issue [T7364](https://phabricator.babeljs.io/T7364) appears to be that when we push `this` onto the scope inside an arrow function, we do not distinguish between when the class has a Superclass and when it does not.

There is already [a test here](https://github.com/ehjay/babel/blob/8d33a9d757d9c7d17451ae1756cd15cc77fdd31d/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/this/expected.js#L18) that covers the case where a class extends a Superclass. In this case, `super()` must be called before `this` can be used, so is fine to declare `_this` when `super()` is called.

However, when the class does not extend a Superclass, we should assign `_this` to `this` immediately so it is available in arrow functions.

Closes [T7364](https://phabricator.babeljs.io/T7364)