### PR TITLE
Add pluginResolutionDir option

### DIFF
--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -35,7 +35,7 @@ export default function buildConfigChain(opts: Object = {}, log?: Logger) {
   builder.mergeConfig({
     options: opts,
     alias: "base",
-    dirname: filename && path.dirname(filename)
+    dirname: opts.pluginResolutionDir || filename && path.dirname(filename)
   });
   
   return builder.configs;

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -199,6 +199,11 @@ module.exports = {
     hidden: true,
   },
 
+  pluginResolutionDir: {
+    type: "filename",
+    description: "The directory from which plugins and presets should be resolved"
+  },
+
   // Deprecate top level parserOpts
   parserOpts: {
     description: "Options to pass into the parser, or to change parsers (parserOpts.parser)",

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -294,4 +294,57 @@ suite("buildConfigChain", function () {
 
     assert.deepEqual(chain, expected);
   });
+
+  test("pluginResolutionDir option", function () {
+    var pluginResolutionDir = 'dir/from/which/plugins/are/resolved';
+
+    var chain = buildConfigChain({
+      filename: fixture("dir1", "src.js"),
+      pluginResolutionDir: pluginResolutionDir
+    });
+
+    var expected = [
+      {
+        options: {
+          plugins: [
+            "extended"
+          ]
+        },
+        alias: fixture("extended.babelrc.json"),
+        loc: fixture("extended.babelrc.json"),
+        dirname: fixture()
+      },
+      {
+        options: {
+          plugins: [
+            "root"
+          ]
+        },
+        alias: fixture(".babelrc"),
+        loc: fixture(".babelrc"),
+        dirname: fixture()
+      },
+      {
+        options: {
+          ignore: [
+            "root-ignore"
+          ]
+        },
+        alias: fixture(".babelignore"),
+        loc: fixture(".babelignore"),
+        dirname: fixture()
+      },
+      {
+        options: {
+          filename: fixture("dir1", "src.js"),
+          pluginResolutionDir: pluginResolutionDir
+        },
+        alias: "base",
+        loc: "base",
+        dirname: pluginResolutionDir
+      }
+    ];
+
+    assert.deepEqual(chain, expected);
+  });
 });


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | n/a
| Tests added/pass? | yes
| Fixed tickets     | n/a
| License           | MIT
| Doc PR            | will create one after review

This PR adds an option called `pluginResolutionDir` (I'm happy to change the name). The option allows users to specify the directory from which plugins/presets should be resolved ([here](https://github.com/babel/babel/blob/37419b44b92a366b92bcc01be4f635459ddd77e6/packages/babel-core/src/transformation/file/options/option-manager.js#L126) and [here](https://github.com/babel/babel/blob/37419b44b92a366b92bcc01be4f635459ddd77e6/packages/babel-core/src/transformation/file/options/option-manager.js#L263)).

This option is useful/necessary if babel will process a file that is not a descendant of the directory in which the babel plugins/presets were installed (because otherwise the linked lines would fail to find the plugin/preset).

One use case (the one that prompted me to make this change) for setting this option is to work with ruby gems that include javascript assets (which is common among Rails plugins). Unlike node modules, ruby gems are installed globally, which means those javascript files won't be inside the application subtree (where your babel plugins and presets are installed). So, when babel processes those files, the default behavior of resolving plugins from [the processed file's `dirname`](https://github.com/rmacklin/babel/blob/37419b44b92a366b92bcc01be4f635459ddd77e6/packages/babel-core/src/transformation/file/options/build-config-chain.js#L38) will fail to find the plugins. With this option, `babel.transform` can be told the directory from which plugins/presets should be resolved, which fixes the issue.

cc @hzoo @loganfsmyth
Let me know what you guys think of this. It was the smallest change I could think of to solve my problem, but I'm open to discussing alternative approaches as well. I'll be available in the Slack group.