### PR TITLE
chore(README): fixed spacing before Stack Overflow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Check out our website: [babeljs.io](http://babeljs.io/)
 
 ## Looking for support?
 
-For questions and support please visit our [discussion forum](https://discuss.babeljs.io/), sign up for our[Slack community](https://slack.babeljs.io/), or [StackOverflow](http://stackoverflow.com/questions/tagged/babeljs).
+For questions and support please visit our [discussion forum](https://discuss.babeljs.io/), sign up for our [Slack community](https://slack.babeljs.io/), or [StackOverflow](http://stackoverflow.com/questions/tagged/babeljs).
 
 ## Want to report a bug or request a feature?
 


### PR DESCRIPTION
This is so trivial, feel free to just fix this in one of your own commits instead of merging this and fluffing commit history