### PR TITLE
Fix conflict when runtime and generator are used at the same time

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -290,7 +290,9 @@ export default class File extends Store {
     if (generator) {
       let res = generator(name);
       if (res) return res;
-    } else if (runtime) {
+    }
+    
+    if (runtime) {
       return t.memberExpression(runtime, t.identifier(name));
     }
 


### PR DESCRIPTION
In my code I was using runtimes with generators. Eg.

```
plugins: [
                    'external-helpers',
                    'add-module-exports',
                    'transform-es2015-template-literals',
                    'transform-es2015-literals',
                    'transform-es2015-arrow-functions',
                    'transform-es2015-block-scoped-functions', ['transform-es2015-classes', {
                        loose: true
                    }],
                    'transform-es2015-object-super',
                    'transform-es2015-shorthand-properties',
                    'transform-es2015-computed-properties',
                    'transform-es2015-for-of',
                    'check-es2015-constants', ['transform-es2015-spread', {
                        loose: true
                    }],
                    'transform-es2015-parameters', ['transform-es2015-destructuring', {
                        loose: true
                    }],
                    'transform-es2015-block-scoping',
                    'transform-es2015-modules-commonjs',
                    'transform-es3-member-expression-literals',
                    'transform-es3-property-literals', ['transform-runtime', {
                        polyfill: false,
                        regenerator: false
                    }]
                ]
```

This broke because the generator evaluated to truthy but generator(name) was falsey and caused babel to return undefined.