### PR TITLE
Fix block scoping transform for declarations in labeled statements

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -497,14 +497,7 @@ class BlockScoping {
         declarators = declarators.concat(node.declarations || node);
       }
       if (t.isLabeledStatement(node)) {
-        node = node.body;
-        if (t.isClassDeclaration(node) || t.isFunctionDeclaration(node) || isBlockScoped(node)) {
-          path = path.get("body");
-          if (isBlockScoped(node)) {
-            convertBlockScopedToVar(path, node, block, this.scope);
-          }
-          declarators = declarators.concat(node.declarations || node);
-        }
+        addDeclarationsFromChild(path.get("body"), node.body);
       }
     };
 

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -488,17 +488,31 @@ class BlockScoping {
       }
     }
 
+    const addDeclarationsFromChild = (path, node) => {
+      node = node || path.node;
+      if (t.isClassDeclaration(node) || t.isFunctionDeclaration(node) || isBlockScoped(node)) {
+        if (isBlockScoped(node)) {
+          convertBlockScopedToVar(path, node, block, this.scope);
+        }
+        declarators = declarators.concat(node.declarations || node);
+      }
+      if (t.isLabeledStatement(node)) {
+        node = node.body;
+        if (t.isClassDeclaration(node) || t.isFunctionDeclaration(node) || isBlockScoped(node)) {
+          path = path.get("body");
+          if (isBlockScoped(node)) {
+            convertBlockScopedToVar(path, node, block, this.scope);
+          }
+          declarators = declarators.concat(node.declarations || node);
+        }
+      }
+    };
+
     //
     if (block.body) {
       for (let i = 0; i < block.body.length; i++) {
-        let declar = block.body[i];
-        if (t.isClassDeclaration(declar) || t.isFunctionDeclaration(declar) || isBlockScoped(declar)) {
-          let declarPath = this.blockPath.get("body")[i];
-          if (isBlockScoped(declar)) {
-            convertBlockScopedToVar(declarPath, null, block, this.scope);
-          }
-          declarators = declarators.concat(declar.declarations || declar);
-        }
+        let declarPath = this.blockPath.get("body")[i];
+        addDeclarationsFromChild(declarPath);
       }
     }
 
@@ -507,14 +521,9 @@ class BlockScoping {
         let consequents = block.cases[i].consequent;
 
         for (let j = 0; j < consequents.length; j++) {
+          let declarPath = this.blockPath.get("cases")[i];
           let declar = consequents[j];
-          if (t.isClassDeclaration(declar) || t.isFunctionDeclaration(declar) || isBlockScoped(declar)) {
-            let declarPath = this.blockPath.get("cases")[i];
-            if (isBlockScoped(declar)) {
-              convertBlockScopedToVar(declarPath, declar, block, this.scope);
-            }
-            declarators = declarators.concat(declar.declarations || declar);
-          }
+          addDeclarationsFromChild(declarPath, declar);
         }
       }
     }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/actual.js
@@ -1,0 +1,9 @@
+let x, y;
+{
+  a: let x;
+  let y;
+}
+
+switch (0) {
+  case 0: a: let x=0;
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/expected.js
@@ -1,0 +1,11 @@
+var x = void 0,
+    y = void 0;
+{
+  a: var _x = void 0;
+  var _y = void 0;
+}
+
+switch (0) {
+  case 0:
+    a: var _x2 = 0;
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | #4122
| License           | MIT

* Reduce code duplication inside `getLetReferences` between block and switch handling;
* Correctly visit `LabeledStatement` nodes when collecting block-scoped declarations to transform.