### PR TITLE
Retain method return types on transform-es2015-classes (closes #4665)

### DIFF
--- a/packages/babel-helper-define-map/src/index.js
+++ b/packages/babel-helper-define-map/src/index.js
@@ -55,6 +55,7 @@ export function push(mutatorMap: Object, node: Object, kind: string, file, scope
     value = node.value;
   } else if (t.isObjectMethod(node) || t.isClassMethod(node)) {
     value = t.functionExpression(null, node.params, node.body, node.generator, node.async);
+    value.returnType = node.returnType;
   }
 
   let inheritedKind = toKind(node);

--- a/packages/babel-plugin-transform-es2015-classes/src/loose.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/loose.js
@@ -17,6 +17,7 @@ export default class LooseClassTransformer extends VanillaTransformer {
       let methodName = t.memberExpression(classRef, node.key, node.computed || t.isLiteral(node.key));
 
       let func = t.functionExpression(null, node.params, node.body, node.generator, node.async);
+      func.returnType = node.returnType;
       let key = t.toComputedKey(node, node.key);
       if (t.isStringLiteral(key)) {
         func = nameFunction({

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/actual.js
@@ -1,0 +1,6 @@
+// @flow
+class C {
+  m(x: number): string {
+    return 'a';
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
@@ -1,0 +1,12 @@
+// @flow
+var C = function () {
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+
+  C.prototype.m = function m(x: number): string {
+    return 'a';
+  };
+
+  return C;
+}();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-function-name", ["transform-es2015-classes", { "loose": true }], "transform-es2015-spread", "transform-es2015-block-scoping", "syntax-flow"]
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/actual.js
@@ -1,0 +1,6 @@
+// @flow
+class C {
+  m(x: number): string {
+    return 'a';
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/expected.js
@@ -1,0 +1,14 @@
+// @flow
+var C = function () {
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+
+  babelHelpers.createClass(C, [{
+    key: 'm',
+    value: function m(x: number): string {
+      return 'a';
+    }
+  }]);
+  return C;
+}();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-function-name", "transform-es2015-classes", "transform-es2015-spread", "transform-es2015-block-scoping", "syntax-flow"]
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/actual.js
@@ -1,0 +1,6 @@
+// @flow
+class C {
+  m(x: number): string {
+    return 'a';
+  }
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// @flow
+var C = function () {
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+
+  C.prototype.m = function m(x /*: number*/) /*: string*/ {
+    return 'a';
+  };
+
+  return C;
+}();

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/options.json
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": [["es2015", { "loose": true }]],
+  "plugins": ["transform-flow-comments", "external-helpers"]
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/actual.js
@@ -1,0 +1,6 @@
+// @flow
+class C {
+  m(x: number): string {
+    return 'a';
+  }
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/expected.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// @flow
+var C = function () {
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+
+  babelHelpers.createClass(C, [{
+    key: 'm',
+    value: function m(x /*: number*/) /*: string*/ {
+      return 'a';
+    }
+  }]);
+  return C;
+}();

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/options.json
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-flow-comments", "external-helpers"]
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/actual.js
@@ -1,0 +1,6 @@
+// @flow
+class C {
+  m(x: number): string {
+    return 'a';
+  }
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var C = function () {
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+
+  C.prototype.m = function m(x) {
+    return 'a';
+  };
+
+  return C;
+}();

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/options.json
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": [["es2015", { "loose": true }]],
+  "plugins": ["transform-flow-strip-types", "external-helpers"]
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/actual.js
@@ -1,0 +1,6 @@
+// @flow
+class C {
+  m(x: number): string {
+    return 'a';
+  }
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/expected.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var C = function () {
+  function C() {
+    babelHelpers.classCallCheck(this, C);
+  }
+
+  babelHelpers.createClass(C, [{
+    key: 'm',
+    value: function m(x) {
+      return 'a';
+    }
+  }]);
+  return C;
+}();

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/options.json
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-flow-strip-types", "external-helpers"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4665
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

Re-attaches return types when converting `ClassMethod` to `FunctionExpression`.

Added tests for loose & spec class transforms, with normal output, `flow-comments` & `flow-strip-types`.