### PR TITLE
Don't treat JSXIdentifier in JSXMemberExpression as HTML tag. Closes #4027

### DIFF
--- a/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/lowercase-member-expression/actual.js
+++ b/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/lowercase-member-expression/actual.js
@@ -1,0 +1,6 @@
+//index.js file
+import { form } from "./export";
+
+function ParentComponent() {
+  return <form.TestComponent />;
+}

--- a/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/lowercase-member-expression/expected.js
+++ b/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/lowercase-member-expression/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var _export = require("./export");
+
+function ParentComponent() {
+  return babelHelpers.jsx(_export.form.TestComponent, {});
+} //index.js file

--- a/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/lowercase-member-expression/options.json
+++ b/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/lowercase-member-expression/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "external-helpers",
+    "syntax-jsx",
+    "transform-react-inline-elements",
+    "transform-react-jsx",
+    "transform-es2015-modules-commonjs"
+  ]
+}

--- a/packages/babel-traverse/src/path/lib/virtual-types.js
+++ b/packages/babel-traverse/src/path/lib/virtual-types.js
@@ -5,7 +5,7 @@ import * as t from "babel-types";
 export let ReferencedIdentifier = {
   types: ["Identifier", "JSXIdentifier"],
   checkPath({ node, parent }: NodePath, opts?: Object): boolean {
-    if (!t.isIdentifier(node, opts)) {
+    if (!t.isIdentifier(node, opts) && !t.isJSXMemberExpression(parent, opts)) {
       if (t.isJSXIdentifier(node, opts)) {
         if (react.isCompatTag(node.name)) return false;
       } else {


### PR DESCRIPTION
**Note that tests will fail for this PR, because it also depends on the work in #4763 to build a valid AST.**

<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4027 
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

<!-- Describe your changes below in as much detail as possible -->

[This commit](https://github.com/babel/babel/commit/9aa17a6c#diff-d7d9bff39a0875da415a51447608e215R9) last year made the `ReferencedIdentifier` virtual type _not_ recognize a `JSXIdentifier` when it doesn't pass the `react.isCompatTag` check (which includes verifying the tag does not start with a lowercase letter). This matched the [new JSX behavior](https://gist.github.com/sebmarkbage/f1f4ba40816e7d7848ad) that Sebastian Markbåge documented, wherein any lowercase `JSXIdentifier` is treated as an HTML tag.

The problem is that this doesn't take into account the scenario where you have an identifier `foo` in scope, and your JSX tag is `<foo.Bar />`. This PR addresses that case.