### PR TITLE
Add missing description to all package.json files

### DIFF
--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-bindify-decorators",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to bindify decorators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-builder-binary-assignment-operator-visitor",
   "version": "6.15.0",
-  "description": "",
+  "description": "Helper function to build binary assignment operator visitors",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-builder-conditional-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-conditional-assignment-operator-visitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-builder-conditional-assignment-operator-visitor",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to build conditional assignment operator visitors",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-conditional-assignment-operator-visitor",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-builder-react-jsx",
   "version": "6.9.0",
-  "description": "",
+  "description": "Helper function to build react jsx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-call-delegate",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to call delegate",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-define-map",
   "version": "6.9.0",
-  "description": "",
+  "description": "Helper function to define a map",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-explode-assignable-expression",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to explode an assignable expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-explode-class",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to explode class",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-fixtures",
   "version": "6.9.0",
-  "description": "",
+  "description": "Helper function to support fixtures",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-function-name",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to change the property 'name' of every function",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-get-function-arity",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to get function arity",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-hoist-variables",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to hoist variables",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-optimise-call-expression",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to optimise call expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-plugin-test-runner",
   "version": "6.8.0",
-  "description": "",
+  "description": "Helper function to support test runner",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-regex",
   "version": "6.9.0",
-  "description": "",
+  "description": "Helper function to check for literal RegEx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-remap-async-to-generator",
   "version": "6.16.2",
-  "description": "",
+  "description": "Helper function to remap async functions to generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-helper-replace-supers",
   "version": "6.16.0",
-  "description": "",
+  "description": "Helper function to replace supers",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-external-helpers",
   "version": "6.8.0",
-  "description": "",
+  "description": "This plugin contains helper functions that’ll be placed at the top of the generated code",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-syntax-flow",
   "version": "6.13.0",
-  "description": "",
+  "description": "Allow parsing of the flow syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-syntax-jsx",
   "version": "6.13.0",
-  "description": "",
+  "description": "Allow parsing of jsx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-class-constructor-call/package.json
+++ b/packages/babel-plugin-transform-class-constructor-call/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-class-constructor-call",
   "version": "6.8.0",
-  "description": "",
+  "description": "This plugin allows Babel to transform class constructors (deprecated)",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-class-constructor-call",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-class-properties/package.json
+++ b/packages/babel-plugin-transform-class-properties/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-class-properties",
   "version": "6.16.0",
-  "description": "",
+  "description": "This plugin transforms static class properties as well as properties declared with the property initializer syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-class-properties",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-es2015-instanceof/package.json
+++ b/packages/babel-plugin-transform-es2015-instanceof/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-instanceof",
   "version": "6.8.0",
-  "description": "",
+  "description": "This plugin transforms all the ES2015 'instanceof' methods",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-instanceof",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-es2015-modules-amd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-modules-amd",
   "version": "6.8.0",
-  "description": "",
+  "description": "This plugin transforms ES2015 modules to AMD",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-amd",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-modules-commonjs",
   "version": "6.16.0",
-  "description": "",
+  "description": "This plugin transforms ES2015 modules to CommonJS",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-commonjs",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-modules-systemjs",
   "version": "6.14.0",
-  "description": "",
+  "description": "This plugin transforms ES2015 modules to SystemJS",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-systemjs",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-es2015-modules-umd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-modules-umd",
   "version": "6.12.0",
-  "description": "",
+  "description": "This plugin transforms ES2015 modules to UMD",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-umd",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-es2015-typeof-symbol",
   "version": "6.8.0",
-  "description": "",
+  "description": "This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-typeof-symbol",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-strict-mode",
   "version": "6.11.3",
-  "description": "TODO",
+  "description": "This plugin places a 'use strict'; directive at the top of all files to enable strict mode",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-traverse",
   "version": "6.16.0",
-  "description": "",
+  "description": "The Babel Traverse module maintains the overall tree state, and is responsible for replacing, removing, and adding nodes",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-types",
   "version": "6.16.0",
-  "description": "",
+  "description": "Babel Types is a Lodash-esque utility library for AST nodes",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | no
| Fixed tickets     | #4559 
| License           | MIT
| Doc PR            | `undefined`

There was no description at all anywhere specially for the `babel-helper-*` ones, some others even had `TODO` in the README.md files, I think some of them are deprecated and if not they should be filled with useful info.

Fixes #4559 

PD: I had to make up some of the descriptions because of the lack of information about the plugins so I have to change anything please tell me and I will do it very willingly, thanks in advance for the feedback provided!