### PR TITLE
added --inspect node flag to use new v8_inspector in node v6.3

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -42,7 +42,7 @@ getV8Flags(function (err, v8Flags) {
       case "--expose-gc":
         args.unshift("--expose-gc");
         break;
-      
+
       case "--nolazy":
         args.unshift("--nolazy");
         break;

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -35,7 +35,7 @@ getV8Flags(function (err, v8Flags) {
         args.unshift(arg);
         break;
       case "--inspect":
-        args.unshift('--inspect');
+        args.unshift("--inspect");
         break;
 
       case "-gc":

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -34,12 +34,15 @@ getV8Flags(function (err, v8Flags) {
       case "--debug-brk":
         args.unshift(arg);
         break;
+      case "--inspect":
+        args.unshift('--inspect');
+        break;
 
       case "-gc":
       case "--expose-gc":
         args.unshift("--expose-gc");
         break;
-
+      
       case "--nolazy":
         args.unshift("--nolazy");
         break;


### PR DESCRIPTION
This adds the --inspect flag to the list of node flags that babel-node will accept.  Allowing you to debug node.js app with the v8 inspector.

For more information about the inspect flag you can read this [pr](https://github.com/nodejs/node/pull/6792)