### PR TITLE
Add clearCache and clearPath as separate APIs under traverse

### DIFF
--- a/packages/babel-traverse/src/cache.js
+++ b/packages/babel-traverse/src/cache.js
@@ -2,6 +2,14 @@ export let path = new WeakMap();
 export let scope = new WeakMap();
 
 export function clear() {
-  path = new WeakMap();
-  scope = new WeakMap();
+  clearPath();
+  clearScope();
+}
+
+export function clearPath() {
+  path = new WeakMap;
+}
+
+export function clearScope() {
+  scope = new WeakMap;
 }

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -98,6 +98,9 @@ traverse.clearCache = function() {
   cache.clear();
 };
 
+traverse.clearCache.clearPath = cache.clearPath;
+traverse.clearCache.clearScope = cache.clearScope;
+
 traverse.copyCache = function(source, destination) {
   if (cache.path.has(source)) {
     cache.path.set(destination, cache.path.get(source));

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -88,7 +88,7 @@ describe("traverse", function () {
     let paths = [];
     let scopes = [];
     traverse(ast, {
-      Program(path) {
+      enter(path) {
         scopes.push(path.scope);
         paths.push(path);
         path.stop();
@@ -100,7 +100,7 @@ describe("traverse", function () {
     let paths2 = [];
     let scopes2 = [];
     traverse(ast, {
-      Program(path) {
+      enter(path) {
         scopes2.push(path.scope);
         paths2.push(path);
         path.stop();
@@ -116,7 +116,7 @@ describe("traverse", function () {
   it("clearPath", function () {
     let paths = [];
     traverse(ast, {
-      enter: function (path) {
+      enter(path) {
         paths.push(path);
       }
     });
@@ -125,7 +125,7 @@ describe("traverse", function () {
 
     let paths2 = [];
     traverse(ast, {
-      enter: function (path) {
+      enter(path) {
         paths2.push(path);
       }
     });
@@ -138,7 +138,7 @@ describe("traverse", function () {
   it("clearScope", function () {
     let scopes = [];
     traverse(ast, {
-      Program(path) {
+      enter(path) {
         scopes.push(path.scope);
         path.stop();
       }
@@ -148,7 +148,7 @@ describe("traverse", function () {
 
     let scopes2 = [];
     traverse(ast, {
-      Program(path) {
+      enter(path) {
         scopes2.push(path.scope);
         path.stop();
       }

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -1,63 +1,23 @@
 let traverse = require("../lib").default;
 let assert   = require("assert");
 let _        = require("lodash");
+let parse = require("babylon").parse;
 
 describe("traverse", function () {
-  let ast = {
-    type: "Program",
-    body: [
-      {
-        "type": "VariableDeclaration",
-        "declarations": [
-          {
-            "type": "VariableDeclarator",
-            "id": {
-              "type": "Identifier",
-              "name": "foo",
-            },
-            "init": {
-              "type": "StringLiteral",
-              "value": "bar",
-              "raw": "\'bar\'"
-            }
-          }
-        ],
-        "kind": "var"
-      },
-      {
-        "type": "ExpressionStatement",
-        "expression": {
-          "type": "AssignmentExpression",
-          "operator": "=",
-          "left": {
-            "type": "MemberExpression",
-            "computed": false,
-            "object": {
-              "type": "ThisExpression"
-            },
-            "property": {
-              "type": "Identifier",
-              "name": "test"
-            }
-          },
-          "right": {
-            "type": "StringLiteral",
-            "value": "wow",
-            "raw": "\'wow\'"
-          }
-        }
-      }
-    ]
-  };
-
-  let body = ast.body;
+  let code = `
+    var foo = "bar";
+    this.test = "wow";
+  `;
+  let ast = parse(code);
+  let program = ast.program;
+  let body = program.body;
 
   it("traverse replace", function () {
     let replacement = {
       type: "StringLiteral",
       value: "foo"
     };
-    let ast2 = _.cloneDeep(ast);
+    let ast2 = _.cloneDeep(program);
 
     traverse(ast2, {
       enter: function (path) {
@@ -76,7 +36,7 @@ describe("traverse", function () {
 
     let actual = [];
 
-    traverse(ast, {
+    traverse(program, {
       enter: function (path) {
         actual.push(path.node);
       }
@@ -101,7 +61,7 @@ describe("traverse", function () {
 
     let actual = [];
 
-    traverse(ast, {
+    traverse(program, {
       blacklist: ["MemberExpression"],
       enter: function (path) {
         actual.push(path.node);
@@ -126,13 +86,42 @@ describe("traverse", function () {
 
   it("clearCache", function () {
     let paths = [];
+    let scopes = [];
+    traverse(ast, {
+      Program(path) {
+        scopes.push(path.scope);
+        paths.push(path);
+        path.stop();
+      }
+    });
+
+    traverse.clearCache();
+
+    let paths2 = [];
+    let scopes2 = [];
+    traverse(ast, {
+      Program(path) {
+        scopes2.push(path.scope);
+        paths2.push(path);
+        path.stop();
+      }
+    });
+
+    scopes2.forEach(function (_, i) {
+      assert.notStrictEqual(scopes[i], scopes2[i]);
+      assert.notStrictEqual(paths[i], paths2[i]);
+    });
+  });
+
+  it("clearPath", function () {
+    let paths = [];
     traverse(ast, {
       enter: function (path) {
         paths.push(path);
       }
     });
 
-    traverse.clearCache();
+    traverse.clearCache.clearPath();
 
     let paths2 = [];
     traverse(ast, {
@@ -143,6 +132,30 @@ describe("traverse", function () {
 
     paths2.forEach(function (p, i) {
       assert.notStrictEqual(p, paths[i]);
+    });
+  });
+
+  it("clearScope", function () {
+    let scopes = [];
+    traverse(ast, {
+      Program(path) {
+        scopes.push(path.scope);
+        path.stop();
+      }
+    });
+
+    traverse.clearCache.clearScope();
+
+    let scopes2 = [];
+    traverse(ast, {
+      Program(path) {
+        scopes2.push(path.scope);
+        path.stop();
+      }
+    });
+
+    scopes2.forEach(function (p, i) {
+      assert.notStrictEqual(p, scopes[i]);
     });
   });
 });


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | #4818 
| License           | MIT
| Doc PR            | reference to the documentation PR, if any

<!-- Describe your changes below in as much detail as possible -->

Related issue #4818. When a binding changes scope as a part of one plugin, the other plugins won't know it. So the other plugins when the want to be in a separate pass, they can call `programPath.scope.crawl()` to re initialise the bindings, references, constantViolations and scope. But when we have the scope cache, crawl ends up in not modifying the binding's scope. And we don't want to clear PathCache - as this will end up in bugs related to path is unaffected by `scope.crawl`. So we provide an API to clear only the scope's cache (to call crawl later).

Note: This doesn't fix the ticket #4818 completely and just provides an API to work around.