### PR TITLE
Added options for commonjs stict and allowTopLevelThis

### DIFF
--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -39,11 +39,11 @@ function preset(context, opts) {
 
   if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
   if (typeof strict !== "boolean") {
-    throw new Error("Preset es2015 'strict' option must be a boolean.")
-  };
+    throw new Error("Preset es2015 'strict' option must be a boolean.");
+  }
   if (typeof allowTopLevelThis !== "boolean") {
-    throw new Error("Preset es2015 'allowTopLevelThis' option must be a boolean.")
-  };
+    throw new Error("Preset es2015 'allowTopLevelThis' option must be a boolean.");
+  }
   if (modules !== false && moduleTypes.indexOf(modules) === -1) {
     throw new Error("Preset es2015 'modules' option must be 'false' to indicate no modules\n" +
       "or a module type which be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'");

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -38,8 +38,12 @@ function preset(context, opts) {
   }
 
   if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
-  if (typeof strict !== "boolean") throw new Error("Preset es2015 'strict' option must be a boolean.");
-  if (typeof allowTopLevelThis !== "boolean") throw new Error("Preset es2015 'allowTopLevelThis' option must be a boolean.");
+  if (typeof strict !== "boolean") {
+    throw new Error("Preset es2015 'strict' option must be a boolean.")
+  };
+  if (typeof allowTopLevelThis !== "boolean") {
+    throw new Error("Preset es2015 'allowTopLevelThis' option must be a boolean.")
+  };
   if (modules !== false && moduleTypes.indexOf(modules) === -1) {
     throw new Error("Preset es2015 'modules' option must be 'false' to indicate no modules\n" +
       "or a module type which be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'");
@@ -66,7 +70,11 @@ function preset(context, opts) {
       [require("babel-plugin-transform-es2015-destructuring"), { loose }],
       require("babel-plugin-transform-es2015-block-scoping"),
       require("babel-plugin-transform-es2015-typeof-symbol"),
-      modules === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose, allowTopLevelThis, strict }],
+      modules === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), {
+        loose, 
+        allowTopLevelThis, 
+        strict
+      }],
       modules === "systemjs" && [require("babel-plugin-transform-es2015-modules-systemjs"), { loose }],
       modules === "amd" && [require("babel-plugin-transform-es2015-modules-amd"), { loose }],
       modules === "umd" && [require("babel-plugin-transform-es2015-modules-umd"), { loose }],

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -26,14 +26,20 @@ Object.defineProperty(module.exports, "buildPreset", {
 function preset(context, opts) {
   const moduleTypes = ["commonjs", "amd", "umd", "systemjs"];
   let loose = false;
+  let strict = true;
   let modules = "commonjs";
+  let allowTopLevelThis = false;
 
   if (opts !== undefined) {
     if (opts.loose !== undefined) loose = opts.loose;
+    if (opts.strict !== undefined) strict = opts.strict;
     if (opts.modules !== undefined) modules = opts.modules;
+    if (opts.allowTopLevelThis !== undefined) allowTopLevelThis = opts.allowTopLevelThis;
   }
 
   if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
+  if (typeof strict !== "boolean") throw new Error("Preset es2015 'strict' option must be a boolean.");
+  if (typeof allowTopLevelThis !== "boolean") throw new Error("Preset es2015 'allowTopLevelThis' option must be a boolean.");
   if (modules !== false && moduleTypes.indexOf(modules) === -1) {
     throw new Error("Preset es2015 'modules' option must be 'false' to indicate no modules\n" +
       "or a module type which be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'");
@@ -60,7 +66,7 @@ function preset(context, opts) {
       [require("babel-plugin-transform-es2015-destructuring"), { loose }],
       require("babel-plugin-transform-es2015-block-scoping"),
       require("babel-plugin-transform-es2015-typeof-symbol"),
-      modules === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose }],
+      modules === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose, allowTopLevelThis, strict }],
       modules === "systemjs" && [require("babel-plugin-transform-es2015-modules-systemjs"), { loose }],
       modules === "amd" && [require("babel-plugin-transform-es2015-modules-amd"), { loose }],
       modules === "umd" && [require("babel-plugin-transform-es2015-modules-umd"), { loose }],


### PR DESCRIPTION
Rather than using a forked package - adding the options to the main es2015 preset.
These options are helpful when working with/migrating legacy code.