### PR TITLE
Add (and fix) failing test of function parameter bindings in a catch block

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -524,7 +524,11 @@ class BlockScoping {
     //
     for (let i = 0; i < declarators.length; i++) {
       let declar = declarators[i];
-      let keys = t.getBindingIdentifiers(declar);
+      // Passing true as the third argument causes t.getBindingIdentifiers
+      // to return only the *outer* binding identifiers of this
+      // declaration, rather than (for example) mistakenly including the
+      // parameters of a function declaration. Fixes #4880.
+      let keys = t.getBindingIdentifiers(declar, false, true);
       extend(this.letReferences, keys);
       this.hasLetReferences = true;
     }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/function-in-catch/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/function-in-catch/actual.js
@@ -1,0 +1,7 @@
+try {
+  foo();
+} catch (x) {
+  function harmless(x) {
+    return x;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/function-in-catch/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/function-in-catch/expected.js
@@ -1,0 +1,7 @@
+try {
+  foo();
+} catch (x) {
+  var harmless = function (x) {
+    return x;
+  };
+}


### PR DESCRIPTION
| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes/yes
| Fixed tickets     | #4880
| License           | MIT
| Doc PR            | no
| Dependency Changes| no

This test can be run in isolation via the following command:
```sh
TEST_GREP='block-scoping.*function in catch' make test-only
```

This test fails because `BlockScoping#getLetReferences` accidentally considers the parameters of the function declaration as `let` bindings in the `catch` scope. When the name of the `catch` parameter is the same as one of the function's parameter names, the function declaration will be unnecessarily wrapped to isolate its parameters from the outer scope.

While the extra wrapping may not seem harmful in this case, this behavior is a symptom of a deeper problem that causes very subtle bugs in transform code involving `catch` parameters and function declarations. This test case was just the simplest example I could find to demonstrate the problem.

~~I have a proposed fix for this problem that I will push as soon as the tests fail for this commit.~~ Pushed!