### PR TITLE
Fix remove hooks for Assignment/Conditional

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -17,5 +17,8 @@
     "globals": "^9.0.0",
     "invariant": "^2.2.0",
     "lodash": "^4.2.0"
+  },
+  "devDependencies": {
+    "babel-generator": "^6.19.0"
   }
 }

--- a/packages/babel-traverse/src/path/lib/removal-hooks.js
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.js
@@ -6,7 +6,11 @@
 
 export let hooks = [
   function (self, parent) {
-    if (self.key === "body" && parent.isArrowFunctionExpression()) {
+    if (
+      self.key === "body" && parent.isArrowFunctionExpression() ||
+      parent.isConditionalExpression() ||
+      self.key === "right" && parent.isAssignmentExpression()
+    ) {
       self.replaceWith(self.scope.buildUndefinedNode());
       return true;
     }

--- a/packages/babel-traverse/src/path/lib/removal-hooks.js
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.js
@@ -7,7 +7,6 @@
 export let hooks = [
   function (self, parent) {
     if (
-      self.key === "body" && parent.isArrowFunctionExpression() ||
       parent.isConditionalExpression() ||
       self.key === "right" && parent.isAssignmentExpression()
     ) {
@@ -73,7 +72,7 @@ export let hooks = [
   function (self, parent) {
     if (
       (parent.isIfStatement() && (self.key === "consequent" || self.key === "alternate")) ||
-      (parent.isLoop() && self.key === "body")
+      (self.key === "body" && (parent.isLoop() || parent.isArrowFunctionExpression()))
     ) {
       self.replaceWith({
         type: "BlockStatement",

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -49,7 +49,7 @@ describe("removal", function () {
       const body = path.get("body");
       body.remove();
 
-      assert.equal(generateCode(rootPath), "x = () => {};", "body should be replaced with undefined");
+      assert.equal(generateCode(rootPath), "x = () => {};", "body should be replaced with BlockStatement");
     });
   });
 

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -49,7 +49,7 @@ describe("removal", function () {
       const body = path.get("body");
       body.remove();
 
-      assert.equal(generateCode(rootPath), "x = () => void 0;", "body should be replaced with undefined");
+      assert.equal(generateCode(rootPath), "x = () => {};", "body should be replaced with undefined");
     });
   });
 

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -1,0 +1,84 @@
+import traverse from "../lib";
+import assert from "assert";
+import { parse } from "babylon";
+import * as t from "babel-types";
+import generate from "babel-generator";
+
+function getPath(code) {
+  const ast = parse(code);
+  let path;
+  traverse(ast, {
+    Program: function (_path) {
+      path = _path;
+      _path.stop();
+    }
+  });
+
+  return path;
+}
+
+function generateCode(path) {
+  return generate(path.node).code;
+}
+
+describe("removal", function () {
+  describe("AssignmentExpression", function () {
+    it.skip("remove left", function () {
+      const rootPath = getPath("x = a;");
+      const path = rootPath.get("body")[0].get('expression');
+      const left = path.get("left");
+      left.remove();
+
+      assert.equal(generate(rootPath.node).code, "?", "?");
+    });
+
+    it("remove right", function () {
+      const rootPath = getPath("x = a;");
+      const path = rootPath.get("body")[0].get('expression');
+      const right = path.get("right");
+      right.remove();
+
+      assert.equal(generateCode(rootPath), "x = void 0;", "right hand side should be replaced with undefined");
+    });
+  });
+
+  describe("ArrowFunction", function () {
+    it("remove body", function () {
+      const rootPath = getPath("x = () => b;");
+      const path = rootPath.get("body")[0].get('expression').get('right');
+      const body = path.get("body");
+      body.remove();
+
+      assert.equal(generateCode(rootPath), "x = () => void 0;", "body should be replaced with undefined");
+    });
+  });
+
+  describe("ConditionalExpression", function () {
+    it("remove alternate", function () {
+      const rootPath = getPath("x = x ? a : b;");
+      const path = rootPath.get("body")[0].get('expression').get('right');
+      const alternate = path.get("alternate");
+      alternate.remove();
+
+      assert.equal(generateCode(rootPath), "x = x ? a : void 0;", "alternate should be replaced with undefined");
+    });
+
+    it("remove consequent", function () {
+      const rootPath = getPath("x = x ? a : b;");
+      const path = rootPath.get("body")[0].get('expression').get('right');
+      const consequent = path.get("consequent");
+      consequent.remove();
+
+      assert.equal(generateCode(rootPath), "x = x ? void 0 : b;", "consequent should be replaced with undefined");
+    });
+
+    it("remove test", function () {
+      const rootPath = getPath("x = x ? a : b;");
+      const path = rootPath.get("body")[0].get('expression').get('right');
+      const test = path.get("test");
+      test.remove();
+
+      assert.equal(generateCode(rootPath), "x = void 0 ? a : b;", "test should be replaced with undefined");
+    });
+  });
+});

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -1,7 +1,6 @@
 import traverse from "../lib";
 import assert from "assert";
 import { parse } from "babylon";
-import * as t from "babel-types";
 import generate from "babel-generator";
 
 function getPath(code) {
@@ -25,7 +24,7 @@ describe("removal", function () {
   describe("AssignmentExpression", function () {
     it.skip("remove left", function () {
       const rootPath = getPath("x = a;");
-      const path = rootPath.get("body")[0].get('expression');
+      const path = rootPath.get("body")[0].get("expression");
       const left = path.get("left");
       left.remove();
 
@@ -34,7 +33,7 @@ describe("removal", function () {
 
     it("remove right", function () {
       const rootPath = getPath("x = a;");
-      const path = rootPath.get("body")[0].get('expression');
+      const path = rootPath.get("body")[0].get("expression");
       const right = path.get("right");
       right.remove();
 
@@ -45,7 +44,7 @@ describe("removal", function () {
   describe("ArrowFunction", function () {
     it("remove body", function () {
       const rootPath = getPath("x = () => b;");
-      const path = rootPath.get("body")[0].get('expression').get('right');
+      const path = rootPath.get("body")[0].get("expression").get("right");
       const body = path.get("body");
       body.remove();
 
@@ -56,7 +55,7 @@ describe("removal", function () {
   describe("ConditionalExpression", function () {
     it("remove alternate", function () {
       const rootPath = getPath("x = x ? a : b;");
-      const path = rootPath.get("body")[0].get('expression').get('right');
+      const path = rootPath.get("body")[0].get("expression").get("right");
       const alternate = path.get("alternate");
       alternate.remove();
 
@@ -65,7 +64,7 @@ describe("removal", function () {
 
     it("remove consequent", function () {
       const rootPath = getPath("x = x ? a : b;");
-      const path = rootPath.get("body")[0].get('expression').get('right');
+      const path = rootPath.get("body")[0].get("expression").get("right");
       const consequent = path.get("consequent");
       consequent.remove();
 
@@ -74,7 +73,7 @@ describe("removal", function () {
 
     it("remove test", function () {
       const rootPath = getPath("x = x ? a : b;");
-      const path = rootPath.get("body")[0].get('expression').get('right');
+      const path = rootPath.get("body")[0].get("expression").get("right");
       const test = path.get("test");
       test.remove();
 


### PR DESCRIPTION
| Q                 | A 
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no 
| New feature?      |  no 
| Deprecations?     |  no 
| Spec compliancy?  |  no 
| Tests added/pass? | yes
| Fixed tickets     | Fixes babel/babili#300 facebook/react-native#10412
| License           | MIT
| Doc PR            | no
| Dependency Changes| no

This ensures that if any subnode of `ConditionalExpression`s and `right` of `AssignmentExpression` are removed they get replaced by `undefined` (or `void 0`).

I'm not sure what should happen if the left-hand-side of an assignment gets removed.

```
x = someCall();
```

If now someone removes the left-hand-side we probably need to turn it into

```
someCall();
```

But I'm not sure. In certain cases, we can probably also remove the whole thing alltogether if there can be no side-effects:
```
x = a;
```


//cc @boopathi @kangax 