### PR TITLE
Only exit if the TRAVIS_COMMIT_RANGE  is not empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   - node_modules
 before_install:
 - |
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(doc))/' || {
+    [ "$TRAVIS_COMMIT_RANGE" = "" ] || git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(doc))/' || {
       echo "Only docs were updated, stopping build process."
       exit
     }


### PR DESCRIPTION
This continues as usual if the $TRAVIS_COMMIT_RANGE is empty. This happens for new branches.
