### PR TITLE
babel-core: add options for different parser/generator

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -418,13 +418,15 @@ export default class File extends Store {
 
     if (parserOpts.parser) {
       if (typeof parserOpts.parser === "string") {
-        let dirname = parserOpts.dirname || process.cwd();
+        let dirname = parserOpts.dirname || path.dirname(this.opts.filename);
         let parser = resolve(parserOpts.parser, dirname);
         if (parser) {
           parseCode = require(parser).parse;
         } else {
           throw new Error(`Couldn't find parser ${parserOpts.parser} with "parse" method relative to directory ${dirname}`);
         }
+      } else {
+        parseCode = parserOpts.parser;
       }
 
       parserOpts = Object.assign({}, this.parserOpts, parserOpts);

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -424,43 +424,21 @@ export default class File extends Store {
         if (parser) {
           parseCode = require(parser).parse;
         } else {
-          throw new Error(`Couldn't find parser ${parseCode} relative to directory ${dirname}`);
+          throw new Error(`Couldn't find parser ${parseCode} with "parse" method relative to directory ${dirname}`);
         }
       }
 
       if (!this.parserOpts.parser) {
-        const babylonOptions = {
-          sourceType: "module",
-          allowImportExportEverywhere: true,
-          allowReturnOutsideFunction: false,
-          plugins: [
-            "asyncFunctions",
-            "asyncGenerators",
-            "classConstructorCall",
-            "classProperties",
-            "decorators",
-            "doExpressions",
-            "exponentiationOperator",
-            "exportExtensions",
-            "flow",
-            "functionSent",
-            "functionBind",
-            "jsx",
-            "objectRestSpread",
-            "trailingFunctionCommas"
-          ]
-        };
-
         this.parserOpts.parser = {
           parse(source) {
-            return require("babylon").parse(source, babylonOptions);
+            return require("babylon").parse(source, this.parserOpts);
           }
         };
       }
     }
 
     this.log.debug("Parse start");
-    let ast = parseCode(code, this.parserOpts);
+    let ast = parseCode(code, opts.parserOpts ? Object.assign({}, this.parserOpts, opts.parserOpts) : this.parserOpts);
     this.log.debug("Parse stop");
     return ast;
   }
@@ -631,14 +609,14 @@ export default class File extends Store {
         if (generator) {
           gen = require(generator).print;
         } else {
-          throw new Error(`Couldn't find generator ${gen} relative to directory ${dirname}`);
+          throw new Error(`Couldn't find generator ${gen} with "print" method relative to directory ${dirname}`);
         }
       }
     }
 
     this.log.debug("Generation start");
 
