### PR TITLE
fix inline sourcemaps bug

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -139,7 +139,7 @@ export default class File extends Store {
     opts = new OptionManager(this.log, this.pipeline).init(opts);
 
     if (opts.inputSourceMap) {
-      opts.sourceMaps = true;
+      opts.sourceMaps = opts.sourceMaps || true; //don't stomp on 'inline' option
     }
 
     if (opts.moduleId) {


### PR DESCRIPTION
'inline' option is getting stomped on resulting in loss of inline sourcemaps.

this very minor change causes 'inline' value to be preserved and not changed to true

#https://github.com/systemjs/plugin-babel/issues/53