### PR TITLE
Fix bodyless async functions

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -152,7 +152,7 @@ function plainFunction(path: NodePath, callId: Object) {
 }
 
 export default function (path: NodePath, file: Object, helpers: Object) {
-  path.get("body").traverse(awaitVisitor, {
+  path.traverse(awaitVisitor, {
     file,
     wrapAwait: helpers.wrapAwait
   });

--- a/packages/babel-plugin-transform-async-generator-functions/src/index.js
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.js
@@ -22,7 +22,7 @@ export default function ({ types: t }) {
       Function(path, state) {
         if (!path.node.async || !path.node.generator) return;
 
-        path.get("body").traverse(yieldStarVisitor, state);
+        path.traverse(yieldStarVisitor, state);
 
         remapAsyncToGenerator(path, state.file, {
           wrapAsync: t.memberExpression(

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4599/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4599/actual.js
@@ -1,0 +1,3 @@
+async () => await promise
+
+async () => { await promise }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4599/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4599/expected.js
@@ -1,0 +1,7 @@
+babelHelpers.asyncToGenerator(function* () {
+  return yield promise;
+});
+
+babelHelpers.asyncToGenerator(function* () {
+  yield promise;
+});


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4599
| License           | MIT
| Doc PR            | -

It was changed in 26e79c543374e99e6742eac69d8f1f9d4ecf5ed1 (for async generator/for-await), but doesn't seem to be required.