### PR TITLE
Fix for object-rest with parameters destructuring nested rest

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -1,33 +1,22 @@
 export default function ({ types: t }) {
-  function hasRestProperty(node) {
-    for (let property of (node.properties)) {
-      if (t.isRestProperty(property)) {
-        return true;
+  function hasRestProperty(path) {
+    let foundRestProperty = false;
+    path.traverse({
+      RestProperty() {
+        foundRestProperty = true;
       }
-      if (t.isObjectProperty(property) && t.isObjectPattern(property.value)) {
-        return hasRestProperty(property.value);
-      }
-    }
-
-    return false;
+    });
+    return foundRestProperty;
   }
 
-  function variableDeclarationHasRestProperty(node) {
-    for (let declar of (node.declarations)) {
-      if (t.isObjectPattern(declar.id)) {
-        return hasRestProperty(declar.id);
+  function hasSpread(path) {
+    let foundSpreadProperty = false;
+    path.traverse({
+      SpreadProperty() {
+        foundSpreadProperty = true;
       }
-    }
-    return false;
-  }
-
-  function hasSpread(node) {
-    for (let prop of (node.properties)) {
-      if (t.isSpreadProperty(prop)) {
-        return true;
-      }
-    }
-    return false;
+    });
+    return foundSpreadProperty;
   }
 
   function createObjectSpread(file, props, objRef) {
@@ -54,7 +43,7 @@ export default function ({ types: t }) {
   }
 
   function replaceRestProperty(paramsPath, i, numParams) {
-    if (paramsPath.isObjectPattern() && hasRestProperty(paramsPath.node)) {
+    if (paramsPath.isObjectPattern() && hasRestProperty(paramsPath)) {
       let parentPath = paramsPath.parentPath;
       let uid = parentPath.scope.generateUidIdentifier("ref");
 
@@ -135,7 +124,7 @@ export default function ({ types: t }) {
       ExportNamedDeclaration(path) {
         let declaration = path.get("declaration");
         if (!declaration.isVariableDeclaration()) return;
-        if (!variableDeclarationHasRestProperty(declaration.node)) return;
+        if (!hasRestProperty(declaration)) return;
 
         let specifiers = [];
 
@@ -157,7 +146,7 @@ export default function ({ types: t }) {
       // ({a, ...b} = c);
       AssignmentExpression(path, file) {
         let leftPath = path.get("left");
-        if (leftPath.isObjectPattern() && hasRestProperty(leftPath.node)) {
+        if (leftPath.isObjectPattern() && hasRestProperty(leftPath)) {
           let nodes = [];
 
           let ref;
@@ -194,10 +183,11 @@ export default function ({ types: t }) {
       // taken from transform-es2015-destructuring/src/index.js#visitor
       ForXStatement(path) {
         let { node, scope } = path;
+        let leftPath = path.get("left");
         let left = node.left;
 
         // for ({a, ...b} of []) {}
-        if (t.isObjectPattern(left) && hasRestProperty(left)) {
+        if (t.isObjectPattern(left) && hasRestProperty(leftPath)) {
           let temp = scope.generateUidIdentifier("ref");
 
           node.left = t.variableDeclaration("var", [
@@ -233,7 +223,7 @@ export default function ({ types: t }) {
       },
       // var a = { ...b, ...c }
       ObjectExpression(path, file) {
-        if (!hasSpread(path.node)) return;
+        if (!hasSpread(path)) return;
 
         let useBuiltIns = file.opts.useBuiltIns || false;
         if (typeof useBuiltIns !== "boolean") {

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -4,6 +4,9 @@ export default function ({ types: t }) {
       if (t.isRestProperty(property)) {
         return true;
       }
+      if (t.isObjectProperty(property) && t.isObjectPattern(property.value)) {
+        return hasRestProperty(property.value);
+      }
     }
 
     return false;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/catch-clause/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/catch-clause/actual.js
@@ -1,6 +1,7 @@
 try {} catch({ ...a34 }) {}
 try {} catch({a1, ...b1}) {}
 try {} catch({a2, b2, ...c2}) {}
+try {} catch({a2, b2, c2: { c3, ...c4 }}) {}
 
 // Unchanged
 try {} catch(a) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/catch-clause/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/catch-clause/expected.js
@@ -9,6 +9,10 @@ try {} catch (_ref3) {
   let { a2, b2 } = _ref3;
   let c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
 }
+try {} catch (_ref4) {
+  let { a2, b2, c2: { c3 } } = _ref4;
+  let c4 = babelHelpers.objectWithoutProperties(_ref4.c2, ["c3"]);
+}
 
 // Unchanged
 try {} catch (a) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/actual.js
@@ -2,6 +2,8 @@ function a({ ...a34 }) {}
 function a2({a1, ...b1}) {}
 function a3({a2, b2, ...c2}) {}
 function a4({a3, ...c3}, {a5, ...c5}) {}
+function a5({a3, b2: { ba1, ...ba2 }, ...c3}) {}
+function a6({a3, b2: { ba1, ...ba2 } }) {}
 // Unchanged
 function b(a) {}
 function b2(a, ...b) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
@@ -20,9 +20,9 @@ function a5(_ref6) {
   let ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]),
       c3 = babelHelpers.objectWithoutProperties(_ref6, ["a3", "b2"]);
 }
-function a6(_ref6) {
-  let { a3, b2: { ba1 } } = _ref6;
-  let ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]);
+function a6(_ref7) {
+  let { a3, b2: { ba1 } } = _ref7;
+  let ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, ["ba1"]);
 }
 // Unchanged
 function b(a) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
@@ -15,6 +15,15 @@ function a4(_ref4, _ref5) {
   let { a3 } = _ref4;
   let c3 = babelHelpers.objectWithoutProperties(_ref4, ["a3"]);
 }
+function a5(_ref6) {
+  let { a3, b2: { ba1 } } = _ref6;
+  let ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]),
+      c3 = babelHelpers.objectWithoutProperties(_ref6, ["a3", "b2"]);
+}
+function a6(_ref6) {
+  let { a3, b2: { ba1 } } = _ref6;
+  let ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]);
+}
 // Unchanged
 function b(a) {}
 function b2(a, ...b) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/actual.js
@@ -15,3 +15,5 @@ let {
   y: { ...d },
   ...g
 } = complex;
+
+let { x4: { ...y4 } } = z;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/expected.js
@@ -19,6 +19,9 @@ const z4 = babelHelpers.objectWithoutProperties(z, ["w3", "x3", "y3"]);
 let {
   x: { a: xa, [d]: f }
 } = complex;
+
 let asdf = babelHelpers.objectWithoutProperties(complex.x, ["a", d]),
     d = babelHelpers.objectWithoutProperties(complex.y, []),
     g = babelHelpers.objectWithoutProperties(complex, ["x"]);
+let {} = z;
+let y4 = babelHelpers.objectWithoutProperties(z.x4, []);


### PR DESCRIPTION

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          |  yes
| Breaking change?  |  no
| New feature?      |  no
| Deprecations?     |  no
| Spec compliancy?  | 
| Tests added/pass? |  yes/yes
| Fixed tickets     | 
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

<!-- Describe your changes below in as much detail as possible -->

@hzoo bug with babel-plugin-transform-object-rest-spread@^6.19.0

actual:

```js
function a6({a3, b2: { ba1, ...ba2 } }) {}
```

transformed to

```js
function a6({ a3, b2: { ba1, ...ba2 } }) {}
```

now transforms to

```js
function a6(_ref7) {
  let { a3, b2: { ba1 } } = _ref7;
  let ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, ["ba1"]);
}
```