### PR TITLE
babel-code-frame: add options for linesBefore, linesAfter

### DIFF
--- a/packages/babel-code-frame/README.md
+++ b/packages/babel-code-frame/README.md
@@ -38,3 +38,5 @@ If the column number is not known, you may pass `null` instead.
 name                   | type     | default         | description
 -----------------------|----------|-----------------|------------------------------------------------------
 highlightCode          | boolean  | `false`         | Syntax highlight the code as JavaScript for terminals
+linesAbove             | number   | 2               | The number of lines to show above the error
+linesBelow             | number   | 3               | The number of lines to show below the error

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -9,7 +9,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "chalk": "^1.1.0",
-    "esutils": "^2.0.2",
     "js-tokens": "^2.0.0"
   }
 }

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -9,6 +9,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "chalk": "^1.1.0",
+    "esutils": "^2.0.2",
     "js-tokens": "^2.0.0"
   }
 }

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -1,5 +1,4 @@
 import jsTokens from "js-tokens";
-import esutils from "esutils";
 import chalk from "chalk";
 
 /**
@@ -24,6 +23,73 @@ let defs = {
  */
 
 const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
+const KEYWORDS = {
+  "abstract": true,
+  "await": true,
+  "boolean": true,
+  "break": true,
+  "byte": true,
+  "case": true,
+  "catch": true,
+  "char": true,
+  "class": true,
+  "const": true,
+  "continue": true,
+  "debugger": true,
+  "default": true,
+  "delete": true,
+  "do": true,
+  "double": true,
+  "else": true,
+  "enum": true,
+  "export": true,
+  "extends": true,
+  "false": true,
+  "final": true,
+  "finally": true,
+  "float": true,
+  "for": true,
+  "function": true,
+  "goto": true,
+  "if": true,
+  "implements": true,
+  "import": true,
+  "in": true,
+  "instanceof": true,
+  "int": true,
+  "interface": true,
+  "let": true,
+  "long": true,
+  "native": true,
+  "new": true,
+  "null": true,
+  "package": true,
+  "private": true,
+  "protected": true,
+  "public": true,
+  "return": true,
+  "short": true,
+  "static": true,
+  "super": true,
+  "switch": true,
+  "synchronized": true,
+  "this": true,
+  "throw": true,
+  "transient": true,
+  "true": true,
+  "try": true,
+  "typeof": true,
+  "var": true,
+  "void": true,
+  "volatile": true,
+  "while": true,
+  "with": true,
+  "yield": true
+};
+
+function isKeyword(str) {
+  return Object.prototype.hasOwnProperty.call(KEYWORDS, str);
+}
 
 /**
  * Get the type of token, specifying punctuator type.
@@ -31,7 +97,7 @@ const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
 
 function getTokenType(match) {
   let token = jsTokens.matchToToken(match);
-  if (token.type === "name" && esutils.keyword.isReservedWordES6(token.value)) {
+  if (token.type === "name" && isKeyword(token.value)) {
     return "keyword";
   }
 

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -1,4 +1,5 @@
 import jsTokens from "js-tokens";
+import esutils from "esutils";
 import chalk from "chalk";
 
 /**
@@ -23,73 +24,6 @@ let defs = {
  */
 
 const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
