### PR TITLE
Fix replacing for-of if inside label

### DIFF
--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -93,7 +93,11 @@ export default function ({ messages, template, types: t }) {
     visitor: {
       ForOfStatement(path, state) {
         if (path.get("right").isArrayExpression()) {
-          return path.replaceWithMultiple(_ForOfStatementArray.call(this, path, state));
+          if (path.parentPath.isLabeledStatement()) {
+            return path.parentPath.replaceWithMultiple(_ForOfStatementArray(path));
+          } else {
+            return path.replaceWithMultiple(_ForOfStatementArray(path));
+          }
         }
 
         let callback = spec;

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-block-label-3858/actual.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-block-label-3858/actual.js
@@ -1,0 +1,5 @@
+if ( true ) {
+  loop: for (let ch of []) {
+  }
+}
+

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-block-label-3858/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-block-label-3858/expected.js
@@ -1,0 +1,7 @@
+if (true) {
+  var _arr = [];
+
+  loop: for (var _i = 0; _i < _arr.length; _i++) {
+    let ch = _arr[_i];
+  }
+}

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-label-3858/actual.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-label-3858/actual.js
@@ -1,0 +1,4 @@
+if ( true )
+  loop: for (let ch of []) {
+  }
+

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-label-3858/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/if-label-3858/expected.js
@@ -1,0 +1,7 @@
+if (true) {
+  var _arr = [];
+
+  loop: for (var _i = 0; _i < _arr.length; _i++) {
+    let ch = _arr[_i];
+  }
+}

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/regression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-for-of"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #3858
| License           | MIT
| Doc PR            |

This replaces the `labeledStatement` instead of the `ForOfStatement` itself as we already
integrate the label in the replacement nodes here: https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-es2015-for-of/src/index.js#L82..L84
Fixes #3858