### PR TITLE
Fix check for JSXMemberExpression deopt in react-constant-elements

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -11,11 +11,12 @@ export default function () {
         return;
       }
 
-      if (path.isJSXIdentifier({ name: "ref" }) && path.parentPath.isJSXAttribute({ name: path.node })) {
+      const isThisMemberExpression = path.isJSXMemberExpression({ object: { name: "this" } });
+      if (path.isJSXIdentifier({ name: "ref" }) && path.parentPath.isJSXAttribute({ name: path.node }) || isThisMemberExpression) {
         return stop();
       }
 
-      if (path.isJSXIdentifier() || path.isIdentifier() || path.isJSXMemberExpression()) {
+      if (path.isJSXIdentifier() || path.isIdentifier()) {
         return;
       }
 

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/actual.js
@@ -1,0 +1,5 @@
+class Component extends React.Component {
+  subComponent = () => <span>Sub Component</span>
+
+  render = () => <this.subComponent />
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/expected.js
@@ -1,0 +1,10 @@
+var _ref = <span>Sub Component</span>;
+
+class Component extends React.Component {
+  constructor(...args) {
+    var _temp;
+
+    return _temp = super(...args), this.subComponent = () => _ref, this.render = () => <this.subComponent />, _temp;
+  }
+
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-jsx", "transform-react-constant-elements", "transform-class-properties"]
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q | A |
| --- | --- |
| Bug fix? | yes |
| Breaking change? | no |
| New feature? | no |
| Deprecations? | no |
| Spec compliancy? | no |
| Tests added/pass? | yes |
| Fixed tickets | #4397 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

<!-- Describe your changes below in as much detail as possible -->

This fixes the bug reported, but I'm not sure that it is the ideal fix.

**Edit**: The more I think about this, the more I'm thinking this may be a bug in `PathHoister`. It (correctly) does not hoist when you do `const self = this;` and then do `<self.subComponent />`. Will keep looking.

Open to any feedback/guidance.