-const KEYWORDS = {
-  "abstract": true,
-  "await": true,
-  "boolean": true,
-  "break": true,
-  "byte": true,
-  "case": true,
-  "catch": true,
-  "char": true,
-  "class": true,
-  "const": true,
-  "continue": true,
-  "debugger": true,
-  "default": true,
-  "delete": true,
-  "do": true,
-  "double": true,
-  "else": true,
-  "enum": true,
-  "export": true,
-  "extends": true,
-  "false": true,
-  "final": true,
-  "finally": true,
-  "float": true,
-  "for": true,
-  "function": true,
-  "goto": true,
-  "if": true,
-  "implements": true,
-  "import": true,
-  "in": true,
-  "instanceof": true,
-  "int": true,
-  "interface": true,
-  "let": true,
-  "long": true,
-  "native": true,
-  "new": true,
-  "null": true,
-  "package": true,
-  "private": true,
-  "protected": true,
-  "public": true,
-  "return": true,
-  "short": true,
-  "static": true,
-  "super": true,
-  "switch": true,
-  "synchronized": true,
-  "this": true,
-  "throw": true,
-  "transient": true,
-  "true": true,
-  "try": true,
-  "typeof": true,
-  "var": true,
-  "void": true,
-  "volatile": true,
-  "while": true,
-  "with": true,
-  "yield": true
-};
-
-function isKeyword(str) {
-  return Object.prototype.hasOwnProperty.call(KEYWORDS, str);
-}
 
 /**
  * Get the type of token, specifying punctuator type.
@@ -97,7 +31,7 @@ function isKeyword(str) {
 
 function getTokenType(match) {
   let token = jsTokens.matchToToken(match);
-  if (token.type === "name" && isKeyword(token.value)) {
+  if (token.type === "name" && esutils.keyword.isReservedWordES6(token.value)) {
     return "keyword";
   }
 

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -83,9 +83,12 @@ export default function (
   let highlighted = opts.highlightCode && chalk.supportsColor;
   if (highlighted) rawLines = highlight(rawLines);
 
+  let linesAbove = opts.linesAbove || 2;
+  let linesBelow = opts.linesBelow || 3;
+
   let lines = rawLines.split(NEWLINE);
-  let start = Math.max(lineNumber - 3, 0);
-  let end   = Math.min(lines.length, lineNumber + 3);
+  let start = Math.max(lineNumber - (linesAbove + 1), 0);
+  let end   = Math.min(lines.length, lineNumber + linesBelow);
 
   if (!lineNumber && !colNumber) {
     start = 0;

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -8,13 +8,13 @@ suite("babel-code-frame", function () {
       "class Foo {",
       "  constructor()",
       "};",
-    ].join('\n');
+    ].join("\n");
     assert.equal(codeFrame(rawLines, 2, 16), [
       "  1 | class Foo {",
       "> 2 |   constructor()",
       "    |                ^",
       "  3 | };",
-    ].join('\n'));
+    ].join("\n"));
   });
 
   test("optional column number", function () {
@@ -22,7 +22,7 @@ suite("babel-code-frame", function () {
       "class Foo {",
       "  constructor()",
       "};",
-    ].join('\n');
+    ].join("\n");
     assert.equal(codeFrame(rawLines, 2, null), [
       "  1 | class Foo {",
       "> 2 |   constructor()",
@@ -104,17 +104,86 @@ suite("babel-code-frame", function () {
       "> 2 | \t  \t\t    constructor\t(\t)",
       "    | \t  \t\t               \t \t ^",
       "  3 | \t};",
-    ].join('\n'));
+    ].join("\n"));
   });
 
   test("opts.highlightCode", function () {
     const rawLines = "console.log('babel')";
-    const result = codeFrame(rawLines, 1, 9, {highlightCode: true})
+    const result = codeFrame(rawLines, 1, 9, {highlightCode: true});
     const stripped = chalk.stripColor(result);
     assert.ok(result.length > stripped.length);
     assert.equal(stripped, [
       "> 1 | console.log('babel')",
       "    |         ^",
-    ].join("\n"))
+    ].join("\n"));
+  });
+
+  test("opts.linesAbove", function () {
+    var rawLines = [
+      "/**",
+      " * Sums two numbers.",
+      " *",
+      " * @param a Number",
+      " * @param b Number",
+      " * @returns Number",
+      " */",
+      "",
+      "function sum(a, b) {",
+      "  return a + b",
+      "}"
+    ].join("\n");
+    assert.equal(codeFrame(rawLines, 7, 2, { linesAbove: 1 }), [
+      "   6 |  * @returns Number",
+      ">  7 |  */",
+      "     |  ^",
+      "   8 | ",
+      "   9 | function sum(a, b) {",
+      "  10 |   return a + b",
+    ].join("\n"));
+  });
+
+  test("opts.linesBelow", function () {
+    var rawLines = [
+      "/**",
+      " * Sums two numbers.",
+      " *",
+      " * @param a Number",
+      " * @param b Number",
+      " * @returns Number",
+      " */",
+      "",
+      "function sum(a, b) {",
+      "  return a + b",
+      "}"
+    ].join("\n");
+    assert.equal(codeFrame(rawLines, 7, 2, { linesBelow: 1 }), [
+      "  5 |  * @param b Number",
+      "  6 |  * @returns Number",
+      "> 7 |  */",
+      "    |  ^",
+      "  8 | "
+    ].join("\n"));
+  });
+
+  test("opts.linesAbove and opts.linesBelow", function () {
+    var rawLines = [
+      "/**",
+      " * Sums two numbers.",
+      " *",
+      " * @param a Number",
+      " * @param b Number",
+      " * @returns Number",
+      " */",
+      "",
+      "function sum(a, b) {",
+      "  return a + b",
+      "}"
+    ].join("\n");
+    assert.equal(codeFrame(rawLines, 7, 2, { linesAbove: 1, linesBelow: 1 }), [
+      "  6 |  * @returns Number",
+      "> 7 |  */",
+      "    |  ^",
+      "  8 | "
+    ].join("\n"));
   });
 });


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

<!-- Describe your changes below in as much detail as possible -->

