### PR TITLE
System.register update expression consistency

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/regression/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["external-helpers", "transform-es2015-modules-systemjs"]
-}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoisting-bindings/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoisting-bindings/actual.js
@@ -1,6 +1,9 @@
 export function a() {
   alert("a");
+  c++;
 }
+
+export var c = 5;
 
 function b() {
   a();

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoisting-bindings/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/hoisting-bindings/expected.js
@@ -1,8 +1,10 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var c;
   function a() {
     alert("a");
+    _export("c", c + 1), c++;
   }
 
   _export("a", a);
@@ -14,6 +16,10 @@ System.register([], function (_export, _context) {
   return {
     setters: [],
     execute: function () {
+      _export("c", c = 5);
+
+      _export("c", c);
+
       b();
     }
   };

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/remap/expected.js
@@ -10,7 +10,7 @@ System.register([], function (_export, _context) {
       _export("test", test);
 
       _export("test", test = 5);
-      _export("test", test++);
+      _export("test", test + 1), test++;
 
       (function () {
         var test = 2;


### PR DESCRIPTION
This change ensures that update expressions like `x++` and `x--`, where `x` is an exported binding, get replaced with the expression `_export('x', x - 1), x--` and `_export('x, x + 1), x++` respectively.

The reason for this is that we need the expression to provide the same outward value, while reporting the correct value for the export binding to the setter functions.

This then allows standard exported counter scenarios to work correctly.