### PR TITLE
Fix class inheritance in IE <=10 (T3041)

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1155/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1155/expected.js
@@ -8,7 +8,7 @@ var Foo = function (_Bar) {
     parentOptions.init = function () {
       this;
     };
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this, parentOptions));
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, parentOptions));
   }
 
   return Foo;

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -125,11 +125,18 @@ export default class ReplaceSupers {
     return t.callExpression(
       this.file.addHelper("set"),
       [
-        t.callExpression(
-          t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
-          [
-            this.isStatic ? this.getObjectRef() : t.memberExpression(this.getObjectRef(), t.identifier("prototype"))
-          ]
+        t.logicalExpression(
+          "||",
+          t.memberExpression(
+            this.isStatic ? this.getObjectRef() : t.memberExpression(this.getObjectRef(), t.identifier("prototype")),
+            t.identifier("__proto__")
+          ),
+          t.callExpression(
+            t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
+            [
+              this.isStatic ? this.getObjectRef() : t.memberExpression(this.getObjectRef(), t.identifier("prototype"))
+            ]
+          ),
         ),
         isComputed ? property : t.stringLiteral(property.name),
         value,
@@ -151,11 +158,18 @@ export default class ReplaceSupers {
     return t.callExpression(
       this.file.addHelper("get"),
       [
-        t.callExpression(
-          t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
-          [
-            this.isStatic ? this.getObjectRef() : t.memberExpression(this.getObjectRef(), t.identifier("prototype"))
-          ]
+        t.logicalExpression(
+          "||",
+          t.memberExpression(
+            this.isStatic ? this.getObjectRef() : t.memberExpression(this.getObjectRef(), t.identifier("prototype")),
+            t.identifier("__proto__")
+          ),
+          t.callExpression(
+            t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
+            [
+              this.isStatic ? this.getObjectRef() : t.memberExpression(this.getObjectRef(), t.identifier("prototype"))
+            ]
+          ),
         ),
         isComputed ? property : t.stringLiteral(property.name),
         t.thisExpression()

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
@@ -5,7 +5,7 @@ var Foo = function (_Bar) {
     var _temp, _this, _ret;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _ret = (_temp = (_this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this, ...args)), _this), _this.bar = "foo", _temp), babelHelpers.possibleConstructorReturn(_this, _ret);
+    return _ret = (_temp = (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, ...args)), _this), _this.bar = "foo", _temp), babelHelpers.possibleConstructorReturn(_this, _ret);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
@@ -6,7 +6,7 @@ var Child = function (_Parent) {
     function Child() {
         babelHelpers.classCallCheck(this, Child);
 
-        var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Child).call(this));
+        var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
 
         _this.scopedFunctionWithThis = function () {
             _this.name = {};

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-expression/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-expression/expected.js
@@ -6,7 +6,7 @@ var Foo = function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    foo((_temp = (_this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this)), _this), _this.bar = "foo", _temp));
+    foo((_temp = (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), _this), _this.bar = "foo", _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-statement/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-statement/expected.js
@@ -4,7 +4,7 @@ var Foo = function (_Bar) {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
 
     _this.bar = "foo";
     return _this;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
@@ -6,7 +6,7 @@ function withContext(ComposedComponent) {
 
         function WithContext() {
             babelHelpers.classCallCheck(this, WithContext);
-            return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(WithContext).apply(this, arguments));
+            return babelHelpers.possibleConstructorReturn(this, (WithContext.__proto__ || Object.getPrototypeOf(WithContext)).apply(this, arguments));
         }
 
         return WithContext;

--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -345,9 +345,13 @@ export default class ClassTransformer {
       }
     } else {
       bareSuperNode = optimiseCall(
-        t.callExpression(
-          t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
-          [this.classRef]
+        t.logicalExpression(
+          "||",
+          t.memberExpression(this.classRef, t.identifier("__proto__")),
+          t.callExpression(
+            t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
+            [this.classRef]
+          )
         ),
         t.thisExpression(),
         bareSuperNode.arguments

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
@@ -22,7 +22,7 @@ var Connection = function (_EventEmitter) {
     function Connection(endpoint, joinKey, joinData, roomId) {
         babelHelpers.classCallCheck(this, Connection);
 
-        var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Connection).call(this));
+        var _this = babelHelpers.possibleConstructorReturn(this, (Connection.__proto__ || Object.getPrototypeOf(Connection)).call(this));
 
         _this.isConnected = false;
         _this.roomId = roomId;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
@@ -13,13 +13,13 @@ var SubFoo = function (_BaseFoo) {
 
   function SubFoo() {
     babelHelpers.classCallCheck(this, SubFoo);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(SubFoo).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (SubFoo.__proto__ || Object.getPrototypeOf(SubFoo)).apply(this, arguments));
   }
 
   babelHelpers.createClass(SubFoo, null, [{
     key: 'talk',
     value: function talk() {
-      babelHelpers.get(Object.getPrototypeOf(SubFoo), 'talk', this).call(this);
+      babelHelpers.get(SubFoo.__proto__ || Object.getPrototypeOf(SubFoo), 'talk', this).call(this);
       console.log('SubFoo.talk');
     }
   }]);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
@@ -13,7 +13,7 @@ var RandomComponent = function (_Component) {
 
   function RandomComponent() {
     babelHelpers.classCallCheck(this, RandomComponent);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(RandomComponent).call(this));
+    return babelHelpers.possibleConstructorReturn(this, (RandomComponent.__proto__ || Object.getPrototypeOf(RandomComponent)).call(this));
   }
 
   babelHelpers.createClass(RandomComponent, [{

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
@@ -14,7 +14,7 @@ var a1 = function (_b) {
   function a1() {
     babelHelpers.classCallCheck(this, a1);
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(a1).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (a1.__proto__ || Object.getPrototypeOf(a1)).call(this));
 
     _this.x = function () {
       return _this;
@@ -31,7 +31,7 @@ var a2 = function (_b2) {
   function a2() {
     babelHelpers.classCallCheck(this, a2);
 
-    var _this2 = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(a2).call(this));
+    var _this2 = babelHelpers.possibleConstructorReturn(this, (a2.__proto__ || Object.getPrototypeOf(a2)).call(this));
 
     _this2.x = function () {
       return _this2;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/expected.js
@@ -6,7 +6,7 @@ var x = {
 
     function _class() {
       babelHelpers.classCallCheck(this, _class);
-      return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(_class).apply(this, arguments));
+      return babelHelpers.possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
     }
 
     return _class;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
@@ -12,7 +12,7 @@ var B = function (_A) {
 
     babelHelpers.classCallCheck(this, B);
 
-    return _ret = (_this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(B).call(this)), _this), babelHelpers.possibleConstructorReturn(_this, _ret);
+    return _ret = (_this = babelHelpers.possibleConstructorReturn(this, (B.__proto__ || Object.getPrototypeOf(B)).call(this)), _this), babelHelpers.possibleConstructorReturn(_this, _ret);
   }
 
   return B;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-class/expected.js
@@ -2,22 +2,22 @@ var Test = function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {
-    var _Object$getPrototypeO, _babelHelpers$get;
+    var _ref, _babelHelpers$get;
 
     babelHelpers.classCallCheck(this, Test);
 
     woops.super.test();
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Test).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
 
-    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).call(_this);
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).call(_this);
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Test).apply(this, arguments));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).apply(this, arguments));
 
-    var _this = babelHelpers.possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Test)).call.apply(_Object$getPrototypeO, [this, "test"].concat(Array.prototype.slice.call(arguments))));
+    var _this = babelHelpers.possibleConstructorReturn(this, (_ref = Test.__proto__ || Object.getPrototypeOf(Test)).call.apply(_ref, [this, "test"].concat(Array.prototype.slice.call(arguments))));
 
-    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).apply(_this, arguments);
-    (_babelHelpers$get = babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this)).call.apply(_babelHelpers$get, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).apply(_this, arguments);
+    (_babelHelpers$get = babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this)).call.apply(_babelHelpers$get, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
     return _this;
   }
 
@@ -26,18 +26,18 @@ var Test = function (_Foo) {
     value: function test() {
       var _babelHelpers$get2;
 
-      babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", this).call(this);
-      babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", this).apply(this, arguments);
-      (_babelHelpers$get2 = babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", this)).call.apply(_babelHelpers$get2, [this, "test"].concat(Array.prototype.slice.call(arguments)));
+      babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", this).call(this);
+      babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", this).apply(this, arguments);
+      (_babelHelpers$get2 = babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", this)).call.apply(_babelHelpers$get2, [this, "test"].concat(Array.prototype.slice.call(arguments)));
     }
   }], [{
     key: "foo",
     value: function foo() {
       var _babelHelpers$get3;
 
-      babelHelpers.get(Object.getPrototypeOf(Test), "foo", this).call(this);
-      babelHelpers.get(Object.getPrototypeOf(Test), "foo", this).apply(this, arguments);
-      (_babelHelpers$get3 = babelHelpers.get(Object.getPrototypeOf(Test), "foo", this)).call.apply(_babelHelpers$get3, [this, "test"].concat(Array.prototype.slice.call(arguments)));
+      babelHelpers.get(Test.__proto__ || Object.getPrototypeOf(Test), "foo", this).call(this);
+      babelHelpers.get(Test.__proto__ || Object.getPrototypeOf(Test), "foo", this).apply(this, arguments);
+      (_babelHelpers$get3 = babelHelpers.get(Test.__proto__ || Object.getPrototypeOf(Test), "foo", this)).call.apply(_babelHelpers$get3, [this, "test"].concat(Array.prototype.slice.call(arguments)));
     }
   }]);
   return Test;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-properties/expected.js
@@ -4,10 +4,10 @@ var Test = function (_Foo) {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Test).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
 
-    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this);
-    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).whatever;
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this);
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).whatever;
     return _this;
   }
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/calling-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/calling-super-properties/expected.js
@@ -4,17 +4,17 @@ var Test = function (_Foo) {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Test).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
 
