### PR TITLE
Update PR template to close an issue via the PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ https://github.com/babel/babel/blob/master/CONTRIBUTING.md
 | Deprecations?     | yes/no
 | Spec compliancy?  | yes/no
 | Tests added/pass? | yes/no
-| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
+| Fixed tickets     | comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR, if any. E.g: `Fixes #1, Fixes #2`
 | License           | MIT
 | Doc PR            | reference to the documentation PR, if any
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | Fixes #4821
| License           | MIT
| Doc PR            | 

As noted [1], you are able to close an issue when a pull request is merged, assuming the pull request makes mention of the issue with a specific syntax [2].

This change updates the pull request template to enforce that specific syntax is included in future pull requests

[1] https://github.com/blog/1506-closing-issues-via-pull-requests
[2] https://help.github.com/articles/closing-issues-via-commit-messages/