### PR TITLE
🚀 Update globals to version 9.0.0

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -14,7 +14,7 @@
     "babel-types": "^6.16.0",
     "babylon": "^6.11.0",
     "debug": "^2.2.0",
-    "globals": "^8.3.0",
+    "globals": "^9.0.0",
     "invariant": "^2.2.0",
     "lodash": "^4.2.0"
   }


### PR DESCRIPTION
We are only using globals.builtins and this part of the json file hasn't changed from 8.x to 9.10
https://github.com/babel/babel/blob/master/packages/babel-traverse/src/scope/index.js#L170 
https://github.com/sindresorhus/globals/commits/master