### PR TITLE
Fix: RegExp of babel-plugin-transform-es2015-literals

### DIFF
--- a/packages/babel-plugin-transform-es2015-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-literals/src/index.js
@@ -10,7 +10,7 @@ export default function () {
 
       StringLiteral({ node }) {
         // unicode escape
-        if (node.extra && /\\[u]/gi.test(node.extra.raw)) {
+        if (node.extra && /\\u\{.*\}/gi.test(node.extra.raw)) {
           node.extra = undefined;
         }
       }


### PR DESCRIPTION
In acorn, [unicode strings](https://github.com/ternjs/acorn/blob/master/src/identifier.js#L30) are transformed into the escaped words and it makes errors when it was used in a chrome extension.

Then, unicode code point escapes should check only the words which are using "{}" like the following:

``` js
console.log('\u{1F680}'); 
```
