### PR TITLE
Fix binding kind of destructured variables.

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/actual.js
@@ -1,0 +1,3 @@
+function render({ text, className, id }) {
+  return () => (<Component text={text} className={className} id={id} />);
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/expected.js
@@ -1,0 +1,9 @@
+function render(_ref) {
+  let text = _ref.text,
+      className = _ref.className,
+      id = _ref.id;
+
+  var _ref2 = <Component text={text} className={className} id={id} />;
+
+  return () => _ref2;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-multi/options.json
@@ -1,0 +1,4 @@
+{
+
+  "plugins": ["transform-es2015-destructuring", "transform-es2015-parameters", "transform-react-constant-elements", "syntax-jsx"]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/actual.js
@@ -1,0 +1,4 @@
+function render({ text, className, id, ...props }) {
+  // intentionally ignoring props
+  return () => (<Component text={text} className={className} id={id} />);
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/expected.js
@@ -1,0 +1,13 @@
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+function render(_ref) {
+  let text = _ref.text,
+      className = _ref.className,
+      id = _ref.id,
+      props = _objectWithoutProperties(_ref, ["text", "className", "id"]);
+
+  var _ref2 = <Component text={text} className={className} id={id} />;
+
+  // intentionally ignoring props
+  return () => _ref2;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-rest/options.json
@@ -1,0 +1,6 @@
+{
+
+  "plugins": ["transform-es2015-destructuring", "transform-es2015-parameters",
+              "transform-es2015-spread", "syntax-object-rest-spread",
+              "transform-react-constant-elements", "syntax-jsx"]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/actual.js
@@ -1,0 +1,3 @@
+function render({ text, className, id, ...props }) {
+  return () => (<Component text={text} className={className} id={id} {...props} />);
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/expected.js
@@ -1,0 +1,10 @@
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+function render(_ref) {
+  let text = _ref.text,
+      className = _ref.className,
+      id = _ref.id,
+      props = _objectWithoutProperties(_ref, ["text", "className", "id"]);
+
+  return () => <Component text={text} className={className} id={id} {...props} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure-spread-deopt/options.json
@@ -1,0 +1,6 @@
+{
+
+  "plugins": ["transform-es2015-destructuring", "transform-es2015-parameters",
+              "transform-es2015-spread", "syntax-object-rest-spread",
+              "transform-react-constant-elements", "syntax-jsx"]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/actual.js
@@ -1,0 +1,3 @@
+function render({ text }) {
+  return () => (<Component text={text} />);
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/expected.js
@@ -1,0 +1,7 @@
+function render(_ref) {
+  let text = _ref.text;
+
+  var _ref2 = <Component text={text} />;
+
+  return () => _ref2;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/parameter-destructure/options.json
@@ -1,0 +1,4 @@
+{
+
+  "plugins": ["transform-es2015-destructuring", "transform-es2015-parameters", "transform-react-constant-elements", "syntax-jsx"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #4516, #4686, #4324
| License           | MIT

As in the above tickets, there are issues with `hoist()` hoisting
a variable above its parameters in combination with destructuring.

A simple example with `transform-react-constant-elements`:

```jsx
function render({ text }) {
  return () => (<Component text={text} />);
}
```

becomes

```jsx
function render(_ref) {
  var _ref2 = <Component text={text} />;
  let text = _ref.text;
  return () => _ref2;
}
```

Thanks to @le0nik's [comment](https://github.com/babel/babel/issues/4516#issuecomment-249769900), I noticed that the `kind` of bindings remained `param` after destructuring, which seems like a bug. It should be reset to the `kind` of the VariableDeclaration.

Above code with this fix:

```jsx
function render(_ref) {
  let text = _ref.text;
  var _ref2 = <Component text={text} />;
  return () => _ref2;
}
```