### PR TITLE
Fix incorrect Flow object whitespacing

### DIFF
--- a/packages/babel-generator/src/node/whitespace.js
+++ b/packages/babel-generator/src/node/whitespace.js
@@ -167,6 +167,7 @@ exports.nodes = {
  */
 
 exports.nodes.ObjectProperty =
+exports.nodes.ObjectTypeProperty =
 exports.nodes.ObjectMethod =
 exports.nodes.SpreadProperty = function (node: Object, parent): ?WhitespaceObject {
   if (parent.properties[0] === node) {

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -82,8 +82,27 @@ suite("programmatic generation", function() {
     var ast = parse(generate.default(ifStatement).code);
     assert.equal(ast.program.body[0].consequent.type, 'BlockStatement');
   });
-});
 
+  test("flow object indentation", function() {
+    var objectStatement = t.objectTypeAnnotation(
+      [
+        t.objectTypeProperty(
+          t.identifier('bar'),
+          t.stringTypeAnnotation()
+        ),
+      ],
+      null,
+      null
+    );
+
+    var output = generate.default(objectStatement).code;
+    assert.equal(output, [
+      '{',
+      '  bar: string;',
+      '}',
+    ].join('\n'));
+  });
+});
 
 suite("whitespace", function () {
   test("empty token list", function () {


### PR DESCRIPTION
Previously, generated Flow ASTs would print the first property of objects incorrectly:

```
export type myFragment = { profilePicture: ?{ uri: ?string;
    width: ?number;
    height: ?number;
  };
};
```

This now correctly prints to:

```
export type myFragment = {
  profilePicture: ?{
    uri: ?string;
    width: ?number;
    height: ?number;
  };
};
```