### PR TITLE
Add resolvePlugin and resolvePreset methods to babel-core API

### DIFF
--- a/packages/babel-core/src/api/node.js
+++ b/packages/babel-core/src/api/node.js
@@ -5,6 +5,7 @@ export { default as File } from "../transformation/file";
 export { default as options } from "../transformation/file/options/config";
 export { default as buildExternalHelpers } from "../tools/build-external-helpers";
 export { default as template } from "babel-template";
+export { default as resolvePlugin } from "../helpers/resolve-plugin";
 export { version } from "../../package";
 
 import * as util from "../util";

--- a/packages/babel-core/src/api/node.js
+++ b/packages/babel-core/src/api/node.js
@@ -6,6 +6,7 @@ export { default as options } from "../transformation/file/options/config";
 export { default as buildExternalHelpers } from "../tools/build-external-helpers";
 export { default as template } from "babel-template";
 export { default as resolvePlugin } from "../helpers/resolve-plugin";
+export { default as resolvePreset } from "../helpers/resolve-preset";
 export { version } from "../../package";
 
 import * as util from "../util";

--- a/packages/babel-core/src/helpers/get-possible-plugin-names.js
+++ b/packages/babel-core/src/helpers/get-possible-plugin-names.js
@@ -1,0 +1,3 @@
+export default function getPossiblePluginNames(pluginName: string): Array<string> {
+  return [`babel-plugin-${pluginName}`, pluginName];
+}

--- a/packages/babel-core/src/helpers/get-possible-preset-names.js
+++ b/packages/babel-core/src/helpers/get-possible-preset-names.js
@@ -1,0 +1,13 @@
+export default function getPossiblePresetNames(presetName: string): Array<string> {
+  let possibleNames = [`babel-preset-${presetName}`, presetName];
+
+  // trying to resolve @organization shortcat
+  // @foo/es2015 -> @foo/babel-preset-es2015
+  let matches = presetName.match(/^(@[^/]+)\/(.+)$/);
+  if (matches) {
+    let [, orgName, presetPath] = matches;
+    possibleNames.push(`${orgName}/babel-preset-${presetPath}`);
+  }
+
+  return possibleNames;
+}

--- a/packages/babel-core/src/helpers/resolve-from-possible-names.js
+++ b/packages/babel-core/src/helpers/resolve-from-possible-names.js
@@ -1,0 +1,5 @@
+import resolve from "./resolve";
+
+export default function resolveFromPossibleNames(possibleNames: Array<string>, dirname: string): ?string {
+  return possibleNames.reduce((accum, curr) => accum || resolve(curr, dirname), null);
+}

--- a/packages/babel-core/src/helpers/resolve-plugin.js
+++ b/packages/babel-core/src/helpers/resolve-plugin.js
@@ -1,6 +1,6 @@
-import resolve from "./resolve";
+import resolveFromPossibleNames from "./resolve-from-possible-names";
 import getPossiblePluginNames from "./get-possible-plugin-names";
 
 export default function resolvePlugin(pluginName: string, dirname: string = process.cwd()): ?string {
-  return getPossiblePluginNames(pluginName).reduce((accum, curr) => accum || resolve(curr, dirname), null);
+  return resolveFromPossibleNames(getPossiblePluginNames(pluginName), dirname);
 }

--- a/packages/babel-core/src/helpers/resolve-plugin.js
+++ b/packages/babel-core/src/helpers/resolve-plugin.js
@@ -1,0 +1,6 @@
+import resolve from "./resolve";
+import getPossiblePluginNames from "./get-possible-plugin-names";
+
+export default function resolvePlugin(pluginName: string, dirname: string = process.cwd()): ?string {
+  return getPossiblePluginNames(pluginName).reduce((accum, curr) => accum || resolve(curr, dirname), null);
+}

--- a/packages/babel-core/src/helpers/resolve-preset.js
+++ b/packages/babel-core/src/helpers/resolve-preset.js
@@ -1,6 +1,6 @@
-import resolve from "./resolve";
+import resolveFromPossibleNames from "./resolve-from-possible-names";
 import getPossiblePresetNames from "./get-possible-preset-names";
 
 export default function resolvePreset(presetName: string, dirname: string = process.cwd()): ?string {
-  return getPossiblePresetNames(presetName).reduce((accum, curr) => accum || resolve(curr, dirname), null);
+  return resolveFromPossibleNames(getPossiblePresetNames(presetName), dirname);
 }

