### PR TITLE
Fixes T2299: Prevent REPL from printing implicit 'use strict'

### DIFF
--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -38,7 +38,7 @@ register({
 
 //
 
-let replPlugin = () => ({
+let replPlugin = ({ types: t }) => ({
   visitor: {
     ModuleDeclaration(path) {
       throw path.buildCodeFrameError("Modules aren't supported in the REPL");
@@ -47,6 +47,14 @@ let replPlugin = () => ({
     VariableDeclaration(path) {
       if (path.node.kind !== "var") {
         throw path.buildCodeFrameError("Only `var` variables are supported in the REPL");
+      }
+    },
+
+    Directive(path) {
+      if (_.isUndefined(path.node.loc)) {
+        // If the executed code doesn't evaluate to a value,
+        // prevent implicit strict mode from printing 'use strict'.
+        path.parent.body.unshift(t.expressionStatement(t.identifier("undefined")));
       }
     }
   }

--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -50,12 +50,12 @@ let replPlugin = ({ types: t }) => ({
       }
     },
 
-    Directive(path) {
-      if (_.isUndefined(path.node.loc)) {
-        // If the executed code doesn't evaluate to a value,
-        // prevent implicit strict mode from printing 'use strict'.
-        path.parent.body.unshift(t.expressionStatement(t.identifier("undefined")));
-      }
+    Program(path) {
+      if (path.get("body").some((child) => child.isExpressionStatement())) return;
+
+      // If the executed code doesn't evaluate to a value,
+      // prevent implicit strict mode from printing 'use strict'.
+      path.pushContainer("body", t.expressionStatement(t.identifier("undefined")));
     }
   }
 });

--- a/packages/babel-cli/test/fixtures/babel-node/no-strict/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/no-strict/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--eval","--print", "var a = 1;"],
+  "stdout": "undefined"
+}


### PR DESCRIPTION
Old PR https://github.com/babel/babel/pull/3360 @eetulatja @loganfsmyth 

```bash
./babel-node.js
> var a =1
undefined
> var a = 1;
undefined
> 'use strict';
undefined
> 'use strict'; var b = 1;
undefined
> 1+1
2
```