### PR TITLE
Add exactGlobals option to transform-es2015-modules-umd plugin to enable more flexibility in specifying global names

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-umd/README.md
+++ b/packages/babel-plugin-transform-es2015-modules-umd/README.md
@@ -20,9 +20,9 @@ $ npm install babel-plugin-transform-es2015-modules-umd
 
 You can also override the names of particular libraries when this module is
 running in the browser.  For example the `es6-promise` library exposes itself
-as `global.Promise` rather than `global.es6Promise`. This can be accomidated by:
+as `global.Promise` rather than `global.es6Promise`. This can be accommodated by:
 
-```
+```json
 {
   "plugins": [
     ["transform-es2015-modules-umd", {

--- a/packages/babel-plugin-transform-es2015-modules-umd/README.md
+++ b/packages/babel-plugin-transform-es2015-modules-umd/README.md
@@ -36,7 +36,7 @@ as `global.Promise` rather than `global.es6Promise`. This can be accommodated by
 
 #### Default semantics
 
-There are a couple things to note about the default semantics.
+There are a few things to note about the default semantics.
 
 _First_, this transform uses the
 [basename](https://en.wikipedia.org/wiki/Basename) of each import to generate
@@ -88,9 +88,11 @@ This means that if you specify an override as a member expression like:
 this will _not_ transpile to `factory(global.fizz.buzz)`. Instead, it will
 transpile to `factory(global.fizzBuzz)` based on the logic in `toIdentifier`.
 
+_Third_, you cannot override the exported global name.
+
 #### More flexible semantics with `exactGlobals: true`
 
-Both of these behaviors can limit the flexibility of the `globals` map. To
+All of these behaviors can limit the flexibility of the `globals` map. To
 remove these limitations, you can set the `exactGlobals` option to `true`.
 Doing this instructs the plugin to:
 
@@ -99,6 +101,8 @@ the global names
 2. skip passing `globals` overrides to the `toIdentifier` function. Instead,
 they are used exactly as written, so you will get errors if you do not use
 valid identifiers or valid uncomputed (dot) member expressions.
+3. allow the exported global name to be overridden via the `globals` map. Any
+override must again be a valid identifier or valid member expression.
 
 Thus, if you set `exactGlobals` to `true` and do not pass any overrides, the
 first example of:
@@ -130,6 +134,33 @@ then it'll transpile to:
 
 ```js
 factory(global.fooBAR, global.mylib.fooBar)
+```
+
+Finally, with the plugin options set to:
+
+```json
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "my/custom/module/name": "My.Custom.Module.Name"
+      },
+      "exactGlobals": true
+    }]
+  ],
+  "moduleId": "my/custom/module/name"
+}
+```
+
+it will transpile to:
+
+```js
+factory(mod.exports);
+global.My = global.My || {};
+global.My.Custom = global.My.Custom || {};
+global.My.Custom.Module = global.My.Custom.Module || {};
+global.My.Custom.Module.Name = mod.exports;
 ```
 
 ### Via CLI

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -112,14 +112,10 @@ export default function ({ types: t }) {
               prerequisiteAssignments = [];
 
               let members = globalName.split(".");
-              let namespacedProperties = members.slice(1).reduce((accum, curr, index) => {
-                let prerequisiteAssignment = buildPrerequisiteAssignment({ GLOBAL_REFERENCE: accum[index] });
-                prerequisiteAssignments.push(prerequisiteAssignment);
-                accum.push(t.memberExpression(accum[index], t.identifier(curr)));
-                return accum;
-              }, [t.memberExpression(t.identifier("global"), t.identifier(members[0]))]);
-
-              globalToAssign = namespacedProperties[namespacedProperties.length -1];
+              globalToAssign = members.slice(1).reduce((accum, curr) => {
+                prerequisiteAssignments.push(buildPrerequisiteAssignment({ GLOBAL_REFERENCE: accum }));
+                return t.memberExpression(accum, t.identifier(curr));
+              }, t.memberExpression(t.identifier("global"), t.identifier(members[0])));
             }
           }
 

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -79,13 +79,9 @@ export default function ({ types: t }) {
               if (state.opts.exactGlobals) {
                 let globalRef = browserGlobals[arg.value];
                 if (globalRef) {
-                  if (globalRef.indexOf(".") > -1) {
-                    memberExpression = globalRef.split(".").reduce(
-                      (accum, curr) => t.memberExpression(accum, t.identifier(curr)), t.identifier("global")
-                    );
-                  } else {
-                    memberExpression = t.memberExpression(t.identifier("global"), t.identifier(globalRef));
-                  }
+                  memberExpression = globalRef.split(".").reduce(
+                    (accum, curr) => t.memberExpression(accum, t.identifier(curr)), t.identifier("global")
+                  );
                 } else {
                   memberExpression = t.memberExpression(
                     t.identifier("global"), t.identifier(t.toIdentifier(arg.value))
@@ -113,21 +109,17 @@ export default function ({ types: t }) {
             let globalName = browserGlobals[moduleNameOrBasename];
 
             if (globalName) {
-              if (globalName.indexOf(".") > -1) {
-                prerequisiteAssignments = [];
+              prerequisiteAssignments = [];
 
-                let members = globalName.split(".");
-                let namespacedProperties = members.slice(1).reduce((accum, curr, index) => {
-                  let prerequisiteAssignment = buildPrerequisiteAssignment({ GLOBAL_REFERENCE: accum[index] });
-                  prerequisiteAssignments.push(prerequisiteAssignment);
-                  accum.push(t.memberExpression(accum[index], t.identifier(curr)));
-                  return accum;
-                }, [t.memberExpression(t.identifier("global"), t.identifier(members[0]))]);
+              let members = globalName.split(".");
+              let namespacedProperties = members.slice(1).reduce((accum, curr, index) => {
+                let prerequisiteAssignment = buildPrerequisiteAssignment({ GLOBAL_REFERENCE: accum[index] });
+                prerequisiteAssignments.push(prerequisiteAssignment);
+                accum.push(t.memberExpression(accum[index], t.identifier(curr)));
+                return accum;
+              }, [t.memberExpression(t.identifier("global"), t.identifier(members[0]))]);
 
-                globalToAssign = namespacedProperties[namespacedProperties.length -1];
-              } else {
-                globalToAssign = t.memberExpression(t.identifier("global"), t.identifier(globalName));
-              }
+              globalToAssign = namespacedProperties[namespacedProperties.length -1];
             }
           }
 

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/actual.js
@@ -1,0 +1,3 @@
+import fooBar1 from "foo-bar";
+import fooBar2 from "./mylib/foo-bar";
+import fizzBuzz from "fizzbuzz";

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["foo-bar", "./mylib/foo-bar", "fizzbuzz"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("foo-bar"), require("./mylib/foo-bar"), require("fizzbuzz"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.fooBAR, global.fooBAR, global.fizzBuzz);
+    global.actual = mod.exports;
+  }
+})(this, function (_fooBar, _fooBar3, _fizzbuzz) {
+  "use strict";
+
+  var _fooBar2 = babelHelpers.interopRequireDefault(_fooBar);
+
+  var _fooBar4 = babelHelpers.interopRequireDefault(_fooBar3);
+
+  var _fizzbuzz2 = babelHelpers.interopRequireDefault(_fizzbuzz);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "foo-bar": "fooBAR",
+        "./mylib/foo-bar": "mylib.fooBar",
+        "fizzbuzz": "fizz.buzz"
+      }
+    }]
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false/actual.js
@@ -1,0 +1,3 @@
+import fooBar1 from "foo-bar";
+import fooBar2 from "./mylib/foo-bar";
+import fizzBuzz from "fizzbuzz";

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-false/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["foo-bar", "./mylib/foo-bar", "fizzbuzz"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("foo-bar"), require("./mylib/foo-bar"), require("fizzbuzz"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.fooBar, global.fooBar, global.fizzbuzz);
+    global.actual = mod.exports;
+  }
+})(this, function (_fooBar, _fooBar3, _fizzbuzz) {
+  "use strict";
+
+  var _fooBar2 = babelHelpers.interopRequireDefault(_fooBar);
+
+  var _fooBar4 = babelHelpers.interopRequireDefault(_fooBar3);
+
+  var _fizzbuzz2 = babelHelpers.interopRequireDefault(_fizzbuzz);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/actual.js
@@ -1,0 +1,3 @@
+import fooBar1 from "foo-bar";
+import fooBar2 from "./mylib/foo-bar";
+import fizzBuzz from "fizzbuzz";

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["foo-bar", "./mylib/foo-bar", "fizzbuzz"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("foo-bar"), require("./mylib/foo-bar"), require("fizzbuzz"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.fooBAR, global.mylib.fooBar, global.fizz.buzz);
+    global.actual = mod.exports;
+  }
+})(this, function (_fooBar, _fooBar3, _fizzbuzz) {
+  "use strict";
+
+  var _fooBar2 = babelHelpers.interopRequireDefault(_fooBar);
+
+  var _fooBar4 = babelHelpers.interopRequireDefault(_fooBar3);
+
+  var _fizzbuzz2 = babelHelpers.interopRequireDefault(_fizzbuzz);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/options.json
@@ -1,0 +1,13 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "foo-bar": "fooBAR",
+        "./mylib/foo-bar": "mylib.fooBar",
+        "fizzbuzz": "fizz.buzz"
+      },
+      "exactGlobals": true
+    }]
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true/actual.js
@@ -1,0 +1,3 @@
+import fooBar1 from "foo-bar";
+import fooBar2 from "./mylib/foo-bar";
+import fizzBuzz from "fizzbuzz";

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["foo-bar", "./mylib/foo-bar", "fizzbuzz"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("foo-bar"), require("./mylib/foo-bar"), require("fizzbuzz"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.fooBar, global.mylibFooBar, global.fizzbuzz);
+    global.actual = mod.exports;
+  }
+})(this, function (_fooBar, _fooBar3, _fizzbuzz) {
+  "use strict";
+
+  var _fooBar2 = babelHelpers.interopRequireDefault(_fooBar);
+
+  var _fooBar4 = babelHelpers.interopRequireDefault(_fooBar3);
+
+  var _fizzbuzz2 = babelHelpers.interopRequireDefault(_fizzbuzz);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-exact-globals-true/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "exactGlobals": true
+    }]
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/actual.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("my custom module name", ["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.foo = global.foo || {};
+    global.foo.bar = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = 42;
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "my custom module name": "foo.bar"
+      },
+      "exactGlobals": true
+    }]
+  ],
+  "moduleId": "my custom module name"
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/actual.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/expected.js
@@ -1,0 +1,23 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("my custom module name", ["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.foo = global.foo || {};
+    global.foo.bar = global.foo.bar || {};
+    global.foo.bar.baz = global.foo.bar.baz || {};
+    global.foo.bar.baz.qux = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = 42;
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "my custom module name": "foo.bar.baz.qux"
+      },
+      "exactGlobals": true
+    }]
+  ],
+  "moduleId": "my custom module name"
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global/actual.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global/expected.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("my custom module name", ["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.baz = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = 42;
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-id-with-overridden-global/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "my custom module name": "baz"
+      },
+      "exactGlobals": true
+    }]
+  ],
+  "moduleId": "my custom module name"
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name-with-overridden-global/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name-with-overridden-global/actual.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name-with-overridden-global/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name-with-overridden-global/expected.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("umd/module-name-with-overridden-global/expected", ["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.baz = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = 42;
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name-with-overridden-global/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/module-name-with-overridden-global/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "umd/module-name-with-overridden-global/expected": "baz"
+      },
+      "exactGlobals": true
+    }]
+  ],
+  "moduleIds": true
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-export-name/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-export-name/actual.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-export-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-export-name/expected.js
@@ -1,0 +1,20 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.baz = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = 42;
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-export-name/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-export-name/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "actual": "baz"
+      },
+      "exactGlobals": true
+    }]
+  ]
+}


