### PR TITLE
Allow relative paths in babelrc options in options.json

### DIFF
--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -102,6 +102,7 @@ export default function get(entryLoc): Array<Suite> {
       if (taskOptsLoc) _.merge(taskOpts, require(taskOptsLoc));
 
       let test = {
+        optionsDir: taskOptsLoc ? path.dirname(taskOptsLoc) : null,
         title: humanize(taskName, true),
         disabled: taskName[0] === ".",
         options: taskOpts,


### PR DESCRIPTION
Dono if this is the best way to do it but wanted to setup fixture tests in babel-preset-env but I wanted to run tests on `lib/index` using `"../../../lib"` instead of `env` which checks node_modules.
