### PR TITLE
Support custom ports for V8 --inspect

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -47,6 +47,7 @@ getV8Flags(function (err, v8Flags) {
       case "debug":
       case "--debug":
       case "--debug-brk":
+      case "--inspect":
         args.unshift(arg);
         break;
 
@@ -54,7 +55,6 @@ getV8Flags(function (err, v8Flags) {
         args.unshift("--expose-gc");
         break;
 
-      case "--inspect":
       case "--nolazy":
         args.unshift(flag);
         break;


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

<!-- Describe your changes below in as much detail as possible -->

When support for V8's `--inspect` was added in #3578, it added support for inspection with only the default port. This prevents multiple inspection instances from being open simultaneously.

This tweak adds support for `--inspect=PORT`, so that custom ports can be used as well.
