### PR TITLE
Fix issue with minified libraries and code coverage

### DIFF
--- a/packages/babel-traverse/src/context.js
+++ b/packages/babel-traverse/src/context.js
@@ -114,7 +114,7 @@ export default class TraversalContext {
       // this path no longer belongs to the tree
       if (path.key === null) continue;
 
-      if (testing && queue.length >= 1000) {
+      if (testing && queue.length >= 10000) {
         this.trap = true;
       }
 


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes?
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | no
| Fixed tickets     | --
| License           | MIT
| Doc PR            | --

<!-- Describe your changes below in as much detail as possible -->

We ran into this issue where including a minified file (specifically -- https://github.com/googlei18n/libphonenumber) was causing it to think it should bail while calculating code coverage for our app. Raising the number to an insane depth (10,000) vs a slightly insane (but easily reachable) depth erased this problem.