--- a/packages/babel-core/src/helpers/resolve-preset.js
+++ b/packages/babel-core/src/helpers/resolve-preset.js
@@ -1,0 +1,6 @@
+import resolve from "./resolve";
+import getPossiblePresetNames from "./get-possible-preset-names";
+
+export default function resolvePreset(presetName: string, dirname: string = process.cwd()): ?string {
+  return getPossiblePresetNames(presetName).reduce((accum, curr) => accum || resolve(curr, dirname), null);
+}

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -5,8 +5,8 @@ import type Logger from "../logger";
 import Plugin from "../../plugin";
 import * as messages from "babel-messages";
 import { normaliseOptions } from "./index";
-import resolve from "../../../helpers/resolve";
 import resolvePlugin from "../../../helpers/resolve-plugin";
+import resolvePreset from "../../../helpers/resolve-preset";
 import cloneDeepWith from "lodash/cloneDeepWith";
 import clone from "lodash/clone";
 import merge from "../../../helpers/merge";
@@ -262,18 +262,7 @@ export default class OptionManager {
       let presetLoc;
       try {
         if (typeof val === "string") {
-          presetLoc = resolve(`babel-preset-${val}`, dirname) || resolve(val, dirname);
-
-          // trying to resolve @organization shortcat
-          // @foo/es2015 -> @foo/babel-preset-es2015
-          if (!presetLoc) {
-            let matches = val.match(/^(@[^/]+)\/(.+)$/);
-            if (matches) {
-              let [, orgName, presetPath] = matches;
-              val = `${orgName}/babel-preset-${presetPath}`;
-              presetLoc = resolve(val, dirname);
-            }
-          }
+          presetLoc = resolvePreset(val, dirname);
 
           if (!presetLoc) {
             throw new Error(`Couldn't find preset ${JSON.stringify(val)} relative to directory ` +

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -6,6 +6,7 @@ import Plugin from "../../plugin";
 import * as messages from "babel-messages";
 import { normaliseOptions } from "./index";
 import resolve from "../../../helpers/resolve";
+import resolvePlugin from "../../../helpers/resolve-plugin";
 import cloneDeepWith from "lodash/cloneDeepWith";
 import clone from "lodash/clone";
 import merge from "../../../helpers/merge";
@@ -123,7 +124,7 @@ export default class OptionManager {
 
       // allow plugins to be specified as strings
       if (typeof plugin === "string") {
-        let pluginLoc = resolve(`babel-plugin-${plugin}`, dirname) || resolve(plugin, dirname);
+        let pluginLoc = resolvePlugin(plugin, dirname);
         if (pluginLoc) {
           plugin = require(pluginLoc);
         } else {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -118,6 +118,10 @@ describe("api", function () {
     assert.equal(babel.resolvePlugin("nonexistent-plugin"), null);
   });
 
+  it("exposes the resolvePreset method", function() {
+    assert.equal(babel.resolvePreset("nonexistent-preset"), null);
+  });
+
   it("transformFile", function (done) {
     babel.transformFile(__dirname + "/fixtures/api/file.js", {}, function (err, res) {
       if (err) return done(err);
@@ -266,7 +270,7 @@ describe("api", function () {
           presets: ["@babel/es2015"]
         });
       },
-      /Couldn\'t find preset \"\@babel\/babel\-preset\-es2015\" relative to directory/
+      /Couldn\'t find preset \"\@babel\/es2015\" relative to directory/
     );
   });
 
@@ -277,7 +281,7 @@ describe("api", function () {
           presets: ["@babel/react/optimizations"]
         });
       },
-      /Couldn\'t find preset \"\@babel\/babel\-preset\-react\/optimizations\" relative to directory/
+      /Couldn\'t find preset \"\@babel\/react\/optimizations\" relative to directory/
     );
   });
 

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -114,6 +114,10 @@ describe("api", function () {
     }).marked[0].message, "foobar");
   });
 
+  it("exposes the resolvePlugin method", function() {
+    assert.equal(babel.resolvePlugin("nonexistent-plugin"), null);
+  });
+
   it("transformFile", function (done) {
     babel.transformFile(__dirname + "/fixtures/api/file.js", {}, function (err, res) {
       if (err) return done(err);

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -263,28 +263,6 @@ describe("api", function () {
 
   });
 
-  it("handles preset shortcuts (adds babel-preset-)", function () {
-    return assert.throws(
-      function () {
-        babel.transform("", {
-          presets: ["@babel/es2015"]
-        });
-      },
-      /Couldn\'t find preset \"\@babel\/es2015\" relative to directory/
-    );
-  });
-
-  it("handles preset shortcuts 2 (adds babel-preset-)", function () {
-    return assert.throws(
-      function () {
-        babel.transform("", {
-          presets: ["@babel/react/optimizations"]
-        });
-      },
-      /Couldn\'t find preset \"\@babel\/react\/optimizations\" relative to directory/
-    );
-  });
-
   it("source map merging", function () {
     let result = babel.transform([
       "function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }",

--- a/packages/babel-core/test/get-possible-plugin-names.js
+++ b/packages/babel-core/test/get-possible-plugin-names.js
@@ -1,0 +1,8 @@
+let assert                 = require("assert");
+let getPossiblePluginNames = require("../lib/helpers/get-possible-plugin-names");
+
+describe("getPossiblePluginNames", function () {
+  it("adds the babel-plugin prefix", function() {
+    assert.deepEqual(getPossiblePluginNames("foobar"), ["babel-plugin-foobar", "foobar"]);
+  });
+});

--- a/packages/babel-core/test/get-possible-preset-names.js
+++ b/packages/babel-core/test/get-possible-preset-names.js
@@ -1,0 +1,22 @@
+let assert                 = require("assert");
+let getPossiblePresetNames = require("../lib/helpers/get-possible-preset-names");
+
+describe("getPossiblePresetNames", function () {
+  it("adds the babel-preset prefix", function() {
+    assert.deepEqual(getPossiblePresetNames("foobar"), ["babel-preset-foobar", "foobar"]);
+  });
+
+  it("inserts babel-preset after @org/", function() {
+    assert.deepEqual(getPossiblePresetNames("@babel/es2015"), [
+      "babel-preset-@babel/es2015",
+      "@babel/es2015",
+      "@babel/babel-preset-es2015"
+    ]);
+
+    assert.deepEqual(getPossiblePresetNames("@babel/react/optimizations"), [
+      "babel-preset-@babel/react/optimizations",
+      "@babel/react/optimizations",
+      "@babel/babel-preset-react/optimizations"
+    ]);
+  });
+});


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q | A |
| --- | --- |
| Bug fix? | no |
| Breaking change? | no |
| New feature? | yes |
| Deprecations? | no |
| Spec compliancy? | no |
| Tests added/pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | will create one once merged |

This PR adds `resolvePlugin` and `resolvePreset` methods to the `babel-core` API.

Exposing these publicly is useful because it allows plugins/preset names to be mapped to their absolute paths, which is necessary if `babel.transform` will process a file that is not a descendant of the directory in which the babel plugins/presets were installed<sup>[1]</sup>. (Otherwise, babel will fail to resolve the plugins/presets because it'll try resolve from [the processed file's `dirname`](https://github.com/babel/babel/blob/37419b44b92a366b92bcc01be4f635459ddd77e6/packages/babel-core/src/transformation/file/options/build-config-chain.js#L38).)

<sup>[1]</sup> One use case for this (the one that prompted me to make this change) is to work with ruby gems that include javascript assets (which is common among Rails plugins). Unlike node modules, ruby gems are installed globally, which means those javascript files won't be inside the application subtree (where your babel plugins and presets are installed). I'm developing a [sprockets](https://github.com/rails/sprockets) plugin to allow transpiling via babel 6 ([sprockets-es6](https://github.com/TannerRogalsky/sprockets-es6) is stuck on babel 5) and with these methods I can transform the user-supplied plugins/presets to their absolute paths so that processing assets inside globally-installed ruby gems will work.
