### PR TITLE
Correct super property access is loose mode

### DIFF
--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -194,7 +194,7 @@ export default class ReplaceSupers {
 
       // super.test(); -> objectRef.prototype.MethodName.call(this);
       // do the super -> objectRef.prototype here to distingish from member access that specHandle will handle
-      callee.object = this.getLooseSuperProperty(callee.object, callee)
+      callee.object = this.getLooseSuperProperty(callee.object, callee);
       t.appendToMemberExpression(callee, t.identifier("call"));
       node.arguments.unshift(t.thisExpression());
       // no need to requeue, now that everything is converted

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -193,9 +193,14 @@ export default class ReplaceSupers {
       if (!t.isSuper(callee.object)) return;
 
       // super.test(); -> objectRef.prototype.MethodName.call(this);
+      // do the super -> objectRef.prototype here to distingish from member access that specHandle will handle
+      callee.object = this.getLooseSuperProperty(callee.object, callee)
       t.appendToMemberExpression(callee, t.identifier("call"));
       node.arguments.unshift(t.thisExpression());
-      return true;
+      // no need to requeue, now that everything is converted
+    } else {
+      // if it is not a call expression, fall back to the spec handle for member access and assignments
+      return this.specHandle(path);
     }
   }
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-properties/expected.js
@@ -6,8 +6,8 @@ var Test = function (_Foo) {
 
     var _this = babelHelpers.possibleConstructorReturn(this, _Foo.call(this));
 
-    _Foo.prototype.test;
-    _Foo.prototype.test.whatever;
+    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this);
+    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).whatever;
     return _this;
   }
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/calling-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/calling-super-properties/expected.js
@@ -6,7 +6,7 @@ var Test = function (_Foo) {
 
     var _this = babelHelpers.possibleConstructorReturn(this, _Foo.call(this));
 
-    _Foo.prototype.test.whatever();
+    babelHelpers.get(Object.getPrototypeOf(Test.prototype), "test", _this).whatever();
     _Foo.prototype.test.call(_this);
     return _this;
   }


### PR DESCRIPTION
In loose mode super property access is wrong, accessing and changing properties on the prototype instance instead of `this`:
https://phabricator.babeljs.io/T7389
This fixes super property access, by using fast/loose lookups of methods on calls, but reverts to spec handling for property access/assignments, where it is necessary to call the setter/getter on the correct `this` instance.

EDIT @aaronang:
Fixes #4312