### PR TITLE
Added jsx-self babel transform plugin

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-self/.npmignore
+++ b/packages/babel-plugin-transform-react-jsx-self/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+*.log
+src
+test

--- a/packages/babel-plugin-transform-react-jsx-self/README.md
+++ b/packages/babel-plugin-transform-react-jsx-self/README.md
@@ -1,0 +1,49 @@
+# babel-plugin-transform-react-jsx-self
+
+Adds `__self` prop to JSX elements, which React will use to generate some runtime warnings.  All React users
+should enable this transform in dev mode.
+
+## Example
+
+###In
+
+```
+<sometag />
+```
+###Out
+
+```
+<sometag __self={this} />
+```
+
+## Installation
+
+```sh
+$ npm install babel-plugin-transform-react-jsx-self
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["transform-react-jsx-self"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins transform-react-jsx-self script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-react-jsx-self"]
+});
+```

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "babel-plugin-transform-react-jsx-self",
+  "version": "6.9.0",
+  "description": "Add a __self prop to all JSX Elements",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "babel-runtime": "^6.9.0",
+    "babel-plugin-syntax-jsx": "^6.8.0"
+  },
+  "devDependencies": {
+    "babel-helper-plugin-test-runner": "^6.8.0"
+  }
+}

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.js
@@ -1,0 +1,30 @@
+
+ /**
+ * This adds {fileName, lineNumber} annotations to React component definitions
+ * and to jsx tag literals.
+ *
+ *
+ * == JSX Literals ==
+ *
+ * <sometag />
+ *
+ * becomes:
+ *
+ * <sometag __self={this} />
+ */
+
+const TRACE_ID = "__self";
+
+export default function ({ types: t }) {
+  let visitor = {
+    JSXOpeningElement(node) {
+      const id = t.jSXIdentifier(TRACE_ID);
+      const trace = t.identifier("this");
+      node.container.openingElement.attributes.push(t.jSXAttribute(id, t.jSXExpressionContainer(trace)));
+    }
+  };
+
+  return {
+    visitor
+  };
+}

--- a/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/basic-sample/actual.js
+++ b/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/basic-sample/actual.js
@@ -1,0 +1,1 @@
+var x = <sometag />

--- a/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/basic-sample/expected.js
+++ b/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/basic-sample/expected.js
@@ -1,0 +1,1 @@
+var x = <sometag __self={this} />;

--- a/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/options.json
+++ b/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-jsx", "transform-react-jsx-self"]
+}

--- a/packages/babel-plugin-transform-react-jsx-self/test/index.js
+++ b/packages/babel-plugin-transform-react-jsx-self/test/index.js
@@ -1,0 +1,1 @@
+require("babel-helper-plugin-test-runner")(__dirname);

--- a/packages/babel-preset-react/index.js
+++ b/packages/babel-preset-react/index.js
@@ -6,11 +6,12 @@ module.exports = {
     require("babel-plugin-syntax-jsx"),
     require("babel-plugin-transform-react-display-name"),
   ],
-  /*env: {
+  env: {
     development: {
       plugins: [
-        require("babel-plugin-transform-react-jsx-source")
+   //     require("babel-plugin-transform-react-jsx-source"),
+        require("babel-plugin-transform-react-jsx-self")
       ]
     }
-  }*/
+  }
 };


### PR DESCRIPTION
This adds a new transform which appends the `__self` prop to jsx elements.  The transform is needed by one of the React warnings that is being introduced, so users should enable it when running React in DEV mode.