### PR TITLE
Further optimize babel-generator Buffer

### DIFF
--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -17,7 +17,7 @@ export default class Buffer {
   }
 
   _map: SourceMap = null;
-  _buf: string = "";
+  _buf: Array = [];
   _last: string = "";
   _queue: Array = [];
 
@@ -36,7 +36,7 @@ export default class Buffer {
     this._flush();
 
     return {
-      code: trimEnd(this._buf),
+      code: trimEnd(this._buf.join("")),
       map: this._map ? this._map.get() : null,
     };
   }
@@ -47,8 +47,8 @@ export default class Buffer {
 
   append(str: string): void {
     this._flush();
-    this._append(str, this._sourcePosition.line, this._sourcePosition.column,
-      this._sourcePosition.filename);
+    const { line, column, filename } = this._sourcePosition;
+    this._append(str, line, column, filename);
   }
 
   /**
@@ -56,8 +56,8 @@ export default class Buffer {
    */
 
   queue(str: string): void {
-    this._queue.unshift([str, this._sourcePosition.line, this._sourcePosition.column,
-      this._sourcePosition.filename]);
+    const { line, column, filename } = this._sourcePosition;
+    this._queue.unshift([str, line, column, filename]);
   }
 
   _flush(): void {
@@ -69,7 +69,7 @@ export default class Buffer {
     // If there the line is ending, adding a new mapping marker is redundant
     if (this._map && str[0] !== "\n") this._map.mark(this._position, line, column, filename);
 
-    this._buf += str;
+    this._buf.push(str);
     this._last = str[str.length - 1];
     this._position.push(str);
   }


### PR DESCRIPTION
We can eek out a bit more speed from Babel generator by turning the buffer into an array as well.
Re: #3565

```
Items: 2 , time: 4 length: 114
Items: 4 , time: 3 length: 218
Items: 8 , time: 3 length: 426
Items: 16 , time: 2 length: 861
Items: 32 , time: 5 length: 1741
Items: 64 , time: 2 length: 3501
Items: 128 , time: 4 length: 7106
Items: 256 , time: 8 length: 14530
Items: 512 , time: 12 length: 29378
Items: 1024 , time: 24 length: 59147
Items: 2048 , time: 38 length: 121611
Items: 4096 , time: 71 length: 246539
Items: 8192 , time: 131 length: 496395
Items: 16384 , time: 350 length: 1015260
Items: 32768 , time: 573 length: 2063836
Items: 65536 , time: 1263 length: 4160988
Items: 131072 , time: 2143 length: 8448509
Items: 262144 , time: 4859 length: 17230333
```

to

```
Items: 2 , time: 4 length: 114
Items: 4 , time: 3 length: 218
Items: 8 , time: 9 length: 426
Items: 16 , time: 1 length: 861
Items: 32 , time: 5 length: 1741
Items: 64 , time: 1 length: 3501
Items: 128 , time: 3 length: 7106
Items: 256 , time: 7 length: 14530
Items: 512 , time: 9 length: 29378
Items: 1024 , time: 17 length: 59147
Items: 2048 , time: 30 length: 121611
Items: 4096 , time: 61 length: 246539
Items: 8192 , time: 113 length: 496395
Items: 16384 , time: 307 length: 1015260
Items: 32768 , time: 443 length: 2063836
Items: 65536 , time: 1065 length: 4160988
Items: 131072 , time: 1799 length: 8448509
Items: 262144 , time: 4217 length: 17230333
```