-    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).whatever();
-    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).call(_this);
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).whatever();
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).call(_this);
     return _this;
   }
 
   babelHelpers.createClass(Test, null, [{
     key: "test",
     value: function test() {
-      return babelHelpers.get(Object.getPrototypeOf(Test), "wow", this).call(this);
+      return babelHelpers.get(Test.__proto__ || Object.getPrototypeOf(Test), "wow", this).call(this);
     }
   }]);
   return Test;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
@@ -10,7 +10,7 @@ var Foo = function (_Bar) {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
-    var _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
 
     _this.state = "test";
     return _this;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/expected.js
@@ -5,7 +5,7 @@ var Foo = function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _this = babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).call(this, () => {
+    return _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, () => {
       _this.test;
     }));
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/export-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/export-super-class/expected.js
@@ -3,7 +3,7 @@ var _class = function (_A) {
 
   function _class() {
     babelHelpers.classCallCheck(this, _class);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(_class).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
   }
 
   return _class;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-call-only-allowed-in-derived-constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-call-only-allowed-in-derived-constructor/expected.js
@@ -1,5 +1,0 @@
-var Foo = function Foo() {
-  babelHelpers.classCallCheck(this, Foo);
-
-  Object.getPrototypeOf(Foo).call(this);
-};

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-anonymous/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-anonymous/expected.js
@@ -3,7 +3,7 @@ var TestEmpty = function (_ref) {
 
   function TestEmpty() {
     babelHelpers.classCallCheck(this, TestEmpty);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(TestEmpty).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (TestEmpty.__proto__ || Object.getPrototypeOf(TestEmpty)).apply(this, arguments));
   }
 
   return TestEmpty;
@@ -20,7 +20,7 @@ var TestConstructorOnly = function (_ref2) {
 
   function TestConstructorOnly() {
     babelHelpers.classCallCheck(this, TestConstructorOnly);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(TestConstructorOnly).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (TestConstructorOnly.__proto__ || Object.getPrototypeOf(TestConstructorOnly)).apply(this, arguments));
   }
 
   return TestConstructorOnly;
@@ -37,7 +37,7 @@ var TestMethodOnly = function (_ref3) {
 
   function TestMethodOnly() {
     babelHelpers.classCallCheck(this, TestMethodOnly);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(TestMethodOnly).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (TestMethodOnly.__proto__ || Object.getPrototypeOf(TestMethodOnly)).apply(this, arguments));
   }
 
   return TestMethodOnly;
@@ -58,7 +58,7 @@ var TestConstructorAndMethod = function (_ref4) {
 
   function TestConstructorAndMethod() {
     babelHelpers.classCallCheck(this, TestConstructorAndMethod);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(TestConstructorAndMethod).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (TestConstructorAndMethod.__proto__ || Object.getPrototypeOf(TestConstructorAndMethod)).apply(this, arguments));
   }
 
   return TestConstructorAndMethod;
@@ -79,7 +79,7 @@ var TestMultipleMethods = function (_ref5) {
 
   function TestMultipleMethods() {
     babelHelpers.classCallCheck(this, TestMultipleMethods);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(TestMultipleMethods).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (TestMultipleMethods.__proto__ || Object.getPrototypeOf(TestMultipleMethods)).apply(this, arguments));
   }
 
   return TestMultipleMethods;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-id-member-expression/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-id-member-expression/expected.js
@@ -3,7 +3,7 @@ var BaseController = function (_Chaplin$Controller) {
 
   function BaseController() {
     babelHelpers.classCallCheck(this, BaseController);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(BaseController).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (BaseController.__proto__ || Object.getPrototypeOf(BaseController)).apply(this, arguments));
   }
 
   return BaseController;
@@ -14,7 +14,7 @@ var BaseController2 = function (_Chaplin$Controller$A) {
 
   function BaseController2() {
     babelHelpers.classCallCheck(this, BaseController2);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(BaseController2).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (BaseController2.__proto__ || Object.getPrototypeOf(BaseController2)).apply(this, arguments));
   }
 
   return BaseController2;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class/expected.js
@@ -3,7 +3,7 @@ var Test = function (_Foo) {
 
   function Test() {
     babelHelpers.classCallCheck(this, Test);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Test).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).apply(this, arguments));
   }
 
   return Test;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-function-fallback/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-function-fallback/expected.js
