### PR TITLE
Added Eclipse IDE paths to .gitignore. Improved CONTRIBUTING doco.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,28 @@
+# OS Specific
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE Specific
+nbproject
+.~lock.*
+.buildpath
+.idea
+composer.lock
+*.sublime-workspace
+*.swp
+*.swo
+/.settings/
+/.project
+
+# Project Specific
 node_modules
-test/tmp
 *.log
+test/tmp
 *.cache
 /templates.json
 /tests.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,12 @@ If you wish to build a copy of Babel for distribution, then run:
 $ make build-dist
 ```
 
-and access the files from `packages/babel-core/dist`.
+and access the built files for individual packages from `packages/<package-name>/lib`.
+
+The "top-level" package is `babel-cli`.  Accordingly, its built files live in `packages/babel-cli/lib`.
+In addition, various entry point scripts live in the top-level package at `packages/babel-cli/bin`.
+These are the shell-executable utility scripts, `babel-doctor.js`, `babel-external-helpers.js` and `babel-node.js`, and the main Babel transpiler command line script, `babel.js` itself.
+
 
 #### Running tests
 

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -292,6 +292,14 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
  - `id` (required)
  - `body` (required)
 
+### t.declareModuleExports(typeAnnotation)
+
+See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
+
+Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+
+ - `typeAnnotation` (required)
+
 ### t.declareTypeAlias(id, typeParameters, right)
 
 See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.


### PR DESCRIPTION
Pretty much as per subject line + organised .gitignore in sections using project lerna as a guide.

The information in CONTRIBUTING.md re where to find build files was out of date and misleading for newbees to the project. Corrected & expanded upon this paragraph after spending too long trying to follow the legacy instructions.