### PR TITLE
🚀 Update detect-indent to version 4.0.0

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -14,7 +14,7 @@
     "babel-messages": "^6.8.0",
     "babel-runtime": "^6.9.0",
     "babel-types": "^6.16.0",
-    "detect-indent": "^3.0.1",
+    "detect-indent": "^4.0.0",
     "jsesc": "^1.3.0",
     "lodash": "^4.2.0",
     "source-map": "^0.5.0"


### PR DESCRIPTION
in 4.0 the cli and it's necessary deps were removed but we only use the node API
in 4.0 repeating was updated to 2.0 (not 3.0) which also removes the cli part and it's dependencies.


https://github.com/sindresorhus/detect-indent/commits/master
https://github.com/sindresorhus/repeating/commits/master