### PR TITLE
Forward bound shadowed function when hoisting identifiers

### DIFF
--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -17,7 +17,7 @@ const superVisitor = {
 
 export default new Plugin({
   name: "internal.shadowFunctions",
-  
+
   visitor: {
     ThisExpression(path) {
       remap(path, "this");
@@ -103,6 +103,10 @@ function remap(path, key) {
     fnPath.traverse(superVisitor, { id });
   } else {
     const init = key === "this" ? t.thisExpression() : t.identifier(key);
+
+    // Forward the shadowed function, so that the identifiers do not get hoisted
+    // up to the first non shadow function but rather up to the bound shadow function
+    if (shadowFunction) init._shadowedFunctionLiteral = shadowFunction;
 
     fnPath.scope.push({ id, init });
   }

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2364/actual.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2364/actual.js
@@ -1,0 +1,10 @@
+function wrapper(fn) {
+  return (...args) => {
+    if (someCondition) {
+      const val = fn(...args);
+      return val.test(() => {
+        console.log(val);
+      });
+    }
+  };
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2364/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2364/expected.js
@@ -1,0 +1,18 @@
+function wrapper(fn) {
+  return function () {
+    var _arguments = arguments;
+
+    if (someCondition) {
+      var _ret = function () {
+        var val = fn(..._arguments);
+        return {
+          v: val.test(function () {
+            console.log(val);
+          })
+        };
+      }();
+
+      if (typeof _ret === "object") return _ret.v;
+    }
+  };
+}

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2364/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2364/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-parameters", "transform-es2015-arrow-functions", "transform-es2015-block-scoping"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | #2364
| License           | MIT
| Doc PR            | 

This change ensures that when hoisting an identifier we do not hoist it up to
the first no shadowed function, but rather up to the bound shadowed function

Fix #2364