### PR TITLE
Fix bug where path.evaluate treats repeated identifiers as undefined

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -91,7 +91,7 @@ export function evaluate(): { confident: boolean; value: any } {
 
       let val = _evaluate(path);
       item.resolved = true;
-      item.value = value;
+      item.value = val;
       return val;
     }
   }

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -90,8 +90,10 @@ export function evaluate(): { confident: boolean; value: any } {
       seen.set(node, item);
 
       let val = _evaluate(path);
-      item.resolved = true;
-      item.value = val;
+      if (confident) {
+        item.resolved = true;
+        item.value = val;
+      }
       return val;
     }
   }

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -37,4 +37,18 @@ suite("evaluation", function () {
       false
     );
   });
+
+  test("should work with repeated, indeterminate identifiers", function () {
+    assert.strictEqual(
+      getPath("var num = foo(); (num > 0 && num < 100);").get("body")[1].evaluateTruthy(),
+      undefined
+    );
+  });
+
+  test("should work with repeated, determinate identifiers", function () {
+    assert.strictEqual(
+      getPath("var num = 5; (num > 0 && num < 100);").get("body")[1].evaluateTruthy(),
+      true
+    );
+  });
 });


### PR DESCRIPTION
Causing it to evaluate indeterminate expressions like `num > 0 && num < 100` to `false` (instead of `undefined`), and even determinate expressions (`num > 0 && num < 100` preceded by `var num = 5`) to `false` (instead of `true`).

~~(Just waiting for the build to fail before pushing the fix)~~
https://travis-ci.org/babel/babel/jobs/140706745#L466
```
1) evaluation should work with repeated, indeterminate identifiers:
     AssertionError: false === undefined
...
2) evaluation should work with repeated, determinate identifiers:
     AssertionError: false === true
```