### PR TITLE
Add TEST_DEBUG env var option for test.sh, to enable node 6 debugger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,12 @@ Use the `TEST_GREP` variable to run a subset of tests by name:
 $ TEST_GREP=transformation make test
 ```
 
+To enable the node debugger added in v6.3.0, set the `TEST_DEBUG` environment variable:
+
+```sh
+$ TEST_DEBUG=true make test
+```
+
 To test the code coverage, use:
 
 ```sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,4 +5,10 @@ if [ -z "$TEST_GREP" ]; then
    TEST_GREP=""
 fi
 
-node node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts --grep "$TEST_GREP"
+node="node"
+
+if [ "$TEST_DEBUG" ]; then
+   node="node --inspect --debug-brk"
+fi
+
+$node node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts --grep "$TEST_GREP"


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | N/A
| License           | MIT
| Doc PR            | docs updated in PR

<!-- Describe your changes below in as much detail as possible -->

I've found myself manually editing `test.sh` frequently so I can walk through code I'm working on. Would be great to be able to do this without manually editing the file each time.