### PR TITLE
Change default value for babelrc option in non-node

### DIFF
--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -1,5 +1,10 @@
 /* eslint max-len: 0 */
 
+// Checks if the current environment is node by creating a new Function which
+// by spec is created in the global scope.
+// http://www.ecma-international.org/ecma-262/5.1/#sec-15.3.2.1
+const isNode = new Function("return typeof global !== 'undefined' && this === global;");
+
 module.exports = {
   filename: {
     type: "filename",
@@ -149,7 +154,9 @@ module.exports = {
   babelrc: {
     description: "Whether or not to look up .babelrc and .babelignore files",
     type: "boolean",
-    default: true
+    // This option defaults to true in node environment and false in other environments which
+    // do not have a filesystem like browser.
+    default: isNode()
   },
 
   sourceType: {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| Breaking change? | maybe(?) |
| New feature? | no |
| Deprecations? | no |
| Spec compliancy? | no |
| Tests added/pass? | yes |
| Fixed tickets | #4778 |
| License | MIT |
| Doc PR | need to create one, if this is okay |

In environments where there is no filesystem, like in the browser it does not make sense to have this option on by default.
This changes the default value in non node environments to be false.

By switching back to fs.existsSync() in #4731, babel does not work in browsers if the babelrc options is set to true.

Another approach would be to just mention to set `babelrc: false` on this page: https://babeljs.io/docs/usage/browser/

Thoughts?
