### PR TITLE
fix(shouldIgnore): filename normalization should be platform sensitive

### DIFF
--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -116,7 +116,9 @@ export function shouldIgnore(
   ignore: Array<RegExp | Function> = [],
   only?: Array<RegExp | Function>,
 ): boolean {
-  filename = slash(filename);
+  if (path.sep !== '/') {
+    filename = filename.replace(/\\/g, '/');
+  }
 
   if (only) {
     for (let pattern of only) {

--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -117,7 +117,7 @@ export function shouldIgnore(
   only?: Array<RegExp | Function>,
 ): boolean {
   filename = filename.replace(/\\/g, "/");
-  
+
   if (only) {
     for (let pattern of only) {
       if (_shouldIgnore(pattern, filename)) return false;

--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -116,8 +116,8 @@ export function shouldIgnore(
   ignore: Array<RegExp | Function> = [],
   only?: Array<RegExp | Function>,
 ): boolean {
-  if (path.sep !== '/') {
-    filename = filename.replace(/\\/g, '/');
+  if (path.sep !== "/") {
+    filename = filename.replace(/\\/g, "/");
   }
 
   if (only) {

--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -116,10 +116,8 @@ export function shouldIgnore(
   ignore: Array<RegExp | Function> = [],
   only?: Array<RegExp | Function>,
 ): boolean {
-  if (path.sep !== "/") {
-    filename = filename.replace(/\\/g, "/");
-  }
-
+  filename = filename.replace(/\\/g, "/");
+  
   if (only) {
     for (let pattern of only) {
       if (_shouldIgnore(pattern, filename)) return false;


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT
| Doc PR            | 

<!-- Describe your changes below in as much detail as possible -->

shouldIgnore normalizes the path of the filename prior to running any "only" regexes or functions. The normalization uses "slash", which has some undesirable special cases for non-ASCII characters and longer paths. Changing the normalization behavior to always replace path separators.

There is no real need to add additional tests, because the tests are not run in an environment where path.sep !== '/' anyway.