### PR TITLE
babel-code-frame: babel-runtime not necessary

### DIFF
--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.0.0",
     "chalk": "^1.1.0",
     "esutils": "^2.0.2",
     "js-tokens": "^2.0.0"


### PR DESCRIPTION
Nothing in the src uses it, and transpiling on the repl gives the same resulting diff