### PR TITLE
Decrease required version of babel-runtime

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -9,7 +9,7 @@
   "browser": "lib/browser.js",
   "dependencies": {
     "babel-core": "^6.9.0",
-    "babel-runtime": "^6.11.6",
+    "babel-runtime": "^6.9.0",
     "core-js": "^2.4.0",
     "home-or-tmp": "^1.0.0",
     "lodash": "^4.2.0",


### PR DESCRIPTION
You cannot do a fresh npm install of any babel module that has a dependency of babel-register due to the fact that the latest version of babel-register depends on ^6.11.6 of babel-runtime which does not exist in the npm versions

```
npm ERR! Valid install targets:
npm ERR! 6.9.2, 6.9.1, 6.9.0, 6.6.1, 6.6.0, 6.5.0, 6.5.0-1, 6.3.19, 6.3.13, 6.2.4, 6.2.0, 6.1.18, 6.1.17, 6.1.4, 6.0.14, 6.0.12, 6.0.8, 6.0.2, 5.8.38, 5.8.35, 5.8.34, 5.8.29, 5.8.25, 5.8.24, 5.8.20, 5.8.19, 5.8.12, 5.8.9, 5.8.8, 5.8.5, 5.8.3, 5.8.2, 5.7.0, 5.6.20, 5.6.19, 5.6.18, 5.6.17, 5.6.16, 5.6.15, 5.6.14, 5.6.12, 5.6.11, 5.6.10, 5.6.9, 5.6.8, 5.6.7, 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.8, 5.5.7, 5.5.6, 5.5.5, 5.5.4, 5.5.3, 5.5.2, 5.5.1, 5.5.0, 5.4.7, 5.4.6, 5.4.5, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0, 5.3.3, 5.3.2, 5.3.1, 5.3.0, 5.2.17, 5.2.16, 5.2.15, 5.2.14, 5.2.13, 5.2.12, 5.2.11, 5.2.10, 5.2.9, 5.2.7, 5.2.6, 5.2.5, 5.2.4, 5.2.3, 5.2.2, 5.2.1, 5.2.0, 5.1.13, 5.1.12, 5.1.11, 5.1.10, 5.1.9, 5.1.8, 5.1.7, 5.1.6, 5.1.5, 5.1.4, 5.1.3, 5.1.2, 5.1.1, 5.1.0, 5.0.13, 5.0.12, 5.0.11, 5.0.10, 5.0.9, 5.0.8, 5.0.7, 5.0.6, 5.0.5, 5.0.4, 5.0.3, 5.0.2, 5.0.1, 5.0.0, 5.0.0-beta4, 5.0.0-beta3, 5.0.0-beta2, 5.0.0-beta1, 4.7.16, 4.7.15, 4.7.14, 4.7.13, 4.7.12, 4.7.11, 4.7.10, 4.7.9, 4.7.8, 4.7.7, 4.7.6, 4.7.5, 4.7.4, 4.7.3, 4.7.2, 4.7.1, 4.7.0, 4.6.6, 4.6.5, 4.6.4, 4.6.3, 4.6.1, 4.6.0, 4.5.5, 4.5.4, 4.5.3, 4.5.2, 4.5.1, 4.5.0, 4.4.6, 4.4.5, 4.4.4, 4.4.3, 4.4.2, 4.4.1, 4.3.0, 4.2.1, 4.2.0, 4.1.1, 4.0.2, 4.0.1
```

This is the [commit](https://github.com/babel/babel/commit/55f20afe1c994ddad093e6277c057597e4697f48) where it was changed