### PR TITLE
Watch mode should wait for file write. (T7411)

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -71,7 +71,11 @@ module.exports = function (commander, filenames) {
     _.each(filenames, function (dirname) {
       let watcher = chokidar.watch(dirname, {
         persistent: true,
-        ignoreInitial: true
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 50,
+          pollInterval: 10,
+        }
       });
 
       _.each(["add", "change"], function (type) {

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -138,7 +138,11 @@ module.exports = function (commander, filenames, opts) {
       let chokidar = util.requireChokidar();
       chokidar.watch(filenames, {
         persistent: true,
-        ignoreInitial: true
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 50,
+          pollInterval: 10,
+        }
       }).on("all", function (type, filename) {
         if (util.shouldIgnore(filename) || !util.canCompile(filename, commander.extensions)) return;
 


### PR DESCRIPTION
https://phabricator.babeljs.io/T7411#81534

The problem is that some editors (e.g. VScode) saves by truncating the file then writing. There's a race condition where
1. Editor truncates the file.
2. File system sends change event, and Babel compiles the empty file
3. Editor writes the file.

I am only seeing this problem happening with the combination of VSCode and Linux.

Fixing this problem would require adding `awaitWriteFinish` to chokidar's watch command.

Not sure what default would work well for everybody. I am using 50ms stability threshold and 10ms polling intervals, which seems to behave well in my case.
