### PR TITLE
Fix destructuring evaluation with call expressions

### DIFF
--- a/packages/babel-plugin-transform-es2015-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/src/index.js
@@ -221,6 +221,9 @@ export default function ({ types: t }) {
       for (let elem of (arr.elements: Array)) {
         // deopt on spread elements
         if (t.isSpreadElement(elem)) return false;
+
+        // deopt call expressions as they might change LHS variables
+        if (t.isCallExpression(elem)) return false;
       }
 
       // deopt on reference to left side identifiers

--- a/packages/babel-plugin-transform-es2015-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/src/index.js
@@ -222,8 +222,11 @@ export default function ({ types: t }) {
         // deopt on spread elements
         if (t.isSpreadElement(elem)) return false;
 
-        // deopt call expressions as they might change LHS variables
+        // deopt call expressions as they might change values of LHS variables
         if (t.isCallExpression(elem)) return false;
+
+        // deopt on member expressions as they may be getter/setters and have side-effects
+        if (t.isMemberExpression(elem)) return false;
       }
 
       // deopt on reference to left side identifiers

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/actual.js
@@ -10,3 +10,4 @@ var [a, b] = [a, b];
 var [a, b] = [...foo, bar];
 var [a, b] = [foo(), bar];
 var [a, b] = [clazz.foo(), bar];
+var [a, b] = [clazz.foo, bar];

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/actual.js
@@ -8,3 +8,5 @@ var [[a, b]] = [[1, 2, 3]];
 var [a, b] = [a, b];
 [a[0], a[1]] = [a[1], a[0]];
 var [a, b] = [...foo, bar];
+var [a, b] = [foo(), bar];
+var [a, b] = [clazz.foo(), bar];

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/expected.js
@@ -31,3 +31,6 @@ var b = _ref6[1];
 var _ref7 = [clazz.foo(), bar];
 var a = _ref7[0];
 var b = _ref7[1];
+var _ref8 = [clazz.foo, bar];
+var a = _ref8[0];
+var b = _ref8[1];

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/array-unpack-optimisation/expected.js
@@ -25,3 +25,9 @@ var _ref5 = [].concat(babelHelpers.toConsumableArray(foo), [bar]);
 
 var a = _ref5[0];
 var b = _ref5[1];
+var _ref6 = [foo(), bar];
+var a = _ref6[0];
+var b = _ref6[1];
+var _ref7 = [clazz.foo(), bar];
+var a = _ref7[0];
+var b = _ref7[1];


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4054
| License           | MIT
| Doc PR            | 

Do not optimize destructions with callExpressions or memberExpressions, as the call
might change the value of a variable that we are assigning to and memberExpressions might be getters with side effects.