### PR TITLE
Fix non-unique 'ref' binding name - fixes T7468

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/expected.js
@@ -2,11 +2,12 @@ function f() {
   var _this = this;
 
   let g = function () {
-    var ref = babelHelpers.asyncToGenerator(function* () {
+    var _ref = babelHelpers.asyncToGenerator(function* () {
       _this;
     });
+
     return function g() {
-      return ref.apply(this, arguments);
+      return _ref.apply(this, arguments);
     };
   }();
 };
@@ -17,11 +18,12 @@ class Class {
 
     return babelHelpers.asyncToGenerator(function* () {
       var c = function () {
-        var ref = babelHelpers.asyncToGenerator(function* (b) {
+        var _ref2 = babelHelpers.asyncToGenerator(function* (b) {
           _this2;
         });
+
         return function c(_x) {
-          return ref.apply(this, arguments);
+          return _ref2.apply(this, arguments);
         };
       }();
     })();

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -7,9 +7,9 @@ Object.defineProperty(exports, "__esModule", {
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var foo = function () {
-  var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee3() {
+  var _ref2 = _asyncToGenerator(regeneratorRuntime.mark(function _callee3() {
     var bar = function () {
-      var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee2() {
+      var _ref3 = _asyncToGenerator(regeneratorRuntime.mark(function _callee2() {
         var baz;
         return regeneratorRuntime.wrap(function _callee2$(_context2) {
           while (1) {
@@ -26,7 +26,7 @@ var foo = function () {
       }));
 
       return function bar() {
-        return ref.apply(this, arguments);
+        return _ref3.apply(this, arguments);
       };
     }();
 
@@ -42,7 +42,7 @@ var foo = function () {
   }));
 
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref2.apply(this, arguments);
   };
 }();
 
@@ -58,7 +58,7 @@ var Foo = function () {
   _createClass(Foo, [{
     key: "bar",
     value: function () {
-      var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
+      var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
         var baz;
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
@@ -75,7 +75,7 @@ var Foo = function () {
       }));
 
       function bar() {
-        return ref.apply(this, arguments);
+        return _ref.apply(this, arguments);
       }
 
       return bar;

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -7,18 +7,18 @@ import * as t from "babel-types";
 
 let buildWrapper = template(`
   (() => {
-    var ref = FUNCTION;
+    var REF = FUNCTION;
     return function NAME(PARAMS) {
-      return ref.apply(this, arguments);
+      return REF.apply(this, arguments);
     };
   })
 `);
 
 let namedBuildWrapper = template(`
   (() => {
-    var ref = FUNCTION;
+    var REF = FUNCTION;
     function NAME(PARAMS) {
-      return ref.apply(this, arguments);
+      return REF.apply(this, arguments);
     }
     return NAME;
   })
@@ -76,6 +76,7 @@ function plainFunction(path: NodePath, callId: Object) {
   let built = t.callExpression(callId, [node]);
   let container = wrapper({
     NAME: asyncFnId,
+    REF: path.scope.generateUidIdentifier("ref"),
     FUNCTION: built,
     PARAMS: node.params.map(() => path.scope.generateUidIdentifier("x"))
   }).expression;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
@@ -5,12 +5,13 @@ let TestClass = {
     var _this = this;
 
     return new Promise((() => {
-      var ref = babelHelpers.asyncToGenerator(function* (resolve) {
+      var _ref = babelHelpers.asyncToGenerator(function* (resolve) {
         console.log(_this);
         setTimeout(resolve, 1000);
       });
+
       return function (_x) {
-        return ref.apply(this, arguments);
+        return _ref.apply(this, arguments);
       };
     })());
   }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
@@ -1,5 +1,5 @@
 let s = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* (x) {
+  var _ref = babelHelpers.asyncToGenerator(function* (x) {
     var _this = this,
         _arguments = arguments;
 
@@ -8,9 +8,9 @@ let s = (() => {
     }
 
     let t = (() => {
-      var ref = babelHelpers.asyncToGenerator(function* (y, a) {
+      var _ref2 = babelHelpers.asyncToGenerator(function* (y, a) {
         let r = (() => {
-          var ref = babelHelpers.asyncToGenerator(function* (z, b) {
+          var _ref3 = babelHelpers.asyncToGenerator(function* (z, b) {
             for (var _len2 = arguments.length, innerArgs = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
               innerArgs[_key2 - 2] = arguments[_key2];
             }
@@ -19,8 +19,9 @@ let s = (() => {
             console.log(_this, innerArgs, _arguments);
             return _this.x;
           });
+
           return function r(_x4, _x5) {
-            return ref.apply(this, arguments);
+            return _ref3.apply(this, arguments);
           };
         })();
         yield r();
@@ -28,15 +29,17 @@ let s = (() => {
         console.log(_this, args, _arguments);
         return _this.g(r);
       });
+
       return function t(_x2, _x3) {
-        return ref.apply(this, arguments);
+        return _ref2.apply(this, arguments);
       };
     })();
 
     yield t();
     return this.h(t);
   });
+
   return function s(_x) {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/expected.js
@@ -1,8 +1,9 @@
 var foo = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* () {
+  var _ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
+
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
@@ -1,10 +1,10 @@
 var foo = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* () {
+  var _ref = babelHelpers.asyncToGenerator(function* () {
     console.log(bar);
   });
 
   function bar() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   }
 
   return bar;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/expected.js
@@ -1,6 +1,7 @@
 let foo = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* (bar) {});
+  var _ref = babelHelpers.asyncToGenerator(function* (bar) {});
+
   return function foo(_x) {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
@@ -1,8 +1,9 @@
 let foo = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* () {
+  var _ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
+
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -6,9 +6,10 @@ Object.defineProperty(exports, "__esModule", {
 exports.foo = undefined;
 
 let foo = exports.foo = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* () {});
+  var _ref = babelHelpers.asyncToGenerator(function* () {});
+
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
@@ -5,8 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 
 let foo = exports.foo = (() => {
-  var ref = babelHelpers.asyncToGenerator(function* () {});
+  var _ref = babelHelpers.asyncToGenerator(function* () {});
+
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
@@ -18,11 +18,12 @@ class Test {
       console.log(_this2);
 
       setTimeout((() => {
-        var ref = babelHelpers.asyncToGenerator(function* (arg) {
+        var _ref2 = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this2);
         });
+
         return function (_x) {
-          return ref.apply(this, arguments);
+          return _ref2.apply(this, arguments);
         };
       })());
     })();
@@ -47,11 +48,12 @@ class Test {
       console.log(_this4);
 
       setTimeout((() => {
-        var ref = babelHelpers.asyncToGenerator(function* (arg) {
+        var _ref4 = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this4);
         });
+
         return function (_x2) {
-          return ref.apply(this, arguments);
+          return _ref4.apply(this, arguments);
         };
       })());
     })();

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/expression/expected.js
@@ -1,10 +1,10 @@
 import { coroutine as _coroutine } from "bluebird";
 var foo = (() => {
-  var ref = _coroutine(function* () {
+  var _ref = _coroutine(function* () {
     var wat = yield bar();
   });
 
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/named-expression/expected.js
@@ -1,11 +1,11 @@
 import { coroutine as _coroutine } from "bluebird";
 var foo = (() => {
-  var ref = _coroutine(function* () {
+  var _ref = _coroutine(function* () {
     console.log(bar);
   });
 
   function bar() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   }
 
   return bar;

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/statement/expected.js
@@ -1,11 +1,11 @@
 import { coroutine as _coroutine } from "bluebird";
 
 let foo = (() => {
-  var ref = _coroutine(function* () {
+  var _ref = _coroutine(function* () {
     var wat = yield bar();
   });
 
   return function foo() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/expected.js
@@ -1,15 +1,16 @@
 var concat = function () {
-  var ref = babelHelpers.asyncToGenerator(function* () {
+  var _ref = babelHelpers.asyncToGenerator(function* () {
     var x = arguments.length <= 0 ? undefined : arguments[0];
     var y = arguments.length <= 1 ? undefined : arguments[1];
   });
+
   return function concat() {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 }();
 
 var x = function () {
-  var ref = babelHelpers.asyncToGenerator(function* () {
+  var _ref2 = babelHelpers.asyncToGenerator(function* () {
     for (var _len = arguments.length, rest = Array(_len), _key = 0; _key < _len; _key++) {
       rest[_key] = arguments[_key];
     }
@@ -17,7 +18,8 @@ var x = function () {
     if (noNeedToWork) return 0;
     return rest;
   });
+
   return function x() {
-    return ref.apply(this, arguments);
+    return _ref2.apply(this, arguments);
   };
 }();


### PR DESCRIPTION
This variable name needs to be dynamically generated or else it could shadow a real variable.