### PR TITLE
Ignore Object and Object prototype keys

### DIFF
--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -141,7 +141,7 @@ export function verify(visitor) {
     if (typeof visitors === "object") {
       for (let visitorKey in visitors) {
         // ignore Object and Object prototype keys (in case the global Object has been modified)
-        if(Object[visitorKey] != undefined || Object.prototype[visitorKey] != undefined) continue;
+        if (Object[visitorKey] != undefined || Object.prototype[visitorKey] != undefined) continue;
         
         if (visitorKey === "enter" || visitorKey === "exit") {
           // verify that it just contains functions
@@ -176,7 +176,7 @@ export function merge(visitors: Array, states: Array = [], wrapper?: ?Function) 
 
     for (let type in visitor) {
       // ignore Object and Object prototype keys (in case the global Object has been modified)
-      if(Object[type] != undefined || Object.prototype[type] != undefined) continue;
+      if (Object[type] != undefined || Object.prototype[type] != undefined) continue;
       
       let visitorType = visitor[type];
 
@@ -261,7 +261,7 @@ function shouldIgnoreKey(key) {
   if (key === "blacklist" || key === "noScope" || key === "skipKeys") return true;
 
   // ignore Object and Object prototype keys (in case the global Object has been modified)
-  if(Object[key] != undefined || Object.prototype[key] != undefined) return true;
+  if (Object[key] != undefined || Object.prototype[key] != undefined) return true;
 
   return false;
 }

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -140,6 +140,9 @@ export function verify(visitor) {
     let visitors = visitor[nodeType];
     if (typeof visitors === "object") {
       for (let visitorKey in visitors) {
+        // ignore Object and Object prototype keys (in case the global Object has been modified)
+        if(Object[visitorKey] != undefined || Object.prototype[visitorKey] != undefined) continue;
+        
         if (visitorKey === "enter" || visitorKey === "exit") {
           // verify that it just contains functions
           validateVisitorMethods(`${nodeType}.${visitorKey}`, visitors[visitorKey]);
@@ -172,6 +175,9 @@ export function merge(visitors: Array, states: Array = [], wrapper?: ?Function) 
     explode(visitor);
 
     for (let type in visitor) {
+      // ignore Object and Object prototype keys (in case the global Object has been modified)
+      if(Object[type] != undefined || Object.prototype[type] != undefined) continue;
+      
       let visitorType = visitor[type];
 
       // if we have state or wrapper then overload the callbacks to take it
@@ -253,6 +259,9 @@ function shouldIgnoreKey(key) {
 
   // ignore other options
   if (key === "blacklist" || key === "noScope" || key === "skipKeys") return true;
+
+  // ignore Object and Object prototype keys (in case the global Object has been modified)
+  if(Object[key] != undefined || Object.prototype[key] != undefined) return true;
 
   return false;
 }


### PR DESCRIPTION
This pull request puts some logic in place which will prevent out of memory errors in case the global Object or global Object.prototype has been modified by any imported code.