### PR TITLE
Allow newer versions of chalk

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -12,7 +12,7 @@
     "babel-polyfill": "^6.16.0",
     "babel-runtime": "^6.9.0",
     "bin-version-check": "^2.1.0",
-    "chalk": "1.1.1",
+    "chalk": "^1.1.1",
     "commander": "^2.8.1",
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^0.1.0",


### PR DESCRIPTION
in 1.1.2 and 1.1.3 only dependencies have changed, but they would be installed right now anyway https://github.com/chalk/chalk/commit/0d8d8c204eb87a4038219131ad4d8369c9f59d24