### PR TITLE
Run ESLint on test files, and fix lint errors in test files.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@ scripts
 lib
 packages/babel-runtime
 packages/*/node_modules
-packages/*/test
 packages/*/dist
 vendor
 _babel.github.io

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "max-len": 0
   },
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ watch: clean
 	./node_modules/.bin/gulp watch
 
 lint:
-	./node_modules/.bin/eslint packages/*/src
+	./node_modules/.bin/eslint packages/*/{src,test}/*.js
 
 fix:
-	./node_modules/.bin/eslint packages/*/src --fix
+	./node_modules/.bin/eslint packages/*/{src,test}/*.js --fix
 
 clean: test-clean
 	rm -rf packages/*/lib

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,30 +1,30 @@
-var readdir        = require("fs-readdir-recursive");
-var helper         = require("babel-helper-fixtures");
-var assert         = require("assert");
-var rimraf         = require("rimraf");
-var outputFileSync = require("output-file-sync");
-var child          = require("child_process");
-var path           = require("path");
-var chai           = require("chai");
-var fs             = require("fs");
-var pathExists     = require("path-exists");
-var _              = require("lodash");
+let readdir        = require("fs-readdir-recursive");
+let helper         = require("babel-helper-fixtures");
+let assert         = require("assert");
+let rimraf         = require("rimraf");
+let outputFileSync = require("output-file-sync");
+let child          = require("child_process");
+let path           = require("path");
+let chai           = require("chai");
+let fs             = require("fs");
+let pathExists     = require("path-exists");
+let _              = require("lodash");
 
-var fixtureLoc = path.join(__dirname, "fixtures");
-var tmpLoc = path.join(__dirname, "tmp");
+let fixtureLoc = path.join(__dirname, "fixtures");
+let tmpLoc = path.join(__dirname, "tmp");
 
