### PR TITLE
feature: Support pure expressions in transform-react-constant-elements

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -1,4 +1,4 @@
-export default function () {
+export default function ({ types: t }) {
   const immutabilityVisitor = {
     enter(path, state) {
       const stop = () => {
@@ -11,15 +11,39 @@ export default function () {
         return;
       }
 
+      // Elements with refs are not safe to hoist.
       if (path.isJSXIdentifier({ name: "ref" }) && path.parentPath.isJSXAttribute({ name: path.node })) {
         return stop();
       }
 
+      // Ignore identifiers & JSX expressions.
       if (path.isJSXIdentifier() || path.isIdentifier() || path.isJSXMemberExpression()) {
         return;
       }
 
-      if (!path.isImmutable()) stop();
+      if (!path.isImmutable()) {
+        // If it's not immutable, it may still be a pure expression, such as string concatenation.
+        // It is still safe to hoist that, so long as its result is immutable.
+        // If not, it is not safe to replace as mutable values (like objects) could be mutated after render.
+        // https://github.com/facebook/react/issues/3226
+        if (path.isPure()) {
+          const expressionResult = path.evaluate();
+          if (expressionResult.confident) {
+            // We know the result; check its mutability.
+            const { value } = expressionResult;
+            const isMutable = (value && typeof value === "object") || (typeof value === "function");
+            if (!isMutable) {
+              // It evaluated to an immutable value, so we can hoist it.
+              return;
+            }
+          } else if (t.isIdentifier(expressionResult.deopt)) {
+            // It's safe to hoist here if the deopt reason is an identifier (e.g. func param).
+            // The hoister will take care of how high up it can be hoisted.
+            return;
+          }
+        }
+        stop();
+      }
     }
   };
 

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-deopt/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-deopt/actual.js
@@ -1,0 +1,5 @@
+// https://github.com/facebook/react/issues/3226
+// Not safe to reuse because it is mutable
+function render() {
+  return <div style={{ width: 100 }} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-deopt/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-deopt/expected.js
@@ -1,0 +1,5 @@
+// https://github.com/facebook/react/issues/3226
+// Not safe to reuse because it is mutable
+function render() {
+  return <div style={{ width: 100 }} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/actual.js
@@ -1,0 +1,5 @@
+function render(offset) {
+  return function () {
+    return <div tabIndex={offset + 1} />;
+  };
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-2/expected.js
@@ -1,0 +1,8 @@
+function render(offset) {
+  var _ref = <div tabIndex={offset + 1} />;
+
+  return function () {
+    return _ref;
+  };
+}
+

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/actual.js
@@ -1,0 +1,10 @@
+const OFFSET = 3;
+
+var Foo = React.createClass({
+  render: function () {
+    return (
+      <div tabIndex={OFFSET + 1} />
+    );
+  }
+});
+

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression-3/expected.js
@@ -1,0 +1,10 @@
+const OFFSET = 3;
+
+var _ref = <div tabIndex={OFFSET + 1} />;
+
+var Foo = React.createClass({
+  render: function () {
+    return _ref;
+  }
+});
+

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/actual.js
@@ -1,0 +1,11 @@
+var Foo = React.createClass({
+  render: function () {
+    return (
+      <div data-text={
+        "Some text, " +
+        "and some more too."
+      } />
+    );
+  }
+});
+

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/pure-expression/expected.js
@@ -1,0 +1,8 @@
+var _ref = <div data-text={"Some text, " + "and some more too."} />;
+
+var Foo = React.createClass({
+  render: function () {
+    return _ref;
+  }
+});
+


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | None
| License           | MIT
| Doc PR            | None

### The Problem 
Could describe this as a bugfix or feature, but when a pure expression of any sort is in a JSXExpression, the node is marked as mutable and isn't hoisted. This prevents otherwise eligible elements from being found.

For example, the following types of elements should be hoistable:

```jsx
<div data-text={
  "Some text, " +
  "and some more too."
} />
```

```jsx
function render(offset) {
  return function () {
    return <div tabIndex={offset + 1} />;
  };
}
```

### The Fix

The fix is very simple: just add a check for `path.isPure()` as an out when determining when to hoist.

The expression will remain in the hoisted code, even though it could be statically evaluated. UglifyJS will take care of that in many cases.

### Deopt

As noted in https://github.com/facebook/react/issues/3226, it's not safe to reuse elements with mutable props. So the following should *not* be hoisted:

```jsx
<div style={{width: 100}} />
```

This is done via an additional check to `path.isObjectExpression()`. Please correct me if this is not the way to find a mutable reference. Unfortunately, this will not catch things like frozen objects.
