### PR TITLE
make babel-register caching more robust

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -1,17 +1,48 @@
 import path from "path";
 import fs from "fs";
-import { sync as mkdirpSync } from "mkdirp";
+import {sync as mkdirpSync} from "mkdirp";
 import homeOrTmp from "home-or-tmp";
 import pathExists from "path-exists";
+import each from "lodash/each";
 
-const FILENAME = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json");
+function addInstance(fn) {
+  if (process.env.NODE_APP_INSTANCE === undefined) {
+    return fn;
+  }
+  const instance = `.${process.env.NODE_APP_INSTANCE}`;
+  if (fn.endsWith(".json")) {
+    return `${fn.substr(0, fn.length-5)}${instance}.json`;
+  } else {
+    return `${fn}${instance}`;
+  }
+}
+
+const FILENAME = addInstance(process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json"));
+const EXPIRE_TIME = 60 * 60 * 24 * 1000 * 10; // 10 days
+const startTime = Date.now();
 let data = {};
+let isDirty = false;
+let enable = !process.env.BABEL_DISABLE_CACHE;
 
 /**
  * Write stringified cache to disk.
  */
 
+let delaySaveTimer;
+
+function clearSaveTimer() {
+  if (delaySaveTimer) {
+    clearTimeout(delaySaveTimer);
+    delaySaveTimer = undefined;
+  }
+}
+
 export function save() {
+  if (!enable || !isDirty) return;
+
+  isDirty = false;
+  clearSaveTimer();
+
   let serialised = {};
   try {
     serialised = JSON.stringify(data, null, "  ");
@@ -23,8 +54,38 @@ export function save() {
       throw err;
     }
   }
+
   mkdirpSync(path.dirname(FILENAME));
   fs.writeFileSync(FILENAME, serialised);
+}
+
+
+function delaySave() {
+  clearSaveTimer();
+
+  delaySaveTimer = setTimeout(() => {
+    delaySaveTimer = undefined;
+    save();
+  }, 500);
+}
+
+function clearExpire() {
+  const now = Date.now();
+  each(data, (result, key) => {
+    if (result.createTime === undefined || result.accessTime === undefined) {
+      isDirty = true;
+      result.createTime = result.accessTime = now;
+    }
+
+    if ((now - result.createTime) >= EXPIRE_TIME && result.accessTime < startTime) {
+      isDirty = true;
+      delete data[key];
+    }
+  });
+
+  if (isDirty) {
+    delaySave();
+  }
 }
 
 /**
@@ -32,15 +93,16 @@ export function save() {
  */
 
 export function load() {
-  if (process.env.BABEL_DISABLE_CACHE) return;
+  enable = !process.env.BABEL_DISABLE_CACHE;
+  if (!enable) return;
 
   process.on("exit", save);
-  process.nextTick(save);
 
   if (!pathExists.sync(FILENAME)) return;
 
   try {
     data = JSON.parse(fs.readFileSync(FILENAME));
+    setTimeout(clearExpire, 120 * 1000);  // clear expire entries in 2 minutes
   } catch (err) {
     return;
   }
@@ -51,5 +113,41 @@ export function load() {
  */
 
 export function get() {
-  return data;
+  return enable && data;
+}
+
+/**
+ * Retrieve an entry for key and mtime
+ * @param key - cache key
+ * @param mtime - optional - mtime to check
+ * @returns {*}
+ */
+
+export function getEntry(key, mtime) {
+  if (enable) {
+    const result = data[key];
+    if (result) {
+      if (mtime !== undefined && result.mtime !== mtime) {
+        return undefined;
+      }
+      result.accessTime = Date.now();
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Create a new entry for key and result
+ * @param key - cache key
+ * @param result - result to cache
+ */
+
+export function newEntry(key, result) {
+  if (enable) {
+    isDirty = true;
+    result.accessTime = result.createTime = Date.now();
+    data[key] = result;
+    delaySave();
+  }
 }

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -58,11 +58,10 @@ function compile(filename) {
   let env = process.env.BABEL_ENV || process.env.NODE_ENV;
   if (env) cacheKey += `:${env}`;
 
+  let cached;
   if (cache) {
-    let cached = cache[cacheKey];
-    if (cached && cached.mtime === mtime(filename)) {
-      result = cached;
-    }
+    cached = registerCache.getEntry(cacheKey, mtime(filename));
+    result = cached;
   }
 
   if (!result) {
@@ -75,9 +74,9 @@ function compile(filename) {
     }));
   }
 
-  if (cache) {
-    cache[cacheKey] = result;
+  if (cache && !cached) {
     result.mtime = mtime(filename);
+    registerCache.newEntry(cacheKey, result);
   }
 
   maps[filename] = result.map;


### PR DESCRIPTION
Make babel-register caching a more robust.
- fix issue where `BABEL_DISABLE_CACHE` doesn't really disable it.  It was only skipping `load` at the beginning.
- check `NODE_APP_INSTANCE` and insert that as part of the filename
- Add a `createTime` and `accessTime` field to track expire entries.  If `createTime` is older than 10 days and `accessTime` is before the time app started, then clear the entry.
- add an `isDirty` flag and only save if it's true
- Automatically set up a 500ms delay to save when a new entry is added or an existing entry updated.
