### PR TITLE
Add clean-all command to reinstall node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ test-clean:
 	rm -rf packages/*/test/tmp
 	rm -rf packages/*/test-fixtures.json
 
+clean-all:
+	rm -rf node_modules
+	rm -rf packages/*/node_modules
+	make clean
+
 # without lint
 test-only:
 	./scripts/test.sh
@@ -64,6 +69,7 @@ publish:
 	#./scripts/build-website.sh
 
 bootstrap:
+	make clean-all
 	npm install
 	./node_modules/.bin/lerna bootstrap
 	make build


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

<!-- Describe your changes below in as much detail as possible -->

It seems to me like there should be a `make` command that allows you to update outdated dependencies of packages (even if the current version satisfies the package.json for that package). I've run into the issue a few times. A good example of this is when a minor or patch version of Babylon is released, but the currently installed version satisfies the package.json for `babel-core`, and so the latest version isn't installed. This leads to tests failing locally while not failing in the CI tests (where everything is installed fresh). 

Thoughts on this approach? I wasn't sure if it would be preferable to leave `make bootstrap` as is and instead have a `make update-deps` (which cleans the current node_modules and runs `npm install again` or something more explicit. Let me know if you think this should be done a different way!