### PR TITLE
fix default exported classes without a name

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -270,7 +270,7 @@ export default function () {
 
                   // Manualy re-queue `export default class {}` expressions so that the ES3 transform
                   // has an opportunity to convert them. Ideally this would happen automatically from the
-                  // replaceWith above. See T7166 for more info.
+                  // replaceWith above. See #4140 for more info.
                   path.parentPath.requeue(path.get("expression.left"));
                 }
               } else {
@@ -278,7 +278,7 @@ export default function () {
 
                 // Manualy re-queue `export default foo;` expressions so that the ES3 transform
                 // has an opportunity to convert them. Ideally this would happen automatically from the
-                // replaceWith above. See T7166 for more info.
+                // replaceWith above. See #4140 for more info.
                 path.parentPath.requeue(path.get("expression.left"));
               }
               exportDefaultFound = true;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -267,6 +267,11 @@ export default function () {
                   ]);
                 } else {
                   path.replaceWith(buildExportsAssignment(defNode, t.toExpression(declaration.node)));
+
+                  // Manualy re-queue `export default class {}` expressions so that the ES3 transform
+                  // has an opportunity to convert them. Ideally this would happen automatically from the
+                  // replaceWith above. See T7166 for more info.
+                  path.parentPath.requeue(path.get("expression.left"));
                 }
               } else {
                 path.replaceWith(buildExportsAssignment(t.identifier("default"), declaration.node));

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/actual.js
@@ -1,0 +1,1 @@
+export default class {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/expected.js
@@ -1,0 +1,6 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = class {};

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-es3-member-expression-literals",
+    "transform-es3-property-literals"
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/actual.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports["default"] = function () {};

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-es3-member-expression-literals",
+    "transform-es3-property-literals"
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/actual.js
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+class Foo {}
+exports["default"] = Foo;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-es3-member-expression-literals",
+    "transform-es3-property-literals"
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/actual.js
@@ -1,0 +1,1 @@
+export default function bat () {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = bat;
+function bat() {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-es3-member-expression-literals",
+    "transform-es3-property-literals"
+  ]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT
| Doc PR            | 

Currently this

```js
export default class {};
```

will be transformed to 

```
exports.default = class{}
```

although the es3-literal transform is active.
Basically a followup of #3368 that @loganfsmyth did.

The fix does the same as for variables and requeues them.

Also added tests for all combinations of `export default`.