### PR TITLE
Fix fileName options passed to babylon

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -53,6 +53,7 @@ export default class File extends Store {
       nonStandard:   this.opts.nonStandard,
       sourceType:    this.opts.sourceType,
       filename:      this.opts.filename,
+      sourceFileName:this.opts.filename,
       plugins:       []
     };
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT
| Doc PR            | 

The filename options used by babylon is called `sourceFilename` and not `filename`. Therefore an additional option called sourceFilename should be passed to babylon parse babel/babylon@bb4919500c54632fe60b8802c663e96a63fd0676