### PR TITLE
Add option to resolve imports in the UMD transform plugin

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 
-import { basename, extname, posix } from "path";
+import { basename, extname, dirname, join, normalize } from "path";
 import template from "babel-template";
 
 let buildPrerequisiteAssignment = template(`
@@ -148,16 +148,16 @@ export default function ({ types: t }) {
 
 function resolveDependency(t, dependency, moduleName) {
   if (moduleName.includes("/")) {
-    moduleName = posix.dirname(moduleName);
+    moduleName = dirname(moduleName);
   }
 
   let [root, ...path] = moduleName.split("/");
   let resolved;
 
   if (dependency.startsWith("./") || dependency.startsWith("../")) {
-    resolved = root + posix.join(`/${path.join("/")}`, posix.normalize(dependency));
+    resolved = root + join(`/${path.join("/")}`, dependency);
   } else {
-    resolved = posix.normalize(dependency);
+    resolved = normalize(dependency);
   }
 
   return t.memberExpression(t.identifier("global"),

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/actual.js
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(['non/relative', './down/the-rabbit-hole/we/go', './baz/../fizzbuzz', '../../../bar'], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require('non/relative'), require('./down/the-rabbit-hole/we/go'), require('./baz/../fizzbuzz'), require('../../../bar'));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.umdResolveImportsWithExactGlobalsTrueDownTheRabbitHoleWeGo, global.umdResolveImportsWithExactGlobalsTrueFizzbuzz, global.umdBar);
+    global.actual = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  'use strict';
+
+  var _relative2 = babelHelpers.interopRequireDefault(_relative);
+
+  var _go2 = babelHelpers.interopRequireDefault(_go);
+
+  var _bar2 = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "resolveImports": true,
+      "exactGlobals": true
+    }]
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/actual.js
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define('MyLib', ['non/relative', './down/the-rabbit-hole/we/go', './baz/../fizzbuzz', '../../../bar'], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require('non/relative'), require('./down/the-rabbit-hole/we/go'), require('./baz/../fizzbuzz'), require('../../../bar'));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.MyLibDownTheRabbitHoleWeGo, global.MyLibFizzbuzz, global.MyLibBar);
+    global.MyLib = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  'use strict';
+
+  var _relative2 = babelHelpers.interopRequireDefault(_relative);
+
+  var _go2 = babelHelpers.interopRequireDefault(_go);
+
+  var _bar2 = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "resolveImports": true
+    }]
+  ],
+  "moduleId": "MyLib"
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/actual.js
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define('umd/resolve-imports-with-module-name/expected', ['non/relative', './down/the-rabbit-hole/we/go', './baz/../fizzbuzz', '../../../bar'], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require('non/relative'), require('./down/the-rabbit-hole/we/go'), require('./baz/../fizzbuzz'), require('../../../bar'));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.umdResolveImportsWithModuleNameDownTheRabbitHoleWeGo, global.umdResolveImportsWithModuleNameFizzbuzz, global.umdBar);
+    global.umdResolveImportsWithModuleNameExpected = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  'use strict';
+
+  var _relative2 = babelHelpers.interopRequireDefault(_relative);
+
+  var _go2 = babelHelpers.interopRequireDefault(_go);
+
+  var _bar2 = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "resolveImports": true
+    }]
+  ],
+  "moduleIds": true
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports/actual.js
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(['non/relative', './down/the-rabbit-hole/we/go', './baz/../fizzbuzz', '../../../bar'], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require('non/relative'), require('./down/the-rabbit-hole/we/go'), require('./baz/../fizzbuzz'), require('../../../bar'));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.umdResolveImportsDownTheRabbitHoleWeGo, global.umdResolveImportsFizzbuzz, global.umdBar);
+    global.actual = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  'use strict';
+
+  var _relative2 = babelHelpers.interopRequireDefault(_relative);
+
+  var _go2 = babelHelpers.interopRequireDefault(_go);
+
+  var _bar2 = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/resolve-imports/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-es2015-modules-umd", {
+      "resolveImports": true
+    }]
+  ]
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q | A |
| --- | --- |
| Bug fix? | no |
| Breaking change? | no |
| New feature? | yes |
| Deprecations? | no |
| Spec compliancy? | n/a |
| Tests added/pass? | yes |
| Fixed tickets | #4381 |
| License | MIT |
| Doc PR | n/a |

<!-- Describe your changes below in as much detail as possible -->
#4381 describes this issue in rather extensive detail. What this PR does is add the `resolveImports` option to the UMD transform plugin, which resolves the aforementioned issue. It should also take care of relative imports, by resolving them relative to the current module if `moduleIds` or `moduleId` is set, or relative to the file importing the dependencies.
