### PR TITLE
Set sourceRoot in babel-register transform to fix paths in stacks

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -49,7 +49,8 @@ function compile(filename) {
 
   // merge in base options and resolve all the plugins and presets relative to this file
   let opts = new OptionManager().init(extend(deepClone(transformOpts), {
-    filename
+    filename,
+    sourceRoot: path.dirname(filename)
   }));
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
@@ -70,7 +71,7 @@ function compile(filename) {
       // calls above and would introduce duplicates.
       babelrc: false,
       sourceMaps: "both",
-      ast:       false
+      ast: false
     }));
   }
 


### PR DESCRIPTION
This is the followup of #3523 which was reverted. 

This change fixes the stacktraces by setting `sourceRoot` in the options. This does not touch the `sources` or `file` property in the map, but adds a property called `sourceRoot`. By spec the sourceRoot is prepended to `sources` and `file`.

> Resolving Sources
> If the sources are not absolute URLs after prepending of the “sourceRoot”, the sources are resolved relative to the SourceMap (like resolving script src in a html document). 

Printing absolute paths is also more in line with node itself, which prints absolute paths in its traces.

I tested the previously [failing project](https://github.com/aureooms/es-itertools) with this change and it worked.

i also thought about tests, but the main blocker right now is that there is no way to unregister babel-register which messes then with other tests. As soon as we merge #3139 it might get possible to write tests and after the test to properly unhook.