### PR TITLE
T7537: can not call super in constructor with conditional branch

### DIFF
--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
@@ -8,7 +8,7 @@ export default function (opts: {
   let visitor = {};
 
   function isAssignment(node) {
-    return node.operator === opts.operator + "=";
+    return node && node.operator === opts.operator + "=";
   }
 
   function buildAssignment(left, right) {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/actual.js
@@ -1,0 +1,7 @@
+class B{}
+class A extends B{
+  constructor(track){
+    if (track !== undefined) super(track);
+    else super();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
@@ -1,0 +1,31 @@
+"use strict";
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var B = function B() {
+  _classCallCheck(this, B);
+};
+
+var A = function (_B) {
+  _inherits(A, _B);
+
+  function A(track) {
+    _classCallCheck(this, A);
+
+    if (track !== undefined) {
+      ;
+
+      var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(A).call(this, track));
+    } else {
+      ;
+
+      var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(A).call(this));
+    }return _possibleConstructorReturn(_this);
+  }
+
+  return A;
+}(B);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["transform-exponentiation-operator"],
+  "presets": ["es2015"]
+}


### PR DESCRIPTION
Fix: [T7537](https://phabricator.babeljs.io/T7537)

When transforming super call in class constructor, part of ast is replaced using method "replaceWithMultiple" here:
https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-es2015-classes/src/vanilla.js#L379

It leads to removing the node (replacing it with null) here:
https://github.com/babel/babel/blob/master/packages/babel-traverse/src/path/replacement.js#L51

But parent ExpressionsStatement is still untouched and when it reaches visitor generated in here
https://github.com/babel/babel/blob/master/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js#L18

It blows up because expression is null from previous visitors.