### PR TITLE
Add transform-class-properties to react-preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "async": "^1.5.0",
     "babel-core": "^6.3.17",
-    "babel-plugin-transform-class-properties": "^6.6.0",
+    "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-plugin-transform-flow-strip-types": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.6.0",

--- a/packages/babel-preset-react/index.js
+++ b/packages/babel-preset-react/index.js
@@ -5,6 +5,7 @@ module.exports = {
     require("babel-plugin-syntax-flow"),
     require("babel-plugin-syntax-jsx"),
     require("babel-plugin-transform-react-display-name"),
+    require("babel-plugin-transform-class-properties"),
   ],
   env: {
     development: {


### PR DESCRIPTION
I just began using Flow and the react-preset is billed as being complete for removing Flow types when working with React. However, I ran into this issue [here](http://stackoverflow.com/questions/38936271/flowtype-annotation-for-react-component-state-not-being-removed-at-compile) when annotating properties on the class and was shown that the solution is to additionally include the transform-class-properties plugin.

Since the [ES Class Fields & Static Properties](https://github.com/jeffmo/es-class-public-fields) is a stage 2 spec it might be beyond the scope of the preset. If not I would like to include this transform in the react-preset as it seems to be essential to fully enabling Flow type annotations with React component classes.

I have submitted the appropriate update to the `preset-react` docs [here](https://github.com/babel/babel.github.io/pull/888) so that the docs will reflect this change if accepted.