### PR TITLE
Add wrapPluginVisitorMethod option to allow introspection and metrics tracking of plugins

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -442,7 +442,11 @@ export default class File extends Store {
       const pluginPasses = this.pluginPasses[i];
       this.call("pre", pluginPasses);
       this.log.debug("Start transform traverse");
-      traverse(this.ast, traverse.visitors.merge(this.pluginVisitors[i], pluginPasses), this.scope);
+
+      // merge all plugin visitors into a single visitor
+      let visitor = traverse.visitors.merge(this.pluginVisitors[i], pluginPasses, this.opts.wrapPluginVisitorMethod);
+      traverse(this.ast, visitor, this.scope);
+
       this.log.debug("End transform traverse");
       this.call("post", pluginPasses);
     }

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -102,6 +102,11 @@ module.exports = {
     description: "optional callback to control whether a comment should be inserted, when this is used the comments option is ignored"
   },
 
+  wrapPluginVisitorMethod: {
+    hidden: true,
+    description: "optional callback to wrap all visitor methods"
+  },
+
   compact: {
     type: "booleanString",
     default: "auto",

--- a/packages/babel-core/src/transformation/internal-plugins/block-hoist.js
+++ b/packages/babel-core/src/transformation/internal-plugins/block-hoist.js
@@ -13,6 +13,8 @@ export default new Plugin({
    *  - 3 We want this to be at the **very** top
    */
 
+  name: "internal.blockHoist",
+
   visitor: {
     Block: {
       exit({ node }) {

--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -16,6 +16,8 @@ const superVisitor = {
 };
 
 export default new Plugin({
+  name: "internal.shadowFunctions",
+  
   visitor: {
     ThisExpression(path) {
       remap(path, "this");

--- a/packages/babel-core/src/transformation/plugin-pass.js
+++ b/packages/babel-core/src/transformation/plugin-pass.js
@@ -1,26 +1,20 @@
 import type Plugin from "./plugin";
 import Store from "../store";
-import traverse from "babel-traverse";
 import File from "./file";
 
 export default class PluginPass extends Store {
   constructor(file: File, plugin: Plugin, options: Object = {}) {
     super();
     this.plugin = plugin;
+    this.key    = plugin.key;
     this.file   = file;
     this.opts   = options;
   }
 
+  key: string;
   plugin: Plugin;
   file: File;
   opts: Object;
-
-  transform() {
-    let file = this.file;
-    file.log.debug(`Start transformer ${this.key}`);
-    traverse(file.ast, this.plugin.visitor, file.scope, file);
-    file.log.debug(`Finish transformer ${this.key}`);
-  }
 
   addHelper(...args) {
     return this.file.addHelper(...args);

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -15,7 +15,7 @@ export default class Plugin extends Store {
 
     this.initialized = false;
     this.raw         = assign({}, plugin);
-    this.key         = key;
+    this.key         = this.take("name") || key;
 
     this.manipulateOptions = this.take("manipulateOptions");
     this.post              = this.take("post");

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -76,6 +76,38 @@ suite("api", function () {
     });
   });
 
+  test("option wrapPluginVisitorMethod", function () {
+    var calledRaw = 0;
+    var calledIntercept = 0;
+
+    babel.transform("function foo() { bar(foobar); }", {
+      wrapPluginVisitorMethod: function (pluginAlias, visitorType, callback) {
+        if (pluginAlias !== "foobar") {
+          return callback;
+        }
+
+        assert.equal(visitorType, "enter");
+
+        return function () {
+          calledIntercept++;
+          return callback.apply(this, arguments);
+        };
+      },
+
+      plugins: [new Plugin({
+        name: "foobar",
+        visitor: {
+          "Program|Identifier": function () {
+            calledRaw++;
+          }
+        }
+      })]
+    });
+
+    assert.equal(calledRaw, 4);
+    assert.equal(calledIntercept, 4);
+  });
+
   test("pass per preset", function () {
     var aliasBaseType = null;
 


### PR DESCRIPTION
I'll submit a PR to `babel.github.io` with docs once this gets accepted. This adds an optional callback that you can use to wrap visitor methods. At FB we're having problems with plugin performance and Babel 6 merging plugin visitors means we have little insight into performance, this will allow us to have granular tracking and telemetry. Usage is displayed in the included test:

```javascript
  test("option wrapPluginVisitorMethod", function () {
    var calledRaw = 0;
    var calledIntercept = 0;

    babel.transform("function foo() { bar(foobar); }", {
      wrapPluginVisitorMethod(pluginAlias, visitorType, callback) {
        if (pluginAlias !== "foobar") {
          return callback;
        }

        assert.equal(visitorType, "enter");

        return function () {
          calledIntercept++;
          return callback.apply(this, arguments);
        };
      },

      plugins: [new Plugin({
        name: "foobar",
        visitor: {
          "Program|Identifier": function () {
            calledRaw++;
          }
        }
      })]
    });

    assert.equal(calledRaw, 4);
    assert.equal(calledIntercept, 4);
  });
```