### PR TITLE
Fix system transformer to ensure consistent modules iteration

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-numbered/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-numbered/actual.js
@@ -1,0 +1,2 @@
+import "2";
+import "1";

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-numbered/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-numbered/expected.js
@@ -2,7 +2,7 @@ System.register(["2", "1"], function (_export, _context) {
   "use strict";
 
   return {
-    setters: [function (_2) {}, function (_1) {}],
+    setters: [function (_) {}, function (_2) {}],
     execute: function () {}
   };
 });

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-numbered/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/imports-numbered/expected.js
@@ -1,0 +1,8 @@
+System.register(["2", "1"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_2) {}, function (_1) {}],
+    execute: function () {}
+  };
+});


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | n/a
| Tests added/pass? | yes
| License           | MIT

Currently  in the system module transformer, the list of module specifiers `modules` is used as an ordered object and iterated via `for (let sourceName in modules)` to output the dependency and setters lists. Relying on plain object property ordering doesn't work for numeric values in JavaScript though.

To make this process more consistent this updates `modules` to an array which can then be iterated reliably. It fixes faulty ordering for cases where module names are numbers, as in the test provided.