### PR TITLE
Fix babel-types README

### DIFF
--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -1,6 +1,12 @@
 # babel-types
 
-This module contains methods for building ASTs manually and for checking the types of AST nodes.
+> This module contains methods for building ASTs manually and for checking the types of AST nodes.
+
+## Install
+
+```sh
+$ npm install --save babel-types
+```
 
 ## API
 

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```sh
-$ npm install --save babel-types
+$ npm install --save-dev babel-types
 ```
 
 ## API


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | no
| License           | MIT
| Doc PR            | yes
| Dependency Changes| no 

Improve and harmonise the `babel-types` package README. Related to babel/babel.github.io#1009.

This documentation will be shown on the Babel website. I know the API documentation is generated. Could you tell me how is it generated ? Is there any way to modify the style ?

<!-- Describe your changes below in as much detail as possible -->

