### PR TITLE
Fix error in rest parameter length optimization

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/exec.js
@@ -1,0 +1,8 @@
+var length = function (a, b, ...items) {
+  return items.length;
+};
+
+assert.equal(length(), 0);
+assert.equal(length(1), 0);
+assert.equal(length(1, 2), 0);
+assert.equal(length(1, 2, 3), 1);

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
@@ -1,6 +1,6 @@
 var t = function (f) {
   arguments.length <= 1 ? undefined : arguments[1];
-  arguments.length <= arguments.length - 1 - 1 + 1 ? undefined : arguments[arguments.length - 1 - 1 + 1];
+  arguments.length <= (arguments.length <= 1 ? 0 : arguments.length - 1) - 1 + 1 ? undefined : arguments[(arguments.length <= 1 ? 0 : arguments.length - 1) - 1 + 1];
 };
 
 function t(f) {

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -63,11 +63,11 @@ var b = function () {
 };
 
 var b = function (foo) {
-  return (arguments.length - 1) * 2;
+  return (arguments.length <= 1 ? 0 : arguments.length - 1) * 2;
 };
 
 var b = function (foo, baz) {
-  return arguments.length - 2;
+  return arguments.length <= 2 ? 0 : arguments.length - 2;
 };
 
 function x() {


### PR DESCRIPTION
If there aren’t enough arguments to get to the offset index, we would
return an negative length.