### PR TITLE
commonjs: simplify the output for a single default import

### DIFF
--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -13,6 +13,4 @@ let foo = exports.foo = (() => {
   };
 })();
 
-var _bar = require('bar');
-
-var _bar2 = babelHelpers.interopRequireDefault(_bar);
+var _bar = babelHelpers.interopRequireDefault(require('bar'));

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
@@ -4,15 +4,11 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
-var _net = require('net');
-
-var _net2 = babelHelpers.interopRequireDefault(_net);
+var _net = babelHelpers.interopRequireDefault(require('net'));
 
 var _events = require('events');
 
-var _binarySerializer = require('./helpers/binary-serializer');
-
-var _binarySerializer2 = babelHelpers.interopRequireDefault(_binarySerializer);
+var _binarySerializer = babelHelpers.interopRequireDefault(require('./helpers/binary-serializer'));
 
 // import ...
 
@@ -34,7 +30,7 @@ var Connection = function (_EventEmitter) {
     babelHelpers.createClass(Connection, [{
         key: 'send',
         value: function send(message) {
-            this.sock.write(_binarySerializer2.default.serializeMessage(message));
+            this.sock.write(_binarySerializer.default.serializeMessage(message));
         }
     }, {
         key: 'disconnect',

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
@@ -4,9 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _BaseFoo2 = require('./BaseFoo');
-
-var _BaseFoo3 = babelHelpers.interopRequireDefault(_BaseFoo2);
+var _BaseFoo2 = babelHelpers.interopRequireDefault(require('./BaseFoo'));
 
 var SubFoo = function (_BaseFoo) {
   babelHelpers.inherits(SubFoo, _BaseFoo);
@@ -24,6 +22,6 @@ var SubFoo = function (_BaseFoo) {
     }
   }]);
   return SubFoo;
-}(_BaseFoo3.default);
+}(_BaseFoo2.default);
 
 exports.default = SubFoo;

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-2/expected.js
@@ -4,9 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _last2 = require("lodash/last");
-
-var _last3 = babelHelpers.interopRequireDefault(_last2);
+var _last2 = babelHelpers.interopRequireDefault(require("lodash/last"));
 
 let Container = function () {
   function Container() {
@@ -20,7 +18,7 @@ let Container = function () {
         return;
       }
 
-      return (0, _last3.default)(this.tokens.get(key));
+      return (0, _last2.default)(this.tokens.get(key));
     }
   }]);
   return Container;

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules/expected.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var _events2 = require("events");
-
-var _events3 = babelHelpers.interopRequireDefault(_events2);
+var _events2 = babelHelpers.interopRequireDefault(require("events"));
 
 let Template = function () {
   function Template() {
@@ -12,7 +10,7 @@ let Template = function () {
   babelHelpers.createClass(Template, [{
     key: "events",
     value: function events() {
-      return _events3.default;
+      return _events2.default;
     }
   }]);
   return Template;

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -70,6 +70,8 @@ export default function ({ types: t }) {
 
       this.hasExports = false;
       this.hasModule = false;
+
+      this.modulesType = "amd";
     },
 
     visitor: {

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default-only/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default-only/actual.js
@@ -1,0 +1,5 @@
+import a from "a";
+import b from "b";
+
+a;
+b;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default-only/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default-only/expected.js
@@ -1,0 +1,10 @@
+define(["a", "b"], function (_a, _b) {
+  "use strict";
+
+  var _a2 = babelHelpers.interopRequireDefault(_a);
+
+  var _b2 = babelHelpers.interopRequireDefault(_b);
+
+  _a2.default;
+  _b2.default;
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default-only/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-default-only/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers"]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -127,6 +127,10 @@ export default function () {
   return {
     inherits: require("babel-plugin-transform-strict-mode"),
 
+    pre() {
+      this.modulesType = "commonjs";
+    },
+
     visitor: {
       ThisExpression(path, state) {
         // If other plugins run after this plugin's Program#exit handler, we allow them to
@@ -360,7 +364,7 @@ export default function () {
             if (specifiers.length) {
               let uid;
 
-              if (hasSingleDefaultImport(specifiers)) {
+              if (hasSingleDefaultImport(specifiers) && this.modulesType === "commonjs") {
                 uid = addRequire(source, maxBlockHoist, {
                   inlineDefault: this.addHelper("interopRequireDefault")
                 });
@@ -401,7 +405,7 @@ export default function () {
               for (let specifier of specifiers) {
                 if (t.isImportSpecifier(specifier)) {
                   let target = uid;
-                  if (specifier.imported.name === "default" && !hasSingleDefaultImport(specifiers)) {
+                  if (specifier.imported.name === "default" && !(hasSingleDefaultImport(specifiers) && this.modulesType === "commonjs")) {
                     if (wildcard) {
                       target = wildcard;
                     } else {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -182,7 +182,7 @@ export default function () {
             let builtRequire = buildRequire(t.stringLiteral(source)).expression;
 
             let varDecl = t.variableDeclaration("var", [
-              t.variableDeclarator(ref, opts.inlineDefault ? t.callExpression(opts.inlineDefault, [builtRequire]) : builtRequire)
+              t.variableDeclarator(ref, opts.inline ? t.callExpression(opts.inline, [builtRequire]) : builtRequire)
             ]);
 
             // Copy location from the original import statement for sourcemap
@@ -366,7 +366,11 @@ export default function () {
 
               if (hasSingleDefaultImport(specifiers) && this.modulesType === "commonjs") {
                 uid = addRequire(source, maxBlockHoist, {
-                  inlineDefault: this.addHelper("interopRequireDefault")
+                  inline: this.addHelper("interopRequireDefault")
+                });
+              } else if (specifiers.length === 1 && t.isImportNamespaceSpecifier(specifiers[0]) && this.modulesType === "commonjs") {
+                uid = addRequire(source, maxBlockHoist, {
+                  inline: this.addHelper("interopRequireWildcard")
                 });
               } else {
                 uid = addRequire(source, maxBlockHoist);
@@ -376,7 +380,7 @@ export default function () {
 
               for (let i = 0; i < specifiers.length; i++) {
                 let specifier = specifiers[i];
-                if (t.isImportNamespaceSpecifier(specifier)) {
+                if (t.isImportNamespaceSpecifier(specifier) && !(specifiers.length === 1 && t.isImportNamespaceSpecifier(specifiers[0]) && this.modulesType === "commonjs")) {
                   if (strict) {
                     remaps[specifier.local.name] = uid;
                   } else {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
@@ -11,23 +11,21 @@ exports.test = undefined;
 
 /*before*/require("./directory/foo-bar") /*after*/;
 
-var /*before*/_foo = require("foo2") /*after*/;
+var /*before*/_foo = babelHelpers.interopRequireDefault(require("foo2")) /*after*/;
 
-/*before*/var _foo2 = babelHelpers.interopRequireDefault(_foo);
+var /*before*/_foo2 = require("foo3") /*after*/;
 
-/*after*/var /*before*/_foo3 = require("foo3") /*after*/;
+/*before*/var /*after*/foo2 = babelHelpers.interopRequireWildcard(_foo2);
 
-/*before*/var /*after*/foo2 = babelHelpers.interopRequireWildcard(_foo3);
+var /*before*/_foo3 = require("foo4") /*after*/;
 
-var /*before*/_foo4 = require("foo4") /*after*/;
-
-var /*before*/_foo5 = require("foo5") /*after*/;
+var /*before*/_foo4 = require("foo5") /*after*/;
 
 /*before*/exports. /*after*/test = test;
 var test = /*before*/exports. /*after*/test = 5;
 
-/*before*/(0, _foo4.bar) /*after*/( /*before*/_foo2.default /*after*/, /*before*/_foo5.foo /*after*/);
+/*before*/(0, _foo3.bar) /*after*/( /*before*/_foo.default /*after*/, /*before*/_foo4.foo /*after*/);
 
 /* my comment */
-/*before*/_foo5.foo /*after*/;
-/*before*/_foo2.default /*after*/;
+/*before*/_foo4.foo /*after*/;
+/*before*/_foo.default /*after*/;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
@@ -13,9 +13,7 @@ exports.test = undefined;
 
 var /*before*/_foo = babelHelpers.interopRequireDefault(require("foo2")) /*after*/;
 
-var /*before*/_foo2 = require("foo3") /*after*/;
-
-/*before*/var /*after*/foo2 = babelHelpers.interopRequireWildcard(_foo2);
+var /*before*/_foo2 = babelHelpers.interopRequireWildcard(require("foo3")) /*after*/;
 
 var /*before*/_foo3 = require("foo4") /*after*/;
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/actual.js
@@ -1,0 +1,5 @@
+import a from "a";
+import b from "b";
+
+a;
+b;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var _a = babelHelpers.interopRequireDefault(require("a"));
+
+var _b = babelHelpers.interopRequireDefault(require("b"));
+
+_a.default;
+_b.default;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers"]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-glob/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-glob/expected.js
@@ -1,5 +1,3 @@
 "use strict";
 
-var _foo = require("foo");
-
-var foo = babelHelpers.interopRequireWildcard(_foo);
+var _foo = babelHelpers.interopRequireWildcard(require("foo"));

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-hoisting/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-hoisting/expected.js
@@ -1,10 +1,8 @@
 "use strict";
 
-var _taggedTemplateLiteral2 = require("babel-runtime/helpers/taggedTemplateLiteral");
+var _taggedTemplateLiteral2 = _interopRequireDefault(require("babel-runtime/helpers/taggedTemplateLiteral"));
 
-var _taggedTemplateLiteral3 = _interopRequireDefault(_taggedTemplateLiteral2);
-
-var _templateObject = (0, _taggedTemplateLiteral3.default)(["foo"], ["foo"]);
+var _templateObject = (0, _taggedTemplateLiteral2.default)(["foo"], ["foo"]);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/actual.js
@@ -2,3 +2,13 @@ import foo, {baz as xyz} from "foo";
 
 foo;
 xyz;
+
+import a from "bar";
+import {b} from "bar";
+
+console.log(a, b);
+
+import { c } from "abc";
+import d from "abc";
+
+console.log(c, d);

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/expected.js
@@ -4,5 +4,17 @@ var _foo = require("foo");
 
 var _foo2 = babelHelpers.interopRequireDefault(_foo);
 
+var _bar = require("bar");
+
+var _bar2 = babelHelpers.interopRequireDefault(_bar);
+
+var _abc = require("abc");
+
+var _abc2 = babelHelpers.interopRequireDefault(_abc);
+
 _foo2.default;
 _foo.baz;
+
+console.log(_bar2.default, _bar.b);
+
+console.log(_abc.c, _abc2.default);

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/expected.js
@@ -11,21 +11,19 @@ require("foo-bar");
 
 require("./directory/foo-bar");
 
-var _foo = require("foo2");
+var _foo = babelHelpers.interopRequireDefault(require("foo2"));
 
-var _foo2 = babelHelpers.interopRequireDefault(_foo);
+var _foo2 = require("foo3");
 
-var _foo3 = require("foo3");
+var foo2 = babelHelpers.interopRequireWildcard(_foo2);
 
-var foo2 = babelHelpers.interopRequireWildcard(_foo3);
+var _foo3 = require("foo4");
 
-var _foo4 = require("foo4");
-
-var _foo5 = require("foo5");
+var _foo4 = require("foo5");
 
 exports.test = test;
 var test = exports.test = 5;
 
-_foo4.bar;
-_foo5.foo;
-_foo2.default;
+_foo3.bar;
+_foo4.foo;
+_foo.default;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/expected.js
@@ -13,9 +13,7 @@ require("./directory/foo-bar");
 
 var _foo = babelHelpers.interopRequireDefault(require("foo2"));
 
-var _foo2 = require("foo3");
-
-var foo2 = babelHelpers.interopRequireWildcard(_foo2);
+var _foo2 = babelHelpers.interopRequireWildcard(require("foo3"));
 
 var _foo3 = require("foo4");
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
@@ -16,9 +16,7 @@ Object.keys(_bar).forEach(function (key) {
   });
 });
 
-var _foo = require('foo');
-
-var _foo2 = _interopRequireDefault(_foo);
+var _foo = _interopRequireDefault(require('foo'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
@@ -2,9 +2,7 @@
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-var _foo = require('foo');
-
-var _foo2 = _interopRequireDefault(_foo);
+var _foo = _interopRequireDefault(require('foo'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility/expected.js
@@ -4,12 +4,10 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _foo = require('foo');
-
-var _foo2 = _interopRequireDefault(_foo);
+var _foo = _interopRequireDefault(require('foo'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-console.log(_foo2['default']);
+console.log(_foo['default']);
 
 exports['default'] = 5;

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -37,6 +37,10 @@ export default function ({ types: t }) {
   return {
     inherits: require("babel-plugin-transform-es2015-modules-amd"),
 
+    pre() {
+      this.modulesType = "umd";
+    },
+
     visitor: {
       Program: {
         exit(path, state) {

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default-only/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default-only/actual.js
@@ -1,0 +1,5 @@
+import a from "a";
+import b from "b";
+
+a;
+b;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default-only/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default-only/expected.js
@@ -1,0 +1,22 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["a", "b"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("a"), require("b"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.a, global.b);
+    global.actual = mod.exports;
+  }
+})(this, function (_a, _b) {
+  "use strict";
+
+  var _a2 = babelHelpers.interopRequireDefault(_a);
+
+  var _b2 = babelHelpers.interopRequireDefault(_b);
+
+  _a2.default;
+  _b2.default;
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default-only/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-default-only/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers"]
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/T7178/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/T7178/expected.js
@@ -1,14 +1,12 @@
 "use strict";
 
-var _props = require("props");
-
-var _props2 = _interopRequireDefault(_props);
+var _props = _interopRequireDefault(require("props"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-console.log(_props2.default);
+console.log(_props.default);
 
 (function () {
   const props = _objectWithoutProperties(this.props, []);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/expected.js
@@ -1,21 +1,17 @@
 "use strict";
 
-var _regenerator = require("babel-runtime/regenerator");
+var _regenerator = _interopRequireDefault(require("babel-runtime/regenerator"));
 
-var _regenerator2 = _interopRequireDefault(_regenerator);
-
-var _keys = require("babel-runtime/core-js/object/keys");
-
-var _keys2 = _interopRequireDefault(_keys);
+var _keys = _interopRequireDefault(require("babel-runtime/core-js/object/keys"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var _marked = [fn].map(_regenerator2.default.mark);
+var _marked = [fn].map(_regenerator.default.mark);
 
-(0, _keys2.default)({});
+(0, _keys.default)({});
 
 function fn() {
-  return _regenerator2.default.wrap(function fn$(_context) {
+  return _regenerator.default.wrap(function fn$(_context) {
     while (1) {
       switch (_context.prev = _context.next) {
         case 0:

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/expected.js
@@ -1,9 +1,7 @@
 "use strict";
 
-var _bar = require("bar");
-
-var _bar2 = _interopRequireDefault(_bar);
+var _bar = _interopRequireDefault(require("bar"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_bar2.default;
+_bar.default;


### PR DESCRIPTION
Ref https://twitter.com/dan_abramov/status/755104686471049218 (thanks to @gaearon for the question/suggestion).

![screen shot 2016-07-18 at 7 00 52 pm](https://cloud.githubusercontent.com/assets/588473/16933263/faf4ef7c-4d19-11e6-8f63-ebd6658f3c8d.png)
### [src change](packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js)
- might be flawed, but the approach was to check (for each individual import) if there was only a single specifier and if that single specifier was a default.
### new [actual test](https://github.com/babel/babel/blob/69bbd551ae554482c1b673f7914da4cd443a2f42/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/actual.js)

``` js
import a from "a";
import b from "b";
a;
b;
```
### expected test of old code 😢

``` js
var _a = require("a");
var _a2 = babelHelpers.interopRequireDefault(_a);
var _b = require("b");
var _b2 = babelHelpers.interopRequireDefault(_b);
_a2.default;
_b2.default;
```
### new [expected test](https://github.com/babel/babel/blob/69bbd551ae554482c1b673f7914da4cd443a2f42/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default-only/expected.js) 😸

``` js
var _a = babelHelpers.interopRequireDefault(require("a"));
var _b = babelHelpers.interopRequireDefault(require("b"));
_a.default;
_b.default;
```

---
## Old test changes

FYI: I remembered that babylon had a feature where if you don't create an `expected.js` file, it will be generated for you automatically. I remembered there might of been something like that for babel and so I found [this](https://github.com/babel/babel/blob/9a6890c92f2ebeadac9c204baa772091a320b110/packages/babel-helper-transform-fixture-test-runner/src/index.js#L79). I just uncommented this for the tests to change to the new expected behavior (saved a lot of time, and yes it should be probably be fixed/added under some flag and added to contributing in https://github.com/babel/babel/blob/master/CONTRIBUTING.md#writing-tests).

---

Will need to think about where else this could be applied (just have to look at some existing tests). I think we can do it for wildcard too)
- [x] wildcard change
