### PR TITLE
Check if babel packages get transpiled by babel

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -234,7 +234,7 @@ export default class OptionManager {
   mergePresets(presets: Array<string | Object>, dirname: string) {
     if (dirname.match(/node_modules\/babel/)) {
       throw new Error(
-        "You are currently trying to transpile babel packages from node_modules with babel itself." +
+        "You are currently trying to transpile babel packages from node_modules with babel itself. " +
         "Ensure to ignore node_modules or at least the babel packages."
       );
     }

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -291,7 +291,7 @@ export default class OptionManager {
         if (typeof val === "object" && val.__esModule) {
           val = val.default;
 
-          if (!val) throw new Error('The preset uses the es-module syntax but does not have a default export.');
+          if (!val) throw new Error("The preset uses the es-module syntax but does not have a default export.");
         }
 
         // For compatibility with babel-core < 6.13.x, allow presets to export an object with a

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -282,7 +282,8 @@ export default class OptionManager {
         }
 
         // If the imported preset is a transpiled ES2015 module, grab the default export.
-        if (typeof val === "object" && val.__esModule) val = val.default;
+        // The || {} handles the case of cycle dependencies when babel-register is used to transpile babel-presets
+        if (typeof val === "object" && val.__esModule) val = val.default || {};
 
         // For compatibility with babel-core < 6.13.x, allow presets to export an object with a
         // a 'buildPreset' function that will return the preset itself, while still exporting a


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  |no
| New feature?      |no
| Deprecations?     |no
| Spec compliancy?  |no
| Tests added/pass? | yes
| Fixed tickets     | #4592 
| License           | MIT
| Doc PR            | 

<!-- Describe your changes below in as much detail as possible -->

This handles cycle dependencies that may occur if babel-register
is used to transpile node_modules

The initial problem is that babel-register without any ignore tries to transpile the first `required()` transform in the es2015 preset. This step then tries to resolve the preset again (cycle!) which gets `{ __esModule: true }` and nothing more because of https://nodejs.org/api/modules.html#modules_cycles and the way the preset [looks like](https://unpkg.com/babel-preset-es2015@6.16.0/lib/index.js), but we still try to resolve `.default` on this object.

We could also change our presets back to not use `export default` but the problem would still be there for 3rd party presets that might use export default.

Maybe @loganfsmyth has a better idea.