### PR TITLE
Ensure correct version of babel installed for preset options

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   },
   "devDependencies": {
     "async": "^1.5.0",
-    "babel-core": "^6.3.17",
+    "babel-core": "^6.13.2",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-flow-strip-types": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.0.0",
     "babel-runtime": "^6.0.0",
     "browserify": "^11.2.0",


### PR DESCRIPTION
While debugging the pirates integration I stumbled upon this, as my local npm was not updating these two dependencies.

As we now se es2015 with options the dependencies should also mirror this requirement imho.