### PR TITLE
Remove ES2015 tests than do not parse in ES2016

### DIFF
--- a/packages/babel-preset-es2015/test/fixtures/traceur/Misc/PrependStatement.js
+++ b/packages/babel-preset-es2015/test/fixtures/traceur/Misc/PrependStatement.js
@@ -9,10 +9,3 @@ var o = {
 function f({x}) {}
 f(o);
 assert.equal(1, count);
-
-count = 0;
-function g({x}) {
-  'use strict';
-}
-g(o);
-assert.equal(1, count);

--- a/packages/babel-preset-es2015/test/fixtures/traceur/Syntax/ParamDuplicateCheckOk.js
+++ b/packages/babel-preset-es2015/test/fixtures/traceur/Syntax/ParamDuplicateCheckOk.js
@@ -1,11 +1,3 @@
-function f(x, y = function(x) {}) {
-  'use strict';
-}
-
-var f2 = (x, y = function(x) {}) => {
-  'use strict';
-};
-
 function g() {
   'use strict';
   function h(x, y = function(x) {}) {


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes (ES2016)
| Tests added/pass? | yes
| Fixed tickets     | babel/babylon#106
| License           | MIT
| Doc PR            | none

<!-- Describe your changes below in as much detail as possible -->

The test fragments contain code that are valid ES2015 programs, but not valid ES2016 ones (they were originally from Traceur, which does not fully support ES2016). To support the ES2016 semantics in Babylon (babel/babylon#106), these tests must be removed.

Specifically, per e.g. [ECMA-262 7<sup>th</sup> Edition §&nbsp;14.1.2](http://www.ecma-international.org/ecma-262/7.0/#sec-function-definitions-static-semantics-early-errors):

> It is a Syntax Error if ContainsUseStrict of *FunctionBody* is **true** and IsSimpleParameterList of *FormalParameters* is **false**.

Similar clauses cover [arrow functions](http://www.ecma-international.org/ecma-262/7.0/#sec-arrow-function-definitions-static-semantics-early-errors), [methods](http://www.ecma-international.org/ecma-262/7.0/#sec-method-definitions-static-semantics-early-errors), and [generator functions/methods](http://www.ecma-international.org/ecma-262/7.0/#sec-generator-function-definitions-static-semantics-early-errors), as well as [async functions](https://tc39.github.io/ecmascript-asyncawait/#async-decls-exprs-static-semantics-early-errors) and [async arrow functions](https://tc39.github.io/ecmascript-asyncawait/#async-arrows-static-semantics-early-errors).