### PR TITLE
cleanup transpiled files in `make clean` - fixes T7434 [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ lint:
 	./node_modules/.bin/kcheck
 
 clean: test-clean
+	rm -rf packages/*/lib
 	rm -rf packages/babel-polyfill/browser*
 	rm -rf coverage
 	rm -rf packages/*/npm-debug*


### PR DESCRIPTION
https://phabricator.babeljs.io/T7434

We do this in make publish because one might of manually change lib without running build or the watcher, etc.

@vjpr