### PR TITLE
Retain return types on ObjectMethods in transform-es2015-shorthand-properties

### DIFF
--- a/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
@@ -6,9 +6,12 @@ export default function () {
       ObjectMethod(path) {
         let { node } = path;
         if (node.kind === "method") {
+          const func = t.functionExpression(null, node.params, node.body, node.generator, node.async);
+          func.returnType = node.returnType;
+
           path.replaceWith(t.objectProperty(
             node.key,
-            t.functionExpression(null, node.params, node.body, node.generator, node.async),
+            func,
             node.computed
           ));
         }

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/test/fixtures/shorthand-properties/method-type-annotations/actual.js
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/test/fixtures/shorthand-properties/method-type-annotations/actual.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method(a: string): number {
+    return 5 + 5;
+  }
+};

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/test/fixtures/shorthand-properties/method-type-annotations/expected.js
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/test/fixtures/shorthand-properties/method-type-annotations/expected.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method: function (a: string): number {
+    return 5 + 5;
+  }
+};

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/test/fixtures/shorthand-properties/method-type-annotations/options.json
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/test/fixtures/shorthand-properties/method-type-annotations/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-shorthand-properties", "syntax-flow"]
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/object-method-type-annotations/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/object-method-type-annotations/actual.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method(a: string): number {
+    return 5 + 5;
+  }
+};

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/object-method-type-annotations/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/object-method-type-annotations/expected.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method: function (a /*: string*/) /*: number*/ {
+    return 5 + 5;
+  }
+};

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/object-method-type-annotations/options.json
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/object-method-type-annotations/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-shorthand-properties", "transform-flow-comments"]
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/object-method-type-annotations/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/object-method-type-annotations/actual.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method(a: string): number {
+    return 5 + 5;
+  }
+};

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/object-method-type-annotations/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/object-method-type-annotations/expected.js
@@ -1,0 +1,5 @@
+var obj = {
+  method: function (a) {
+    return 5 + 5;
+  }
+};

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/object-method-type-annotations/options.json
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/object-method-type-annotations/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-shorthand-properties", "transform-flow-strip-types"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

Similar to #4668. Found `ObjectMethod`s transformed with `es2015-shorthand-properties` weren't retaining the return types either.