### PR TITLE
Link to new AST spec location

### DIFF
--- a/doc/ast/spec.md
+++ b/doc/ast/spec.md
@@ -1,0 +1,1 @@
+The [AST specification](https://github.com/babel/babylon/blob/master/ast/spec.md) has been moved to the Babylon repo, `babel/babylon`.


### PR DESCRIPTION
Since we can't do a redirect we should point people to the new location. The link from [Babel Handbook](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#asts) is now just broken, for example.