### PR TITLE
transform-async-generator: use babel-runtime 6

### DIFF
--- a/packages/babel-plugin-transform-async-generator-functions/package.json
+++ b/packages/babel-plugin-transform-async-generator-functions/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-helper-remap-async-to-generator": "^6.16.2",
     "babel-plugin-syntax-async-generators": "^6.5.0",
-    "babel-runtime": "^5.0.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.3.13"


### PR DESCRIPTION
Fixes https://github.com/babel/babel/issues/4624