### PR TITLE
Fixed incorrect compilation of async iterator methods

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -90,6 +90,10 @@ function classOrObjectMethod(path: NodePath, callId: Object) {
       []
     ))
   ];
+
+  // Regardless of whether or not the wrapped function is a an async method
+  // or generator the outer function should not be
+  node.generator = false;
 }
 
 function plainFunction(path: NodePath, callId: Object) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/class-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/class-method/expected.js
@@ -1,5 +1,5 @@
 class C {
-  *g() {
+  g() {
     var _this = this;
 
     return babelHelpers.asyncGenerator.wrap(function* () {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/object-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/object-method/expected.js
@@ -1,5 +1,5 @@
 ({
-  *g() {
+  g() {
     var _this = this;
 
     return babelHelpers.asyncGenerator.wrap(function* () {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/static-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/static-method/expected.js
@@ -1,5 +1,5 @@
 class C {
-  static *g() {
+  static g() {
     var _this = this;
 
     return babelHelpers.asyncGenerator.wrap(function* () {


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | yes for spec compliancy
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | changed 3 tests for spec compliancy
| Fixed tickets     | 4705
| License           | MIT
| Doc PR            | n/a

This pull request is to fix an issue with how async generators are implemented in methods/objects/state methods to actually result in correct behaviour (see #4705). This closes #4705.
