### PR TITLE
Remove shouldIgnore check

### DIFF
--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -71,7 +71,6 @@ export default function get(entryLoc): Array<Suite> {
     if (suiteOptsLoc) suite.options = require(suiteOptsLoc);
 
     for (let taskName of fs.readdirSync(suite.filename)) {
-      if (shouldIgnore(taskName)) continue;
       push(taskName, suite.filename + "/" + taskName);
     }
 


### PR DESCRIPTION
| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | yes
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | no
| License           | MIT
| Doc PR            | no
| Dependency Changes| no

Otherwise tasks will never be marked as disabled

I noticed this in babylon, where around 60 tests are skipped (foldername starts with .) but ava is not seeing them.