### PR TITLE
Update eslint, use codeframe formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ watch: clean
 	./node_modules/.bin/gulp watch
 
 lint:
-	./node_modules/.bin/eslint packages/*/{src,test}/*.js
+	./node_modules/.bin/eslint packages/*/{src,test}/*.js --format=codeframe
 
 fix:
-	./node_modules/.bin/eslint packages/*/{src,test}/*.js --fix
+	./node_modules/.bin/eslint packages/*/{src,test}/*.js --format=codeframe --fix
 
 clean: test-clean
 	rm -rf packages/*/lib

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chalk": "1.1.1",
     "codecov.io": "^0.1.6",
     "derequire": "^2.0.2",
-    "eslint": "^3.7.1",
+    "eslint": "^3.9.0",
     "eslint-config-babel": "^2.0.1",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flowtype": "^2.20.0",


### PR DESCRIPTION
Looks like
<img width="672" alt="screen shot 2016-10-29 at 12 45 37 pm" src="https://cloud.githubusercontent.com/assets/588473/19840535/3d2e5152-9ece-11e6-8d24-2ab95e7ee931.png">

Uses babel-code-frame