### PR TITLE
Use plain js to do the pre/postpublish for the polyfill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ lint:
 clean: test-clean
 	rm -rf packages/*/lib
 	rm -rf packages/babel-polyfill/browser*
+	rm -rf packages/babel-polyfill/dist
 	rm -rf coverage
 	rm -rf packages/*/npm-debug*
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "readline-sync": "^1.2.19",
     "rimraf": "^2.4.3",
     "semver": "^5.0.0",
-    "shelljs": "^0.7.4",
     "through2": "^2.0.0",
     "uglify-js": "^2.4.16"
   },

--- a/packages/babel-polyfill/scripts/postpublish.js
+++ b/packages/babel-polyfill/scripts/postpublish.js
@@ -1,1 +1,7 @@
-rm(__dirname + "/../browser.js");
+var fs = require("fs");
+var path = require("path");
+
+try {
+  fs.unlinkSync(path.join(__dirname, "../browser.js"));
+} catch (err) {}
+

--- a/packages/babel-polyfill/scripts/prepublish.js
+++ b/packages/babel-polyfill/scripts/prepublish.js
@@ -1,7 +1,8 @@
-require("shelljs/global");
+var fs = require("fs");
+var path = require("path");
 
 function relative(loc) {
-  return __dirname + "/../" + loc;
+  return path.join(__dirname, "..", loc);
 }
 
-cp(relative("dist/polyfill.min.js"), relative("browser.js"));
+fs.writeFileSync(relative("browser.js"), fs.readFileSync(relative("dist/polyfill.min.js")));


### PR DESCRIPTION
We only use shelljs for these two scripts, so it is not really necessary I think.