### PR TITLE
Support ObjectExpression in static path evaluation

### DIFF
--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -10,7 +10,7 @@ describe("evaluation", function () {
       visitor[type] = function (path) {
         let evaluate = path.evaluate();
         assert.equal(evaluate.confident, !notConfident);
-        assert.equal(evaluate.value, value);
+        assert.deepEqual(evaluate.value, value);
       };
 
       traverse(parse(code, {
@@ -63,4 +63,7 @@ describe("evaluation", function () {
   addTest("'abc' === 'xyz' || (1 === 1 && config.flag)", "LogicalExpression", undefined, true);
   addTest("'abc' === 'xyz' || (1 === 1 && 'four' === 'four')", "LogicalExpression", true);
   addTest("'abc' === 'abc' && (1 === 1 && 'four' === 'four')", "LogicalExpression", true);
+  addTest("({})", "ObjectExpression", {});
+  addTest("({a: '1'})", "ObjectExpression", {a: "1"});
+  addTest("({['a' + 'b']: 10 * 20, 'z': [1, 2, 3]})", "ObjectExpression", {ab: 200, z: [1, 2, 3]});
 });


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| License           | MIT

This gives `babel-traverse` the ability to statically evaluate simple object literals.

When this is released I will use it to implement https://github.com/istanbuljs/babel-plugin-istanbul/issues/4#issuecomment-254309187, resolving https://github.com/babel/babel/pull/4740#issuecomment-254227152, allowing us to move forward with #4740 and get more useful code coverage reports.

cc @danez