### PR TITLE
Make JSXText Immutable. Fixes #T7251

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/actual.js
@@ -1,0 +1,8 @@
+var Foo = React.createClass({
+  render: function () {
+    return <div className="class-name">
+      Text
+    </div>;
+  }
+});
+

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/text-children/expected.js
@@ -1,0 +1,10 @@
+var _ref = <div className="class-name">
+      Text
+    </div>;
+
+var Foo = React.createClass({
+  render: function () {
+    return _ref;
+  }
+});
+

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -127,7 +127,7 @@ defineType("JSXSpreadAttribute", {
 });
 
 defineType("JSXText", {
-  aliases: ["JSX"],
+  aliases: ["JSX", "Immutable"],
   builder: ["value"],
   fields: {
     value: {


### PR DESCRIPTION
Treats `JSXText` as `Immutable` type. It fixes `babel-plugin-transform-react-constant-elements`, where JSX elements aren't hoisted if they contain any `JSXText`, the issue for which is https://phabricator.babeljs.io/T7251