### PR TITLE
Add support for preset organization shortcuts

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -260,6 +260,17 @@ export default class OptionManager {
       let presetLoc;
       if (typeof val === "string") {
         presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+
+        // trying to resolve @organization shortcat
+        // @foo/es2015 -> @foo/babel-preset-es2015
+        if (!presetLoc) {
+          let matches = val.match(/^(@[^/]+)\/(.+)$/);
+          if (matches) {
+            let [, orgName, presetPath] = matches;
+            presetLoc = resolve(`${orgName}/babel-preset-${presetPath}`, dirname);
+          }
+        }
+
         if (!presetLoc) {
           throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ` +
             JSON.stringify(dirname));

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -258,45 +258,53 @@ export default class OptionManager {
       }
 
       let presetLoc;
-      if (typeof val === "string") {
-        presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+      try {
+        if (typeof val === "string") {
+          presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
 
-        // trying to resolve @organization shortcat
-        // @foo/es2015 -> @foo/babel-preset-es2015
-        if (!presetLoc) {
-          let matches = val.match(/^(@[^/]+)\/(.+)$/);
-          if (matches) {
-            let [, orgName, presetPath] = matches;
-            presetLoc = resolve(`${orgName}/babel-preset-${presetPath}`, dirname);
+          // trying to resolve @organization shortcat
+          // @foo/es2015 -> @foo/babel-preset-es2015
+          if (!presetLoc) {
+            let matches = val.match(/^(@[^/]+)\/(.+)$/);
+            if (matches) {
+              let [, orgName, presetPath] = matches;
+              val = `${orgName}/babel-preset-${presetPath}`;
+              presetLoc = resolve(val, dirname);
+            }
           }
+
+          if (!presetLoc) {
+            throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ` +
+              JSON.stringify(dirname));
+          }
+
+          val = require(presetLoc);
         }
 
-        if (!presetLoc) {
-          throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ` +
-            JSON.stringify(dirname));
+        // For compatibility with babel-core < 6.13.x, allow presets to export an object with a
+        // a 'buildPreset' function that will return the preset itself, while still exporting a
+        // simple object (rather than a function), for supporting old Babel versions.
+        if (typeof val === "object" && val.buildPreset) val = val.buildPreset;
+
+
+        if (typeof val !== "function" && options !== undefined) {
+          throw new Error(`Options ${JSON.stringify(options)} passed to ` +
+            (presetLoc || "a preset") + " which does not accept options.");
         }
 
-        val = require(presetLoc);
+        if (typeof val === "function") val = val(context, options);
+
+        if (typeof val !== "object") {
+          throw new Error(`Unsupported preset format: ${val}.`);
+        }
+
+        onResolve && onResolve(val, presetLoc);
+      } catch (e) {
+        if (presetLoc) {
+          e.message += ` (While processing preset: ${JSON.stringify(presetLoc)})`;
+        }
+        throw e;
       }
-
-      // For compatibility with babel-core < 6.13.x, allow presets to export an object with a
-      // a 'buildPreset' function that will return the preset itself, while still exporting a
-      // simple object (rather than a function), for supporting old Babel versions.
-      if (typeof val === "object" && val.buildPreset) val = val.buildPreset;
-
-
-      if (typeof val !== "function" && options !== undefined) {
-        throw new Error(`Options ${JSON.stringify(options)} passed to ` +
-          (presetLoc || "a preset") + " which does not accept options.");
-      }
-
-      if (typeof val === "function") val = val(context, options);
-
-      if (typeof val !== "object") {
-        throw new Error(`Unsupported preset format: ${val}.`);
-      }
-
-      onResolve && onResolve(val);
       return val;
     });
   }

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -185,12 +185,26 @@ suite("api", function () {
 
   });
 
-  test("preset shortcut doesn\'t throw errors", function () {
-    return transformAsync("", {
-      presets: ["@babel/es2015", "@babel/react/optimizations"]
-    }).then(function (result) {
-      assert.ok(result.options.presets);
-    });
+    test("handles preset shortcuts (adds babel-preset-)", function () {
+    return assert.throws(
+      function () {
+        babel.transform("", {
+          presets: ["@babel/es2015"]
+        });
+      },
+      /Couldn\'t find preset \"\@babel\/babel\-preset\-es2015\" relative to directory/
+    );
+  });
+
+  test("handles preset shortcuts 2 (adds babel-preset-)", function () {
+    return assert.throws(
+      function () {
+        babel.transform("", {
+          presets: ["@babel/react/optimizations"]
+        });
+      },
+      /Couldn\'t find preset \"\@babel\/babel\-preset\-react\/optimizations\" relative to directory/
+    );
   });
 
   test("source map merging", function () {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -185,6 +185,14 @@ suite("api", function () {
 
   });
 
+  test("preset shortcut doesn\'t throw errors", function () {
+    return transformAsync("", {
+      presets: ["@babel/es2015", "@babel/react/optimizations"]
+    }).then(function (result) {
+      assert.ok(result.options.presets);
+    });
+  });
+
   test("source map merging", function () {
     var result = babel.transform([
       'function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }',


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added? | no
| Fixed tickets     | #4362
| License           | MIT
| Doc PR            | nope

This change allows use 
```json
{
  "prests": ["@org/react"]
}
```
instead of 

```json
{
  "prests": ["@org/babel-preset-react"]
}
```
