### PR TITLE
Default parameters cleanup

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/default.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/default.js
@@ -79,7 +79,7 @@ export let visitor = {
       let param = params[i];
 
       if (!param.isAssignmentPattern()) {
-        if (!param.isIdentifier()) {
+        if (!state.iife && !param.isIdentifier()) {
           param.traverse(iifeVisitor, state);
         }
 

--- a/packages/babel-plugin-transform-es2015-parameters/src/default.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/default.js
@@ -13,10 +13,6 @@ let buildDefaultParam = template(`
       ARGUMENTS[ARGUMENT_KEY];
 `);
 
-let buildDefaultParamAssign = template(`
-  if (VARIABLE_NAME === undefined) VARIABLE_NAME = DEFAULT_VALUE;
-`);
-
 let buildCutOff = template(`
   let $0 = $1[$2];
 `);
@@ -64,27 +60,14 @@ export let visitor = {
 
     // push a default parameter definition
     function pushDefNode(left, right, i) {
-      let defNode;
-      if (exceedsLastNonDefault(i) || t.isPattern(left)) {
-        defNode = buildDefaultParam({
-          VARIABLE_NAME: left,
-          DEFAULT_VALUE: right,
-          ARGUMENT_KEY:  t.numericLiteral(i),
-          ARGUMENTS:     argsIdentifier
-        });
-      } else {
-        defNode = buildDefaultParamAssign({
-          VARIABLE_NAME: left,
-          DEFAULT_VALUE: right
-        });
-      }
+      const defNode = buildDefaultParam({
+        VARIABLE_NAME: left,
+        DEFAULT_VALUE: right,
+        ARGUMENT_KEY:  t.numericLiteral(i),
+        ARGUMENTS:     argsIdentifier
+      });
       defNode._blockHoist = node.params.length - i;
       body.push(defNode);
-    }
-
-    // check if an index exceeds the functions arity
-    function exceedsLastNonDefault(i) {
-      return i + 1 > lastNonDefaultParam;
     }
 
     //
@@ -107,7 +90,7 @@ export let visitor = {
       let right = param.get("right");
 
       //
-      if (exceedsLastNonDefault(i) || left.isPattern()) {
+      if (i >= lastNonDefaultParam || left.isPattern()) {
         let placeholder = scope.generateUidIdentifier("x");
         placeholder._isDefaultPlaceholder = true;
         node.params[i] = placeholder;


### PR DESCRIPTION
This seems to have been [added](https://github.com/babel/babel/commit/4b85b05839017ab2abc03ba2d1e875a63f002890) in v5.5.4 to address [#1690](https://phabricator.babeljs.io/T1690). It [became “dead”](https://github.com/babel/babel/blob/v6.0.0/packages/babel-core/test/fixtures/transformation/es6.parameters/default-before-last/expected.js) (as far as I can tell) in the [v6.0.0 commit](https://github.com/babel/babel/commit/ae7d5367f1c3d438667242d6925db024f875fccd).

Either way, this code is never executed.

- `pushDefNode` is only called when the param is a default param.
- `buildDefaultParamAssign` (which is inside `pushDefNode`) only runs if the param index is less than or equals to the lastNonDefaultParam. AKA, is this param before any non-defaulting params.

Which is a contradiction.