### PR TITLE
fix(bable-generator): default to double quotes

### DIFF
--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -93,6 +93,11 @@ function normalizeOptions(code, opts, tokens): Format {
  * Determine if input code uses more single or double quotes.
  */
 function findCommonStringDelimiter(code, tokens) {
+  const DEFAULT_STRING_DELIMITER = "double";
+  if (!code) {
+    return DEFAULT_STRING_DELIMITER;
+  }
+
   let occurences = {
     single: 0,
     double: 0
@@ -117,7 +122,7 @@ function findCommonStringDelimiter(code, tokens) {
   if (occurences.single > occurences.double) {
     return "single";
   } else {
-    return "double";
+    return DEFAULT_STRING_DELIMITER;
   }
 }
 


### PR DESCRIPTION
When not providing any code or just an empty string to the `generate`function, it should still work just fine (in my opinion), so the API would just be:

`const code = generate(ast)`

Before this change, `findCommonStringDelimiter` failed at `code.slice`.