### PR TITLE
Only set options in cli if different from default

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -107,7 +107,7 @@ if (errors.length) {
 let opts = exports.opts = {};
 
 each(options, function (opt, key) {
-  if (commander[key] !== undefined) {
+  if (commander[key] !== undefined && commander[key] !== opt.default) {
     opts[key] = commander[key];
   }
 });

--- a/packages/babel-cli/test/fixtures/babel/filename --no-comments/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/filename --no-comments/in-files/script.js
@@ -1,0 +1,7 @@
+/*
+ Test comment
+ */
+
+arr.map(x => x * MULTIPLIER);
+
+// END OF FILE

--- a/packages/babel-cli/test/fixtures/babel/filename --no-comments/options.json
+++ b/packages/babel-cli/test/fixtures/babel/filename --no-comments/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["script.js", "--out-file", "script2.js", "--no-comments"]
+}

--- a/packages/babel-cli/test/fixtures/babel/filename --no-comments/out-files/script2.js
+++ b/packages/babel-cli/test/fixtures/babel/filename --no-comments/out-files/script2.js
@@ -1,0 +1,5 @@
+"use strict";
+
+arr.map(function (x) {
+  return x * MULTIPLIER;
+});

--- a/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/.babelrc
+++ b/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/.babelrc
@@ -1,0 +1,3 @@
+{
+  "comments": false
+}

--- a/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/in-files/script.js
@@ -1,0 +1,7 @@
+/*
+ Test comment
+ */
+
+arr.map(x => x * MULTIPLIER);
+
+// END OF FILE

--- a/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/options.json
+++ b/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["script.js", "--out-file", "script2.js"]
+}

--- a/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/out-files/script2.js
+++ b/packages/babel-cli/test/fixtures/babel/filename babelrc no comments/out-files/script2.js
@@ -1,0 +1,5 @@
+"use strict";
+
+arr.map(function (x) {
+  return x * MULTIPLIER;
+});

--- a/packages/babel-cli/test/fixtures/babel/filename default comments/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/filename default comments/in-files/script.js
@@ -1,0 +1,7 @@
+/*
+ Test comment
+ */
+
+arr.map(x => x * MULTIPLIER);
+
+// END OF FILE

--- a/packages/babel-cli/test/fixtures/babel/filename default comments/options.json
+++ b/packages/babel-cli/test/fixtures/babel/filename default comments/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["script.js", "--out-file", "script2.js"]
+}

--- a/packages/babel-cli/test/fixtures/babel/filename default comments/out-files/script2.js
+++ b/packages/babel-cli/test/fixtures/babel/filename default comments/out-files/script2.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/*
+ Test comment
+ */
+
+arr.map(function (x) {
+  return x * MULTIPLIER;
+});
+
+// END OF FILE


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     |no
| Spec compliancy?  |no
| Tests added/pass? | yes
| Fixed tickets     | #4385, #3899, babel/babili#67
| License           | MIT
| Doc PR            | 

Currently default values (like `comments: true`) will be set always for the transform.
This behaviour does not allow for setting this options from babelrc as the default would always have precedence.

This is WIP, I still want to write tests and find all related issues.