### PR TITLE
update minimatch to v3.0.2

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -38,7 +38,7 @@
     "debug": "^2.1.1",
     "json5": "^0.4.0",
     "lodash": "^4.2.0",
-    "minimatch": "^2.0.3",
+    "minimatch": "^3.0.2",
     "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",


### PR DESCRIPTION
update minimatch to v3.0.2 to avoid warning
```
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```