### PR TITLE
babel-preset-stage-2: Add transform-unicode-property-regex

### DIFF
--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -8,9 +8,10 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
   "main": "lib/index.js",
   "dependencies": {
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-plugin-transform-decorators": "^6.22.0",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-unicode-property-regex": "^2.0.0",
     "babel-preset-stage-3": "^6.22.0"
   }
 }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -1,8 +1,9 @@
 import presetStage3 from "babel-preset-stage-3";
 
+import syntaxDynamicImport from "babel-plugin-syntax-dynamic-import";
 import transformClassProperties from "babel-plugin-transform-class-properties";
 import transformDecorators from "babel-plugin-transform-decorators";
-import syntaxDynamicImport from "babel-plugin-syntax-dynamic-import";
+import transformUnicodePropertyRegex from "babel-plugin-transform-unicode-property-regex";
 
 export default {
   presets: [
@@ -11,6 +12,7 @@ export default {
   plugins: [
     syntaxDynamicImport,
     transformClassProperties,
-    transformDecorators
+    transformDecorators,
+    transformUnicodePropertyRegex
   ]
 };


### PR DESCRIPTION
**Note:** This transform depends on [regexpu-core](https://github.com/mathiasbynens/regexpu-core) which supports Node.js v4+ only. So, this patch is blocked by https://phabricator.babeljs.io/T7392 / #4315.

---

This enables the use of Unicode property escapes of the form `\p{…}` and `\P{…}` in regular expressions with the `u` flag enabled.
- More info: https://mathiasbynens.be/notes/es-unicode-property-escapes
- Proposal: https://github.com/mathiasbynens/es-regexp-unicode-property-escapes
- Plugin: https://github.com/mathiasbynens/babel-plugin-transform-unicode-property-regex
- PR with docs: https://github.com/babel/babel.github.io/pull/904
