### PR TITLE
fix(Path): "TypeError: Path must be a string"

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -330,7 +330,7 @@ export default class OptionManager {
           throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ${JSON.stringify(dirname)}`);
         }
       } else if (typeof val === "object") {
-        onResolve && onResolve(val);
+        onResolve && onResolve(val,"");
         return val;
       } else {
         throw new Error(`Unsupported preset format: ${val}.`);


### PR DESCRIPTION
**"TypeError: Path must be a string" after break from project**

Related Issue webpack/webpack#2463

Work with awesome-typescirpt-loader and babel. 
Got following stacktrace: 

```

ERROR in ./Scripts/Performance.ts
Module build failed: TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:697:5)
    at ...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:376:36
    at ...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:402:22
    at Array.map (native)
    at OptionManager.resolvePresets (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:389:20)
    at OptionManager.mergePresets (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:369:10)
    at OptionManager.mergeOptions (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:328:14)
    at ...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:372:14
    at ...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:395:24
    at Array.map (native)
    at OptionManager.resolvePresets (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:389:20)
    at OptionManager.mergePresets (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:369:10)
    at OptionManager.mergeOptions (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:328:14)
    at OptionManager.addConfig (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:234:10)
    at OptionManager.findConfigs (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:440:16)
    at OptionManager.init (...\node_modules\babel-core\lib\transformation\file\options\option-manager.js:488:12)
    at File.initOptions (...\node_modules\babel-core\lib\transformation\file\index.js:211:75)
    at new File (...\node_modules\babel-core\lib\transformation\file\index.js:129:22)
    at Pipeline.transform (...\node_modules\babel-core\lib\transformation\pipeline.js:48:16)
    at transpile (...\node_modules\babel-loader\index.js:14:22)
    at Object.module.exports (...\node_modules\babel-loader\index.js:88:12)
 @ multi Performance
```
