### PR TITLE
Prevent flow-strip-types/flow-comments from removing entire ClassProperty

### DIFF
--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/actual.js
@@ -1,0 +1,5 @@
+class X {
+  foo = 2
+  bar: number = 3
+  baz: ?string
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/expected.js
@@ -1,0 +1,5 @@
+class X {
+  foo = 2;
+  bar /*: number*/ = 3;
+  baz /*: ?string*/;
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/options.json
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-flow-comments",
+    "syntax-class-properties"
+  ]
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-values/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-values/actual.js
@@ -1,0 +1,5 @@
+class X {
+  foo = 2
+  bar: number = 3
+  baz: ?string
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-values/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-values/expected.js
@@ -1,0 +1,4 @@
+class X {
+  foo = 2;
+  bar = 3;
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-values/options.json
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/class-prop-values/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-flow-strip-types",
+    "syntax-class-properties"
+  ]
+}

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -45,7 +45,7 @@ defineType("ClassImplements", {
 defineType("ClassProperty", {
   visitor: ["key", "value", "typeAnnotation", "decorators"],
   builder: ["key", "value", "typeAnnotation", "decorators", "computed"],
-  aliases: ["Flow", "Property"],
+  aliases: ["Property"],
   fields: {
     computed: {
       validate: assertValueType("boolean"),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4388
| License           | MIT
| Doc PR            | -

`ClassProperty` had the `Flow` alias, which was causing it [to be stripped](https://github.com/babel/babel/blob/5ea57d5e9cb1c049fba142930ba3acde9cc473c2/packages/babel-plugin-transform-flow-strip-types/src/index.js#L20-L22), or [converted to a comment](https://github.com/babel/babel/blob/5ea57d5e9cb1c049fba142930ba3acde9cc473c2/packages/babel-plugin-transform-flow-comments/src/index.js#L41-L47).

It's the only non-Flow-specific syntax with that alias, and removing the alias doesn't break any other tests.

---

Input:

```js
class X {
  foo = 2
  bar: number = 3
  baz: ?string
}
```

Previous `flow-strip-types`:

```js
class X {}
```

New `flow-strip-types`:

```js
class X {
  foo = 2;
  bar = 3;
}
```

Previous `flow-comments`:

```js
class X {
  /*:: foo = 2*/
  /*:: bar: number = 3*/
  /*:: baz: ?string*/
}
```

New `flow-comments`:

```js
class X {
  foo = 2;
  bar /*: number*/ = 3;
  baz /*: ?string*/;
}
```