### PR TITLE
Allow overwritting of sourceRoot

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -48,10 +48,11 @@ function compile(filename) {
   let result;
 
   // merge in base options and resolve all the plugins and presets relative to this file
-  let opts = new OptionManager().init(extend(deepClone(transformOpts), {
-    filename,
-    sourceRoot: path.dirname(filename)
-  }));
+  let opts = new OptionManager().init(extend(
+    { sourceRoot: path.dirname(filename) }, // sourceRoot can be overwritten
+    deepClone(transformOpts),
+    { filename }
+  ));
 
   let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
 


### PR DESCRIPTION
There was an issue raised here: https://phabricator.babeljs.io/rBC54115fbdae875206e4ef6f0e76c7132568045ea4

This change allows sourceRoot to be overwritten.