### PR TITLE
Make special case for class property initializers in `shadow-functions`

### DIFF
--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -17,7 +17,7 @@ const superVisitor = {
 
 export default new Plugin({
   name: "internal.shadowFunctions",
-  
+
   visitor: {
     ThisExpression(path) {
       remap(path, "this");
@@ -49,21 +49,25 @@ function remap(path, key) {
   let currentFunction;
   let passedShadowFunction = false;
 
-  let fnPath = path.findParent(function (path) {
-    if (path.isProgram() || path.isFunction()) {
+  let fnPath = path.find(function (innerPath) {
+    if (innerPath.parentPath && innerPath.parentPath.isClassProperty() && innerPath.key === "value") {
+      return true;
+    }
+    if (path === innerPath) return false;
+    if (innerPath.isProgram() || innerPath.isFunction()) {
       // catch current function in case this is the shadowed one and we can ignore it
-      currentFunction = currentFunction || path;
+      currentFunction = currentFunction || innerPath;
     }
 
-    if (path.isProgram()) {
+    if (innerPath.isProgram()) {
       passedShadowFunction = true;
 
       return true;
-    } else if (path.isFunction() && !path.isArrowFunctionExpression()) {
+    } else if (innerPath.isFunction() && !innerPath.isArrowFunctionExpression()) {
       if (shadowFunction) {
-        if (path === shadowFunction || path.node === shadowFunction.node) return true;
+        if (innerPath === shadowFunction || innerPath.node === shadowFunction.node) return true;
       } else {
-        if (!path.is("shadow")) return true;
+        if (!innerPath.is("shadow")) return true;
       }
 
       passedShadowFunction = true;

--- a/packages/babel-core/test/fixtures/transformation/misc/class-property-initializer-blocks-shadow/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/class-property-initializer-blocks-shadow/actual.js
@@ -1,0 +1,10 @@
+class A {
+  prop1 = () => this;
+  static prop2 = () => this;
+  prop3 = () => arguments;
+  static prop4 = () => arguments;
+  prop5 = this;
+  static prop6 = this;
+  prop7 = arguments;
+  static prop8 = arguments;
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/class-property-initializer-blocks-shadow/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/class-property-initializer-blocks-shadow/expected.js
@@ -1,0 +1,10 @@
+class A {
+  prop1 = () => this;
+  static prop2 = () => this;
+  prop3 = () => arguments;
+  static prop4 = () => arguments;
+  prop5 = this;
+  static prop6 = this;
+  prop7 = arguments;
+  static prop8 = arguments;
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/class-property-initializer-blocks-shadow/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/class-property-initializer-blocks-shadow/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-class-properties"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | #4337 (partially), #4230 (needs verification)
| License           | MIT

This modifies `shadow-functions` to leave references to `this` and `arguments` unmodified in the context of a class property's `value` expression. The effect is akin to introducing an implicit scope around each such initializer, and is in line with the current [proposal](https://github.com/tc39/proposal-class-public-fields) AFAICT.

All this applies only when emitting code with the class properties syntax and not running it through `transform-class-properties` - which is the only way such syntax can reach `shadow-functions`. The transform itself is correct and unchanged.