### PR TITLE
Remove jsx-self from react preset

### DIFF
--- a/packages/babel-preset-react/index.js
+++ b/packages/babel-preset-react/index.js
@@ -9,8 +9,8 @@ module.exports = {
   env: {
     development: {
       plugins: [
-   //     require("babel-plugin-transform-react-jsx-source"),
-        require("babel-plugin-transform-react-jsx-self")
+        // require("babel-plugin-transform-react-jsx-source"),
+        // require("babel-plugin-transform-react-jsx-self")
       ]
     }
   }


### PR DESCRIPTION
And I guess we could remove both packages from package.json too?

I didn't have much context in the plugin at the time, so everyone will have to opt-in to adding this then?

Ok I believe it's since the env defaults to development but the issue is that users don't always set the env to production.

@jimfb @spicyj 