### PR TITLE
Update: Eslint to 3.0 and update CI builds (fixes #4638)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,16 @@ node_js:
 - '5'
 - '4'
 - '0.12'
-script: make test-ci
+script: 
+  - 'if [ -n "${LINT-}" ]; then make lint ; fi'
+  - 'if [ -z "${LINT-}" ]; then make test-ci ; fi'
 
+matrix:
+  fast_finish: true
+  include:
+    - node_js: "node"
+      env: LINT=true
+      
 notifications:
   on_success: change
   on_failure: always

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ test-cov: clean
 	./scripts/test-cov.sh
 
 test-ci:
-	make lint
 	NODE_ENV=test make bootstrap
 	# if ./node_modules/.bin/semver `npm --version` -r ">=3.3.0"; then ./node_modules/.bin/flow check; fi
 	./scripts/test-cov.sh

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "async": "^1.5.0",
     "babel-core": "^6.13.2",
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.0.0",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-flow-strip-types": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
@@ -21,7 +21,7 @@
     "chalk": "1.1.1",
     "codecov.io": "^0.1.6",
     "derequire": "^2.0.2",
-    "eslint": "^2.13.1",
+    "eslint": "^3.7.1",
     "eslint-config-babel": "^1.0.1",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flow-vars": "^0.5.0",

--- a/packages/babel-cli/src/babel-doctor/rules/deduped.js
+++ b/packages/babel-cli/src/babel-doctor/rules/deduped.js
@@ -1,4 +1,4 @@
-export default async function (packages) {
+export default async function (packages) { // eslint-disable-line require-yield
   let foundDeps = {};
   let foundDuplicated = false;
   let duplicatedPackages = {};

--- a/packages/babel-cli/src/babel-doctor/rules/has-config.js
+++ b/packages/babel-cli/src/babel-doctor/rules/has-config.js
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 
-export default async function () {
+export default async function () { // eslint-disable-line require-yield
   let cwd = process.cwd();
   let parts = cwd.split(path.sep);
 


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  |no
| New feature?      |no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? |no
| Fixed tickets     | #4638 
| License           | MIT
| Doc PR            | reference to the documentation PR, if any


Update ESLint to 3.0 and make sure lint is only run under nodejs version greater than 4 (run on latest).

Questions:

Lint has 2 errors.

```sh
babel\packages\babel-cli\src\babel-doctor\rules\deduped.js
  1:16  error  This generator function does not have 'yield'  require-yield

babel\packages\babel-cli\src\babel-doctor\rules\has-config.js
  4:16  error  This generator function does not have 'yield'  require-yield

✖ 2 problems (2 errors, 0 warnings)

```

@hzoo any idea what should i do with these errors? (asking bcz I dont have a good idea abt the code base yet :smile: )

