### PR TITLE
If loading a preset fails, show its name/path (#4506)

### DIFF
--- a/packages/babel-core/test/fixtures/option-manager/not-a-preset.js
+++ b/packages/babel-core/test/fixtures/option-manager/not-a-preset.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  throw new Error('Not a real preset');
+}

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var OptionManager = require("../lib/transformation/file/options/option-manager");
 var Logger = require("../lib/transformation/file/logger");
+var path = require("path");
 
 suite("option-manager", function () {
   suite("memoisePluginContainer", function () {
@@ -41,6 +42,17 @@ suite("option-manager", function () {
           });
         },
         /Using removed Babel 5 option: base.auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`/
+      );
+    })
+    test("throws for resolved but erroring preset", function() {
+      return assert.throws(
+        function () {
+          var opt = new OptionManager(new Logger(null, "unknown"));
+          opt.init({
+            'presets': [path.resolve(__dirname, "fixtures", "option-manager", "not-a-preset")]
+          });
+        },
+        /While processing preset: .*option-manager(?:\/|\\\\)not-a-preset\.js/
       );
     })
   });


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4506
| License           | MIT
| Doc PR            | 

This is my preferred solution out of several ideas that would help in cases like #4506.

This PR amends `resolvePresets` to catch and rethrow any error that occurs when requiring presets, invoking function-type presets, or merging preset options; if the preset's name or path (`presetLoc`) is available, the string `(While processing preset: "path/to/preset.js")` is added to the error message.

The above does not apply to module resolution errors, which are thrown only when `presetLoc` is unavailable and therefore continue to work as they have in the past.

Taking #4506 as an example, this behavior would make the error message mention `node_modules/react` which is a better pointer towards the actual problem (that `babel-preset-react` isn't installed) than what we have today.