### PR TITLE
Correctly pass the strictMode option

### DIFF
--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -26,11 +26,13 @@ Object.defineProperty(module.exports, "buildPreset", {
 function preset(context, opts) {
   const moduleTypes = ["commonjs", "amd", "umd", "systemjs"];
   let loose = false;
+  let strictMode = undefined;
   let modules = "commonjs";
   let spec = false;
 
   if (opts !== undefined) {
     if (opts.loose !== undefined) loose = opts.loose;
+    if (opts.strictMode !== undefined) strictMode = opts.strictMode;
     if (opts.modules !== undefined) modules = opts.modules;
     if (opts.spec !== undefined) spec = opts.spec;
   }
@@ -63,7 +65,7 @@ function preset(context, opts) {
       [require("babel-plugin-transform-es2015-destructuring"), { loose }],
       require("babel-plugin-transform-es2015-block-scoping"),
       require("babel-plugin-transform-es2015-typeof-symbol"),
-      modules === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose }],
+      modules === "commonjs" && [require("babel-plugin-transform-es2015-modules-commonjs"), { loose, strictMode }],
       modules === "systemjs" && [require("babel-plugin-transform-es2015-modules-systemjs"), { loose }],
       modules === "amd" && [require("babel-plugin-transform-es2015-modules-amd"), { loose }],
       modules === "umd" && [require("babel-plugin-transform-es2015-modules-umd"), { loose }],


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | 
| License           | MIT
| Doc PR            | 

**babel-plugin-transform-es2015-modules-commonjs** inherits from **babel-plugin-transform-strict-mode** which, following #3562, will regard the `strictMode` option but the presets file does not pass that option to the plugin at all. This commit will have the option to reach the plugin.