### PR TITLE
Switch to pirates for babel-register.

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,7 +13,7 @@
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
-    "pirates": "^2.1.1",
+    "pirates": "danez/pirates",
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,7 +13,7 @@
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
-    "pirates": "^2.1.2",
+    "pirates": "^3.0.1",
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,6 +13,7 @@
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
+    "pirates": "^2.1.1",
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,7 +13,7 @@
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
-    "pirates": "danez/pirates",
+    "pirates": "^2.1.2",
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,6 +17,7 @@
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {
-    "decache": "^4.1.0"
+    "decache": "^4.1.0",
+    "default-require-extensions": "^1.0.0"
   }
 }

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -36,8 +36,6 @@ function mtime(filename) {
 }
 
 function compile(code, filename) {
-  let result;
-
   // merge in base options and resolve all the plugins and presets relative to this file
   const opts = new OptionManager().init(Object.assign(
     { sourceRoot: path.dirname(filename) }, // sourceRoot can be overwritten
@@ -46,7 +44,7 @@ function compile(code, filename) {
   ));
 
   // Bail out ASAP if the file has been ignored.
-  if (opts === null) return null;
+  if (opts === null) return code;
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
 
@@ -57,19 +55,17 @@ function compile(code, filename) {
   if (cache) {
     const cached = cache[cacheKey];
     if (cached && cached.mtime === mtime(filename)) {
-      result = cached;
+      return cached.code;
     }
   }
 
-  if (!result) {
-    result = babel.transform(code, Object.assign(opts, {
-      // Do not process config files since has already been done with the OptionManager
-      // calls above and would introduce duplicates.
-      babelrc: false,
-      sourceMaps: "both",
-      ast: false,
-    }));
-  }
+  const result = babel.transform(code, Object.assign(opts, {
+    // Do not process config files since has already been done with the OptionManager
+    // calls above and would introduce duplicates.
+    babelrc: false,
+    sourceMaps: "both",
+    ast: false,
+  }));
 
   if (cache) {
     cache[cacheKey] = result;

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -10,7 +10,7 @@ import path from "path";
 
 const maps = {};
 const transformOpts = {};
-let revert = null;
+let piratesRevert = null;
 
 sourceMapSupport.install({
   handleUncaughtExceptions: false,
@@ -82,8 +82,13 @@ function compile(code, filename) {
 }
 
 function hookExtensions(exts) {
-  if (revert) revert();
-  revert = addHook(compile, { exts, ignoreNodeModules: false });
+  if (piratesRevert) piratesRevert();
+  piratesRevert = addHook(compile, { exts, ignoreNodeModules: false });
+}
+
+export function revert() {
+  if (piratesRevert) piratesRevert();
+  delete require.cache[require.resolve(__filename)];
 }
 
 register({

--- a/packages/babel-register/test/__data__/es2015.js
+++ b/packages/babel-register/test/__data__/es2015.js
@@ -1,0 +1,3 @@
+import a from "assert";
+
+export default () => { a.foo(); return "b"; };

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import fs from "fs";
+import path from "path";
+import decache from "decache";
+
+const testCacheFilename = path.join(__dirname, ".babel");
+const oldBabelDisableCacheValue = process.env.BABEL_DISABLE_CACHE;
+
+process.env.BABEL_CACHE_PATH = testCacheFilename;
+delete process.env.BABEL_DISABLE_CACHE;
+
+function writeCache(data) {
+  if (typeof data === "object") {
+    data = JSON.stringify(data);
+  }
+
+  fs.writeFileSync(testCacheFilename, data);
+}
+
+function cleanCache() {
+
+  try {
+    fs.unlinkSync(testCacheFilename);
+  } catch (e) {
+    // It is convenient to always try to clear
+  }
+}
+
+function resetCache() {
+  process.env.BABEL_CACHE_PATH = null;
+  process.env.BABEL_DISABLE_CACHE = oldBabelDisableCacheValue;
+}
+
+describe("babel register", () => {
+
+  describe("cache", () => {
+    let load, get, save;
+
+    beforeEach(() => {
+      // Since lib/cache is a singleton we need to fully reload it
+      decache("../lib/cache");
+      const cache = require("../lib/cache");
+
+      load = cache.load;
+      get = cache.get;
+      save = cache.save;
+    });
+
+    afterEach(cleanCache);
+    after(resetCache);
+
+    it("should load and get cached data", () => {
+      writeCache({ foo: "bar" });
+
+      load();
+
+      expect(get()).to.be.an("object");
+      expect(get()).to.deep.equal({ foo: "bar" });
+    });
+
+    it("should load and get an object with no cached data", () => {
+      load();
+
+      expect(get()).to.be.an("object");
+      expect(get()).to.deep.equal({});
+    });
+
+    it("should load and get an object with invalid cached data", () => {
+      writeCache("foobar");
+
+      load();
+
+      expect(get()).to.be.an("object");
+      expect(get()).to.deep.equal({});
+    });
+
+    it("should create the cache on save", () => {
+      save();
+
+      expect(fs.existsSync(testCacheFilename)).to.be.true;
+      expect(get()).to.deep.equal({});
+    });
+  });
+});

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -1,11 +1,12 @@
-import assert from "assert";
+import chai from "chai";
 import path from "path";
 import decache from "decache";
 
 const DATA_ES2015 = require.resolve("./__data__/es2015");
 
 describe("babel-register", function () {
-  let babelRegister = null;
+  let babelRegister;
+  let oldCompiler;
 
   function setupRegister(config) {
     babelRegister = require("../lib/node");
@@ -23,23 +24,31 @@ describe("babel-register", function () {
     }
   }
 
+  before(() => {
+    const js = require("default-require-extensions/js");
+    oldCompiler = require.extensions[".js"];
+    require.extensions[".js"] = js;
+  });
+
+  after(() => {
+    require.extensions[".js"] = oldCompiler;
+  });
+
   afterEach(() => {
     revertRegister();
     decache(DATA_ES2015);
   });
 
-  it("basic usage", function () {
+  it("registers correctly", () => {
     setupRegister();
 
-    assert.ok(require(DATA_ES2015).default);
+    chai.expect(require(DATA_ES2015)).to.be.ok;
   });
 
   it("reverts correctly", () => {
     setupRegister();
     revertRegister();
 
-    assert.throws(function () {
-      require(DATA_ES2015);
-    }, SyntaxError);
+    chai.expect(() => { require(DATA_ES2015); }).to.throw(SyntaxError);
   });
 });

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -8,12 +8,11 @@ describe("babel-register", function () {
   let babelRegister;
   let oldCompiler;
 
-  function setupRegister(config) {
+  function setupRegister(config = {}) {
     babelRegister = require("../lib/node");
     babelRegister.default(Object.assign({
       presets: [path.join(__dirname, "../../babel-preset-es2015")],
       babelrc: false,
-      only: ["__data__"],
     }, config));
   }
 
@@ -47,6 +46,10 @@ describe("babel-register", function () {
 
   it("reverts correctly", () => {
     setupRegister();
+
+    chai.expect(require(DATA_ES2015)).to.be.ok;
+    decache(DATA_ES2015);
+
     revertRegister();
 
     chai.expect(() => { require(DATA_ES2015); }).to.throw(SyntaxError);


### PR DESCRIPTION
This is the follow up for #3139 and #3609 

This uses pirates for registering the module extension and adds basic tests

https://github.com/ariporad/pirates/pull/27
