### PR TITLE
Only base async fn arity on non-default/non-rest params - fixes #4891

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -122,7 +122,18 @@ function plainFunction(path: NodePath, callId: Object) {
     NAME: asyncFnId,
     REF: path.scope.generateUidIdentifier("ref"),
     FUNCTION: built,
-    PARAMS: node.params.map(() => path.scope.generateUidIdentifier("x"))
+    PARAMS: node.params.reduce((acc, param) => {
+      acc.done = acc.done || !t.isIdentifier(param);
+
+      if (!acc.done) {
+        acc.params.push(path.scope.generateUidIdentifier("x"));
+      }
+
+      return acc;
+    }, {
+      params: [],
+      done: false,
+    }).params,
   }).expression;
 
   if (isDeclaration) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/async-in-params/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/async-in-params/expected.js
@@ -6,7 +6,7 @@ let g = (() => {
     yield 3;
   });
 
-  return function g(_x) {
+  return function g() {
     return _ref.apply(this, arguments);
   };
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/actual.js
@@ -1,0 +1,4 @@
+async function one(a, b = 1) {}
+async function two(a, b, ...c) {}
+async function three(a, b = 1, c, d = 3) {}
+async function four(a, b = 1, c, ...d) {}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/expected.js
@@ -1,0 +1,31 @@
+let one = (() => {
+  var _ref = babelHelpers.asyncToGenerator(function* (a, b = 1) {});
+
+  return function one(_x) {
+    return _ref.apply(this, arguments);
+  };
+})();
+
+let two = (() => {
+  var _ref2 = babelHelpers.asyncToGenerator(function* (a, b, ...c) {});
+
+  return function two(_x2, _x3) {
+    return _ref2.apply(this, arguments);
+  };
+})();
+
+let three = (() => {
+  var _ref3 = babelHelpers.asyncToGenerator(function* (a, b = 1, c, d = 3) {});
+
+  return function three(_x4) {
+    return _ref3.apply(this, arguments);
+  };
+})();
+
+let four = (() => {
+  var _ref4 = babelHelpers.asyncToGenerator(function* (a, b = 1, c, ...d) {});
+
+  return function four(_x5) {
+    return _ref4.apply(this, arguments);
+  };
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/options.json
@@ -1,0 +1,6 @@
+{
+	"plugins": [
+		"transform-async-to-generator",
+		"external-helpers"
+	]
+}


### PR DESCRIPTION
| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | Y
| Breaking change?  | N
| New feature?      | 
| Deprecations?     | 
| Spec compliancy?  | 
| Tests added/pass? | 
| Fixed tickets     | Fixes #4891 
| License           | MIT
| Doc PR            | 
| Dependency Changes| 

Only add params up to the first non-idenfier param.
