### PR TITLE
Stop traversing when the callback returns true.

### DIFF
--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -28,7 +28,7 @@ export function _call(fns?: Array<Function>): boolean {
     if (!node) return true;
 
     let ret = fn.call(this.state, this, this.state);
-    if (ret) throw new Error(`Unexpected return value from visitor method ${fn}`);
+    if (ret) return;
 
     // node has been replaced, it will have been requeued
     if (this.node !== node) return true;

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -28,7 +28,7 @@ export function _call(fns?: Array<Function>): boolean {
     if (!node) return true;
 
     let ret = fn.call(this.state, this, this.state);
-    if (ret) return;
+    if (ret) return true;
 
     // node has been replaced, it will have been requeued
     if (this.node !== node) return true;


### PR DESCRIPTION
It seems most of the traverse implementation stop the traverse when the callback return true. Is this the case for babel traverse?