### PR TITLE
Fix rest parameters with flow type casting

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -30,6 +30,8 @@ let memberExpressionOptimisationVisitor = {
   },
 
   Flow(path) {
+    // Do not skip TypeCastExpressions as the contain valid non flow code
+    if (path.isTypeCastExpression()) return;
     // don't touch reference in type annotations
     path.skip();
   },

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4634/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4634/actual.js
@@ -1,0 +1,6 @@
+let oneOf = (...nodes) => {
+  if (nodes.length === 1) {
+    return nodes[0];
+  }
+  return ((new OneOfNode(nodes)): any)
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4634/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4634/expected.js
@@ -1,0 +1,10 @@
+let oneOf = function () {
+  for (var _len = arguments.length, nodes = Array(_len), _key = 0; _key < _len; _key++) {
+    nodes[_key] = arguments[_key];
+  }
+
+  if (nodes.length === 1) {
+    return nodes[0];
+  }
+  return new OneOfNode(nodes);
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4634/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4634/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-flow", "transform-flow-strip-types", "transform-es2015-parameters", "transform-es2015-destructuring", "transform-es2015-arrow-functions"]
+}


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4634 
| License           | MIT
| Doc PR            | 

Do not skip TypeCastExpressions when finding referenced identifiers as the
type cast contains valid non flow code that we need to visit.