### PR TITLE
Handle side effects correctly in rest params index expressions (#4348)

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4348/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4348/actual.js
@@ -1,0 +1,4 @@
+function first(...values) {
+  var index = 0;
+  return values[index++];
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4348/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4348/expected.js
@@ -1,0 +1,6 @@
+function first() {
+  var _ref;
+
+  var index = 0;
+  return _ref = index++ + 0, arguments.length <= _ref ? undefined : arguments[_ref];
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-length/expected.js
@@ -1,6 +1,8 @@
 var t = function (f) {
+  var _ref;
+
   arguments.length <= 1 ? undefined : arguments[1];
-  arguments.length <= (arguments.length <= 1 ? 0 : arguments.length - 1) - 1 + 1 ? undefined : arguments[(arguments.length <= 1 ? 0 : arguments.length - 1) - 1 + 1];
+  _ref = (arguments.length <= 1 ? 0 : arguments.length - 1) - 1 + 1, arguments.length <= _ref ? undefined : arguments[_ref];
 };
 
 function t(f) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4348
| License           | MIT

This uses the `scope.isPure` heuristic to detect possible side effects of the constructed index expression, avoiding double execution as in #4348.

