### PR TITLE
Fix buildExportAll to account for commonjs/amd/systemjs

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/exports-from/expected.js
@@ -5,7 +5,7 @@ define(["exports", "foo"], function (exports, _foo) {
     value: true
   });
   Object.keys(_foo).forEach(function (key) {
-    if (key === "default") return;
+    if (key === "default" || key === "__esModule") return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -33,7 +33,7 @@ let buildExportsAssignment = template(`
 
 let buildExportAll = template(`
   Object.keys(OBJECT).forEach(function (key) {
-    if (key === "default") return;
+    if (key === "default" || key === "__esModule") return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
@@ -1,0 +1,37 @@
+var assert = require("assert");
+var babel = require("babel-core");
+var vm = require("vm");
+
+test("Re-export doesn't overwrite __esModule flag", function () {
+  var code = 'export * from "./dep";';
+  var depStub = {
+    __esModule: false,
+  };
+
+  var context = {
+    module: {
+      exports: {}
+    },
+    require: function (id) {
+      if (id === "./dep") return depStub;
+      return require(id);
+    },
+  };
+  context.exports = context.module.exports;
+
+  code = babel.transform(code, {
+    "plugins": [
+      [require("../"), {loose: true}],
+    ],
+    "ast": false,
+  }).code;
+
+  vm.runInNewContext(code, context);
+
+  // exports.__esModule shouldn't be overwritten.
+  assert.equal(
+    context.exports.__esModule,
+    true,
+    "Expected exports.__esModule === true"
+  );
+});

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-from/expected.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _foo = require("foo");
 
 Object.keys(_foo).forEach(function (key) {
-  if (key === "default") return;
+  if (key === "default" || key === "__esModule") return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _bar = require('bar');
 
 Object.keys(_bar).forEach(function (key) {
-  if (key === "default") return;
+  if (key === "default" || key === "__esModule") return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _mod = require('mod');
 
 Object.keys(_mod).forEach(function (key) {
-  if (key === "default") return;
+  if (key === "default" || key === "__esModule") return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -18,7 +18,7 @@ let buildTemplate = template(`
 
 let buildExportAll = template(`
   for (var KEY in TARGET) {
-    if (KEY !== "default") EXPORT_OBJ[KEY] = TARGET[KEY];
+    if (KEY !== "default" && key !== "__esModule") EXPORT_OBJ[KEY] = TARGET[KEY];
   }
 `);
 

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-from/expected.js
@@ -6,7 +6,7 @@ System.register(["foo"], function (_export, _context) {
       var _exportObj = {};
 
       for (var _key in _foo) {
-        if (_key !== "default") _exportObj[_key] = _foo[_key];
+        if (_key !== "default" && key !== "__esModule") _exportObj[_key] = _foo[_key];
       }
 
       _exportObj.foo = _foo.foo;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/exports-from/expected.js
@@ -17,7 +17,7 @@
     value: true
   });
   Object.keys(_foo).forEach(function (key) {
-    if (key === "default") return;
+    if (key === "default" || key === "__esModule") return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {


### PR DESCRIPTION
Original PRs
- https://github.com/babel/babel/pull/3427 @EisenbergEffect (sorry for the long wait!!)
- https://github.com/babel/babel/pull/3467 @jmm

> If the re-exported module was generated with Babel and it is a commonjs or amd module and so is the current module, this will result in an attempt to redefine the __esModule property, which throws a runtime error.