### PR TITLE
Confident status is not restored when evaluating cached items

### DIFF
--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -63,4 +63,5 @@ suite("evaluation", function () {
   addTest("'abc' === 'xyz' || (1 === 1 && config.flag)", "LogicalExpression", undefined, true);
   addTest("'abc' === 'xyz' || (1 === 1 && 'four' === 'four')", "LogicalExpression", true);
   addTest("'abc' === 'abc' && (1 === 1 && 'four' === 'four')", "LogicalExpression", true);
+  addTest("var a; a > 1 && a < 100", "LogicalExpression", undefined, true);
 });

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -80,6 +80,9 @@ export function evaluate(): { confident: boolean; value: any } {
     if (seen.has(node)) {
       let existing = seen.get(node);
       if (existing.resolved) {
+        if (!existing.confident) {
+          confident = false;
+        }
         return existing.value;
       } else {
         deopt(path);
@@ -90,6 +93,7 @@ export function evaluate(): { confident: boolean; value: any } {
       seen.set(node, item);
 
       let val = _evaluate(path);
+      item.confident = confident;
       item.resolved = true;
       item.value = value;
       return val;


### PR DESCRIPTION
* Fix bug https://phabricator.babeljs.io/T7500
* Storing the confident status in the cached item and restoring the status
when reusing the same item later.