### PR TITLE
Misc: remove deps from syntax plugins

### DIFF
--- a/packages/babel-plugin-syntax-async-functions/package.json
+++ b/packages/babel-plugin-syntax-async-functions/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-class-constructor-call/package.json
+++ b/packages/babel-plugin-syntax-class-constructor-call/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-exponentiation-operator/package.json
+++ b/packages/babel-plugin-syntax-exponentiation-operator/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-export-extensions/package.json
+++ b/packages/babel-plugin-syntax-export-extensions/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -8,10 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
-  "devDependencies": {
-    "babel-helper-plugin-test-runner": "^6.8.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel-plugin-syntax-trailing-function-commas/package.json
+++ b/packages/babel-plugin-syntax-trailing-function-commas/package.json
@@ -8,9 +8,7 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.8.0"
   }


### PR DESCRIPTION
Ok keeping it in `babel-plugin-syntax-trailing-function-commas` since it has tests.

Although it does seem like we can just move the `babel-helper-plugin-test-runner` devDep to the top level?