### PR TITLE
Remove travis short-circuit script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ language: node_js
 cache:
   directories:
   - node_modules
-before_install:
-- |
-    [ "$TRAVIS_COMMIT_RANGE" = "" ] || git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(doc))/' || {
-      echo "Only docs were updated, stopping build process."
-      exit
-    }
 node_js:
 - '6'
 - '5'


### PR DESCRIPTION
This is a stopgap measure against the false positives we're seeing in some Travis builds, where the `before_install` script fails with messages like `fatal: Invalid symmetric difference expression 7f772e94cea0aa140431f9172e880e03bf3db7b1...d276d574646e124da9b5cd2d6824af78eb3ee9cf
`

Example build log [here](https://travis-ci.org/babel/babel/jobs/165258111).