### PR TITLE
Exclude super from being assign to ref variable

### DIFF
--- a/packages/babel-helper-explode-assignable-expression/src/index.js
+++ b/packages/babel-helper-explode-assignable-expression/src/index.js
@@ -3,7 +3,10 @@ import * as t from "babel-types";
 
 function getObjRef(node, nodes, file, scope) {
   let ref;
-  if (t.isIdentifier(node)) {
+  if (t.isSuper(node)) {
+    // Super cannot be directly assigned so lets return it directly
+    return node;
+  } else if (t.isIdentifier(node)) {
     if (scope.hasBinding(node.name)) {
       // this variable is declared in scope so we can be 100% sure
       // that evaluating it multiple times wont trigger a getter
@@ -17,10 +20,11 @@ function getObjRef(node, nodes, file, scope) {
   } else if (t.isMemberExpression(node)) {
     ref = node.object;
 
-    if (t.isIdentifier(ref) && scope.hasBinding(ref.name)) {
+    if (t.isSuper(ref) || t.isIdentifier(ref) && scope.hasBinding(ref.name)) {
       // the object reference that we need to save is locally declared
       // so as per the previous comment we can be 100% sure evaluating
       // it multiple times will be safe
+      // Super cannot be directly assigned so lets return it also
       return ref;
     }
   } else {

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/actual.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/actual.js
@@ -1,0 +1,5 @@
+foo = {
+  bar() {
+    return super.baz **= 12;
+  }
+}

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/expected.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/expected.js
@@ -1,0 +1,11 @@
+var _obj;
+
+var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+var _set = function set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; };
+
+foo = _obj = {
+  bar() {
+    return _set(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", Math.pow(_get(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", this), 12), this);
+  }
+};

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/options.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-object-super", "transform-exponentiation-operator"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4349 
| License           | MIT
| Doc PR            | 

Assigning of super is not allowed `var ref = super;` This fix adds an exception into
the explode helper so that super stays untouched and does not get assigned to a variable.