### PR TITLE
Remove unused Position#unshift

### DIFF
--- a/packages/babel-generator/src/position.js
+++ b/packages/babel-generator/src/position.js
@@ -25,18 +25,4 @@ export default class Position {
       }
     }
   }
-
-  /**
-   * Unshift a string from the current position, mantaining the current line and column.
-   */
-
-  unshift(str: string): void {
-    for (let i = 0; i < str.length; i++) {
-      if (str[i] === "\n") {
-        this.line--;
-      } else {
-        this.column--;
-      }
-    }
-  }
 }


### PR DESCRIPTION
Not only is it unused, it'll break things if you push a newline since it doesn't set a new `#column` value.