### PR TITLE
Print Flow optional & type annotations in function params with defaults

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -144,6 +144,8 @@ export function ExpressionStatement(node: Object) {
 
 export function AssignmentPattern(node: Object) {
   this.print(node.left, node);
+  if (node.left.optional) this.token("?");
+  this.print(node.left.typeAnnotation, node);
   this.space();
   this.token("=");
   this.space();

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
@@ -115,3 +115,5 @@ var a: {| [a: number]: string; [b: number]: string; |};
 var a: {| add(x: number, ...y: Array<string>): void |};
 var a: {| subtract: (x: number, ...y: Array<string>) => void |};
 var a: {| id<T>(x: T): T; |};
+function foo(numVal: number = 2) {}
+function foo(numVal?: number = 2) {}

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
@@ -119,3 +119,5 @@ var a: {| [a: number]: string; [b: number]: string; |};
 var a: {| add: (x: number, ...y: Array<string>) => void |};
 var a: {| subtract: (x: number, ...y: Array<string>) => void |};
 var a: {| id: <T>(x: T) => T |};
+function foo(numVal: number = 2) {}
+function foo(numVal?: number = 2) {}

--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -30,6 +30,12 @@ export default function ({ types: t }) {
         path.addComment("trailing", ":: ?");
       },
 
+      AssignmentPattern: {
+        exit({ node }) {
+          node.left.optional = false;
+        }
+      },
+
       // strip optional property from function params - facebook/fbjs#17
       Function: {
         exit({ node }) {

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/default-parameters/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/default-parameters/actual.js
@@ -1,0 +1,6 @@
+function foo(numVal?) {}
+function foo(numVal? = 2) {}
+function foo(numVal: number) {}
+function foo(numVal?: number) {}
+function foo(numVal: number = 2) {}
+function foo(numVal?: number = 2) {}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/default-parameters/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/default-parameters/expected.js
@@ -1,0 +1,6 @@
+function foo(numVal /*:: ?*/) {}
+function foo(numVal /*:: ?*/ = 2) {}
+function foo(numVal /*: number*/) {}
+function foo(numVal /*:: ?: number*/) {}
+function foo(numVal /*: number*/ = 2) {}
+function foo(numVal /*:: ?: number*/ = 2) {}

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -40,6 +40,10 @@ export default function ({ types: t }) {
         });
       },
 
+      AssignmentPattern({ node }) {
+        node.left.optional = false;
+      },
+
       Function({ node }) {
         for (let i = 0; i < node.params.length; i++) {
           let param = node.params[i];

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/default-parameters/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/default-parameters/actual.js
@@ -1,0 +1,6 @@
+function foo(numVal?) {}
+function foo(numVal? = 2) {}
+function foo(numVal: number) {}
+function foo(numVal?: number) {}
+function foo(numVal: number = 2) {}
+function foo(numVal?: number = 2) {}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/default-parameters/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/default-parameters/expected.js
@@ -1,0 +1,6 @@
+function foo(numVal) {}
+function foo(numVal = 2) {}
+function foo(numVal) {}
+function foo(numVal) {}
+function foo(numVal = 2) {}
+function foo(numVal = 2) {}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | Fixes #4863
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

Previously optional & type annotations weren't being printed for an `AssignmentPattern` in function params. e.g. 

```js
function foo(numVal: number = 2) {}
function foo(numVal?: number = 2) {}
```

Before & after with just `syntax-flow`:

```diff
-function foo(numVal = 2) {}
-function foo(numVal = 2) {}
+function foo(numVal: number = 2) {}
+function foo(numVal?: number = 2) {}
```

Also had to update `transform-flow-comments` to handle the change. Before any changes, it would print:

```js
function foo(numVal = 2) {}
function foo(numVal = 2) {}
```

After the generator change, `transform-flow-comments` would print:

```js
function foo(numVal /*:: ?*/? = 2) {}
function foo(numVal? /*:: ?: number*/ = 2) {}
```

Now, it prints:

```js
function foo(numVal /*:: ?*/ = 2) {}
function foo(numVal /*:: ?: number*/ = 2) {}
```

Also a similar change to `transform-flow-strip-types` to prevent it printing the `?` optional.
