### PR TITLE
Switch to nyc, babel-plugin-istanbul & codecov-node for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist
 /packages/*/lib
 _babel.github.io
 /tests/.browser-build.js
+/.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ dist
 /packages/*/lib
 _babel.github.io
 /tests/.browser-build.js
-/.nyc_output
+.nyc_output

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,5 +1,0 @@
-instrumentation:
-  root: .
-  excludes:
-    - "**/node_modules/**"
-    - "scripts/*.js"

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,7 +9,6 @@ var gulp    = require("gulp");
 var path    = require("path");
 
 var scripts = "./packages/*/src/**/*.js";
-var dest = "packages";
 
 var srcEx, libFragment;
 
@@ -21,6 +20,9 @@ if (path.win32 === path) {
   libFragment = "$1/lib/";
 }
 
+var mapToDest = function (path) { return path.replace(srcEx, libFragment); };
+var dest = "packages";
+
 gulp.task("default", ["build"]);
 
 gulp.task("build", function () {
@@ -30,17 +32,17 @@ gulp.task("build", function () {
         gutil.log(err.stack);
       }
     }))
+    .pipe(newer({map: mapToDest}))
     .pipe(through.obj(function (file, enc, callback) {
-      file._path = file.path;
-      file.path = file.path.replace(srcEx, libFragment);
-      callback(null, file);
-    }))
-    .pipe(newer(dest))
-    .pipe(through.obj(function (file, enc, callback) {
-      gutil.log("Compiling", "'" + chalk.cyan(file._path) + "'...");
+      gutil.log("Compiling", "'" + chalk.cyan(file.path) + "'...");
       callback(null, file);
     }))
     .pipe(babel())
+    .pipe(through.obj(function (file, enc, callback) {
+      file._path = file.path;
+      file.path = mapToDest(file.path);
+      callback(null, file);
+    }))
     .pipe(gulp.dest(dest));
 });
 

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,14 @@ test: lint test-only
 test-cov: clean
 	# rebuild with test
 	rm -rf packages/*/lib
-	BABEL_ENV=test; ./node_modules/.bin/gulp build
+	BABEL_ENV=test ./node_modules/.bin/gulp build
 	./scripts/test-cov.sh
 
 test-ci:
 	NODE_ENV=test make bootstrap
-	./scripts/test-cov.sh
-	cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
+	# if ./node_modules/.bin/semver `npm --version` -r ">=3.3.0"; then ./node_modules/.bin/flow check; fi
+	make test-cov
+	./node_modules/.bin/codecov -f coverage/coverage-final.json
 
 publish:
 	git pull --rebase

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ test-cov: clean
 
 test-ci:
 	NODE_ENV=test make bootstrap
-	# if ./node_modules/.bin/semver `npm --version` -r ">=3.3.0"; then ./node_modules/.bin/flow check; fi
 	make test-cov
 	./node_modules/.bin/codecov -f coverage/coverage-final.json
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lerna-changelog": "^0.2.0",
     "lodash": "^4.2.0",
     "mocha": "^3.0.0",
-    "nyc": "^8.3.1",
+    "nyc": "^10.0.0",
     "output-file-sync": "^1.1.1",
     "rimraf": "^2.4.3",
     "semver": "^5.0.0",
@@ -74,8 +74,8 @@
     }
   },
   "nyc": {
+    "all": true,
     "exclude": [
-      "**/node_modules/**",
       "scripts/*.js",
       "packages/*/test/**"
     ],

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
   "nyc": {
     "exclude": [
       "**/node_modules/**",
-      "scripts/*.js"
+      "scripts/*.js",
+      "packages/*/test/**"
     ],
     "sourceMap": false,
     "instrument": false

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "async": "^1.5.0",
     "babel-core": "^6.13.2",
     "babel-eslint": "^7.0.0",
+    "babel-plugin-istanbul": "^2.0.1",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-flow-strip-types": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
@@ -22,7 +23,7 @@
     "bundle-collapser": "^1.2.1",
     "chai": "^3.5.0",
     "chalk": "1.1.1",
-    "codecov.io": "^0.1.6",
+    "codecov": "^1.0.1",
     "derequire": "^2.0.2",
     "eslint": "^3.9.0",
     "eslint-config-babel": "^2.0.1",
@@ -35,11 +36,11 @@
     "gulp-plumber": "^1.0.1",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",
-    "istanbul": "^0.4.5",
     "lerna": "2.0.0-beta.23",
     "lerna-changelog": "^0.2.0",
     "lodash": "^4.2.0",
     "mocha": "^3.0.0",
+    "nyc": "^8.3.1",
     "output-file-sync": "^1.1.1",
     "rimraf": "^2.4.3",
     "semver": "^5.0.0",
@@ -65,8 +66,19 @@
     ],
     "env": {
       "test": {
-        "auxiliaryCommentBefore": "istanbul ignore next"
+        "auxiliaryCommentBefore": "istanbul ignore next",
+        "plugins": [
+          "istanbul"
+        ]
       }
     }
+  },
+  "nyc": {
+    "exclude": [
+      "**/node_modules/**",
+      "scripts/*.js"
+    ],
+    "sourceMap": false,
+    "instrument": false
   }
 }

--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
 
-node node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- `scripts/_get-test-directories.sh` --opts test/mocha.opts
+node_modules/.bin/nyc node_modules/mocha/bin/_mocha --opts test/mocha.opts `scripts/_get-test-directories.sh`
+node_modules/.bin/nyc report --reporter=json


### PR DESCRIPTION
This sees @motiz88's work over the finish line; I released a couple more changes to nyc for babel's benefit (caching on by default, configurable debug output) and tested thoroughly:

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          |  No
| Breaking change?  | No
| New feature?      |  No
| Deprecations?     |  No
| Spec compliancy?  |  No
| Tests added/pass? |  No (they pass though, woo!)
| Fixed tickets     | `See #4740`
| License           | MIT
| Doc PR            |  Nope
| Dependency Changes| 

<!-- Describe your changes below in as much detail as possible -->

Just a couple tweaks to @motiz88's work, and a rebase with master; would love to see this over the finish line:

_Note: we do now add empty reports for files that aren't accessed._

CC: @danez, @hzoo