### PR TITLE
Add async-functions to ES2017 to ensure it is active

### DIFF
--- a/packages/babel-preset-es2017/index.js
+++ b/packages/babel-preset-es2017/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: [
+    require("babel-plugin-syntax-async-functions"),
     require("babel-plugin-syntax-trailing-function-commas"),
     require("babel-plugin-transform-async-to-generator")
   ]

--- a/packages/babel-preset-es2017/package.json
+++ b/packages/babel-preset-es2017/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2017",
   "main": "index.js",
   "dependencies": {
+    "babel-plugin-syntax-async-functions": "^6.8.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0"
   }


### PR DESCRIPTION
This is a little bit paranoid 🤓, but currently the minimum babylon version is set to ^6.9.0.
The ES2017 plugins in babylon are activated by default with 6.9.1.
And the ES2017 preset does only include the syntax plugin for trailing function comma, but not for async functions.

This means depending if es2017 is used together with babylon 6.9.0 or .1 it does something different.

It probably doesn't mater, but to make sure that async function are enabled for the ES2017 preset I added the syntax plugin for async functions. I could have also raised the version of babylon, but this seems more correct to me.

Thoughts?