### PR TITLE
Wait for file write to finish before recompiling, fix T7411

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -71,7 +71,8 @@ module.exports = function (commander, filenames) {
     _.each(filenames, function (dirname) {
       let watcher = chokidar.watch(dirname, {
         persistent: true,
-        ignoreInitial: true
+        ignoreInitial: true,
+        awaitWriteFinish: true
       });
 
       _.each(["add", "change"], function (type) {


### PR DESCRIPTION
Linked issue: https://phabricator.babeljs.io/T7411

Related chokidar issue: https://github.com/paulmillr/chokidar/issues/365