### PR TITLE
4701: Fix for SystemJS function decl hoisting causing non-hoisted types to not be in lexical scope

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -202,6 +202,12 @@ export default function ({ types: t }) {
                   }
                 }
               }
+            } else if (path.isClassDeclaration()) {
+              const id = path.node.id;
+              variableIds.push(id);
+              path.node.type = "ClassExpression";
+              const classAssignment = t.assignmentExpression("=", id, path.node);
+              path.replaceWith(classAssignment);
             }
           }
 

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/non-hoistable/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/non-hoistable/actual.js
@@ -1,0 +1,7 @@
+class Foo {
+  constructor() { this.foo = "foo"; }
+}
+
+export function createInstance() {
+  return new Foo();
+}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/non-hoistable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/non-hoistable/expected.js
@@ -1,0 +1,21 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  let Foo;
+  function createInstance() {
+    return new Foo();
+  }
+
+  _export("createInstance", createInstance);
+
+  return {
+    setters: [],
+    execute: function () {
+      Foo = class Foo {
+        constructor() {
+          this.foo = "foo";
+        }
+      };
+    }
+  };
+});


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q | A |
| --- | --- |
| Bug fix? | yes |
| Breaking change? | no |
| New feature? | /no |
| Deprecations? | no |
| Spec compliancy? | no |
| Tests added/pass? | yes |
| Fixed tickets     #4701 |  |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

<!-- Describe your changes below in as much detail as possible -->

This is a start. This fixes the specific case w/ classes reported in #4701, but I suspect there are other cases I'm overlooking.

Looking for feedback

**Edit**: Yeah, this still has tons of edge-cases. Due to the SystemJS format, we really need to hoist all declarations, afaict. Have most of it done, but working through some cases with named exports that are proving to be challenging.