-    let _result = gen(ast, opts, this.code);
+    let _result = gen(ast, opts.generatorOpts ? Object.assign(opts, opts.generatorOpts) : opts, this.code);
     result.code = _result.code;
     result.map  = _result.map;
 

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -414,27 +414,30 @@ export default class File extends Store {
 
   parse(code: string) {
     let parseCode = parse;
-    let parserOpts = this.opts.parserOpts;
+    let parserOpts = this.opts.parserOpts || this.parserOpts;
 
-    if (parserOpts.parser) {
-      if (typeof parserOpts.parser === "string") {
-        let dirname = parserOpts.dirname || path.dirname(this.opts.filename);
-        let parser = resolve(parserOpts.parser, dirname);
-        if (parser) {
-          parseCode = require(parser).parse;
-        } else {
-          throw new Error(`Couldn't find parser ${parserOpts.parser} with "parse" method relative to directory ${dirname}`);
-        }
-      } else {
-        parseCode = parserOpts.parser;
-      }
-
+    if (parserOpts) {
       parserOpts = Object.assign({}, this.parserOpts, parserOpts);
-      parserOpts.parser = {
-        parse(source) {
-          return parse(source, parserOpts);
+
+      if (parserOpts.parser) {
+        if (typeof parserOpts.parser === "string") {
+          let dirname = parserOpts.dirname || path.dirname(this.opts.filename);
+          let parser = resolve(parserOpts.parser, dirname);
+          if (parser) {
+            parseCode = require(parser).parse;
+          } else {
+            throw new Error(`Couldn't find parser ${parserOpts.parser} with "parse" method relative to directory ${dirname}`);
+          }
+        } else {
+          parseCode = parserOpts.parser;
         }
-      };
+
+        parserOpts.parser = {
+          parse(source) {
+            return parse(source, parserOpts);
+          }
+        };
+      }
     }
 
     this.log.debug("Parse start");

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -413,32 +413,30 @@ export default class File extends Store {
   }
 
   parse(code: string) {
-    let opts = this.opts;
     let parseCode = parse;
-    if (opts.parserOpts.parser) {
-      parseCode = opts.parserOpts.parser;
+    let parserOpts = this.opts.parserOpts;
 
-      if (typeof parseCode === "string") {
-        let dirname = opts.parserOpts.dirname || process.cwd();
-        let parser = resolve(parseCode, dirname);
+    if (parserOpts.parser) {
+      if (typeof parserOpts.parser === "string") {
+        let dirname = parserOpts.dirname || process.cwd();
+        let parser = resolve(parserOpts.parser, dirname);
         if (parser) {
           parseCode = require(parser).parse;
         } else {
-          throw new Error(`Couldn't find parser ${parseCode} with "parse" method relative to directory ${dirname}`);
+          throw new Error(`Couldn't find parser ${parserOpts.parser} with "parse" method relative to directory ${dirname}`);
         }
       }
 
-      if (!this.parserOpts.parser) {
-        this.parserOpts.parser = {
-          parse(source) {
-            return require("babylon").parse(source, this.parserOpts);
-          }
-        };
-      }
+      parserOpts = Object.assign({}, this.parserOpts, parserOpts);
+      parserOpts.parser = {
+        parse(source) {
+          return parse(source, parserOpts);
+        }
+      };
     }
 
     this.log.debug("Parse start");
-    let ast = parseCode(code, opts.parserOpts ? Object.assign({}, this.parserOpts, opts.parserOpts) : this.parserOpts);
+    let ast = parseCode(code, parserOpts);
     this.log.debug("Parse stop");
     return ast;
   }

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -421,7 +421,7 @@ export default class File extends Store {
 
       if (parserOpts.parser) {
         if (typeof parserOpts.parser === "string") {
-          let dirname = parserOpts.dirname || path.dirname(this.opts.filename);
+          let dirname = path.dirname(this.opts.filename) || process.cwd();
           let parser = resolve(parserOpts.parser, dirname);
           if (parser) {
             parseCode = require(parser).parse;
@@ -607,7 +607,7 @@ export default class File extends Store {
       gen = opts.generatorOpts.generator;
 
       if (typeof gen === "string") {
-        let dirname = opts.generatorOpts.dirname || process.cwd();
+        let dirname = path.dirname(this.opts.filename) || process.cwd();
         let generator = resolve(gen, dirname);
         if (generator) {
           gen = require(generator).print;

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -198,4 +198,16 @@ module.exports = {
     default: false,
     hidden: true,
   },
+
+  // Deprecate top level parserOpts
+  parserOpts: {
+    description: "Options to pass into the parser, or to change parsers (parserOpts.parser)",
+    default: false
+  },
+
+  // Deprecate top level generatorOpts
+  generatorOpts: {
+    description: "Options to pass into the generator, or to change generators (generatorOpts.generator)",
+    default: false
+  }
 };

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -23,6 +23,37 @@ function transformAsync(code, opts) {
   };
 }
 
+suite("parser and generator options", function() {
+  var oldString = "original;";
+  var newString = "withOptions;";
+
+  test("no options", function() {
+    var noOptsResults = babel.transform(oldString, {});
+
+    assert.deepEqual(noOptsResults.ast, babel.transform(oldString).ast);
+    assert.equal(noOptsResults.code, oldString);
+  });
+
+  test("options", function() {
+    var recast = {
+      parse: function() { return babel.transform(newString).ast; },
+      print: function() { return { code: newString }; }
+    };
+
+    var results = babel.transform(oldString, {
+      parserOpts: {
+        parser: recast.parse
+      },
+      generatorOpts: {
+        generator: recast.print
+      }
+    });
+
+    assert.deepEqual(results.ast, babel.transform(newString).ast);
+    assert.equal(results.code, newString);
+  });
+});
+
 suite("api", function () {
   test("analyze", function () {
     assert.equal(babel.analyse("foobar;").marked.length, 0);

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -52,6 +52,64 @@ suite("parser and generator options", function() {
     assert.deepEqual(results.ast, babel.transform(newString).ast);
     assert.equal(results.code, newString);
   });
+
+  test("experimental syntax", function() {
+    var experimental = "var a: number = 1;";
+    var recast = {
+      parse: function() { return babel.transform(experimental, {
+        parserOpts: {
+          plugins: ['flow']
+        }
+      }).ast; },
+      print: function() { return { code: experimental }; }
+    };
+
+    var results = babel.transform(oldString, {
+      parserOpts: {
+        parser: recast.parse,
+        plugins: ['flow']
+      },
+      generatorOpts: {
+        generator: recast.print
+      }
+    });
+
+    assert.deepEqual(results.ast, babel.transform(experimental, {
+      parserOpts: {
+        plugins: ['flow']
+      }
+    }).ast);
+    assert.equal(results.code, experimental);
+  });
+
+  test("other options", function() {
+    var experimental = "if (true) { import a from 'a'; }";
+    var recast = {
+      parse: function() { return babel.transform(experimental, {
+        parserOpts: {
+          allowImportExportEverywhere: true
+        }
+      }).ast; },
+      print: function() { return { code: experimental }; }
+    };
+
+    var results = babel.transform(oldString, {
+      parserOpts: {
+        parser: recast.parse,
+        allowImportExportEverywhere: true
+      },
+      generatorOpts: {
+        generator: recast.print
+      }
+    });
+
+    assert.deepEqual(results.ast, babel.transform(experimental, {
+      parserOpts: {
+        allowImportExportEverywhere: true
+      }
+    }).ast);
+    assert.equal(results.code, experimental);
+  });
 });
 
 suite("api", function () {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -39,8 +39,7 @@ suite("parser and generator options", function() {
       parserOpts: {
         parser: recast.parse,
         plugins: ["flow"],
-        allowImportExportEverywhere: true,
-        sourceType: "script"
+        allowImportExportEverywhere: true
       },
       generatorOpts: {
         generator: recast.print
@@ -68,8 +67,7 @@ suite("parser and generator options", function() {
       return babel.transform(string, {
         plugins: [__dirname + "/../../babel-plugin-syntax-flow"],
         parserOpts: {
-          parser: recast.parse,
-          sourceType: "script"
+          parser: recast.parse
         },
         generatorOpts: {
           generator: recast.print

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -93,6 +93,11 @@ function normalizeOptions(code, opts, tokens): Format {
  * Determine if input code uses more single or double quotes.
  */
 function findCommonStringDelimiter(code, tokens) {
+  const DEFAULT_STRING_DELIMITER = "double";
+  if (!code) {
+    return DEFAULT_STRING_DELIMITER;
+  }
+
   let occurences = {
     single: 0,
     double: 0
@@ -117,7 +122,7 @@ function findCommonStringDelimiter(code, tokens) {
   if (occurences.single > occurences.double) {
     return "single";
   } else {
-    return "double";
+    return DEFAULT_STRING_DELIMITER;
   }
 }
 


### PR DESCRIPTION
![recast](https://cloud.githubusercontent.com/assets/588473/16584612/04a82078-428b-11e6-9f79-a665eef848ea.gif)

Ref https://github.com/mohebifar/lebab/issues/138

#### Background

Babel as a compiler has 3 steps: parsing, transforming, and generation.

At a high level, the process is: 
- parsing: take a string (input code) and turn it into JSON.
- transforming (all the plugins): take JSON and make a different JSON structure)
- generation: turn the JSON back into a string (output code).

The last step of babel (out of 3) is the code generator. Traditionally, the code generator doesn't really need to care about the format of your code (spaces, quotes, etc). This is because the output code is your "compiled" code and will probably go in the dist/lib directory and you will eventually minify it, etc.

But what if you want to write a babel plugin that runs on your source code and outputs to source (`babel src -d src` rather than `babel src -d lib`). You would want your diff to be readable and for the plugin to only modify what is necessary and what conforms to your style guide.

This is because you want to write a plugin that transforms the source itself. And the use case I was thinking about is a project called [lebab](https://github.com/mohebifar/lebab
) which is literally 5to6 or the opposite of babel. Currently, [it isn't a babel plugin](https://github.com/mohebifar/lebab/issues/138) so I wanted to help support that usecase.

So the cool thing that would happen is that you would use the eventual "lebab" preset to convert your es5 codebase to es6, and then run babel again to support older browsers.

===

Idea is to allow recast instead of babel-generator so we can run on src files. (so https://github.com/mohebifar/lebab can be a babel preset)

something like `babel src -d src --presets=lebab`

Had to patch recast/ast-types locally
- [ ] recast printer PR https://github.com/benjamn/recast/pull/298, https://github.com/benjamn/recast/pull/299
  - [ ] testing
- [ ] ast-types for babel 6 https://github.com/benjamn/ast-types/pull/162
  - [ ] testing