### PR TITLE
Add getBindingIdentifierPaths/getOuterBindingIdentifierPaths

### DIFF
--- a/packages/babel-traverse/src/path/family.js
+++ b/packages/babel-traverse/src/path/family.js
@@ -118,17 +118,11 @@ export function _getPattern(parts, context) {
   return path;
 }
 
-export function getBindingIdentifiers(duplicates, returnPaths = false) {
-  if (returnPaths) {
-    return this.getBindingIdentifierPaths(duplicates);
-  }
+export function getBindingIdentifiers(duplicates?) {
   return t.getBindingIdentifiers(this.node, duplicates);
 }
 
-export function getOuterBindingIdentifiers(duplicates, returnPaths = false) {
-  if (returnPaths) {
-    return this.getBindingIdentifierPaths(duplicates, true);
-  }
+export function getOuterBindingIdentifiers(duplicates?) {
   return t.getOuterBindingIdentifiers(this.node, duplicates);
 }
 
@@ -187,4 +181,8 @@ export function getBindingIdentifierPaths(duplicates = false, outerOnly = false)
   }
 
   return ids;
+}
+
+export function getOuterBindingIdentifierPaths(duplicates?) {
+  return this.getBindingIdentifierPaths(duplicates, true);
 }

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -9,11 +9,11 @@ describe("path/family", function () {
     traverse(ast, {
       VariableDeclaration(path) {
         nodes = path.getBindingIdentifiers();
-        paths = path.getBindingIdentifiers(false, true);
+        paths = path.getBindingIdentifierPaths();
       },
       FunctionDeclaration(path) {
         outerNodes = path.getOuterBindingIdentifiers();
-        outerPaths = path.getOuterBindingIdentifiers(false, true);
+        outerPaths = path.getOuterBindingIdentifierPaths();
       }
     });
 

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -1,0 +1,60 @@
+let traverse = require("../lib").default;
+let assert = require("assert");
+let parse = require("babylon").parse;
+
+describe("path/family", function () {
+  describe("getBindingIdentifiers", function () {
+    let ast = parse("var a = 1, {b} = c, [d] = e; function f() {}");
+    let nodes = {}, paths = {}, outerNodes = {}, outerPaths = {};
+    traverse(ast, {
+      VariableDeclaration(path) {
+        nodes = path.getBindingIdentifiers();
+        paths = path.getBindingIdentifiers(false, true);
+      },
+      FunctionDeclaration(path) {
+        outerNodes = path.getOuterBindingIdentifiers();
+        outerPaths = path.getOuterBindingIdentifiers(false, true);
+      }
+    });
+
+    it("should contain keys of nodes in paths", function () {
+      Object.keys(nodes).forEach((id) => {
+        assert.strictEqual(hop(paths, id), true, "Node's keys exists in paths");
+      });
+    });
+
+    it("should contain outer bindings", function () {
+      Object.keys(outerNodes).forEach((id) => {
+        assert.strictEqual(hop(outerPaths, id), true, "Has same outer keys");
+      });
+    });
+
+    it("should return paths", function () {
+      Object.keys(paths).forEach((id) => {
+        assert.strictEqual(!!paths[id].node, true, "Has a property node that's not falsy");
+        assert.strictEqual(paths[id].type, paths[id].node.type, "type matches");
+      });
+
+      Object.keys(outerPaths).forEach((id) => {
+        assert.strictEqual(!!outerPaths[id].node, true, "has property node");
+        assert.strictEqual(outerPaths[id].type, outerPaths[id].node.type, "type matches");
+      });
+    });
+
+    it("should match paths and nodes returned for the same ast", function () {
+      Object.keys(nodes).forEach((id) => {
+        assert.strictEqual(nodes[id], paths[id].node, "Nodes match");
+      });
+    });
+
+    it("should match paths and nodes returned for outer Bindings", function () {
+      Object.keys(outerNodes).forEach((id) => {
+        assert.strictEqual(outerNodes[id], outerPaths[id].node, "nodes match");
+      });
+    });
+  });
+});
+
+function hop(o, key) {
+  return Object.hasOwnProperty.call(o, key);
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

<!-- Describe your changes below in as much detail as possible -->

The path API - `getBindingIdentifers()` returns a list of `Nodes` instead of `Paths`.

New APIs:

+ `path.getBindingIdentifierPaths()` - same as `getBindingIdentifiers()` - but returns Paths instead of Nodes
+ `path.getOuterBindingIdentifierPaths()` - same as `getOuterBindingIdentifiers()` - but returns Paths instead of Nodes
