### PR TITLE
Add JSX spread children to babel-types and babel-generator

### DIFF
--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -35,6 +35,13 @@ export function JSXExpressionContainer(node: Object) {
   this.token("}");
 }
 
+export function JSXSpreadChild(node: Object) {
+  this.token("{");
+  this.token("...");
+  this.print(node.expression, node);
+  this.token("}");
+}
+
 export function JSXText(node: Object) {
   this.token(node.value);
 }

--- a/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/actual.js
+++ b/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/actual.js
@@ -1,0 +1,1 @@
+<div>{...this.props.children}</div>;

--- a/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/expected.js
+++ b/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/expected.js
@@ -1,0 +1,1 @@
+<div>{...this.props.children}</div>;

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -67,7 +67,7 @@ defineType("JSXSpreadChild", {
       validate: assertNodeType("Expression")
     }
   }
-})
+});
 
 defineType("JSXIdentifier", {
   builder: ["name"],

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -39,7 +39,7 @@ defineType("JSXElement", {
     children: {
       validate: chain(
         assertValueType("array"),
-        assertEach(assertNodeType("JSXText", "JSXExpressionContainer", "JSXElement"))
+        assertEach(assertNodeType("JSXText", "JSXExpressionContainer", "JSXSpreadChild", "JSXElement"))
       )
     }
   }
@@ -58,6 +58,16 @@ defineType("JSXExpressionContainer", {
     }
   }
 });
+
+defineType("JSXSpreadChild", {
+  visitor: ["expression"],
+  aliases: ["JSX", "Immutable"],
+  fields: {
+    expression: {
+      validate: assertNodeType("Expression")
+    }
+  }
+})
 
 defineType("JSXIdentifier", {
   builder: ["name"],


### PR DESCRIPTION
The JSX syntax has been changed as of https://github.com/facebook/jsx/pull/59

In addition to this PR there is another PR open to `babylon` here: https://github.com/babel/babylon/pull/42

For more information about the initial proposal see: https://github.com/facebook/jsx/issues/57

cc @kittens, @danez 
