### PR TITLE
Upgrades of various 'requires' in babel/xxx-packages to ES2015 module import syntax.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,28 @@
+# OS Specific
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE Specific
+nbproject
+.~lock.*
+.buildpath
+.idea
+composer.lock
+*.sublime-workspace
+*.swp
+*.swo
+/.settings/
+/.project
+
+# Project Specific
 node_modules
-test/tmp
 *.log
+test/tmp
 *.cache
 /templates.json
 /tests.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,12 @@ If you wish to build a copy of Babel for distribution, then run:
 $ make build-dist
 ```
 
-and access the files from `packages/babel-core/dist`.
+and access the built files for individual packages from `packages/<package-name>/lib`.
+
+The "top-level" package is `babel-cli`.  Accordingly, its built files live in `packages/babel-cli/lib`.
+In addition, various entry point scripts live in the top-level package at `packages/babel-cli/bin`.
+These are the shell-executable utility scripts, `babel-doctor.js`, `babel-external-helpers.js` and `babel-node.js`, and the main Babel transpiler command line script, `babel.js` itself.
+
 
 #### Running tests
 

--- a/packages/babel-plugin-transform-async-functions/src/index.js
+++ b/packages/babel-plugin-transform-async-functions/src/index.js
@@ -1,5 +1,7 @@
+import { default as syntaxAsyncFunctions } from "babel-plugin-syntax-async-functions";
+
 export default function () {
   return {
-    inherits: require("babel-plugin-syntax-async-functions")
+    inherits: syntaxAsyncFunctions
   };
 }

--- a/packages/babel-plugin-transform-async-to-generator/src/index.js
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.js
@@ -1,8 +1,9 @@
+import { default as syntaxAsyncFunctions } from "babel-plugin-syntax-async-functions";
 import remapAsyncToGenerator from "babel-helper-remap-async-to-generator";
 
 export default function () {
   return {
-    inherits: require("babel-plugin-syntax-async-functions"),
+    inherits: syntaxAsyncFunctions,
 
     visitor: {
       Function(path, state) {

--- a/packages/babel-plugin-transform-async-to-module-method/src/index.js
+++ b/packages/babel-plugin-transform-async-to-module-method/src/index.js
@@ -1,8 +1,9 @@
+import { default as syntaxAsyncFunctions } from "babel-plugin-syntax-async-functions";
 import remapAsyncToGenerator from "babel-helper-remap-async-to-generator";
 
 export default function () {
   return {
-    inherits: require("babel-plugin-syntax-async-functions"),
+    inherits: syntaxAsyncFunctions,
 
     visitor: {
       Function(path, state) {

--- a/packages/babel-plugin-transform-class-constructor-call/src/index.js
+++ b/packages/babel-plugin-transform-class-constructor-call/src/index.js
@@ -1,3 +1,4 @@
+import { default as syntaxClassConstructorCall } from "babel-plugin-syntax-class-constructor-call";
 import template from "babel-template";
 
 let buildWrapper = template(`
