### PR TITLE
Fix `typeof Symbol.prototype`

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -9,7 +9,7 @@ helpers.typeof = template(`
   (typeof Symbol === "function" && typeof Symbol.iterator === "symbol")
     ? function (obj) { return typeof obj; }
     : function (obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype
           ? "symbol"
           : typeof obj;
       };

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -8,7 +8,11 @@ export default helpers;
 helpers.typeof = template(`
   (typeof Symbol === "function" && typeof Symbol.iterator === "symbol")
     ? function (obj) { return typeof obj; }
-    : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+    : function (obj) {
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol
+          ? "symbol"
+          : typeof obj;
+      };
 `);
 
 helpers.jsx = template(`

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/shadow/expected.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/shadow/expected.js
@@ -1,4 +1,4 @@
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _Symbol = foo();
 typeof s === "undefined" ? "undefined" : _typeof(s);

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/exec.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/exec.js
@@ -1,3 +1,4 @@
 var s = Symbol("s");
 assert.equal(typeof s, "symbol");
 assert.ok(typeof s === "symbol");
+assert.ok(typeof Symbol.prototype === 'object', "`typeof Symbol.prototype` should be 'object'");


### PR DESCRIPTION
fix `typeof Symbol.prototype`

Babel uses a helper function to return the correct value for `typeof
obj` when obj is a Symbol and support for Symbol has been polyfilled.

This function assumes that `obj.constructor === Symbol` implies `typeof
obj === 'symbol'`.

This isn't true when obj is `Symbol.prototype`. In that case (REPL from
node 6, the same holds in Firefox):

```
> Symbol.prototype.constructor === Symbol
true
> typeof Symbol.prototype
'object'
>
```

AFAICS, that's the only case where the assumption doesn't hold.

The test added by this patch fails only on node 0.10, as 0.12 already
has a native implementation of Symbol and the polyfill code doesn't run.

This caused a problem in core-js when it's compiled with babel (the
issue was isolated by @skozin here:
https://github.com/zloirock/core-js/issues/189#issuecomment-209864582).