### PR TITLE
Preserve null in babel-types' clone and deepClone.

### DIFF
--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -259,6 +259,7 @@ export function ensureBlock(node: Object, key: string = "body"): Object {
  */
 
 export function clone(node: Object): Object {
+  if (node == null) return null;
   let newNode = {};
   for (let key in node) {
     if (key[0] === "_") continue;
@@ -283,6 +284,7 @@ export function cloneWithoutLoc(node: Object): Object {
  */
 
 export function cloneDeep(node: Object): Object {
+  if (node == null) return null;
   let newNode = {};
 
   for (let key in node) {

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -259,7 +259,7 @@ export function ensureBlock(node: Object, key: string = "body"): Object {
  */
 
 export function clone(node: Object): Object {
-  if (node == null) return null;
+  if (!node) return node;
   let newNode = {};
   for (let key in node) {
     if (key[0] === "_") continue;
@@ -284,7 +284,7 @@ export function cloneWithoutLoc(node: Object): Object {
  */
 
 export function cloneDeep(node: Object): Object {
-  if (node == null) return null;
+  if (!node) return node;
   let newNode = {};
 
   for (let key in node) {

--- a/packages/babel-types/test/cloning.js
+++ b/packages/babel-types/test/cloning.js
@@ -4,6 +4,12 @@ let parse = require("babylon").parse;
 
 suite("cloning", function () {
   suite("clone", function () {
+    it("should handle undefined", function () {
+      let node = undefined;
+      let cloned = t.clone(node);
+      assert(cloned === undefined);
+    });
+
     it("should handle null", function () {
       let node = null;
       let cloned = t.clone(node);
@@ -11,7 +17,7 @@ suite("cloning", function () {
     });
 
     it("should handle simple cases", function () {
-      let node = t.memberExpression(t.identifier("a"), t.identifier("b"));
+      let node = t.arrayExpression([null, t.identifier("a")]);
       let cloned = t.clone(node);
       assert(node !== cloned);
       assert(t.isNodesEquivalent(node, cloned) === true);
@@ -19,6 +25,12 @@ suite("cloning", function () {
   });
 
   suite("cloneDeep", function () {
+    it("should handle undefined", function () {
+      let node = undefined;
+      let cloned = t.cloneDeep(node);
+      assert(cloned === undefined);
+    });
+
     it("should handle null", function () {
       let node = null;
       let cloned = t.cloneDeep(node);
@@ -26,7 +38,7 @@ suite("cloning", function () {
     });
 
     it("should handle simple cases", function () {
-      let node = t.memberExpression(t.identifier("a"), t.identifier("b"));
+      let node = t.arrayExpression([null, t.identifier("a")]);
       let cloned = t.cloneDeep(node);
       assert(node !== cloned);
       assert(t.isNodesEquivalent(node, cloned) === true);
@@ -48,7 +60,7 @@ suite("cloning", function () {
     });
 
     it("should handle missing array element", function () {
-      let node = parse("[,1]");
+      let node = parse("[,0]");
       let cloned = t.cloneDeep(node);
       assert(node !== cloned);
       assert(t.isNodesEquivalent(node, cloned) === true);

--- a/packages/babel-types/test/cloning.js
+++ b/packages/babel-types/test/cloning.js
@@ -1,0 +1,57 @@
+let t = require("../lib");
+let assert = require("assert");
+let parse = require("babylon").parse;
+
+suite("cloning", function () {
+  suite("clone", function () {
+    it("should handle null", function () {
+      let node = null;
+      let cloned = t.clone(node);
+      assert(cloned === null);
+    });
+
+    it("should handle simple cases", function () {
+      let node = t.memberExpression(t.identifier("a"), t.identifier("b"));
+      let cloned = t.clone(node);
+      assert(node !== cloned);
+      assert(t.isNodesEquivalent(node, cloned) === true);
+    });
+  });
+
+  suite("cloneDeep", function () {
+    it("should handle null", function () {
+      let node = null;
+      let cloned = t.cloneDeep(node);
+      assert(cloned === null);
+    });
+
+    it("should handle simple cases", function () {
+      let node = t.memberExpression(t.identifier("a"), t.identifier("b"));
+      let cloned = t.cloneDeep(node);
+      assert(node !== cloned);
+      assert(t.isNodesEquivalent(node, cloned) === true);
+    });
+
+    it("should handle full programs", function () {
+      let node = parse("1 + 1");
+      let cloned = t.cloneDeep(node);
+      assert(node !== cloned);
+      assert(t.isNodesEquivalent(node, cloned) === true);
+    });
+
+    it("should handle complex programs", function () {
+      let program = "'use strict'; function lol() { wow();return 1; }";
+      let node = parse(program);
+      let cloned = t.cloneDeep(node);
+      assert(node !== cloned);
+      assert(t.isNodesEquivalent(node, cloned) === true);
+    });
+
+    it("should handle missing array element", function () {
+      let node = parse("[,1]");
+      let cloned = t.cloneDeep(node);
+      assert(node !== cloned);
+      assert(t.isNodesEquivalent(node, cloned) === true);
+    });
+  });
+});


### PR DESCRIPTION
| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | Yes
| Breaking change?  | No
| New feature?      | No
| Deprecations?     | No
| Spec compliancy?  | No
| Tests added/pass? | Yes
| Fixed tickets     | Fixes #4852
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

Preserve null in babel-types' clone and deepClone.
(The current behavior turns null into {}, which is not equivalent. Null is a valid expression used to represent missing array elements. The Printer in particular cannot generate code for {}, but it does handle null.)
Add tests.