@@ -50,7 +51,7 @@ export default function ({ types: t }) {
   }
 
   return {
-    inherits: require("babel-plugin-syntax-class-constructor-call"),
+    inherits: syntaxClassConstructorCall,
 
     visitor: {
       Class(path) {

--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -1,5 +1,6 @@
 /* eslint max-len: 0 */
 // todo: define instead of assign
+import { default as syntaxClassProperties } from "babel-plugin-syntax-class-properties";
 import nameFunction from "babel-helper-function-name";
 
 export default function ({ types: t }) {
@@ -21,7 +22,7 @@ export default function ({ types: t }) {
   };
 
   return {
-    inherits: require("babel-plugin-syntax-class-properties"),
+    inherits: syntaxClassProperties,
 
     visitor: {
       Class(path) {

--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -1,3 +1,4 @@
+import { default as syntaxDecorators } from "babel-plugin-syntax-decorators";
 import template from "babel-template";
 import explodeClass from "babel-helper-explode-class";
 
@@ -88,7 +89,7 @@ The repo url is: https://github.com/loganfsmyth/babel-plugin-transform-decorator
   }
 
   return {
-    inherits: require("babel-plugin-syntax-decorators"),
+    inherits: syntaxDecorators,
 
     visitor: {
       ClassExpression(path) {

--- a/packages/babel-plugin-transform-do-expressions/src/index.js
+++ b/packages/babel-plugin-transform-do-expressions/src/index.js
@@ -1,6 +1,8 @@
+import { default as syntaxDoExpressions } from "babel-plugin-syntax-do-expressions";
+
 export default function () {
   return {
-    inherits: require("babel-plugin-syntax-do-expressions"),
+    inherits: syntaxDoExpressions,
 
     visitor: {
       DoExpression(path) {

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -1,3 +1,4 @@
+import { default as transformES2015ModulesCommonJS } from "babel-plugin-transform-es2015-modules-commonjs";
 import template from "babel-template";
 
 let buildDefine = template(`
@@ -58,7 +59,7 @@ export default function ({ types: t }) {
   };
 
   return {
-    inherits: require("babel-plugin-transform-es2015-modules-commonjs"),
+    inherits: transformES2015ModulesCommonJS,
 
     pre() {
       // source strings

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -1,6 +1,7 @@
 /* eslint max-len: 0 */
 
 import { basename, extname } from "path";
+import { default as transformStrictMode } from "babel-plugin-transform-strict-mode";
 import template from "babel-template";
 import * as t from "babel-types";
 
@@ -125,7 +126,7 @@ export default function () {
   };
 
   return {
-    inherits: require("babel-plugin-transform-strict-mode"),
+    inherits: transformStrictMode,
 
     visitor: {
       ThisExpression(path, state) {

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -1,6 +1,7 @@
 /* eslint max-len: 0 */
 
 import { basename, extname } from "path";
+import { default as transformES2015ModulesAMD } from "babel-plugin-transform-es2015-modules-amd";
 import template from "babel-template";
 
 let buildPrerequisiteAssignment = template(`
@@ -44,7 +45,7 @@ export default function ({ types: t }) {
   }
 
   return {
-    inherits: require("babel-plugin-transform-es2015-modules-amd"),
+    inherits: transformES2015ModulesAMD,
 
     visitor: {
       Program: {

--- a/packages/babel-plugin-transform-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/src/index.js
@@ -1,8 +1,9 @@
+import { default as syntaxExponentiationOperator } from "babel-plugin-syntax-exponentiation-operator";
 import build from "babel-helper-builder-binary-assignment-operator-visitor";
 
 export default function ({ types: t }) {
   return {
-    inherits: require("babel-plugin-syntax-exponentiation-operator"),
+    inherits: syntaxExponentiationOperator,
 
     visitor: build({
       operator: "**",

--- a/packages/babel-plugin-transform-export-extensions/src/index.js
+++ b/packages/babel-plugin-transform-export-extensions/src/index.js
@@ -1,3 +1,5 @@
+import { default as syntaxExportExtensions } from "babel-plugin-syntax-export-extensions";
+
 export default function ({ types: t }) {
   function build(node, nodes, scope) {
     let first = node.specifiers[0];
@@ -20,7 +22,7 @@ export default function ({ types: t }) {
   }
 
   return {
-    inherits: require("babel-plugin-syntax-export-extensions"),
+    inherits: syntaxExportExtensions,
 
     visitor: {
       ExportNamedDeclaration(path) {

--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -1,3 +1,5 @@
+import { default as syntaxFlow } from "babel-plugin-syntax-flow";
+
 export default function ({ types: t }) {
   function wrapInFlowComment(path, parent) {
     path.addComment("trailing", generateComment(path, parent));
@@ -12,7 +14,7 @@ export default function ({ types: t }) {
   }
 
   return {
-    inherits: require("babel-plugin-syntax-flow"),
+    inherits: syntaxFlow,
 
     visitor: {
       TypeCastExpression(path) {

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -1,8 +1,10 @@
+import { default as syntaxFlow } from "babel-plugin-syntax-flow";
+
 export default function ({ types: t }) {
   const FLOW_DIRECTIVE = "@flow";
 
   return {
-    inherits: require("babel-plugin-syntax-flow"),
+    inherits: syntaxFlow,
 
     visitor: {
       Program(path, { file: { ast: { comments } } }) {

--- a/packages/babel-plugin-transform-function-bind/src/index.js
+++ b/packages/babel-plugin-transform-function-bind/src/index.js
@@ -1,3 +1,5 @@
+import { default as syntaxFunctionBind } from "babel-plugin-syntax-function-bind";
+
 export default function ({ types: t }) {
   function getTempId(scope) {
     let id = scope.path.getData("functionBind");
@@ -29,7 +31,7 @@ export default function ({ types: t }) {
   }
 
   return {
-    inherits: require("babel-plugin-syntax-function-bind"),
+    inherits: syntaxFunctionBind,
 
     visitor: {
       CallExpression({ node, scope }) {

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -1,3 +1,5 @@
+import { default as syntaxObjectRestSpread } from "babel-plugin-syntax-object-rest-spread";
+
 export default function ({ types: t }) {
   function hasSpread(node) {
     for (let prop of (node.properties: Array<Object>)) {
@@ -9,7 +11,7 @@ export default function ({ types: t }) {
   }
 
   return {
-    inherits: require("babel-plugin-syntax-object-rest-spread"),
+    inherits: syntaxObjectRestSpread,
 
     visitor: {
       ObjectExpression(path, file) {

--- a/packages/babel-plugin-transform-react-jsx-compat/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-compat/src/index.js
@@ -1,10 +1,12 @@
+import { default as helperBuilderReactJSX } from "babel-helper-builder-react-jsx";
+
 export default function ({ types: t }) {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");
     },
 
-    visitor: require("babel-helper-builder-react-jsx")({
+    visitor: helperBuilderReactJSX({
       pre(state) {
         state.callee = state.tagExpr;
       },

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -1,9 +1,12 @@
 /* eslint max-len: 0 */
 
+import { default as helperBuilderReactJSX } from "babel-helper-builder-react-jsx";
+import { default as syntaxJSX } from "babel-plugin-syntax-jsx";
+
 export default function ({ types: t }) {
   let JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
 
-  let visitor = require("babel-helper-builder-react-jsx")({
+  let visitor = helperBuilderReactJSX({
     pre(state) {
       let tagName = state.tagName;
       let args    = state.args;
@@ -44,7 +47,7 @@ export default function ({ types: t }) {
   };
 
   return {
-    inherits: require("babel-plugin-syntax-jsx"),
+    inherits: syntaxJSX,
     visitor
   };
 }

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -292,6 +292,14 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
  - `id` (required)
  - `body` (required)
 
+### t.declareModuleExports(typeAnnotation)
+
+See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
+
+Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+
+ - `typeAnnotation` (required)
+
 ### t.declareTypeAlias(id, typeParameters, right)
 
 See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.


### PR DESCRIPTION
Upgraded index.js src files in 18 packages to use ES2015 module import syntax in lieu of the legacy usages of 'require()'. This was only done in cases where the imported module was already using ES2015 export syntax.
