### PR TITLE
Fix regression in transform-flow-comments for class properties

### DIFF
--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -37,6 +37,12 @@ export default function ({ types: t }) {
         }
       },
 
+      // support for `class X { foo: string }` - #4622
+      ClassProperty(path) {
+        let { node, parent } = path;
+        if (!node.value) wrapInFlowComment(path, parent);
+      },
+
       // support `export type a = {}` - #8 Error: You passed path.replaceWith() a falsy node
       "ExportNamedDeclaration|Flow"(path) {
         let { node, parent } = path;

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/actual.js
@@ -1,0 +1,4 @@
+class X {
+  a: number
+  b: ?string
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/expected.js
@@ -1,0 +1,4 @@
+class X {
+  /*:: a: number*/
+  /*:: b: ?string*/
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/options.json
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-flow-comments"
+  ]
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/actual.js
@@ -1,0 +1,5 @@
+class X {
+  a: number = 2
+  b: ?string = '3'
+  c: ?number
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/expected.js
@@ -1,0 +1,7 @@
+class X {
+  constructor() {
+    this.a = 2;
+    this.b = '3';
+  }
+
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/options.json
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-flow-comments",
+    "transform-class-properties"
+  ]
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/expected.js
@@ -1,5 +1,5 @@
 class X {
   foo = 2;
   bar /*: number*/ = 3;
-  baz /*: ?string*/;
+  /*:: baz: ?string*/
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4622
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

#4587 allowed class property Flow annotations to print as comments. However it introduced a regression where using `flow-comments` without `{syntax,transform}-class-property` would produce invalid code (by not removing the class properties & printing them).

This PR fixes the case for using `transform-flow-comments` without the other plugins. Matching #3655, it only works if you don't initialize the value. If you do that, you need `{syntax,transform}-class-property`.

---

Input:

```js
class X {
  a: number
  b: ?string
}
```

_Previous_ Output:

```js
class X {}
```

_Current_ Output (invalid JS):

```js
class X {
  a /*: number*/;
  b /*: ?string*/;
```

_New_ Output:

```js
class X {
  /*:: a: number*/
  /*:: b: ?string*/
}
```