### PR TITLE
systemjs: hoist named function exports - fixes T6973

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/T6973/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/T6973/actual.js
@@ -1,0 +1,9 @@
+export function a() {
+  alert("a");
+}
+
+function b() {
+  a();
+}
+
+b();

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/T6973/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/T6973/expected.js
@@ -1,0 +1,20 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  function a() {
+    alert("a");
+  }
+
+  _export("a", a);
+
+  function b() {
+    a();
+  }
+
+  return {
+    setters: [],
+    execute: function () {
+      b();
+    }
+  };
+});

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-modules-systemjs"]
+}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/exports-named/expected.js
@@ -1,6 +1,14 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  function foo() {}
+
+  _export("foo", foo);
+
+  function foo2(bar) {}
+
+  _export("foo2", foo2);
+
   return {
     setters: [],
     execute: function () {
@@ -17,14 +25,6 @@ System.register([], function (_export, _context) {
       _export("default", foo);
 
       _export("bar", bar);
-
-      function foo() {}
-
-      _export("foo", foo);
-
-      function foo2(bar) {}
-
-      _export("foo2", foo2);
     }
   };
 });

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/expected.js
@@ -2,17 +2,17 @@ System.register(["./evens"], function (_export, _context) {
   "use strict";
 
   var isEven, p, a, i, j, isOdd;
+  function nextOdd(n) {
+    return _export("p", p = isEven(n) ? n + 1 : n + 2);
+  }
+
+  _export("nextOdd", nextOdd);
+
   return {
     setters: [function (_evens) {
       isEven = _evens.isEven;
     }],
     execute: function () {
-      function nextOdd(n) {
-        return _export("p", p = isEven(n) ? n + 1 : n + 2);
-      }
-
-      _export("nextOdd", nextOdd);
-
       _export("p", p = 5);
 
       _export("p", p);


### PR DESCRIPTION
Currently the following function declarations are hoisted in SystemJS modules:
* named functions in root scope
* *default* exported functions

_Named_ *exported* functions are not being hoisted for some reason. This leads to functions being declared in different scopes and not being able to call each other: https://phabricator.babeljs.io/T6973

Also the current hoisting mechanism removes the nodes prematurely which leads to `reassignmentVisitor` not being able to traverse them.

This PR addresses these problems.

// cc @guybedford 