### PR TITLE
Avoid regex dos attack, per nsp advisory 118

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -38,7 +38,7 @@
     "debug": "^2.1.1",
     "json5": "^0.4.0",
     "lodash": "^4.2.0",
-    "minimatch": "^2.0.3",
+    "minimatch": "3.0.2",
     "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",


### PR DESCRIPTION
Our build is failing with the following error:

```
Errored while running RunCommand.execute
Error: Command failed: /bin/sh -c npm run test
(+) 2 vulnerabilities found
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ minimatch                                                       │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 2.0.10                                                          │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=3.0.1                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >=3.0.2                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ react-server-cli@0.3.2 > babel-core@6.9.1 > minimatch@2.0.10    │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/118                          │
└───────────────┴─────────────────────────────────────────────────────────────────┘
```

This pr resolves the security vulnerability.  Find out more in the [nsp advisory]( https://nodesecurity.io/advisories/118)