### PR TITLE
Enable babel for tests

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,3 +1,5 @@
 instrumentation:
   root: .
-  excludes: "**/node_modules/**"
+  excludes:
+    - "**/node_modules/**"
+    - "scripts/*.js"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.0.0",
+    "babel-register": "^6.14.0",
     "babel-runtime": "^6.0.0",
     "browserify": "^11.2.0",
     "bundle-collapser": "^1.2.1",

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,5 +1,3 @@
-if (process.env.running_under_istanbul) return;
-
 var readdir        = require("fs-readdir-recursive");
 var helper         = require("babel-helper-fixtures");
 var assert         = require("assert");
@@ -79,7 +77,6 @@ var buildTest = function (binName, testName, opts) {
   var binLoc = path.join(__dirname, "../lib", binName);
 
   return function (callback) {
-    this.timeout(5000);
     clear();
     saveInFiles(opts.inFiles);
 

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,29 +1,22 @@
-var assert = require("assert");
-var OptionManager = require("../lib/transformation/file/options/option-manager");
-var Logger = require("../lib/transformation/file/logger");
-var path = require("path");
+import assert from "assert";
+import OptionManager from "../lib/transformation/file/options/option-manager";
+import Logger from "../lib/transformation/file/logger";
+import path from "path";
 
-suite("option-manager", function () {
-  suite("memoisePluginContainer", function () {
-    test("throws for babel 5 plugin", function() {
+suite("option-manager", () => {
+  suite("memoisePluginContainer", () => {
+    test("throws for babel 5 plugin", () => {
       return assert.throws(
-        function () {
-          OptionManager.memoisePluginContainer(
-            function (ref) {
-              var Plugin = ref.Plugin;
-              return new Plugin("object-assign", {});
-            }
-          );
-        },
+        () => OptionManager.memoisePluginContainer(({ Plugin }) => new Plugin("object-assign", {})),
         /Babel 5 plugin is being run with Babel 6/
       );
     })
   });
 
-  suite("mergeOptions", function () {
-    test("throws for removed babel 5 options", function() {
+  suite("mergeOptions", () => {
+    test("throws for removed babel 5 options", () => {
       return assert.throws(
-        function () {
+        () => {
           var opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
             'randomOption': true
@@ -33,9 +26,9 @@ suite("option-manager", function () {
       );
     });
 
-    test("throws for removed babel 5 options", function() {
+    test("throws for removed babel 5 options", () => {
       return assert.throws(
-        function () {
+        () => {
           var opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
             'auxiliaryComment': true,
@@ -46,9 +39,9 @@ suite("option-manager", function () {
       );
     });
 
-    test("throws for resolved but erroring preset", function() {
+    test("throws for resolved but erroring preset", () => {
       return assert.throws(
-        function () {
+        () => {
           var opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
             'presets': [path.join(__dirname, "fixtures/option-manager/not-a-preset")]

--- a/scripts/babel-register.js
+++ b/scripts/babel-register.js
@@ -16,7 +16,8 @@ if (babel.plugins) {
 register(babel);
 register({
   extensions: [".js"],
-  only: 'packages/*/test',
+  // Only js files in the test folder but not in the subfolder fixtures.
+  only: /packages\/.+\/test\/(?!fixtures\/).+\.js$/,
   babelrc: false,
   compact: true,
 });

--- a/scripts/babel-register.js
+++ b/scripts/babel-register.js
@@ -16,6 +16,7 @@ if (babel.plugins) {
 register(babel);
 register({
   extensions: [".js"],
+  only: 'packages/*/test',
   babelrc: false,
   compact: true,
 });

--- a/scripts/babel-register.js
+++ b/scripts/babel-register.js
@@ -1,0 +1,21 @@
+var babel = require("../package.json").babel;
+var register = require("babel-register");
+var path = require("path");
+
+if (babel.plugins) {
+  // correct path of relative plugins
+  babel.plugins = babel.plugins.map(function (plugin) {
+    if (plugin.charAt(0) === '.') {
+      return plugin.replace(/^\./, path.join(__dirname, '..'));
+    }
+
+    return plugin;
+  });
+}
+
+register(babel);
+register({
+  extensions: [".js"],
+  babelrc: false,
+  compact: true,
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---reporter dot --ui tdd --timeout 10000
+--reporter dot --ui tdd --timeout 10000 --compilers js:./scripts/babel-register


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT
| Doc PR            |

<!-- Describe your changes below in as much detail as possible -->

This enables babel for tests by using a mocha compiler and it uses the babel config from package.json
I transformed OptionsManager test to es2015 to see if it works

Also removed the 5s timeout from cli tests, as the default timeout is already 10s, this should probably fix the timouts on travis that we had in babylon

Also run the cli tests on travis, they were disabled if istanbul is active, but istanbul is always active on travis so we were never running this tests. If they still timeout sometimes, we might need to investigate