### PR TITLE
Fix error when constructor default arg refers to self or own static property

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/src/default.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/default.js
@@ -24,10 +24,16 @@ function hasDefaults(node) {
   return false;
 }
 
+function isSafeBinding(scope, node) {
+  if (!scope.hasOwnBinding(node.name)) return true;
+  const { kind } = scope.getOwnBinding(node.name);
+  return kind === "param" || kind === "local";
+}
+
 let iifeVisitor = {
   ReferencedIdentifier(path, state) {
-    let name = path.node.name;
-    if (name === "eval" || (path.scope.hasOwnBinding(name) && path.scope.getOwnBinding(name).kind !== "param")) {
+    const { scope, node } = path;
+    if (node.name === "eval" || !isSafeBinding(scope, node)) {
       state.iife = true;
       path.stop();
     }
@@ -100,7 +106,7 @@ export let visitor = {
 
       //
       if (!state.iife) {
-        if (right.isIdentifier() && scope.hasOwnBinding(right.node.name) && scope.getOwnBinding(right.node.name).kind !== "param") {
+        if (right.isIdentifier() && !isSafeBinding(scope, right.node)) {
           // the right hand side references a parameter
           state.iife = true;
         } else {

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-4253/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-4253/actual.js
@@ -1,0 +1,6 @@
+class Ref {
+  constructor(id = ++Ref.nextID) {
+    this.id = id
+  }
+}
+Ref.nextID = 0

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-4253/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-4253/exec.js
@@ -1,0 +1,9 @@
+class Ref {
+  static nextId = 0
+  constructor(id = ++Ref.nextId, n = id) {
+    this.id = n
+  }
+}
+
+assert.equal(1, new Ref().id)
+assert.equal(2, new Ref().id)

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-4253/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-4253/expected.js
@@ -1,0 +1,8 @@
+var Ref = function Ref() {
+  var id = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : ++Ref.nextID;
+  babelHelpers.classCallCheck(this, Ref);
+
+  this.id = id;
+};
+
+Ref.nextID = 0;

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-self/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-self/actual.js
@@ -1,0 +1,11 @@
+class Ref {
+  constructor(ref = Ref) {
+    this.ref = ref
+  }
+}
+
+class X {
+  constructor(x = foo) {
+    this.x = x
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-self/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-self/exec.js
@@ -1,0 +1,7 @@
+class Ref {
+  constructor(ref = Ref) {
+    this.ref = ref
+  }
+}
+
+assert.equal(Ref, new Ref().ref)

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-self/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-iife-self/expected.js
@@ -1,0 +1,13 @@
+var Ref = function Ref() {
+  var ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Ref;
+  babelHelpers.classCallCheck(this, Ref);
+
+  this.ref = ref;
+};
+
+var X = function X() {
+  var x = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : foo;
+  babelHelpers.classCallCheck(this, X);
+
+  this.x = x;
+};


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | #4253, #4442
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

They currently throw `Cannot call a class as a function` due to being incorrectly wrapped in an IIFE.