### PR TITLE
Fix: for babel-runtime, regenerator-runtime should be a dependency now

### DIFF
--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -6,12 +6,12 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {
-    "core-js": "^2.4.0"
+    "core-js": "^2.4.0",
+    "regenerator-runtime": "^0.9.5"
   },
   "devDependencies": {
     "babel-helpers": "^6.6.0",
     "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-template": "^6.9.0",
-    "regenerator-runtime": "^0.9.5"
+    "babel-template": "^6.9.0"
   }
 }


### PR DESCRIPTION
Since users are reporting

`Error: Cannot find module 'regenerator-runtime'/node_modules/babel-runtime/regenerator/index.js:1:80)`

cc @benjamn 