### PR TITLE
Allow empty export statements with no export specifiers - fixes T7439

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -308,37 +308,35 @@ export default function () {
               }
 
               let specifiers = path.get("specifiers");
-              if (specifiers.length) {
-                let nodes = [];
-                let source = path.node.source;
-                if (source) {
-                  let ref = addRequire(source.value, path.node._blockHoist);
+              let nodes = [];
+              let source = path.node.source;
+              if (source) {
+                let ref = addRequire(source.value, path.node._blockHoist);
 
-                  for (let specifier of specifiers) {
-                    if (specifier.isExportNamespaceSpecifier()) {
-                      // todo
-                    } else if (specifier.isExportDefaultSpecifier()) {
-                      // todo
-                    } else if (specifier.isExportSpecifier()) {
-                      if (specifier.node.local.name === "default") {
-                        topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(t.callExpression(this.addHelper("interopRequireDefault"), [ref]), specifier.node.local)));
-                      } else {
-                        topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(ref, specifier.node.local)));
-                      }
-                      nonHoistedExportNames[specifier.node.exported.name] = true;
+                for (let specifier of specifiers) {
+                  if (specifier.isExportNamespaceSpecifier()) {
+                    // todo
+                  } else if (specifier.isExportDefaultSpecifier()) {
+                    // todo
+                  } else if (specifier.isExportSpecifier()) {
+                    if (specifier.node.local.name === "default") {
+                      topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(t.callExpression(this.addHelper("interopRequireDefault"), [ref]), specifier.node.local)));
+                    } else {
+                      topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name), t.memberExpression(ref, specifier.node.local)));
                     }
-                  }
-                } else {
-                  for (let specifier of specifiers) {
-                    if (specifier.isExportSpecifier()) {
-                      addTo(exports, specifier.node.local.name, specifier.node.exported);
-                      nonHoistedExportNames[specifier.node.exported.name] = true;
-                      nodes.push(buildExportsAssignment(specifier.node.exported, specifier.node.local));
-                    }
+                    nonHoistedExportNames[specifier.node.exported.name] = true;
                   }
                 }
-                path.replaceWithMultiple(nodes);
+              } else {
+                for (let specifier of specifiers) {
+                  if (specifier.isExportSpecifier()) {
+                    addTo(exports, specifier.node.local.name, specifier.node.exported);
+                    nonHoistedExportNames[specifier.node.exported.name] = true;
+                    nodes.push(buildExportsAssignment(specifier.node.exported, specifier.node.local));
+                  }
+                }
               }
+              path.replaceWithMultiple(nodes);
             } else if (path.isExportAllDeclaration()) {
               let exportNode = buildExportAll({
                 OBJECT: addRequire(path.node.source.value, path.node._blockHoist)

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-3/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-3/actual.js
@@ -1,0 +1,3 @@
+export {};
+
+export {} from 'foo';

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-3/expected.js
@@ -1,0 +1,3 @@
+'use strict';
+
+var _foo = require('foo');


### PR DESCRIPTION
Just removes the `if (specifiers.length) {` check around this part of the code, since it's totally valid for these to have no specifiers in the export list.