### PR TITLE
babel-code-frame: Upgrade to js-tokens@2

### DIFF
--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -11,6 +11,6 @@
     "babel-runtime": "^6.0.0",
     "chalk": "^1.1.0",
     "esutils": "^2.0.2",
-    "js-tokens": "^1.0.2"
+    "js-tokens": "^2.0.0"
   }
 }


### PR DESCRIPTION
That version brings ES2016 support. However, the difference in syntax
highlighting is not distinguishable, because both `*` and `**` get the
same color.