### PR TITLE
Infer class name for classes that have static property initializer(s)

### DIFF
--- a/packages/babel-plugin-transform-class-properties/package.json
+++ b/packages/babel-plugin-transform-class-properties/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "babel-helper-function-name": "^6.8.0",
     "babel-plugin-syntax-class-properties": "^6.8.0",
     "babel-runtime": "^6.9.1"
   },

--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -1,5 +1,6 @@
 /* eslint max-len: 0 */
 // todo: define instead of assign
+import nameFunction from "babel-helper-function-name";
 
 export default function ({ types: t }) {
   let findBareSupers = {
@@ -43,6 +44,7 @@ export default function ({ types: t }) {
         let ref;
 
         if (path.isClassExpression() || !path.node.id) {
+          nameFunction(path);
           ref = path.scope.generateUidIdentifier("class");
         } else { // path.isClassDeclaration() && path.node.id
           ref = path.node.id;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-infer-name/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-infer-name/actual.js
@@ -1,0 +1,3 @@
+var Foo = class {
+  static num = 0;
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-infer-name/exec.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-infer-name/exec.js
@@ -1,0 +1,7 @@
+var Foo = class {
+  static num = 0;
+}
+
+assert.equal(Foo.num, 0);
+assert.equal(Foo.num = 1, 1);
+assert.equal(Foo.name, "Foo");

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-infer-name/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/static-infer-name/expected.js
@@ -1,0 +1,5 @@
+var _class, _temp;
+
+var Foo = (_temp = _class = function Foo() {
+  babelHelpers.classCallCheck(this, Foo);
+}, _class.num = 0, _temp);


### PR DESCRIPTION
Currently when we transform a class that has static property initializer(s), it gets transformed from

```javascript
var Foo = class {
  static num = 0;
}
```
to
```javascript
var _class, _temp;

var Foo = (_temp = _class = function _class() {
  babelHelpers.classCallCheck(this, _class);
}, _class.num = 0, _temp);
```

The transform doesn't infer class name from the LHS/property key/etc. In React we use the `.name` field of a class component to show warning/error messages, so it'd be great if more component classes get named. 

Thanks for reviewing! cc @spicyj 