### PR TITLE
Better error messaging when preset options are given without a corresponding preset

### DIFF
--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -178,12 +178,13 @@ export default class OptionManager {
 
       // check for an unknown option
       if (!option && this.log) {
-        let pluginOptsInfo = "Check out http://babeljs.io/docs/usage/options/ for more info";
-
         if (removed[key]) {
           this.log.error(`Using removed Babel 5 option: ${alias}.${key} - ${removed[key].message}`, ReferenceError);
         } else {
-          this.log.error(`Unknown option: ${alias}.${key}. ${pluginOptsInfo}`, ReferenceError);
+          let unknownOptErr = `Unknown option: ${alias}.${key}. Check out http://babeljs.io/docs/usage/options/ for more information about options.`;
+          let presetConfigErr = `A common cause of this error is the presence of a configuration options object without the corresponding preset name. Example:\n\nInvalid:\n  \`{ presets: [{option: value}] }\`\nValid:\n  \`{ presets: ['pluginName', {option: value}] }\`\n\nFor more detailed information on preset configuration, please see http://babeljs.io/docs/plugins/#pluginpresets-options.`;
+
+          this.log.error(`${unknownOptErr}\n\n${presetConfigErr}`, ReferenceError);
         }
       }
     }

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -57,6 +57,18 @@ suite("option-manager", function () {
         /While processing preset: .*option-manager(?:\/|\\\\)not-a-preset\.js/
       );
     });
+
+    test("throws for invalid preset configuration", function() {
+      return assert.throws(
+        function () {
+          var opt = new OptionManager(new Logger(null, "unknown"));
+          opt.init({
+            'presets': [{ option: "value" }]
+          });
+        },
+        /Unknown option: foreign.option\.(?:.|\n)+A common cause of this error is the presence of a configuration options object without the corresponding preset name/
+      );
+    });
   });
 
   suite("presets", function () {


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes, I think?
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | https://github.com/babel/babel/issues/4677
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

<!-- Describe your changes below in as much detail as possible -->
~~Checking for the presence of the `presets` array in `mergeOptions` and then checking the elements in that array seems like the best way to do this to me. The other place I looked at putting this check was in [resolvePresets](https://github.com/babel/babel/blob/a62905c61d9c995a11703ab4dcdc7d759c71ce4b/packages/babel-core/src/transformation/file/options/option-manager.js#L249), but that didn't seem as reliable as this (lots more cases to account for).~~

~~Let me know if you had something else or a better solution in mind!~~

*Edit*: [See comment below](https://github.com/babel/babel/pull/4685#issuecomment-252790002)