### PR TITLE
Fix path.evaluate for references before declarations

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -173,6 +173,10 @@ export function evaluate(): { confident: boolean; value: any } {
         return deopt(binding.path);
       }
 
+      if (binding && path.node.start < binding.path.node.end) {
+        return deopt(binding.path);
+      }
+
       if (binding && binding.hasValue) {
         return binding.value;
       } else {

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -86,4 +86,16 @@ describe("evaluation", function () {
       false
     );
   });
+
+  it("should deopt ids that are referenced before the bindings", function () {
+    assert.strictEqual(
+      getPath("let x = y + 5; let y = 5;").get("body.0.declarations.0.init").evaluate().confident,
+      false
+    );
+    assert.strictEqual(
+      getPath("if (typeof x === 'undefined') var x = {}")
+        .get("body.0.test").evaluate().confident,
+      false
+    );
+  });
 });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | (Fixes #4420)
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

<!-- Describe your changes below in as much detail as possible -->

When the declaration is present after reference, then evaluate should deopt instead of using that. Visit #4420 for more info. 

This fix is also necessary for babili in the following places -

+ https://github.com/babel/babili/issues/258
+ https://github.com/babel/babili/issues/192
