### PR TITLE
Try find preset/plugin in in `process.cwd()`

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -123,7 +123,7 @@ export default class OptionManager {
 
       // allow plugins to be specified as strings
       if (typeof plugin === "string") {
-        let pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname);
+        let pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname) || resolve(`babel-plugin-${plugin}`) || resolve(plugin);
         if (pluginLoc) {
           plugin = require(pluginLoc);
         } else {
@@ -260,7 +260,7 @@ export default class OptionManager {
       let presetLoc;
       try {
         if (typeof val === "string") {
-          presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
+          presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname) || resolve(`babel-preset-${val}`) || resolve(val);
 
           // trying to resolve @organization shortcat
           // @foo/es2015 -> @foo/babel-preset-es2015


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| Breaking change? | no |
| New feature? | no |
| Deprecations? | no |
| Spec compliancy? | yes |
| Tests added/pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

When `.babelrc` not in directory of node, but in another project directory, we should try `process.cwd()` before throw a error.
