### PR TITLE
Add block if parent is non-block statement for remove-console/debugger

### DIFF
--- a/packages/babel-plugin-transform-remove-console/test/fixtures/remove-console/statement-no-block/actual.js
+++ b/packages/babel-plugin-transform-remove-console/test/fixtures/remove-console/statement-no-block/actual.js
@@ -1,0 +1,6 @@
+if (blah) console.log(blah);
+for (;;) console.log(blah);
+for (var blah in []) console.log(blah);
+for (var blah of []) console.log(blah);
+while (blah) console.log(blah);
+do console.log(blah); while (blah);

--- a/packages/babel-plugin-transform-remove-console/test/fixtures/remove-console/statement-no-block/expected.js
+++ b/packages/babel-plugin-transform-remove-console/test/fixtures/remove-console/statement-no-block/expected.js
@@ -1,0 +1,6 @@
+if (blah) {}
+for (;;) {}
+for (var blah in []) {}
+for (var blah of []) {}
+while (blah) {}
+do {} while (blah);

--- a/packages/babel-plugin-transform-remove-debugger/test/fixtures/remove-debugger/options.json
+++ b/packages/babel-plugin-transform-remove-debugger/test/fixtures/remove-debugger/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-remove-debugger"]
+}

--- a/packages/babel-plugin-transform-remove-debugger/test/fixtures/remove-debugger/statement-no-block/actual.js
+++ b/packages/babel-plugin-transform-remove-debugger/test/fixtures/remove-debugger/statement-no-block/actual.js
@@ -1,0 +1,6 @@
+if (blah) debugger;
+for (;;) debugger;
+for (var blah in []) debugger;
+for (var blah of []) debugger;
+while (blah) debugger;
+do debugger; while (blah);

--- a/packages/babel-plugin-transform-remove-debugger/test/fixtures/remove-debugger/statement-no-block/expected.js
+++ b/packages/babel-plugin-transform-remove-debugger/test/fixtures/remove-debugger/statement-no-block/expected.js
@@ -1,0 +1,6 @@
+if (blah) {}
+for (;;) {}
+for (var blah in []) {}
+for (var blah of []) {}
+while (blah) {}
+do {} while (blah);

--- a/packages/babel-plugin-transform-remove-debugger/test/index.js
+++ b/packages/babel-plugin-transform-remove-debugger/test/index.js
@@ -1,0 +1,1 @@
+require("babel-helper-plugin-test-runner")(__dirname);

--- a/packages/babel-traverse/src/path/lib/removal-hooks.js
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.js
@@ -64,5 +64,18 @@ export let hooks = [
       }
       return true;
     }
+  },
+
+  function (self, parent) {
+    if (
+      (parent.isIfStatement() && (self.key === 'consequent' || self.key === 'alternate')) ||
+      (parent.isLoop() && self.key === 'body')
+    ) {
+      self.replaceWith({
+        type: 'BlockStatement',
+        body: []
+      });
+      return true;
+    }
   }
 ];


### PR DESCRIPTION
This PR is re-work for https://github.com/babel/babel/pull/3453. Fixes the error if we use no block statement (e.g. `if (blah) console.log(blah)`) :

```
Property consequent of IfStatement expected node to be of a type ["Statement"] but instead got null
```

Transform

```js
if (blah) console.log(blah);
for (;;) console.log(blah);
while (blah) console.log(blah);
```

to

```js
if (blah) {}
for (;;) {}
while (blah) {}
```