### PR TITLE
"name" should not be visited for TypeParameter

### DIFF
--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -234,7 +234,7 @@ defineType("TypeCastExpression", {
 });
 
 defineType("TypeParameter", {
-  visitor: ["name", "bound"],
+  visitor: ["bound"],
   aliases: ["Flow"],
   fields: {
     // todo


### PR DESCRIPTION
I think the name should not be visited as it is just a string.
https://github.com/babel/babylon/commit/fe5193a40a87a374f0a1791f05e1f246856da168#diff-c2fde1d661107d896c90647d0eb3295dR93

This is also the cause for the parse error in babel-eslint. babel/babel-eslint#321