### PR TITLE
Support all variations of v8Flags in babel-node

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -20,9 +20,24 @@ if (argSeparator > -1) {
   babelArgs = babelArgs.slice(0, argSeparator);
 }
 
+/**
+ * Replace dashes with underscores in the v8Flag name
+ * Also ensure that if the arg contains a value (e.g. --arg=true)
+ * that only the flag is returned.
+ */
+function getNormalizedV8Flag(arg) {
+  const matches = arg.match(/--(.+)/);
+
+  if (matches) {
+    return `--${matches[1].replace(/-/g, "_")}`;
+  }
+
+  return arg;
+}
+
 getV8Flags(function (err, v8Flags) {
   babelArgs.forEach(function(arg) {
-    let flag = arg.split("=")[0];
+    const flag = arg.split("=")[0];
 
     switch (flag) {
       case "-d":
@@ -36,16 +51,16 @@ getV8Flags(function (err, v8Flags) {
         break;
 
       case "-gc":
-      case "--expose-gc":
         args.unshift("--expose-gc");
         break;
 
+      case "--inspect":
       case "--nolazy":
-        args.unshift("--nolazy");
+        args.unshift(flag);
         break;
 
       default:
-        if (v8Flags.indexOf(arg) >= 0 || arg.indexOf("--trace") === 0) {
+        if (v8Flags.indexOf(getNormalizedV8Flag(flag)) >= 0 || arg.indexOf("--trace") === 0) {
           args.unshift(arg);
         } else {
           args.push(arg);

--- a/packages/babel-cli/test/fixtures/babel-node/v8Flag-dashed-with-param/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/v8Flag-dashed-with-param/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--expose-debug-as=customDebug", "--eval", "console.log(customDebug.Debug.DebugEvent.Break)"],
+  "stdout": "1"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/v8Flag-dashed/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/v8Flag-dashed/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--expose-gc", "--eval", "console.log(typeof global.gc)"],
+  "stdout": "function"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/v8Flag-underscored-with-param/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/v8Flag-underscored-with-param/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--expose_debug_as=customDebug", "--eval", "console.log(customDebug.Debug.DebugEvent.Break)"],
+  "stdout": "1"
+}

--- a/packages/babel-cli/test/fixtures/babel-node/v8Flag-underscored/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/v8Flag-underscored/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--expose_gc", "--eval", "console.log(typeof global.gc)"],
+  "stdout": "function"
+}


### PR DESCRIPTION
This adds support for specifying v8Flags with dashes in babel-node. Previously only underscores
were allowed. (e.g. `--expose_gc` vs. `--expose-gc`). Both are supported by node. (see also comment [here](https://github.com/babel/babel/pull/3577#issuecomment-232327577))

This change now also allows specifying values for v8Flags in the form `--flag=value`, which was not supported till now.

Also add `--inspect` support. (Superseeds #3568)

Closes #3577 

Was mentioned here: http://stackoverflow.com/questions/38294457/how-to-pass-options-to-node-when-using-babel-node