### PR TITLE
Switch to pirates for babel-register.

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -15,6 +15,7 @@
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
     "path-exists": "^1.0.0",
+    "pirates": "^2.1.1",
     "source-map-support": "^0.2.10"
   }
 }

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -3,7 +3,7 @@ import sourceMapSupport from "source-map-support";
 import * as registerCache from "./cache";
 import extend from "lodash/extend";
 import * as babel from "babel-core";
-import each from "lodash/each";
+import { addHook } from "pirates";
 import { util, OptionManager } from "babel-core";
 import fs from "fs";
 import path from "path";
@@ -31,7 +31,7 @@ let transformOpts = {};
 let ignore;
 let only;
 
-let oldHandlers   = {};
+let revert        = null;
 let maps          = {};
 
 let cwd = process.cwd();
@@ -44,7 +44,7 @@ function mtime(filename) {
   return +fs.statSync(filename).mtime;
 }
 
-function compile(filename) {
+function compile(code, filename) {
   let result;
 
   // merge in base options and resolve all the plugins and presets relative to this file
@@ -65,7 +65,7 @@ function compile(filename) {
   }
 
   if (!result) {
-    result = babel.transformFileSync(filename, extend(opts, {
+    result = babel.transform(code, extend(opts, {
       // Do not process config files since has already been done with the OptionManager
       // calls above and would introduce duplicates.
       babelrc: false,
@@ -92,37 +92,9 @@ function shouldIgnore(filename) {
   }
 }
 
-function loader(m, filename) {
-  m._compile(compile(filename), filename);
-}
-
-function registerExtension(ext) {
-  let old = oldHandlers[ext] || oldHandlers[".js"] || require.extensions[".js"];
-
-  require.extensions[ext] = function (m, filename) {
-    if (shouldIgnore(filename)) {
-      old(m, filename);
-    } else {
-      loader(m, filename, old);
-    }
-  };
-}
-
-function hookExtensions(_exts) {
-  each(oldHandlers, function (old, ext) {
-    if (old === undefined) {
-      delete require.extensions[ext];
-    } else {
-      require.extensions[ext] = old;
-    }
-  });
-
-  oldHandlers = {};
-
-  each(_exts, function (ext) {
-    oldHandlers[ext] = require.extensions[ext];
-    registerExtension(ext);
-  });
+function hookExtensions(exts) {
+  if (revert) revert();
+  revert = addHook(compile, { exts, matcher: shouldIgnore, ignoreNodeModules: false });
 }
 
 hookExtensions(util.canCompile.EXTENSIONS);


### PR DESCRIPTION
Copied from https://github.com/babel/babel/pull/3139 but fixed merge conflicts @ariporad 
---

Pirates is a simple module that enables easy require hooking. It makes sure that your require hook works properly. It also makes the implimentation of babel-register a lot simpler.

For more on pirates: http://ariporad.link/piratesjs

> As was discussed in #3062, this PR uses `pirates` to implement require hooks. That means that the `babel-register` require hook implementation is drastically simpler, and plays nicely with other hooks.

This change is completely transparent (a patch version bump), and all the tests still pass.

Fixes #3062.