@@ -1,5 +1,5 @@
 var Test = function Test() {
   babelHelpers.classCallCheck(this, Test);
 
-  babelHelpers.get(Object.getPrototypeOf(Test.prototype), "hasOwnProperty", this).call(this, "test");
+  babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "hasOwnProperty", this).call(this, "test");
 };

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-3/expected.js
@@ -11,7 +11,7 @@ let Login = function (_React$Component) {
 
   function Login() {
     babelHelpers.classCallCheck(this, Login);
-    return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Login).apply(this, arguments));
+    return babelHelpers.possibleConstructorReturn(this, (Login.__proto__ || Object.getPrototypeOf(Login)).apply(this, arguments));
   }
 
   babelHelpers.createClass(Login, [{

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/statically-bound/expected.js
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/statically-bound/expected.js
@@ -2,6 +2,6 @@ var _obj;
 
 var o = _obj = {
   m: function () {
-    return babelHelpers.get(Object.getPrototypeOf(_obj), "x", this);
+    return babelHelpers.get(_obj.__proto__ || Object.getPrototypeOf(_obj), "x", this);
   }
 };

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-iife/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-iife/expected.js
@@ -5,7 +5,7 @@ function broken(x) {
 
       function Foo() {
         babelHelpers.classCallCheck(this, Foo);
-        return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+        return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
       }
 
       return Foo;


### PR DESCRIPTION
### Problem summary

Internet Explorer 10 and below **do not support** `__proto__` at all, they **don't have** `Object.setPrototypeOf()`, but they **have** `Object.getPrototypeOf()`.

When babel is doing the inheritance it is trying to use `Object.setPrototypeOf()` if this function is available. As mentioned this function isn't available (even with core-js, as also core-js can't polyfill this). In this case the helper falls back to just [set `__proto__`](https://github.com/babel/babel/blob/master/packages/babel-helpers/src/helpers.js#L223) on the object. For IE <=10 this is just some custom property that gets set on the target, with no special meaning.

In the constructor after the inherit helper finished its work, babel [uses `Object.getPrototypeOf()`](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-es2015-classes/src/vanilla.js#L349) to get the prototype. This is supported by IE, but as babel can't set the prototype on the target, this will just return the base Object-prototype and not the wanted superclass.

### Proposed solution

The solution simply changes the retrieval of the prototype by first trying to get `__proto__` and if not available falling back to `Object.getPrototypeOf()`. This fixes the behavior in IE as babel reads the custom prop `__proto__` that the inherit helper was setting. In all other browsers this should not have any effect, as `__proto__` should be the same as `Object.getPrototypeOf()`.

Does anyone see a problem with this solution? Anything that I maybe have missed?

~~P.S.: I did not yet change any of the tests, as I wanted to get feedback first on the solution.~~