### PR TITLE
🚀 Update home-or-tmp to version 2.0.0

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -11,7 +11,7 @@
     "babel-core": "^6.16.0",
     "babel-runtime": "^6.11.6",
     "core-js": "^2.4.0",
-    "home-or-tmp": "^1.0.0",
+    "home-or-tmp": "^2.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
     "path-exists": "^1.0.0",


### PR DESCRIPTION
The only change is this one:
https://github.com/sindresorhus/home-or-tmp/commit/b90ce6a26d3951172212e2255299d3a9396d6538

Which should not affect us.