-var presetLocs = [
+let presetLocs = [
   path.join(__dirname, "../../babel-preset-es2015"),
   path.join(__dirname, "../../babel-preset-react")
 ].join(",");
 
-var pluginLocs = [
+let pluginLocs = [
   path.join(__dirname, "/../../babel-plugin-transform-strict-mode"),
   path.join(__dirname, "/../../babel-plugin-transform-es2015-modules-commonjs"),
 ].join(",");
 
-var readDir = function (loc) {
-  var files = {};
+let readDir = function (loc) {
+  let files = {};
   if (pathExists.sync(loc)) {
     _.each(readdir(loc), function (filename) {
       files[filename] = helper.readFile(path.join(loc, filename));
@@ -33,14 +33,14 @@ var readDir = function (loc) {
   return files;
 };
 
-var saveInFiles = function (files) {
+let saveInFiles = function (files) {
   _.each(files, function (content, filename) {
     outputFileSync(filename, content);
   });
 };
 
-var assertTest = function (stdout, stderr, opts) {
-  var expectStderr = opts.stderr.trim();
+let assertTest = function (stdout, stderr, opts) {
+  let expectStderr = opts.stderr.trim();
   stderr = stderr.trim();
 
   if (opts.stderr) {
@@ -53,7 +53,7 @@ var assertTest = function (stdout, stderr, opts) {
     throw new Error("stderr:\n" + stderr);
   }
 
-  var expectStdout = opts.stdout.trim();
+  let expectStdout = opts.stdout.trim();
   stdout = stdout.trim();
   stdout = stdout.replace(/\\/g, "/");
 
@@ -68,19 +68,19 @@ var assertTest = function (stdout, stderr, opts) {
   }
 
   _.each(opts.outFiles, function (expect, filename) {
-    var actual = helper.readFile(filename);
+    let actual = helper.readFile(filename);
     chai.expect(actual).to.equal(expect, "out-file " + filename);
   });
 };
 
-var buildTest = function (binName, testName, opts) {
-  var binLoc = path.join(__dirname, "../lib", binName);
+let buildTest = function (binName, testName, opts) {
+  let binLoc = path.join(__dirname, "../lib", binName);
 
   return function (callback) {
     clear();
     saveInFiles(opts.inFiles);
 
-    var args = [binLoc];
+    let args = [binLoc];
 
     if (binName !== "babel-external-helpers") {
       args.push("--presets", presetLocs, "--plugins", pluginLocs);
@@ -92,10 +92,10 @@ var buildTest = function (binName, testName, opts) {
 
     args = args.concat(opts.args);
 
-    var spawn = child.spawn(process.execPath, args);
+    let spawn = child.spawn(process.execPath, args);
 
-    var stderr = "";
-    var stdout = "";
+    let stderr = "";
+    let stdout = "";
 
     spawn.stderr.on("data", function (chunk) {
       stderr += chunk;
@@ -106,7 +106,7 @@ var buildTest = function (binName, testName, opts) {
     });
 
     spawn.on("close", function () {
-      var err;
+      let err;
 
       try {
         assertTest(stdout, stderr, opts);
@@ -128,7 +128,7 @@ var buildTest = function (binName, testName, opts) {
   };
 };
 
-var clear = function () {
+let clear = function () {
   process.chdir(__dirname);
   if (pathExists.sync(tmpLoc)) rimraf.sync(tmpLoc);
   fs.mkdirSync(tmpLoc);
@@ -138,22 +138,22 @@ var clear = function () {
 _.each(fs.readdirSync(fixtureLoc), function (binName) {
   if (binName[0] === ".") return;
 
-  var suiteLoc = path.join(fixtureLoc, binName);
+  let suiteLoc = path.join(fixtureLoc, binName);
   suite("bin/" + binName, function () {
     _.each(fs.readdirSync(suiteLoc), function (testName) {
       if (testName[0] === ".") return;
 
-      var testLoc = path.join(suiteLoc, testName);
+      let testLoc = path.join(suiteLoc, testName);
 
-      var opts = {
+      let opts = {
         args: []
       };
 
-      var optionsLoc = path.join(testLoc, "options.json");
+      let optionsLoc = path.join(testLoc, "options.json");
       if (pathExists.sync(optionsLoc)) _.merge(opts, require(optionsLoc));
 
       _.each(["stdout", "stdin", "stderr"], function (key) {
-        var loc = path.join(testLoc, key + ".txt");
+        let loc = path.join(testLoc, key + ".txt");
         if (pathExists.sync(loc)) {
           opts[key] = helper.readFile(loc);
         } else {
@@ -164,10 +164,10 @@ _.each(fs.readdirSync(fixtureLoc), function (binName) {
       opts.outFiles = readDir(path.join(testLoc, "out-files"));
       opts.inFiles  = readDir(path.join(testLoc, "in-files"));
 
-      var babelrcLoc = path.join(testLoc, ".babelrc");
+      let babelrcLoc = path.join(testLoc, ".babelrc");
       if (pathExists.sync(babelrcLoc)) {
         // copy .babelrc file to tmp directory
-        opts.inFiles['.babelrc'] = helper.readFile(babelrcLoc);
+        opts.inFiles[".babelrc"] = helper.readFile(babelrcLoc);
       }
 
       test(testName, buildTest(binName, testName, opts));

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -1,6 +1,6 @@
-var assert = require("assert");
-var chalk = require("chalk");
-var codeFrame = require("..");
+let assert = require("assert");
+let chalk = require("chalk");
+let codeFrame = require("..");
 
 suite("babel-code-frame", function () {
   test("basic usage", function () {
@@ -98,7 +98,7 @@ suite("babel-code-frame", function () {
       "\tclass Foo {",
       "\t  \t\t    constructor\t(\t)",
       "\t};",
-    ].join('\n');
+    ].join("\n");
     assert.equal(codeFrame(rawLines, 2, 25), [
       "  1 | \tclass Foo {",
       "> 2 | \t  \t\t    constructor\t(\t)",
@@ -119,7 +119,7 @@ suite("babel-code-frame", function () {
   });
 
   test("opts.linesAbove", function () {
-    var rawLines = [
+    let rawLines = [
       "/**",
       " * Sums two numbers.",
       " *",
@@ -143,7 +143,7 @@ suite("babel-code-frame", function () {
   });
 
   test("opts.linesBelow", function () {
-    var rawLines = [
+    let rawLines = [
       "/**",
       " * Sums two numbers.",
       " *",
@@ -166,7 +166,7 @@ suite("babel-code-frame", function () {
   });
 
   test("opts.linesAbove and opts.linesBelow", function () {
-    var rawLines = [
+    let rawLines = [
       "/**",
       " * Sums two numbers.",
       " *",

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -1,11 +1,9 @@
-var babel                = require("../lib/api/node");
-var buildExternalHelpers = require("../lib/tools/build-external-helpers");
-var Pipeline             = require("../lib/transformation/pipeline");
-var sourceMap            = require("source-map");
-var assert               = require("assert");
-var File                 = require("../lib/transformation/file").default;
-var Plugin               = require("../lib/transformation/plugin");
-var generator            = require("babel-generator").default;
+let babel                = require("../lib/api/node");
+let buildExternalHelpers = require("../lib/tools/build-external-helpers");
+let sourceMap            = require("source-map");
+let assert               = require("assert");
+let Plugin               = require("../lib/transformation/plugin");
+let generator            = require("babel-generator").default;
 
 function assertIgnored(result) {
   assert.ok(result.ignored);
@@ -25,7 +23,7 @@ function transformAsync(code, opts) {
 }
 
 suite("parser and generator options", function() {
-  var recast = {
+  let recast = {
     parse: function(code, opts) {
       return opts.parser.parse(code);
     },
@@ -48,13 +46,13 @@ suite("parser and generator options", function() {
   }
 
   test("options", function() {
-    var string = "original;";
+    let string = "original;";
     assert.deepEqual(newTransform(string).ast, babel.transform(string).ast);
     assert.equal(newTransform(string).code, string);
   });
 
   test("experimental syntax", function() {
-    var experimental = "var a: number = 1;";
+    let experimental = "var a: number = 1;";
 
     assert.deepEqual(newTransform(experimental).ast, babel.transform(experimental, {
       parserOpts: {
@@ -84,7 +82,7 @@ suite("parser and generator options", function() {
   });
 
   test("other options", function() {
-    var experimental = "if (true) {\n  import a from 'a';\n}";
+    let experimental = "if (true) {\n  import a from 'a';\n}";
 
     assert.notEqual(newTransform(experimental).ast, babel.transform(experimental, {
       parserOpts: {
@@ -149,8 +147,8 @@ suite("api", function () {
   });
 
   test("option wrapPluginVisitorMethod", function () {
-    var calledRaw = 0;
-    var calledIntercept = 0;
+    let calledRaw = 0;
+    let calledIntercept = 0;
 
     babel.transform("function foo() { bar(foobar); }", {
       wrapPluginVisitorMethod: function (pluginAlias, visitorType, callback) {
@@ -181,10 +179,10 @@ suite("api", function () {
   });
 
   test("pass per preset", function () {
-    var aliasBaseType = null;
+    let aliasBaseType = null;
 
     function execTest(passPerPreset) {
-      return babel.transform('type Foo = number; let x = (y): Foo => y;', {
+      return babel.transform("type Foo = number; let x = (y): Foo => y;", {
         passPerPreset: passPerPreset,
         presets: [
           // First preset with our plugin, "before"
@@ -193,7 +191,7 @@ suite("api", function () {
               new Plugin({
                 visitor: {
                   Function: function(path) {
-                    var alias = path.scope.getProgramParent().path.get('body')[0].node;
+                    let alias = path.scope.getProgramParent().path.get("body")[0].node;
                     if (!babel.types.isTypeAlias(alias)) return;
 
                     // In case of `passPerPreset` being `false`, the
@@ -227,32 +225,32 @@ suite("api", function () {
 
     // 1. passPerPreset: true
 
-    var result = execTest(true);
+    let result = execTest(true);
 
     assert.equal(aliasBaseType, "NumberTypeAnnotation");
 
     assert.deepEqual([
-      '"use strict";',
-      '',
-      'var x = function x(y) {',
-      '  return y;',
-      '};'
+      "\"use strict\";",
+      "",
+      "var x = function x(y) {",
+      "  return y;",
+      "};"
     ].join("\n"), result.code);
 
     // 2. passPerPreset: false
 
     aliasBaseType = null;
 
-    var result = execTest(false);
+    result = execTest(false);
 
     assert.equal(aliasBaseType, null);
 
     assert.deepEqual([
-      '"use strict";',
-      '',
-      'var x = function x(y) {',
-      '  return y;',
-      '};'
+      "\"use strict\";",
+      "",
+      "var x = function x(y) {",
+      "  return y;",
+      "};"
     ].join("\n"), result.code);
 
   });
@@ -280,14 +278,14 @@ suite("api", function () {
   });
 
   test("source map merging", function () {
-    var result = babel.transform([
-      'function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }',
-      '',
-      'let Foo = function Foo() {',
-      '  _classCallCheck(this, Foo);',
-      '};',
-      '',
-      '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0ZG91dCJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztJQUFNLEdBQUcsWUFBSCxHQUFHO3dCQUFILEdBQUciLCJmaWxlIjoidW5kZWZpbmVkIiwic291cmNlc0NvbnRlbnQiOlsiY2xhc3MgRm9vIHt9XG4iXX0='
+    let result = babel.transform([
+      "function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\"Cannot call a class as a function\"); } }",
+      "",
+      "let Foo = function Foo() {",
+      "  _classCallCheck(this, Foo);",
+      "};",
+      "",
+      "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0ZG91dCJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztJQUFNLEdBQUcsWUFBSCxHQUFHO3dCQUFILEdBQUciLCJmaWxlIjoidW5kZWZpbmVkIiwic291cmNlc0NvbnRlbnQiOlsiY2xhc3MgRm9vIHt9XG4iXX0="
     ].join("\n"), {
       sourceMap: true
     });
@@ -295,7 +293,7 @@ suite("api", function () {
     assert.deepEqual([
       "function _classCallCheck(instance, Constructor) {",
       "  if (!(instance instanceof Constructor)) {",
-      '    throw new TypeError("Cannot call a class as a function");',
+      "    throw new TypeError(\"Cannot call a class as a function\");",
       "  }",
       "}",
       "",
@@ -304,7 +302,7 @@ suite("api", function () {
       "};"
     ].join("\n"), result.code);
 
-    var consumer = new sourceMap.SourceMapConsumer(result.map);
+    let consumer = new sourceMap.SourceMapConsumer(result.map);
 
     assert.deepEqual(consumer.originalPositionFor({
       line: 7,
@@ -334,7 +332,7 @@ suite("api", function () {
       auxiliaryCommentBefore: "before",
       auxiliaryCommentAfter: "after",
       plugins: [function (babel) {
-        var t = babel.types;
+        let t = babel.types;
         return {
           visitor: {
             Program: function (path) {
@@ -351,7 +349,7 @@ suite("api", function () {
 
   test("modules metadata", function () {
     return Promise.all([
-      transformAsync('import { externalName as localName } from "external";').then(function (result) {
+      transformAsync("import { externalName as localName } from \"external\";").then(function (result) {
         assert.deepEqual(result.metadata.modules.imports[0], {
           source: "external",
           imported: ["externalName"],
@@ -363,7 +361,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('import * as localName2 from "external";').then(function (result) {
+      transformAsync("import * as localName2 from \"external\";").then(function (result) {
         assert.deepEqual(result.metadata.modules.imports[0], {
           source: "external",
           imported: ["*"],
@@ -374,7 +372,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('import localName3 from "external";').then(function (result) {
+      transformAsync("import localName3 from \"external\";").then(function (result) {
         assert.deepEqual(result.metadata.modules.imports[0], {
           source: "external",
           imported: ["default"],
@@ -386,7 +384,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('import localName from "./array";', {
+      transformAsync("import localName from \"./array\";", {
         resolveModuleSource: function() {
           return "override-source";
         }
@@ -406,11 +404,11 @@ suite("api", function () {
         ]);
       }),
 
-      transformAsync('export * as externalName1 from "external";', {
+      transformAsync("export * as externalName1 from \"external\";", {
         plugins: [require("../../babel-plugin-syntax-export-extensions")]
       }).then(function (result) {
-         assert.deepEqual(result.metadata.modules.exports, {
-          exported: ['externalName1'],
+        assert.deepEqual(result.metadata.modules.exports, {
+          exported: ["externalName1"],
           specifiers: [{
             kind: "external-namespace",
             exported: "externalName1",
@@ -419,7 +417,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('export externalName2 from "external";', {
+      transformAsync("export externalName2 from \"external\";", {
         plugins: [require("../../babel-plugin-syntax-export-extensions")]
       }).then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
@@ -433,7 +431,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('export function namedFunction() {}').then(function (result) {
+      transformAsync("export function namedFunction() {}").then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
           exported: ["namedFunction"],
           specifiers: [{
@@ -444,7 +442,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('export var foo = "bar";').then(function (result) {
+      transformAsync("export var foo = \"bar\";").then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
           "exported": ["foo"],
           specifiers: [{
@@ -466,7 +464,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('export { externalName4 } from "external";').then(function (result) {
+      transformAsync("export { externalName4 } from \"external\";").then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
           exported: ["externalName4"],
           specifiers: [{
@@ -478,7 +476,7 @@ suite("api", function () {
         });
       }),
 
-      transformAsync('export * from "external";').then(function (result) {
+      transformAsync("export * from \"external\";").then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
           exported: [],
           specifiers: [{
@@ -551,12 +549,12 @@ suite("api", function () {
         only: "foo/node_modules/*.bar",
         filename: "/foo/node_modules/bar.foo"
       }).then(assertIgnored)
-    ])
+    ]);
   });
 
   suite("env option", function () {
-    var oldBabelEnv = process.env.BABEL_ENV;
-    var oldNodeEnv = process.env.NODE_ENV;
+    let oldBabelEnv = process.env.BABEL_ENV;
+    let oldNodeEnv = process.env.NODE_ENV;
 
     setup(function () {
       // Tests need to run with the default and specific values for these. They
@@ -571,7 +569,7 @@ suite("api", function () {
     });
 
     test("default", function () {
-      var result = babel.transform("foo;", {
+      let result = babel.transform("foo;", {
         env: {
           development: { code: false }
         }
@@ -582,7 +580,7 @@ suite("api", function () {
 
     test("BABEL_ENV", function () {
       process.env.BABEL_ENV = "foo";
-      var result = babel.transform("foo;", {
+      let result = babel.transform("foo;", {
         env: {
           foo: { code: false }
         }
@@ -592,7 +590,7 @@ suite("api", function () {
 
     test("NODE_ENV", function () {
       process.env.NODE_ENV = "foo";
-      var result = babel.transform("foo;", {
+      let result = babel.transform("foo;", {
         env: {
           foo: { code: false }
         }
@@ -602,8 +600,8 @@ suite("api", function () {
   });
 
   test("resolveModuleSource option", function () {
-    var actual = 'import foo from "foo-import-default";\nimport "foo-import-bare";\nexport { foo } from "foo-export-named";';
-    var expected = 'import foo from "resolved/foo-import-default";\nimport "resolved/foo-import-bare";\nexport { foo } from "resolved/foo-export-named";';
+    let actual = "import foo from \"foo-import-default\";\nimport \"foo-import-bare\";\nexport { foo } from \"foo-export-named\";";
+    let expected = "import foo from \"resolved/foo-import-default\";\nimport \"resolved/foo-import-bare\";\nexport { foo } from \"resolved/foo-export-named\";";
 
     return transformAsync(actual, {
       resolveModuleSource: function (originalSource) {
@@ -616,25 +614,25 @@ suite("api", function () {
 
   suite("buildExternalHelpers", function () {
     test("all", function () {
-      var script = buildExternalHelpers();
+      let script = buildExternalHelpers();
       assert.ok(script.indexOf("classCallCheck") >= -1);
       assert.ok(script.indexOf("inherits") >= 0);
     });
 
     test("whitelist", function () {
-      var script = buildExternalHelpers(["inherits"]);
+      let script = buildExternalHelpers(["inherits"]);
       assert.ok(script.indexOf("classCallCheck") === -1);
       assert.ok(script.indexOf("inherits") >= 0);
     });
 
     test("empty whitelist", function () {
-      var script = buildExternalHelpers([]);
+      let script = buildExternalHelpers([]);
       assert.ok(script.indexOf("classCallCheck") === -1);
       assert.ok(script.indexOf("inherits") === -1);
     });
 
     test("underscored", function () {
-      var script = buildExternalHelpers(["typeof"]);
+      let script = buildExternalHelpers(["typeof"]);
       assert.ok(script.indexOf("typeof") >= 0);
     });
   });

--- a/packages/babel-core/test/browserify.js
+++ b/packages/babel-core/test/browserify.js
@@ -1,11 +1,11 @@
-var browserify = require("browserify");
-var assert = require("assert");
-var path = require("path");
-var vm = require("vm");
+let browserify = require("browserify");
+let assert = require("assert");
+let path = require("path");
+let vm = require("vm");
 
 suite("browserify", function() {
   test("babel/register may be used without breaking browserify", function(done) {
-    var bundler = browserify(path.join(__dirname, "fixtures/browserify/register.js"));
+    let bundler = browserify(path.join(__dirname, "fixtures/browserify/register.js"));
 
     bundler.bundle(function(err, bundle) {
       if (err) return done(err);
@@ -14,6 +14,6 @@ suite("browserify", function() {
       // ensure that the code runs without throwing an exception
       vm.runInNewContext("var global = this;\n" + bundle, {});
       done();
-    })
-  })
+    });
+  });
 });

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1,18 +1,18 @@
-var assert = require("assert");
-var path = require("path");
-var buildConfigChain = require("../lib/transformation/file/options/build-config-chain");
+let assert = require("assert");
+let path = require("path");
+let buildConfigChain = require("../lib/transformation/file/options/build-config-chain");
 
 function fixture() {
-  var args = [__dirname, "fixtures", "config"];
-  for (var i = 0; i < arguments.length; i ++) {
+  let args = [__dirname, "fixtures", "config"];
+  for (let i = 0; i < arguments.length; i ++) {
     args.push(arguments[i]);
   }
   return path.join.apply(path, args);
 }
 
 suite("buildConfigChain", function () {
-  var oldBabelEnv;
-  var oldNodeEnv;
+  let oldBabelEnv;
+  let oldNodeEnv;
 
   beforeEach(function () {
     oldBabelEnv = process.env.BABEL_ENV;
@@ -28,11 +28,11 @@ suite("buildConfigChain", function () {
   });
 
   test("dir1", function () {
-    var chain = buildConfigChain({
+    let chain = buildConfigChain({
       filename: fixture("dir1", "src.js")
     });
 
-    var expected = [
+    let expected = [
       {
         options: {
           plugins: [
@@ -77,11 +77,11 @@ suite("buildConfigChain", function () {
   });
 
   test("dir2", function () {
-    var chain = buildConfigChain({
+    let chain = buildConfigChain({
       filename: fixture("dir2", "src.js")
     });
 
-    var expected = [
+    let expected = [
       {
         options: {
           plugins: [
@@ -116,11 +116,11 @@ suite("buildConfigChain", function () {
   });
 
   test("env - base", function () {
-    var chain = buildConfigChain({
+    let chain = buildConfigChain({
       filename: fixture("env", "src.js")
     });
 
-    var expected = [
+    let expected = [
       {
         options: {
           plugins: [
@@ -157,11 +157,11 @@ suite("buildConfigChain", function () {
   test("env - foo", function () {
     process.env.NODE_ENV = "foo";
 
-    var chain = buildConfigChain({
+    let chain = buildConfigChain({
       filename: fixture("env", "src.js")
     });
 
-    var expected = [
+    let expected = [
       {
         options: {
           plugins: [
@@ -209,11 +209,11 @@ suite("buildConfigChain", function () {
     process.env.NODE_ENV = "foo"; // overridden
     process.env.NODE_ENV = "bar";
 
-    var chain = buildConfigChain({
+    let chain = buildConfigChain({
       filename: fixture("env", "src.js")
     });
 
-    var expected = [
+    let expected = [
       {
         options: {
           plugins: [
@@ -261,11 +261,11 @@ suite("buildConfigChain", function () {
   test("env - foo", function () {
     process.env.NODE_ENV = "foo";
 
-    var chain = buildConfigChain({
+    let chain = buildConfigChain({
       filename: fixture("pkg", "src.js")
     });
 
-    var expected = [
+    let expected = [
       {
         options: {
           plugins: ["pkg-plugin"]

--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -1,14 +1,14 @@
-var traverse = require("babel-traverse").default;
-var assert   = require("assert");
-var parse    = require("babylon").parse;
+let traverse = require("babel-traverse").default;
+let assert   = require("assert");
+let parse    = require("babylon").parse;
 
 suite("evaluation", function () {
   function addTest(code, type, value, notConfident) {
     test(type + ": " + code, function () {
-      var visitor = {};
+      let visitor = {};
 
       visitor[type] = function (path) {
-        var evaluate = path.evaluate();
+        let evaluate = path.evaluate();
         assert.equal(evaluate.confident, !notConfident);
         assert.equal(evaluate.value, value);
       };

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -10,16 +10,16 @@ suite("option-manager", () => {
         () => OptionManager.memoisePluginContainer(({ Plugin }) => new Plugin("object-assign", {})),
         /Babel 5 plugin is being run with Babel 6/
       );
-    })
+    });
   });
 
   suite("mergeOptions", () => {
     test("throws for removed babel 5 options", () => {
       return assert.throws(
         () => {
-          var opt = new OptionManager(new Logger(null, "unknown"));
+          let opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
-            'randomOption': true
+            "randomOption": true
           });
         },
         /Unknown option: base.randomOption/
@@ -29,10 +29,10 @@ suite("option-manager", () => {
     test("throws for removed babel 5 options", () => {
       return assert.throws(
         () => {
-          var opt = new OptionManager(new Logger(null, "unknown"));
+          let opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
-            'auxiliaryComment': true,
-            'blacklist': true
+            "auxiliaryComment": true,
+            "blacklist": true
           });
         },
         /Using removed Babel 5 option: base.auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`/
@@ -42,9 +42,9 @@ suite("option-manager", () => {
     test("throws for resolved but erroring preset", () => {
       return assert.throws(
         () => {
-          var opt = new OptionManager(new Logger(null, "unknown"));
+          let opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
-            'presets': [path.join(__dirname, "fixtures/option-manager/not-a-preset")]
+            "presets": [path.join(__dirname, "fixtures/option-manager/not-a-preset")]
           });
         },
         /While processing preset: .*option-manager(?:\/|\\\\)not-a-preset\.js/
@@ -54,9 +54,9 @@ suite("option-manager", () => {
     test("throws for invalid preset configuration", function() {
       return assert.throws(
         function () {
-          var opt = new OptionManager(new Logger(null, "unknown"));
+          let opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
-            'presets': [{ option: "value" }]
+            "presets": [{ option: "value" }]
           });
         },
         /Unknown option: foreign.option\.(?:.|\n)+A common cause of this error is the presence of a configuration options object without the corresponding preset name/
@@ -67,9 +67,9 @@ suite("option-manager", () => {
   suite("presets", function () {
     function presetTest(name) {
       test(name, function () {
-        var opt = new OptionManager(new Logger(null, "unknown"));
-        var options = opt.init({
-          'presets': [path.join(__dirname, "fixtures/option-manager/presets", name)]
+        let opt = new OptionManager(new Logger(null, "unknown"));
+        let options = opt.init({
+          "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)]
         });
 
         assert.equal(true, Array.isArray(options.plugins));
@@ -77,14 +77,14 @@ suite("option-manager", () => {
       });
     }
 
-    presetTest('es5');
-    presetTest('es5_function');
-    presetTest('es2015_default');
-    presetTest('es2015_default_function');
-    presetTest('es2015_default_object_function');
-    presetTest('es2015_function');
-    presetTest('es2015_function_fallback');
-    presetTest('es2015_named');
+    presetTest("es5");
+    presetTest("es5_function");
+    presetTest("es2015_default");
+    presetTest("es2015_default_function");
+    presetTest("es2015_default_object_function");
+    presetTest("es2015_function");
+    presetTest("es2015_function_fallback");
+    presetTest("es2015_named");
 
   });
 });

--- a/packages/babel-core/test/path.js
+++ b/packages/babel-core/test/path.js
@@ -1,13 +1,12 @@
-var transform = require("../lib/api/node").transform;
-var Plugin    = require("../lib/transformation/plugin");
-var babel     = require("../lib/api/node");
-var chai      = require("chai");
+let transform = require("../lib/api/node").transform;
+let Plugin    = require("../lib/transformation/plugin");
+let chai      = require("chai");
 
 suite("traversal path", function () {
   test("replaceWithSourceString", function () {
-    var expectCode = "function foo() {}";
+    let expectCode = "function foo() {}";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           FunctionDeclaration: function (path) {
@@ -21,9 +20,9 @@ suite("traversal path", function () {
   });
 
   test("replaceWith (arrow expression body to block statement body)", function () {
-    var expectCode = "var fn = () => true;";
+    let expectCode = "var fn = () => true;";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           ArrowFunctionExpression: function (path) {
@@ -46,9 +45,9 @@ suite("traversal path", function () {
   });
 
   test("replaceWith (arrow block statement body to expression body)", function () {
-    var expectCode = "var fn = () => { return true; }";
+    let expectCode = "var fn = () => { return true; }";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           ArrowFunctionExpression: function (path) {
@@ -65,9 +64,9 @@ suite("traversal path", function () {
   });
 
   test("replaceWith (for-in left expression to variable declaration)", function () {
-    var expectCode = "for (KEY in right);";
+    let expectCode = "for (KEY in right);";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           ForInStatement: function (path) {
@@ -91,9 +90,9 @@ suite("traversal path", function () {
   });
 
   test("replaceWith (for-in left variable declaration to expression)", function () {
-    var expectCode = "for (var KEY in right);";
+    let expectCode = "for (var KEY in right);";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           ForInStatement: function (path) {
@@ -110,9 +109,9 @@ suite("traversal path", function () {
   });
 
   test("replaceWith (for-loop left expression to variable declaration)", function () {
-    var expectCode = "for (KEY;;);";
+    let expectCode = "for (KEY;;);";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           ForStatement: function (path) {
@@ -136,9 +135,9 @@ suite("traversal path", function () {
   });
 
   test("replaceWith (for-loop left variable declaration to expression)", function () {
-    var expectCode = "for (var KEY;;);";
+    let expectCode = "for (var KEY;;);";
 
-    var actualCode = transform(expectCode, {
+    let actualCode = transform(expectCode, {
       plugins: [new Plugin({
         visitor: {
           ForStatement: function (path) {

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -1,14 +1,14 @@
-var assert = require("assert");
-var async = require("async");
-var babel = require("../lib/api/node");
-var fs = require("fs");
-var path = require("path");
+let assert = require("assert");
+let async = require("async");
+let babel = require("../lib/api/node");
+let fs = require("fs");
+let path = require("path");
 
 // Test that plugins & presets are resolved relative to `filename`.
 suite("addon resolution", function () {
   test("addon resolution", function (done) {
-    var fixtures = {};
-    var paths = {};
+    let fixtures = {};
+    let paths = {};
 
     paths.fixtures = path.join(
       __dirname,
@@ -33,7 +33,7 @@ suite("addon resolution", function () {
     function fixturesReady (err) {
       if (err) return done(err);
 
-      var actual = babel.transform(fixtures.actual, {
+      let actual = babel.transform(fixtures.actual, {
         filename: paths.actual,
         plugins: ["addons/plugin"],
         presets: ["addons/preset"],

--- a/packages/babel-core/test/util.js
+++ b/packages/babel-core/test/util.js
@@ -1,6 +1,6 @@
-var assert = require("assert");
-var util   = require("../lib/util");
-var t      = require("babel-types");
+let assert = require("assert");
+let util   = require("../lib/util");
+let t      = require("babel-types");
 
 suite("util", function () {
   test("canCompile", function () {
@@ -36,7 +36,7 @@ suite("util", function () {
     assert.deepEqual(util.list(["foo", "bar"]), ["foo", "bar"]);
     assert.deepEqual(util.list(/foo/), [/foo/]);
 
-    var date = new Date;
+    let date = new Date;
     assert.deepEqual(util.list(date), [date]);
   });
 
@@ -84,8 +84,8 @@ suite("util", function () {
   });
 
   test("shouldIgnore", function () {
-    var reIgnore = /\-reIgnore\.js/;
-    var fnIgnore = function (src) {
+    let reIgnore = /\-reIgnore\.js/;
+    let fnIgnore = function (src) {
       if (src.indexOf("fnIgnore") > 0) {
         return true;
       }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,11 +1,11 @@
-var Whitespace = require("../lib/whitespace");
-var Printer    = require("../lib/printer");
-var generate   = require("../lib");
-var assert     = require("assert");
-var parse      = require("babylon").parse;
-var chai       = require("chai");
-var t          = require("babel-types");
-var _          = require("lodash");
+let Whitespace = require("../lib/whitespace");
+let Printer    = require("../lib/printer");
+let generate   = require("../lib");
+let assert     = require("assert");
+let parse      = require("babylon").parse;
+let chai       = require("chai");
+let t          = require("babel-types");
+let _          = require("lodash");
 
 suite("generation", function () {
   test("completeness", function () {
@@ -20,16 +20,16 @@ suite("generation", function () {
   });
 
   test("multiple sources", function () {
-    var sources = {
+    let sources = {
       "a.js": "function hi (msg) { console.log(msg); }\n",
       "b.js": "hi('hello');\n"
     };
-    var parsed = _.keys(sources).reduce(function (_parsed, filename) {
+    let parsed = _.keys(sources).reduce(function (_parsed, filename) {
       _parsed[filename] = parse(sources[filename], { sourceFilename: filename });
       return _parsed;
     }, {});
 
-    var combinedAst = {
+    let combinedAst = {
       "type": "File",
       "program": {
         "type": "Program",
@@ -38,22 +38,21 @@ suite("generation", function () {
       }
     };
 
-    var generated = generate.default(combinedAst, { sourceMaps: true }, sources);
+    let generated = generate.default(combinedAst, { sourceMaps: true }, sources);
 
     chai.expect(generated.map).to.deep.equal({
       version: 3,
-      sources: [ 'a.js', 'b.js' ],
-      names: [],
-      mappings: 'AAAA,SAASA,EAAT,CAAaC,GAAb,EAAkB;AAAEC,UAAQC,GAAR,CAAYF,GAAZ;AAAmB;;ACAvCD,GAAG,OAAH',
+      sources: [ "a.js", "b.js" ],
+      mappings: "AAAA,SAASA,EAAT,CAAaC,GAAb,EAAkB;AAAEC,UAAQC,GAAR,CAAYF,GAAZ;AAAmB;;ACAvCD,GAAG,OAAH",
       names: [
-        'hi',
-        'msg',
-        'console',
-        'log',
+        "hi",
+        "msg",
+        "console",
+        "log",
       ],
       sourcesContent: [
-      'function hi (msg) { console.log(msg); }\n',
-        'hi(\'hello\');\n'
+        "function hi (msg) { console.log(msg); }\n",
+        "hi('hello');\n"
       ]
     }, "sourcemap was incorrectly generated");
 
@@ -64,20 +63,20 @@ suite("generation", function () {
   });
 
   test("identifierName", function () {
-    var code = "function foo() { bar; }\n";
+    let code = "function foo() { bar; }\n";
 
-    var ast = parse(code, { filename: "inline" }).program;
-    var fn = ast.body[0];
+    let ast = parse(code, { filename: "inline" }).program;
+    let fn = ast.body[0];
 
-    var id = fn.id;
+    let id = fn.id;
     id.name += "2";
     id.loc.identifierName = "foo";
 
-    var id2 = fn.body.body[0].expression;
+    let id2 = fn.body.body[0].expression;
     id2.name += "2";
     id2.loc.identiferName = "bar";
 
-    var generated = generate.default(ast, {
+    let generated = generate.default(ast, {
       filename: "inline",
       sourceFileName: "inline",
       sourceMaps: true
@@ -102,12 +101,12 @@ suite("generation", function () {
 suite("programmatic generation", function() {
   test("numeric member expression", function() {
     // Should not generate `0.foo`
-    var mem = t.memberExpression(t.numericLiteral(60702), t.identifier("foo"));
+    let mem = t.memberExpression(t.numericLiteral(60702), t.identifier("foo"));
     new Function(generate.default(mem).code);
   });
 
   test("nested if statements needs block", function() {
-    var ifStatement = t.ifStatement(
+    let ifStatement = t.ifStatement(
       t.stringLiteral("top cond"),
       t.whileStatement(
         t.stringLiteral("while cond"),
@@ -119,15 +118,15 @@ suite("programmatic generation", function() {
       t.expressionStatement(t.stringLiteral("alt"))
     );
 
-    var ast = parse(generate.default(ifStatement).code);
-    assert.equal(ast.program.body[0].consequent.type, 'BlockStatement');
+    let ast = parse(generate.default(ifStatement).code);
+    assert.equal(ast.program.body[0].consequent.type, "BlockStatement");
   });
 
   test("flow object indentation", function() {
-    var objectStatement = t.objectTypeAnnotation(
+    let objectStatement = t.objectTypeAnnotation(
       [
         t.objectTypeProperty(
-          t.identifier('bar'),
+          t.identifier("bar"),
           t.stringTypeAnnotation()
         ),
       ],
@@ -135,32 +134,32 @@ suite("programmatic generation", function() {
       null
     );
 
-    var output = generate.default(objectStatement).code;
+    let output = generate.default(objectStatement).code;
     assert.equal(output, [
-      '{',
-      '  bar: string;',
-      '}',
-    ].join('\n'));
+      "{",
+      "  bar: string;",
+      "}",
+    ].join("\n"));
   });
 });
 
 suite("whitespace", function () {
   test("empty token list", function () {
-    var w = new Whitespace([]);
-    assert.equal(w.getNewlinesBefore(t.stringLiteral('1')), 0);
+    let w = new Whitespace([]);
+    assert.equal(w.getNewlinesBefore(t.stringLiteral("1")), 0);
   });
 });
 
-var suites = require("babel-helper-fixtures").default(__dirname + "/fixtures");
+let suites = require("babel-helper-fixtures").default(__dirname + "/fixtures");
 
 suites.forEach(function (testSuite) {
   suite("generation/" + testSuite.title, function () {
     _.each(testSuite.tests, function (task) {
       test(task.title, !task.disabled && function () {
-        var expect = task.expect;
-        var actual = task.actual;
+        let expect = task.expect;
+        let actual = task.actual;
 
-        var actualAst = parse(actual.code, {
+        let actualAst = parse(actual.code, {
           filename: actual.loc,
           plugins: [
             "jsx",
@@ -176,7 +175,7 @@ suites.forEach(function (testSuite) {
           sourceType: "module",
         });
 
-        var actualCode = generate.default(actualAst, task.options, actual.code).code;
+        let actualCode = generate.default(actualAst, task.options, actual.code).code;
         chai.expect(actualCode).to.equal(expect.code, actual.loc + " !== " + expect.loc);
       });
     });

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
@@ -1,14 +1,14 @@
-var assert = require("assert");
-var babel = require("babel-core");
-var vm = require("vm");
+let assert = require("assert");
+let babel = require("babel-core");
+let vm = require("vm");
 
 test("Re-export doesn't overwrite __esModule flag", function () {
-  var code = 'export * from "./dep";';
-  var depStub = {
+  let code = "export * from \"./dep\";";
+  let depStub = {
     __esModule: false,
   };
 
-  var context = {
+  let context = {
     module: {
       exports: {}
     },

--- a/packages/babel-preset-es2015/test/index.js
+++ b/packages/babel-preset-es2015/test/index.js
@@ -1,6 +1,5 @@
-var es2015 = require("../lib");
-var assert = require("assert");
-var expect = require("chai").expect;
+let es2015 = require("../lib");
+let expect = require("chai").expect;
 
 suite("es2015 preset", function () {
   test("exposes an object", function () {
@@ -16,7 +15,7 @@ suite("es2015 preset", function () {
     expect(function () {
       es2015.buildPreset(null);
     }).not.to.throw();
-  })
+  });
 
   suite("options", function () {
     suite("loose", function () {

--- a/packages/babel-preset-es2015/test/traceur.js
+++ b/packages/babel-preset-es2015/test/traceur.js
@@ -1,5 +1,4 @@
-var fs = require("fs");
-var _  = require("lodash");
+let _  = require("lodash");
 
 require("babel-helper-transform-fixture-test-runner")(__dirname + "/fixtures/traceur", "traceur", {
   ignoreSuites: [

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -1,8 +1,8 @@
-var generator = require('../../babel-generator').default;
-var template  = require("../lib");
-var chai      = require("chai");
+let generator = require("../../babel-generator").default;
+let template  = require("../lib");
+let chai      = require("chai");
 
-var comments = "// Sum two numbers\nconst add = (a, b) => a + b;";
+let comments = "// Sum two numbers\nconst add = (a, b) => a + b;";
 
 suite("templating", function () {
   test("import statement will cause parser to throw by default", function () {
@@ -13,18 +13,18 @@ suite("templating", function () {
 
   test("import statements are allowed with sourceType: module", function () {
     chai.expect(function () {
-      template("import foo from 'foo'", {sourceType: 'module'})({});
+      template("import foo from 'foo'", {sourceType: "module"})({});
     }).not.to.throw();
   });
 
   test("should strip comments by default", function () {
-    var code = "const add = (a, b) => a + b;"
-    var output = template(comments)();
+    let code = "const add = (a, b) => a + b;";
+    let output = template(comments)();
     chai.expect(generator(output).code).to.be.equal(code);
   });
 
   test("should preserve comments with a flag", function () {
-    var output = template(comments, {preserveComments: true})();
+    let output = template(comments, {preserveComments: true})();
     chai.expect(generator(output).code).to.be.equal(comments);
   });
 });

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -1,10 +1,10 @@
-var traverse = require("../lib").default;
-var assert = require("assert");
-var parse = require("babylon").parse;
+let traverse = require("../lib").default;
+let assert = require("assert");
+let parse = require("babylon").parse;
 
 function getPath(code) {
-  var ast = parse(code);
-  var path;
+  let ast = parse(code);
+  let path;
   traverse(ast, {
     Program: function (_path) {
       path = _path;

--- a/packages/babel-traverse/test/inference.js
+++ b/packages/babel-traverse/test/inference.js
@@ -1,10 +1,10 @@
-var traverse = require("../lib").default;
-var assert = require("assert");
-var parse = require("babylon").parse;
+let traverse = require("../lib").default;
+let assert = require("assert");
+let parse = require("babylon").parse;
 
 function getPath(code) {
-  var ast = parse(code);
-  var path;
+  let ast = parse(code);
+  let path;
   traverse(ast, {
     Program: function (_path) {
       path = _path;
@@ -17,38 +17,38 @@ function getPath(code) {
 suite("inference", function () {
   suite("baseTypeStrictlyMatches", function () {
     test("it should work with null", function () {
-      var path = getPath("var x = null; x === null").get("body")[1].get("expression");
-      var left = path.get("left");
-      var right = path.get("right");
-      var strictMatch = left.baseTypeStrictlyMatches(right);
+      let path = getPath("var x = null; x === null").get("body")[1].get("expression");
+      let left = path.get("left");
+      let right = path.get("right");
+      let strictMatch = left.baseTypeStrictlyMatches(right);
 
       assert.ok(strictMatch, "null should be equal to null");
     });
 
     test("it should work with numbers", function () {
-      var path = getPath("var x = 1; x === 2").get("body")[1].get("expression");
-      var left = path.get("left");
-      var right = path.get("right");
-      var strictMatch = left.baseTypeStrictlyMatches(right);
+      let path = getPath("var x = 1; x === 2").get("body")[1].get("expression");
+      let left = path.get("left");
+      let right = path.get("right");
+      let strictMatch = left.baseTypeStrictlyMatches(right);
 
       assert.ok(strictMatch, "null should be equal to null");
     });
 
     test("it should bail when type changes", function () {
-      var path = getPath("var x = 1; if (foo) x = null;else x = 3; x === 2").get("body")[2].get("expression");
-      var left = path.get("left");
-      var right = path.get("right");
+      let path = getPath("var x = 1; if (foo) x = null;else x = 3; x === 2").get("body")[2].get("expression");
+      let left = path.get("left");
+      let right = path.get("right");
 
-      var strictMatch = left.baseTypeStrictlyMatches(right);
+      let strictMatch = left.baseTypeStrictlyMatches(right);
 
       assert.ok(!strictMatch, "type might change in if statement");
     });
 
     test("it should differentiate between null and undefined", function () {
-      var path = getPath("var x; x === null").get("body")[1].get("expression");
-      var left = path.get("left");
-      var right = path.get("right");
-      var strictMatch = left.baseTypeStrictlyMatches(right);
+      let path = getPath("var x; x === null").get("body")[1].get("expression");
+      let left = path.get("left");
+      let right = path.get("right");
+      let strictMatch = left.baseTypeStrictlyMatches(right);
 
       assert.ok(!strictMatch, "null should not match undefined");
     });

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -1,10 +1,10 @@
-var traverse = require("../lib").default;
-var assert = require("assert");
-var parse = require("babylon").parse;
+let traverse = require("../lib").default;
+let assert = require("assert");
+let parse = require("babylon").parse;
 
 function getPath(code) {
-  var ast = parse(code);
-  var path;
+  let ast = parse(code);
+  let path;
   traverse(ast, {
     Program: function (_path) {
       path = _path;

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -1,9 +1,9 @@
-var traverse = require("../lib").default;
-var assert   = require("assert");
-var _        = require("lodash");
+let traverse = require("../lib").default;
+let assert   = require("assert");
+let _        = require("lodash");
 
 suite("traverse", function () {
-  var ast = {
+  let ast = {
     type: "Program",
     body: [
       {
@@ -50,14 +50,14 @@ suite("traverse", function () {
     ]
   };
 
-  var body = ast.body;
+  let body = ast.body;
 
   test("traverse replace", function () {
-    var replacement = {
+    let replacement = {
       type: "StringLiteral",
       value: "foo"
     };
-    var ast2 = _.cloneDeep(ast);
+    let ast2 = _.cloneDeep(ast);
 
     traverse(ast2, {
       enter: function (path) {
@@ -69,12 +69,12 @@ suite("traverse", function () {
   });
 
   test("traverse", function () {
-    var expect = [
+    let expect = [
       body[0], body[0].declarations[0], body[0].declarations[0].id, body[0].declarations[0].init,
       body[1], body[1].expression, body[1].expression.left, body[1].expression.left.object, body[1].expression.left.property, body[1].expression.right
     ];
 
-    var actual = [];
+    let actual = [];
 
     traverse(ast, {
       enter: function (path) {
@@ -94,12 +94,12 @@ suite("traverse", function () {
   });
 
   test("traverse blacklistTypes", function () {
-    var expect = [
+    let expect = [
       body[0], body[0].declarations[0], body[0].declarations[0].id, body[0].declarations[0].init,
       body[1], body[1].expression, body[1].expression.right
     ];
 
-    var actual = [];
+    let actual = [];
 
     traverse(ast, {
       blacklist: ["MemberExpression"],
@@ -125,7 +125,7 @@ suite("traverse", function () {
   });
 
   test("clearCache", function () {
-    var paths = [];
+    let paths = [];
     traverse(ast, {
       enter: function (path) {
         paths.push(path);
@@ -134,7 +134,7 @@ suite("traverse", function () {
 
     traverse.clearCache();
 
-    var paths2 = [];
+    let paths2 = [];
     traverse(ast, {
       enter: function (path) {
         paths2.push(path);


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidlines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | #4714
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

 Closes #4714. Updated ESLint globbing patterns in the `makefile` to run over `test` folders now under `packages`, in addition to `src`. Also ran `--fix` to autofix a bunch of errors, and manually fixed the few that aren't autofixable.

This change includes adding ~~some globals~~ new env (mocha) globals to be ignored in `.eslintrc`. I should note that this will treat those identifiers as globals in _all_ files, not just test files. The alternative to this would be to drop a `.eslintrc` in _every_ test directory, or add an ignore comment to the top of each test file, but that seems like it would be a pain longterm.