### PR TITLE
Add an option for custom runtime

### DIFF
--- a/packages/babel-plugin-transform-runtime/README.md
+++ b/packages/babel-plugin-transform-runtime/README.md
@@ -42,7 +42,8 @@ Add the following line to your `.babelrc` file:
     ["transform-runtime", {
       "helpers": false, // defaults to true
       "polyfill": false, // defaults to true
-      "regenerator": true // defaults to true
+      "regenerator": true, // defaults to true
+      "moduleName": "babel-runtime" // defaults to "babel-runtime"
     }]
   ]
 }

--- a/packages/babel-plugin-transform-runtime/src/options.json
+++ b/packages/babel-plugin-transform-runtime/src/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-runtime", "transform-regenerator"]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/custom-runtime/actual.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/custom-runtime/actual.js
@@ -1,0 +1,9 @@
+import foo, * as bar from "someModule";
+
+export const myWord = Symbol("abc");
+export function* giveWord () {
+  yield myWord;
+}
+
+foo;
+bar;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/custom-runtime/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/custom-runtime/expected.js
@@ -1,0 +1,24 @@
+import _regeneratorRuntime from "foo/regenerator";
+import _Symbol from "foo/core-js/symbol";
+
+var _marked = [giveWord].map(_regeneratorRuntime.mark);
+
+import foo, * as bar from "someModule";
+
+export const myWord = _Symbol("abc");
+export function giveWord() {
+  return _regeneratorRuntime.wrap(function giveWord$(_context) {
+    while (1) switch (_context.prev = _context.next) {
+      case 0:
+        _context.next = 2;
+        return myWord;
+
+      case 2:
+      case "end":
+        return _context.stop();
+    }
+  }, _marked[0], this);
+}
+
+foo;
+bar;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/custom-runtime/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/custom-runtime/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-runtime", { "moduleName": "foo" }], "transform-regenerator"]
+}


### PR DESCRIPTION
This adds support for a custom runtime package to `babel-plugin-transform-runtime`.  
Usage:

```
{
  "plugins": ["transform-runtime", {
    "moduleName": "my-custom-babel-runtime"
  }]
}
```

My real use case looks like this:

```js
{
  "plugins": [
    [require.resolve('babel-plugin-transform-runtime'), {
      moduleName: path.dirname(require.resolve('babel-runtime/package'))
    }]
  ]
}
```

Context: [Create React App](https://github.com/facebookincubator/create-react-app) hides all development dependencies from user. We want to support ES6 generators out of the box with `runtime` but we don’t want to force everybody to have `babel-runtime` in their `package.json`.

Related issue: https://github.com/facebookincubator/create-react-app/issues/255