### PR TITLE
babel-code-frame: Highlight strings with green (not red)

### DIFF
--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -13,7 +13,7 @@ let defs = {
   punctuator:  chalk.yellow,
   // bracket:  intentionally omitted.
   number:      chalk.magenta,
-  string:      chalk.red,
+  string:      chalk.green,
   regex:       chalk.magenta,
   comment:     chalk.grey,
   invalid:     chalk.white.bgRed.bold,


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | ye
| Fixed tickets     | -
| License           | MIT
| Doc PR            | -

<!-- Describe your changes below in as much detail as possible -->

- Red makes it look like something is wrong with the string.
- On Ubuntu-based systems, it looks kinda broken.
- The error markers (`>` and `^`) as well as invalid tokens are already
  marked with red. By not having strings red, the most important
  information -- the error location -- is more visible.

This is a continuation of commit fa1de5ce (PR #4572).

Before:

![screenshot from 2016-09-27 16-29-34](https://cloud.githubusercontent.com/assets/2142817/18882764/d85e5328-84e0-11e6-9d3b-2435bb8b5bc2.png)

After:

![screenshot from 2016-09-27 16-30-04](https://cloud.githubusercontent.com/assets/2142817/18882769/de232f4a-84e0-11e6-9164-7bd43dc61764.png)
