### PR TITLE
Output babel-generator deopt message to stdout

### DIFF
--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -78,7 +78,7 @@ function normalizeOptions(code, opts, tokens): Format {
     format.compact = code.length > 100000; // 100KB
 
     if (format.compact) {
-      console.error("[BABEL] " + messages.get("codeGeneratorDeopt", opts.filename, "100KB"));
+      console.log("[BABEL] " + messages.get("codeGeneratorDeopt", opts.filename, "100KB"));
     }
   }
 


### PR DESCRIPTION
When `compact` is set to `auto` and the file size is too large, `compact` automatically gets set to `true` and the following message is logged to `stderr`.

```
"Note: The code generator has deoptimised the styling of $1 as it exceeds the max of $2."
```

This message seems to be an informational message rather than an error.