### PR DESCRIPTION
The addition of a global names overrides map in https://github.com/babel/babel/pull/3366 was a great idea. However, I've noticed the current implementation limits the flexibility users have to control the global names. The first limitation is caused by [using the basename](https://github.com/babel/babel/blob/5a8a2512d0b2ae157c3e473b4db0f13dbe74e5f4/packages/babel-plugin-transform-es2015-modules-umd/src/index.js#L68-L69) as the keys for this map. Consider this code:
```js
import fooBar1 from "foo-bar";
import fooBar2 from "./mylib/foo-bar";
```
where `foo-bar` and `./mylib/foo-bar` are distinct modules that export the browser globals `fooBar` and `mylib.fooBar` respectively. By default, the UMD transform will turn this into:
```js
(function (global, factory) {
  if (typeof define === "function" && define.amd) {
    define(['foo-bar', './mylib/foo-bar'], factory);
  } else if (typeof exports !== "undefined") {
    factory(require('foo-bar'), require('./mylib/foo-bar'));
  } else {
    var mod = {
      exports: {}
    };
    factory(global.fooBar, global.fooBar); // <--- see here
    global.input4 = mod.exports;
  }
})(this, function (_fooBar, _fooBar3) {
  // ...
});
```
That is, because we only use the basename to generate the name of the exported global, the transform assumes both modules export a browser global called `fooBar`. And the real problem is, you cannot create a `globals` map to fix this, since you'd need to map `"foo-bar"` to both `"fooBar"` and `"mylib.fooBar"`. This wouldn't be an issue if `browserGlobals` was indexed via `arg.value` (the full import string) since that would provide two distinct keys, `"foo-bar"` and `"./mylib/foo-bar"`:
```js
{
  "globals": {
    "foo-bar": "fooBar",
    "./mylib/foo-bar": "mylib.fooBar"
  }
}
```

The second limitation is that the values specified in the `globals` map are still passed to the `toIdentifier` function. This means that setting a value to `"mylib.fooBar"`, like in the previous example, would _not_ result in code referencing `global.mylib.fooBar`. Instead, it would reference `global.mylibFooBar`.

Personally, I think the `globals` map in this plugin's options should be a map from the full import string to the desired global name, not from the basename to an input of the `toIdentifier` function. Unfortunately, changing these semantics would be a breaking change, so we cannot do that without a major version bump. Until the next major version, we can enable these changes behind a new option. So in this PR I introduced an `exactGlobals` option that enables these more flexible semantics.