### PR TITLE
Correct source map paths for babel-register.

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -48,8 +48,11 @@ function compile(filename) {
   let result;
 
   // merge in base options and resolve all the plugins and presets relative to this file
+  let relativePath = getRelativePath(filename);
   let opts = new OptionManager().init(extend(deepClone(transformOpts), {
-    filename
+    filename,
+    sourceMapTarget: relativePath,
+    sourceFileName: relativePath,
   }));
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;


### PR DESCRIPTION
Stack traces for `babel-register` aren't entirely correct. For example, I get this:

```
next (application.js:86:13)
Context.route (route.js:19:12)
next (application.js:93:12)
...
```

But there is no `application.js` or `route.js` in my project root. Instead, I expect this:

```
next (lib/application.js:86:13)
Context.route (lib/middleware/route.js:19:12)
next (lib/application.js:93:12)
...
```

This PR fixes that problem.

I couldn't find any tests for `babel-register`, so no tests.