### PR TITLE
Flip default parameter template

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1168/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1168/expected.js
@@ -1,5 +1,5 @@
 function test() {
-  var x = arguments.length <= 0 || arguments[0] === undefined ? "hi" : arguments[0];
+  var x = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "hi";
 
   return x;
 }

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/default-parameters/expected.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/default-parameters/expected.js
@@ -1,11 +1,11 @@
 var some = function () {
-  let count = arguments.length <= 0 || arguments[0] === undefined ? "30" : arguments[0];
+  let count = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "30";
 
   console.log("count", count);
 };
 
 var collect = function () {
-  let since = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
+  let since = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
   let userid = arguments[1];
 
   console.log(userid);

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/default-precedence/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/default-precedence/expected.js
@@ -1,6 +1,6 @@
 var f0 = function (a) {
-  var b = arguments.length <= 1 || arguments[1] === undefined ? a : arguments[1];
-  var c = arguments.length <= 2 || arguments[2] === undefined ? b : arguments[2];
+  var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : a;
+  var c = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : b;
 
   return [a, b, c];
 };
@@ -9,8 +9,8 @@ assert.deepEqual(f0(1), [1, 1, 1]);
 
 var f1 = function (_ref) {
   var a = _ref.a;
-  var b = arguments.length <= 1 || arguments[1] === undefined ? a : arguments[1];
-  var c = arguments.length <= 2 || arguments[2] === undefined ? b : arguments[2];
+  var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : a;
+  var c = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : b;
 
   return [a, b, c];
 };
@@ -19,8 +19,8 @@ assert.deepEqual(f1({ a: 1 }), [1, 1, 1]);
 
 var f2 = function (_ref2) {
   var a = _ref2.a;
-  var b = arguments.length <= 1 || arguments[1] === undefined ? a : arguments[1];
-  var c = arguments.length <= 2 || arguments[2] === undefined ? a : arguments[2];
+  var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : a;
+  var c = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : a;
 
   return [a, b, c];
 };

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7160/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7160/expected.js
@@ -4,9 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 var foo = exports.foo = function foo(gen) {
-  var ctx = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
+  var ctx = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
 };
 
 var bar = exports.bar = function bar(gen) {
-  var ctx = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
+  var ctx = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
 };

--- a/packages/babel-plugin-transform-es2015-parameters/src/default.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/default.js
@@ -7,10 +7,10 @@ import * as t from "babel-types";
 
 let buildDefaultParam = template(`
   let VARIABLE_NAME =
-    ARGUMENTS.length <= ARGUMENT_KEY || ARGUMENTS[ARGUMENT_KEY] === undefined ?
-      DEFAULT_VALUE
+    ARGUMENTS.length > ARGUMENT_KEY && ARGUMENTS[ARGUMENT_KEY] !== undefined ?
+      ARGUMENTS[ARGUMENT_KEY]
     :
-      ARGUMENTS[ARGUMENT_KEY];
+      DEFAULT_VALUE;
 `);
 
 let buildCutOff = template(`

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-before-last/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-before-last/expected.js
@@ -1,4 +1,4 @@
 function foo() {
-  var a = arguments.length <= 0 || arguments[0] === undefined ? "foo" : arguments[0];
+  var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "foo";
   var b = arguments[1];
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-eval/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-eval/expected.js
@@ -1,8 +1,8 @@
 var x = "outside";
 function outer() {
-  var a = arguments.length <= 0 || arguments[0] === undefined ? function () {
+  var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : function () {
     return eval("x");
-  } : arguments[0];
+  };
   return function () {
     var x = "inside";
     return a();

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-multiple/expected.js
@@ -1,12 +1,12 @@
 var t = function () {
-  var e = arguments.length <= 0 || arguments[0] === undefined ? "foo" : arguments[0];
-  var f = arguments.length <= 1 || arguments[1] === undefined ? 5 : arguments[1];
+  var e = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "foo";
+  var f = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 5;
 
   return e + " bar " + f;
 };
 
 var a = function (e) {
-  var f = arguments.length <= 1 || arguments[1] === undefined ? 5 : arguments[1];
+  var f = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 5;
 
   return e + " bar " + f;
 };

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-single/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-single/expected.js
@@ -1,5 +1,5 @@
 var t = function () {
-  var f = arguments.length <= 0 || arguments[0] === undefined ? "foo" : arguments[0];
+  var f = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "foo";
 
   return f + " bar";
 };

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/destructuring-rest/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/destructuring-rest/expected.js
@@ -1,6 +1,6 @@
 // T6809
 function t() {
-  var x = arguments.length <= 0 || arguments[0] === undefined ? "default" : arguments[0];
+  var x = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "default";
   var _ref = arguments[1];
   var a = _ref.a;
   var b = _ref.b;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | 
| License           | MIT
| Doc PR            |

YMMV, I saved ~10b on a 2kb library. Not noticeable at the small scale, by why not do it anyway?

I've (unscientifically) found that flipping the default parameter conditional yields better gzip results. I think this is due to the slightly longer string it can now repeatedly match:

```js
// old
var param = arguments.length <= 0 || void 0 === arguments[0] ? null : arguments[0]
--------------------------------------------------------------^

// new
var param = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : null
----------------------------------------------------------------------------^
```

Though it's entirely likely gzip will also choose up to the index of the arguments if you many default parameters at different indexes. Or maybe the results are smaller because we use `>` instead of `<=` now, ¯\_(ツ)_/¯.