### PR TITLE
Added flowUsesCommas option for object types

### DIFF
--- a/packages/babel-generator/README.md
+++ b/packages/babel-generator/README.md
@@ -36,6 +36,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 quotes                 | `'single'` or `'double'` | autodetect based on `ast.tokens` | The type of quote to use in the output
 filename               | string   |                 | Used in warning messages
+flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 
 Options for source maps:
 

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -254,7 +254,11 @@ export function ObjectTypeAnnotation(node: Object) {
       statement: true,
       iterator: () => {
         if (props.length !== 1) {
-          this.semicolon();
+          if (this.format.flowCommaSeparator) {
+            this.token(",");
+          } else {
+            this.semicolon();
+          }
           this.space();
         }
       }

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -62,7 +62,8 @@ function normalizeOptions(code, opts, tokens): Format {
       adjustMultilineComment: true,
       style: style,
       base: 0
-    }
+    },
+    flowCommaSeparator: opts.flowCommaSeparator,
   };
 
   if (format.minified) {

--- a/packages/babel-generator/test/fixtures/flowUsesCommas/ObjectExpression/actual.js
+++ b/packages/babel-generator/test/fixtures/flowUsesCommas/ObjectExpression/actual.js
@@ -1,0 +1,10 @@
+var a: { numVal: number };
+var a: { numVal: number; };
+var a: { numVal: number; [indexer: string]: number };
+var a: ?{ numVal: number };
+var a: { numVal: number; strVal: string }
+var a: { subObj: {strVal: string} }
+var a: { subObj: ?{strVal: string} }
+var a: { param1: number; param2: string }
+var a: { param1: number; param2?: string }
+var a: { [a: number]: string; [b: number]: string; };

--- a/packages/babel-generator/test/fixtures/flowUsesCommas/ObjectExpression/expected.js
+++ b/packages/babel-generator/test/fixtures/flowUsesCommas/ObjectExpression/expected.js
@@ -1,0 +1,10 @@
+var a: { numVal: number };
+var a: { numVal: number };
+var a: { numVal: number, [indexer: string]: number, };
+var a: ?{ numVal: number };
+var a: { numVal: number, strVal: string, };
+var a: { subObj: { strVal: string } };
+var a: { subObj: ?{ strVal: string } };
+var a: { param1: number, param2: string, };
+var a: { param1: number, param2?: string, };
+var a: { [a: number]: string, [b: number]: string, };

--- a/packages/babel-generator/test/fixtures/flowUsesCommas/options.json
+++ b/packages/babel-generator/test/fixtures/flowUsesCommas/options.json
@@ -1,0 +1,3 @@
+{
+  "flowCommaSeparator": true
+}


### PR DESCRIPTION
Currently there are 2 supported syntaxes (, and ;) in Flow Object Types. The use of commas is in line with the more popular style and matches how objects are defined in JS, making it a bit more natural to write. Recently FB added a lint rule that enforces the use of commas, so it would great to have this option in Babel as well. Thanks!
