### PR TITLE
babel-register: update source-map-support to latest

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -15,6 +15,6 @@
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
     "path-exists": "^1.0.0",
-    "source-map-support": "^0.2.10"
+    "source-map-support": "^0.4.2"
   }
 }


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | kind of
| Breaking change?  | probably not
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | -
| License           | MIT
| Doc PR            | -

<!-- Describe your changes below in as much detail as possible -->

This allows in some case when you use other modules that use this source-map-support lib to get only a single version at the root of node_modules. For example, this can prevent issues when requiring using webpack Banner plugin (compiled code is not always requiring dependencies as you would expect).