### PR TITLE
Make the code generator write-only to avoid exponential time generation

### DIFF
--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -124,10 +124,10 @@ export default class Buffer {
    * Add a space to the buffer unless it is compact.
    */
 
-  space() {
+  space(force: boolean = false) {
     if (this.format.compact) return;
 
-    if (this.buf && !this.endsWith(" ") && !this.endsWith("\n")) {
+    if ((this.buf && !this.endsWith(" ") && !this.endsWith("\n")) || force) {
       this.push(" ");
     }
   }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -106,7 +106,7 @@ export default class Buffer {
     if (!this.endsWith("\n")) this.newline();
 
     if (this.format.minified && !this._lastPrintedIsEmptyStatement) {
-      this._removeLast(";");
+      this.removeLast(";");
     }
     this.token("}");
   }
@@ -166,11 +166,6 @@ export default class Buffer {
    */
 
   removeLast(cha: string) {
-    if (this.format.compact) return;
-    return this._removeLast(cha);
-  }
-
-  _removeLast(cha: string) {
     if (!this.endsWith(cha)) return;
     this.buf = this.buf.slice(0, -1);
     this.last = this.buf[this.buf.length - 1];

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -238,7 +238,6 @@ export default class Buffer {
       this.removeLast("\n");
     }
 
-    this.removeLast(" ");
     this._removeSpacesAfterLastNewline();
     for (let j = 0; j < i; j++) {
       this.push("\n");
@@ -250,12 +249,13 @@ export default class Buffer {
    */
 
   _removeSpacesAfterLastNewline() {
-    let lastNewlineIndex = this.buf.lastIndexOf("\n");
-    if (lastNewlineIndex >= 0 && this.get().length <= lastNewlineIndex) {
-      let toRemove = this.buf.slice(lastNewlineIndex + 1);
-      this.buf = this.buf.substring(0, lastNewlineIndex + 1);
-      this.last = "\n";
-      this._position.unshift(toRemove);
+    const originalBuf = this.buf;
+    this.buf = this.buf.replace(/[ \t]+$/, "");
+
+    if (originalBuf.length !== this.buf.length){
+      const removed = originalBuf.slice(this.buf.length);
+      this._position.unshift(removed);
+      this.last = this.buf[this.buf.length - 1];
     }
   }
 

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -319,7 +319,8 @@ export default class Buffer {
     }
 
     // If there the line is ending, adding a new mapping marker is redundant
-    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this._position, this._sourcePosition);
+    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this._position, this._sourcePosition.line,
+      this._sourcePosition.column, this._sourcePosition.filename);
 
     //
     this._position.push(str);

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -37,14 +37,10 @@ export default class Buffer {
   buf: string;
   last: string;
 
-  /**
-   * Description
-   */
-
-  catchUp(node: Object) {
+  _catchUp(){
     // catch up to this nodes newline if we're behind
-    if (node.loc && this.format.retainLines && this.buf) {
-      while (this.getCurrentLine() < node.loc.start.line) {
+    if (this.format.retainLines && this._sourcePosition.line !== null) {
+      while (this.getCurrentLine() < this._sourcePosition.line) {
         this.push("\n");
       }
     }
@@ -276,6 +272,8 @@ export default class Buffer {
     this._sourcePosition.line = pos ? pos.line : null;
     this._sourcePosition.column = pos ? pos.column : null;
     this._sourcePosition.filename = loc && loc.filename || null;
+
+    this._catchUp();
   }
 
   /**
@@ -283,7 +281,7 @@ export default class Buffer {
    */
 
   withSource(prop: string, loc: Location, cb: () => void) {
-    if (!this.opts.sourceMaps) return cb();
+    if (!this.opts.sourceMaps && !this.format.retainLines) return cb();
 
     // Use the call stack to manage a stack of "source location" data.
     let originalLine = this._sourcePosition.line;

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,251 +1,99 @@
 import Position from "./position";
-import repeat from "lodash/repeat";
+import type SourceMap from "./source-map";
 import trimEnd from "lodash/trimEnd";
 
 /**
- * Buffer for collecting generated output.
+ * The Buffer class exists to manage the queue of tokens being pushed onto the output string
+ * in such a way that the final string buffer is treated as write-only until the final .get()
+ * call. This allows V8 to optimize the output efficiently by not requiring it to store the
+ * string in contiguous memory.
  */
 
 export default class Buffer {
-  constructor(format: Object) {
-    this.printedCommentStarts = {};
-    this.parenPushNewlineState = null;
-    this._position = new Position();
-    this._indent = format.indent.base;
-    this.format = format;
-    this.buf = "";
-
-    // Maintaining a reference to the last char in the buffer is an optimization
-    // to make sure that v8 doesn't "flatten" the string more often than needed
-    // see https://github.com/babel/babel/pull/3283 for details.
-    this.last = "";
-
-    this.map = null;
-    this._sourcePosition = {
-      line: null,
-      column: null,
-      filename: null,
-    };
-    this._endsWithWord = false;
+  constructor(map: ?SourceMap) {
+    this._map = map;
   }
 
-  printedCommentStarts: Object;
-  parenPushNewlineState: ?Object;
-  position: Position;
-  _indent: number;
-  format: Object;
-  buf: string;
-  last: string;
+  _map: SourceMap = null;
+  _buf: string = "";
+  _last: string = "";
+  _queue: Array = [];
 
-  _catchUp(){
-    // catch up to this nodes newline if we're behind
-    if (this.format.retainLines && this._sourcePosition.line !== null) {
-      while (this.getCurrentLine() < this._sourcePosition.line) {
-        this.push("\n");
-      }
-    }
-  }
+  _position: Position = new Position;
+  _sourcePosition: Object = {
+    line: null,
+    column: null,
+    filename: null,
+  };
 
   /**
-   * Get the current trimmed buffer.
+   * Get the final string output from the buffer, along with the sourcemap if one exists.
    */
 
-  get(): string {
-    return trimEnd(this.buf);
-  }
-
-  /**
-   * Get the current indent.
-   */
-
-  getIndent(): string {
-    if (this.format.compact || this.format.concise) {
-      return "";
-    } else {
-      return repeat(this.format.indent.style, this._indent);
-    }
-  }
-
-  /**
-   * Get the current indent size.
-   */
-
-  indentSize(): number {
-    return this.getIndent().length;
-  }
-
-  /**
-   * Increment indent size.
-   */
-
-  indent() {
-    this._indent++;
-  }
-
-  /**
-   * Decrement indent size.
-   */
-
-  dedent() {
-    this._indent--;
-  }
-
-  /**
-   * Add a semicolon to the buffer.
-   */
-
-  semicolon() {
-    this.token(";");
-  }
-
-  /**
-   * Add a right brace to the buffer.
-   */
-
-  rightBrace() {
-    if (!this.endsWith("\n")) this.newline();
-
-    if (this.format.minified && !this._lastPrintedIsEmptyStatement) {
-      this.removeLast(";");
-    }
-    this.token("}");
-  }
-
-  /**
-   * Add a keyword to the buffer.
-   */
-
-  keyword(name: string) {
-    this.word(name);
-    this.space();
-  }
-
-  /**
-   * Add a space to the buffer unless it is compact.
-   */
-
-  space(force: boolean = false) {
-    if (this.format.compact) return;
-
-    if ((this.buf && !this.endsWith(" ") && !this.endsWith("\n")) || force) {
-      this.push(" ");
-    }
-  }
-
-  /**
-   * Writes a token that can't be safely parsed without taking whitespace into account.
-   */
-
-  word(str: string) {
-    if (this._endsWithWord) this.push(" ");
-
-    this.push(str);
-    this._endsWithWord = true;
-  }
-
-  /**
-   * Writes a simple token.
-   */
-
-  token(str: string) {
-    // space is mandatory to avoid outputting <!--
-    // http://javascript.spec.whatwg.org/#comment-syntax
-    if ((str === "--" && this.last === "!") ||
-
-      // Need spaces for operators of the same kind to avoid: `a+++b`
-      (str[0] === "+" && this.last === "+") ||
-      (str[0] === "-" && this.last === "-")) {
-      this.push(" ");
-    }
-
-    this.push(str);
-  }
-
-  /**
-   * Remove the last character.
-   */
-
-  removeLast(cha: string) {
-    if (!this.endsWith(cha)) return;
-    this.buf = this.buf.slice(0, -1);
-    this.last = this.buf[this.buf.length - 1];
-    this._position.unshift(cha);
-  }
-
-  /**
-   * Set some state that will be modified if a newline has been inserted before any
-   * non-space characters.
-   *
-   * This is to prevent breaking semantics for terminatorless separator nodes. eg:
-   *
-   *    return foo;
-   *
-   * returns `foo`. But if we do:
-   *
-   *   return
-   *   foo;
-   *
-   *  `undefined` will be returned and not `foo` due to the terminator.
-   */
-
-  startTerminatorless(): Object {
-    return this.parenPushNewlineState = {
-      printed: false
+  get(): Object {
+    return {
+      code: trimEnd(this._buf),
+      map: this._map ? this._map.get() : null,
     };
   }
 
   /**
-   * Print an ending parentheses if a starting one has been printed.
+   * Add a string to the buffer that cannot be reverted.
    */
 
-  endTerminatorless(state: Object) {
-    if (state.printed) {
-      this.dedent();
-      this.newline();
-      this.token(")");
-    }
+  append(str: string): void {
+    // If there the line is ending, adding a new mapping marker is redundant
+    if (this._map && str[0] !== "\n") this._map.mark(this._position, this._sourcePosition.line,
+      this._sourcePosition.column, this._sourcePosition.filename);
+
+    this._buf += str;
+    this._last = str[str.length - 1];
+    this._position.push(str);
   }
 
   /**
-   * Add a newline (or many newlines), maintaining formatting.
+   * Add a string to the buffer than can be reverted.
    */
 
-  newline(i?: number) {
-    if (this.format.retainLines || this.format.compact) return;
-
-    if (this.format.concise) {
-      this.space();
-      return;
-    }
-
-    // never allow more than two lines
-    if (this.endsWith("\n\n")) return;
-
-    if (typeof i !== "number") i = 1;
-
-    i = Math.min(2, i);
-    if (this.endsWith("{\n") || this.endsWith(":\n")) i--;
-    if (i <= 0) return;
-
-    this._removeSpacesAfterLastNewline();
-    for (let j = 0; j < i; j++) {
-      this.push("\n");
-    }
+  queue(str: string): void {
+    this.append(str);
   }
 
-  /**
-   * If buffer ends with a newline and some spaces after it, trim those spaces.
-   */
+  removeTrailingSpaces(): void {
+    const oldBuf = this._buf;
+    this._buf = this._buf.replace(/[ \t]+$/, "");
+    this._last = this._buf[this._buf.length - 1];
+    this._position.unshift(oldBuf.slice(this._buf.length));
+  }
 
-  _removeSpacesAfterLastNewline() {
-    const originalBuf = this.buf;
-    this.buf = this.buf.replace(/[ \t]+$/, "");
+  removeTrailingNewline(): void {
+    if (this._last !== "\n") return;
 
-    if (originalBuf.length !== this.buf.length){
-      const removed = originalBuf.slice(this.buf.length);
-      this._position.unshift(removed);
-      this.last = this.buf[this.buf.length - 1];
-    }
+    this._buf = this._buf.slice(0, -1);
+    this._last = this._buf[this._buf.length - 1];
+    this._position.unshift("\n");
+  }
+
+  removeLastSemicolon(): void {
+    if (this._last !== ";") return;
+
+    this._buf = this._buf.slice(0, -1);
+    this._last = this._buf[this._buf.length - 1];
+    this._position.unshift(";");
+  }
+
+  endsWith(str: string): boolean {
+    if (str.length === 1) return str === this._last;
+
+    return this._buf.slice(-str.length) === str;
+  }
+
+  getLast(): string {
+    return this._last;
+  }
+
+  hasContent(): boolean {
+    return !!this._last;
   }
 
   /**
@@ -253,7 +101,7 @@ export default class Buffer {
    * will be given this position in the sourcemap.
    */
 
-  source(prop: string, loc: Location) {
+  source(prop: string, loc: Location): void {
     if (prop && !loc) return;
 
     let pos = loc ? loc[prop] : null;
@@ -261,16 +109,14 @@ export default class Buffer {
     this._sourcePosition.line = pos ? pos.line : null;
     this._sourcePosition.column = pos ? pos.column : null;
     this._sourcePosition.filename = loc && loc.filename || null;
-
-    this._catchUp();
   }
 
   /**
    * Call a callback with a specific source location and restore on completion.
    */
 
-  withSource(prop: string, loc: Location, cb: () => void) {
-    if (!this.opts.sourceMaps && !this.format.retainLines) return cb();
+  withSource(prop: string, loc: Location, cb: () => void): void {
+    if (!this._map) return cb();
 
     // Use the call stack to manage a stack of "source location" data.
     let originalLine = this._sourcePosition.line;
@@ -286,68 +132,11 @@ export default class Buffer {
     this._sourcePosition.filename = originalFilename;
   }
 
-  /**
-   * Push a string to the buffer, maintaining indentation and newlines.
-   */
-
-  push(str: string) {
-    if (!this.format.compact && this._indent && str[0] !== "\n") {
-      // we've got a newline before us so prepend on the indentation
-      if (this.endsWith("\n")) str = this.getIndent() + str;
-    }
-
-    // see startTerminatorless() instance method
-    let parenPushNewlineState = this.parenPushNewlineState;
-    if (parenPushNewlineState) {
-      for (let i = 0; i < str.length; i++) {
-        let cha = str[i];
-
-        // we can ignore spaces since they wont interupt a terminatorless separator
-        if (cha === " ") continue;
-
-        this.parenPushNewlineState = null;
-
-        if (cha === "\n" || cha === "/") {
-          // we're going to break this terminator expression so we need to add a parentheses
-          str = "(" + str;
-          this.indent();
-          parenPushNewlineState.printed = true;
-        }
-
-        break;
-      }
-    }
-
-    // If there the line is ending, adding a new mapping marker is redundant
-    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this._position, this._sourcePosition.line,
-      this._sourcePosition.column, this._sourcePosition.filename);
-
-    //
-    this._position.push(str);
-    this.buf += str;
-    this.last = str[str.length - 1];
-
-    // Clear any state-tracking flags that may have been set.
-    this._endsWithWord = false;
-  }
-
-  /**
-   * Test if the buffer ends with a string.
-   */
-
-  endsWith(str: string): boolean {
-    if (str.length === 1) {
-      return this.last === str;
-    } else {
-      return this.buf.slice(-str.length) === str;
-    }
-  }
-
-  getCurrentColumn() {
+  getCurrentColumn(): number {
     return this._position.column;
   }
 
-  getCurrentLine() {
+  getCurrentLine(): number {
     return this._position.line;
   }
 }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -103,7 +103,8 @@ export default class Buffer {
    */
 
   rightBrace() {
-    this.newline(true);
+    if (!this.endsWith("\n")) this.newline();
+
     if (this.format.minified && !this._lastPrintedIsEmptyStatement) {
       this._removeLast(";");
     }
@@ -212,10 +213,9 @@ export default class Buffer {
 
   /**
    * Add a newline (or many newlines), maintaining formatting.
-   * Strips multiple newlines if removeLast is true.
    */
 
-  newline(i?: boolean | number, removeLast?: boolean) {
+  newline(i?: number) {
     if (this.format.retainLines || this.format.compact) return;
 
     if (this.format.concise) {
@@ -226,17 +226,11 @@ export default class Buffer {
     // never allow more than two lines
     if (this.endsWith("\n\n")) return;
 
-    if (typeof i === "boolean") removeLast = i;
     if (typeof i !== "number") i = 1;
 
     i = Math.min(2, i);
     if (this.endsWith("{\n") || this.endsWith(":\n")) i--;
     if (i <= 0) return;
-
-    // remove the last newline
-    if (removeLast) {
-      this.removeLast("\n");
-    }
 
     this._removeSpacesAfterLastNewline();
     for (let j = 0; j < i; j++) {

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -333,7 +333,7 @@ export default class Buffer {
     }
 
     // If there the line is ending, adding a new mapping marker is redundant
-    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this._sourcePosition);
+    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this.position, this._sourcePosition);
 
     //
     this.position.push(str);

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,4 +1,4 @@
-import type Position from "./position";
+import Position from "./position";
 import repeat from "lodash/repeat";
 import trimEnd from "lodash/trimEnd";
 
@@ -7,10 +7,10 @@ import trimEnd from "lodash/trimEnd";
  */
 
 export default class Buffer {
-  constructor(position: Position, format: Object) {
+  constructor(format: Object) {
     this.printedCommentStarts = {};
     this.parenPushNewlineState = null;
-    this.position = position;
+    this._position = new Position();
     this._indent = format.indent.base;
     this.format = format;
     this.buf = "";
@@ -44,7 +44,7 @@ export default class Buffer {
   catchUp(node: Object) {
     // catch up to this nodes newline if we're behind
     if (node.loc && this.format.retainLines && this.buf) {
-      while (this.position.line < node.loc.start.line) {
+      while (this.getCurrentLine() < node.loc.start.line) {
         this.push("\n");
       }
     }
@@ -164,7 +164,6 @@ export default class Buffer {
     this.push(str);
   }
 
-
   /**
    * Remove the last character.
    */
@@ -178,7 +177,7 @@ export default class Buffer {
     if (!this.endsWith(cha)) return;
     this.buf = this.buf.slice(0, -1);
     this.last = this.buf[this.buf.length - 1];
-    this.position.unshift(cha);
+    this._position.unshift(cha);
   }
 
   /**
@@ -260,7 +259,7 @@ export default class Buffer {
       let toRemove = this.buf.slice(lastNewlineIndex + 1);
       this.buf = this.buf.substring(0, lastNewlineIndex + 1);
       this.last = "\n";
-      this.position.unshift(toRemove);
+      this._position.unshift(toRemove);
     }
   }
 
@@ -333,10 +332,10 @@ export default class Buffer {
     }
 
     // If there the line is ending, adding a new mapping marker is redundant
-    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this.position, this._sourcePosition);
+    if (this.opts.sourceMaps && str[0] !== "\n") this.map.mark(this._position, this._sourcePosition);
 
     //
-    this.position.push(str);
+    this._position.push(str);
     this.buf += str;
     this.last = str[str.length - 1];
 
@@ -358,4 +357,11 @@ export default class Buffer {
     }
   }
 
+  getCurrentColumn() {
+    return this._position.column;
+  }
+
+  getCurrentLine() {
+    return this._position.line;
+  }
 }

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -335,8 +335,6 @@ export default class Buffer {
    */
 
   endsWith(str: string): boolean {
-    if (Array.isArray(str)) return str.some((s) => this.endsWith(s));
-
     if (str.length === 1) {
       return this.last === str;
     } else {

--- a/packages/babel-generator/src/generators/base.js
+++ b/packages/babel-generator/src/generators/base.js
@@ -21,7 +21,7 @@ export function BlockStatement(node: Object) {
     if (node.directives && node.directives.length) this.newline();
 
     this.printSequence(node.body, node, { indent: true });
-    if (!this.format.retainLines && !this.format.concise) this.removeLast("\n");
+    if (!this.format.retainLines && !this.format.concise) this.removeTrailingNewline();
 
     this.source("end", node.loc);
     this.rightBrace();

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -88,7 +88,7 @@ export function Decorator(node: Object) {
 
 function commaSeparatorNewline() {
   this.token(",");
-  this.push("\n");
+  this.newline();
 }
 
 export function CallExpression(node: Object) {

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -208,14 +208,14 @@ export function DebuggerStatement() {
 function variableDeclarationIdent() {
   // "let " or "var " indentation.
   this.token(",");
-  this.push("\n");
+  this.newline();
   for (let i = 0; i < 4; i++) this.push(" ");
 }
 
 function constDeclarationIdent() {
   // "const " indentation.
   this.token(",");
-  this.push("\n");
+  this.newline();
   for (let i = 0; i < 6; i++) this.push(" ");
 }
 

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -209,14 +209,14 @@ function variableDeclarationIdent() {
   // "let " or "var " indentation.
   this.token(",");
   this.newline();
-  for (let i = 0; i < 4; i++) this.push(" ");
+  for (let i = 0; i < 4; i++) this.space(true);
 }
 
 function constDeclarationIdent() {
   // "const " indentation.
   this.token(",");
   this.newline();
-  for (let i = 0; i < 6; i++) this.push(" ");
+  for (let i = 0; i < 6; i++) this.space(true);
 }
 
 export function VariableDeclaration(node: Object, parent: Object) {

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -31,7 +31,7 @@ class Generator extends Printer {
     this._inForStatementInitCounter = 0;
 
     this.whitespace = new Whitespace(tokens);
-    this.map        = new SourceMap(position, opts, code);
+    this.map        = new SourceMap(opts, code);
   }
 
   format: {

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -17,7 +17,9 @@ class Generator extends Printer {
     let tokens   = ast.tokens || [];
     let format   = Generator.normalizeOptions(code, opts, tokens);
 
-    super(format);
+    let map        = opts.sourceMaps ? new SourceMap(opts, code) : null;
+
+    super(format, map);
 
     this.comments = comments;
     this.tokens   = tokens;
@@ -27,7 +29,6 @@ class Generator extends Printer {
     this._inForStatementInitCounter = 0;
 
     this.whitespace = new Whitespace(tokens);
-    this.map        = new SourceMap(opts, code);
   }
 
   format: {
@@ -50,7 +51,6 @@ class Generator extends Printer {
   auxiliaryCommentBefore: string;
   auxiliaryCommentAfter: string;
   whitespace: Whitespace;
-  map: SourceMap;
   comments: Array<Object>;
   tokens: Array<Object>;
   opts: Object;
@@ -148,10 +148,7 @@ class Generator extends Printer {
     this.print(this.ast);
     this.printAuxAfterComment();
 
-    return {
-      map:  this.map.get(),
-      code: this.get()
-    };
+    return this._buf.get();
   }
 }
 

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -1,7 +1,6 @@
 import detectIndent from "detect-indent";
 import Whitespace from "./whitespace";
 import SourceMap from "./source-map";
-import Position from "./position";
 import * as messages from "babel-messages";
 import Printer from "./printer";
 
@@ -18,12 +17,9 @@ class Generator extends Printer {
     let tokens   = ast.tokens || [];
     let format   = Generator.normalizeOptions(code, opts, tokens);
 
-    let position = new Position;
-
-    super(position, format);
+    super(format);
 
     this.comments = comments;
-    this.position = position;
     this.tokens   = tokens;
     this.format   = format;
     this.opts     = opts;
@@ -54,7 +50,6 @@ class Generator extends Printer {
   auxiliaryCommentBefore: string;
   auxiliaryCommentAfter: string;
   whitespace: Whitespace;
-  position: Position;
   map: SourceMap;
   comments: Array<Object>;
   tokens: Array<Object>;

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -45,8 +45,6 @@ export default class Printer extends Buffer {
 
     this.printLeadingComments(node, parent);
 
-    this.catchUp(node);
-
     this._printNewline(true, node, parent, opts);
 
     if (opts.before) opts.before();
@@ -264,9 +262,7 @@ export default class Printer extends Buffer {
     }
 
     // Exclude comments from source mappings since they will only clutter things.
-    this.withSource(null, null, () => {
-      this.catchUp(comment);
-
+    this.withSource("start", comment.loc, () => {
       // whitespace before
       this.newline(this.whitespace.getNewlinesBefore(comment));
 

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -266,7 +266,7 @@ export default class Printer extends Buffer {
       // whitespace before
       this.newline(this.whitespace.getNewlinesBefore(comment));
 
-      if (!this.endsWith(["[", "{"])) this.space();
+      if (!this.endsWith("[") && !this.endsWith("{")) this.space();
 
       let val    = this.generateComment(comment);
 

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -272,7 +272,6 @@ export default class Printer extends Buffer {
 
       if (!this.endsWith(["[", "{"])) this.space();
 
-      let column = this.position.column;
       let val    = this.generateComment(comment);
 
       //
@@ -283,7 +282,7 @@ export default class Printer extends Buffer {
           val = val.replace(newlineRegex, "\n");
         }
 
-        let indent = Math.max(this.indentSize(), column);
+        let indent = Math.max(this.indentSize(), this.getCurrentColumn());
         val = val.replace(/\n/g, `\n${repeat(" ", indent)}`);
       }
 

--- a/packages/babel-generator/src/source-map.js
+++ b/packages/babel-generator/src/source-map.js
@@ -5,8 +5,7 @@ import sourceMap from "source-map";
  */
 
 export default class SourceMap {
-  constructor(position, opts, code) {
-    this.position = position;
+  constructor(opts, code) {
     this.opts     = opts;
     this.last     = {generated: {}, original: {}};
 
@@ -46,11 +45,9 @@ export default class SourceMap {
    * values to insert a mapping to nothing.
    */
 
-  mark(sourcePos: Object) {
+  mark(position, sourcePos: Object) {
     let map = this.map;
     if (!map) return; // no source map
-
-    let position = this.position;
 
     // Adding an empty mapping at the start of a generated line just clutters the map.
     if (this._lastGenLine !== position.line && sourcePos.line === null) return;

--- a/packages/babel-generator/src/source-map.js
+++ b/packages/babel-generator/src/source-map.js
@@ -1,4 +1,5 @@
 import sourceMap from "source-map";
+import type Position from "./position";
 
 /**
  * Build a sourcemap.
@@ -45,33 +46,33 @@ export default class SourceMap {
    * values to insert a mapping to nothing.
    */
 
-  mark(position, sourcePos: Object) {
+  mark(position: Position, line: number, column: number, filename: ?string) {
     let map = this.map;
     if (!map) return; // no source map
 
     // Adding an empty mapping at the start of a generated line just clutters the map.
-    if (this._lastGenLine !== position.line && sourcePos.line === null) return;
+    if (this._lastGenLine !== position.line && line === null) return;
 
     // If this mapping points to the same source location as the last one, we can ignore it since
     // the previous one covers it.
-    if (this._lastGenLine === position.line && this._lastSourceLine === sourcePos.line &&
-      this._lastSourceColumn === sourcePos.column) {
+    if (this._lastGenLine === position.line && this._lastSourceLine === line &&
+      this._lastSourceColumn === column) {
       return;
     }
 
     this._lastGenLine = position.line;
-    this._lastSourceLine = sourcePos.line;
-    this._lastSourceColumn = sourcePos.column;
+    this._lastSourceLine = line;
+    this._lastSourceColumn = column;
 
     map.addMapping({
       generated: {
         line: position.line,
         column: position.column
       },
-      source: sourcePos.line == null ? null : sourcePos.filename || this.opts.sourceFileName,
-      original: sourcePos.line == null ? null : {
-        line: sourcePos.line,
-        column: sourcePos.column,
+      source: line == null ? null : filename || this.opts.sourceFileName,
+      original: line == null ? null : {
+        line: line,
+        column: column,
       },
     });
   }

--- a/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-and-compact-option/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-and-compact-option/expected.js
@@ -1,4 +1,6 @@
 function foo(l){
 return(
 
-l);}
+l);
+
+}

--- a/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-option/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-option/expected.js
@@ -1,10 +1,11 @@
 function foo(l) {
   return (
-    l);}
+    l);
 
-
+}
 
 function foo() {
   return (
     1 && 2 || 
-    3);}
+    3);
+}


### PR DESCRIPTION
There's a bit of refactoring in here to get this all to work, but mostly it's the last two commits that are the meat of it:

1. Factor out all of the code responsible for mutating the output buffer into a discrete set of actions.
2. Re-implement those actions with a temporary queue so that queued changes can be reversed without requiring any reads from the output string itself.

Our old logic constantly referenced the output value, meaning every reference got more expensive as the output for larger, leading to an exponential increase in codegen times.

For example, using the example script from https://github.com/istanbuljs/babel-plugin-istanbul/issues/5#issuecomment-229248426 which generates doubling AST array, generation time changes as shown:

Items: the size of the array being generated
Time: The time in ms to generate the code
Length: The number of characters in the output code

```
Items: 2 ,	time: 9 ,	length: 239
Items: 4 ,	time: 2 ,	length: 465
Items: 8 ,	time: 6 ,	length: 917
Items: 16 ,	time: 6 ,	length: 1840
Items: 32 ,	time: 15 ,	length: 3696
Items: 64 ,	time: 25 ,	length: 7408
Items: 128 ,	time: 93 ,	length: 14917
Items: 256 ,	time: 380 ,	length: 30149
Items: 512 ,	time: 1399 ,	length: 60613
Items: 1024 ,	time: 5301 ,	length: 121614
Items: 2048 ,	time: 20676 ,	length: 246542
```

to 

```
Items: 2 ,	time: 7 ,	length: 239
Items: 4 ,	time: 5 ,	length: 465
Items: 8 ,	time: 5 ,	length: 917
Items: 16 ,	time: 6 ,	length: 1840
Items: 32 ,	time: 11 ,	length: 3696
Items: 64 ,	time: 3 ,	length: 7408
Items: 128 ,	time: 13 ,	length: 14917
Items: 256 ,	time: 18 ,	length: 30149
Items: 512 ,	time: 45 ,	length: 60613
Items: 1024 ,	time: 63 ,	length: 121614
Items: 2048 ,	time: 117 ,	length: 246542
Items: 4096 ,	time: 266 ,	length: 496398
Items: 8192 ,	time: 460 ,	length: 996110
Items: 16384 ,	time: 980 ,	length: 2014687
Items: 32768 ,	time: 2008 ,	length: 4062687
Items: 65536 ,	time: 3819 ,	length: 8158687
Items: 131072 ,	time: 7359 ,	length: 16443904
```