### PR TITLE
Fixes #4072 - Properly handle #require Member Expresions when perform…

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -54,6 +54,16 @@ export default function ({ types: t }) {
       this.sources.push([id.node, source]);
 
       path.remove();
+    },
+    MemberExpression(path) {
+      let obj = path.get("object");
+      if (!isValidRequireCall(obj)) return;
+
+      let source = obj.node.arguments[0];
+      let id = path.scope.generateUidIdentifierBasedOnNode(source);
+      this.sourceNames[source.value] = true;
+      this.sources.push([id, source]);
+      obj.replaceWith(id);
     }
   };
 

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-call-expression/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-call-expression/actual.js
@@ -1,0 +1,1 @@
+require('foo');

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-call-expression/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-call-expression/expected.js
@@ -1,0 +1,1 @@
+define(['foo'], function () {});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-member-expression/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-member-expression/actual.js
@@ -1,0 +1,1 @@
+require('foo').bar;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-member-expression/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-member-expression/expected.js
@@ -1,0 +1,5 @@
+define(['foo'], function (_foo) {
+  'use strict';
+
+  _foo.bar;
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-mix/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-mix/actual.js
@@ -1,0 +1,2 @@
+require('foo');
+var a = require('foo').bar;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-mix/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-mix/expected.js
@@ -1,0 +1,5 @@
+define(['foo'], function (_foo) {
+  'use strict';
+
+  var a = _foo.bar;
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-variable-declarator/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-variable-declarator/actual.js
@@ -1,0 +1,1 @@
+var bar = require('foo');

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-variable-declarator/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/require-variable-declarator/expected.js
@@ -1,0 +1,1 @@
+define(['foo'], function (bar) {});


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          |  yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | #4072
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

## The AMD transformer was not properly handling `MemberExpression`s with a `#require` object. 

The AMD visitor previously always removed the `require` `CallExpression` path, which led to a _"Property object of MemberExpression expected node to be of a type ["Expression"] but instead got null"_ error when a property was referenced on the #require call, for example `require('foo').bar`

The solution was to replace the object node in the `MemberExpression` with the source identifier when _object expression_ is a valid require call.

Also, added unit tests for the various ways `require` is handled in the AMD transform.

…ing an AMD transform