### PR TITLE
Missing FlowType definition opts.deprecatedAlias

### DIFF
--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -124,6 +124,7 @@ export default function defineType(
     aliases?: Array<string>;
     builder?: Array<string>;
     inherits?: string;
+    deprecatedAlias?: string;
   } = {},
 ) {
   let inherits = (opts.inherits && store[opts.inherits]) || {};


### PR DESCRIPTION
Added missing FlowType definition `opts.deprecatedAlias` for `defineType()` in `babel-types/src/definitions/index.js`