### PR TITLE
Strip flow-only class props without needing transform-class-properties.

### DIFF
--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -26,8 +26,17 @@ export default function ({ types: t }) {
         if (!path.node.value) path.remove();
       },
 
-      Class({ node }) {
-        node.implements = null;
+      Class(path) {
+        path.node.implements = null;
+
+        // We do this here instead of in a `ClassProperty` visitor because the class transform
+        // would transform the class before we reached the class property.
+        path.get("body.body").forEach((child) => {
+          if (child.isClassProperty()) {
+            child.node.typeAnnotation = null;
+            if (!child.node.value) child.remove();
+          }
+        });
       },
 
       Function({ node }) {

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-types/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-types/actual.js
@@ -1,0 +1,3 @@
+class Test {
+  prop: string;
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-types/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-types/expected.js
@@ -1,0 +1,3 @@
+let Test = function Test() {
+  babelHelpers.classCallCheck(this, Test);
+};

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-types/options.json
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-types/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-flow-strip-types",
+    "transform-es2015-classes",
+    "external-helpers"
+  ]
+}


### PR DESCRIPTION
Alternate fix for https://github.com/babel/babel/pull/3654