### PR TITLE
fixed babel/babel#4632 - missing parentheses around yield expression …

### DIFF
--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -142,7 +142,9 @@ export function YieldExpression(node: Object, parent: Object): boolean {
          t.isUnaryLike(parent) ||
          t.isCallExpression(parent) ||
          t.isMemberExpression(parent) ||
-         t.isNewExpression(parent);
+         t.isNewExpression(parent) ||
+         (t.isConditionalExpression(parent) && node === parent.test);
+
 }
 
 export { YieldExpression as AwaitExpression };

--- a/packages/babel-generator/test/fixtures/parentheses/yield-expression/actual.js
+++ b/packages/babel-generator/test/fixtures/parentheses/yield-expression/actual.js
@@ -2,7 +2,7 @@ function* asdf() {
   (yield 1) || (yield 2);
   (yield b)();
   new (yield b)();
-  true ? (yield 1) : (yield 2);
+  (yield 1) ? (yield 2) : (yield 3);
   yield (yield 1);
 }
 

--- a/packages/babel-generator/test/fixtures/parentheses/yield-expression/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/yield-expression/expected.js
@@ -2,7 +2,7 @@ function* asdf() {
   (yield 1) || (yield 2);
   (yield b)();
   new (yield b)();
-  true ? yield 1 : yield 2;
+  (yield 1) ? yield 2 : yield 3;
   yield yield 1;
 }
 


### PR DESCRIPTION
Fixes #4632 

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  |no
| New feature?      |no
| Deprecations?     |no
| Spec compliancy?  | yes
| Tests added/pass? | no
| Fixed tickets     | #4632
| License           | MIT
| Doc PR            | none

I don't have a test yet.