### PR TITLE
Deprecate babel-plugin-undeclared-variables-check

### DIFF
--- a/packages/babel-plugin-undeclared-variables-check/README.md
+++ b/packages/babel-plugin-undeclared-variables-check/README.md
@@ -1,5 +1,8 @@
 # babel-plugin-undeclared-variables-check
 
+> Deprecated: use ESLint or another linter for this use case and more.
+> For ESLint you can use the [`no-undef` rule](http://eslint.org/docs/rules/no-undef)
+
 Throw a compile-time error on references to undeclared variables
 
 ## Installation


### PR DESCRIPTION
I don't think we can maintain this right now

As much as it would be awesome/fun to make babel a linting platform we have ESLint already (and instead we can figure out better interop in babel/eslint itself or through babel-eslint

(Or we can just move it out of the repo)