### PR TITLE
Use the first item in the queue since it is the most recent.

### DIFF
--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -99,7 +99,7 @@ export default class Buffer {
 
   getLast(): string {
     if (this._queue.length > 0) {
-      const last = this._queue[this._queue.length - 1][0];
+      const last = this._queue[0][0];
       return last[last.length - 1];
     }
 


### PR DESCRIPTION
I don't think the current usage of `getLast` makes it possible for this to trigger any bugs. No matter what, the queue case can only result in whitespace or semicolons, none of which would match the case that currently calls `.getLast`. That said, it's definitely wrong, and this is the fix :) Good catch @jridgewell 