### PR TITLE
Fixed incorrect printing of array of nullable flow type

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -236,11 +236,7 @@ export function TypeParameter(node: Object) {
 
 export function TypeParameterInstantiation(node: Object) {
   this.token("<");
-  this.printList(node.params, node, {
-    iterator: (node: Object) => {
-      this.print(node.typeAnnotation, node);
-    }
-  });
+  this.printList(node.params, node, {});
   this.token(">");
 }
 

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
@@ -100,4 +100,4 @@ export type { foo };
 export type { foo } from "bar";
 export interface foo { p: number };
 export interface foo<T> { p: T };
-var a: ?Array<?string>
+var a: ?Array<?string>;

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
@@ -100,3 +100,4 @@ export type { foo };
 export type { foo } from "bar";
 export interface foo { p: number };
 export interface foo<T> { p: T };
+var a: ?Array<?string>

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
@@ -104,3 +104,4 @@ export type { foo };
 export type { foo } from "bar";
 export interface foo { p: number };
 export interface foo<T> { p: T };
+var a: ?Array<?string>;


### PR DESCRIPTION
Before, `var a: ?Array<?string>;` was being parsed and printed incorrectly as `var a: ?Array<?string string>;`.