### PR TITLE
Update minimatch to 3.0.2

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -38,7 +38,7 @@
     "debug": "^2.1.1",
     "json5": "^0.4.0",
     "lodash": "^4.2.0",
-    "minimatch": "^2.0.3",
+    "minimatch": "^3.0.2",
     "path-exists": "^1.0.0",
     "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",


### PR DESCRIPTION
This resolves a RegEx DoS concern. 

https://nodesecurity.io/advisories/118