### PR TITLE
Docs/babel plugin check es2015 constants

### DIFF
--- a/packages/babel-plugin-check-es2015-constants/README.md
+++ b/packages/babel-plugin-check-es2015-constants/README.md
@@ -5,7 +5,7 @@ Validate ES2015 constants
 <blockquote class="babel-callout babel-callout-info">
   <h4>Syntax only</h4>
   <p>
-    This check will only validate consts. If you need it to compile down to `var` then you must also install and enable <a href="/docs/plugins/transform-es2015-block-scoping">transform-es2015-block-scoping</a>.
+    This check will only validate consts. If you need it to compile down to `var` then you must also install and enable <a href="https://babeljs.io/docs/plugins/transform-es2015-block-scoping">transform-es2015-block-scoping</a>.
   </p>
 </blockquote>
 

--- a/packages/babel-plugin-check-es2015-constants/README.md
+++ b/packages/babel-plugin-check-es2015-constants/README.md
@@ -2,10 +2,17 @@
 
 Validate ES2015 constants
 
+<blockquote class="babel-callout babel-callout-info">
+  <h4>Syntax only</h4>
+  <p>
+    This check will only validate consts. If you need it to compile down to `var` then you must also install and enable <a href="/docs/plugins/transform-es2015-block-scoping">transform-es2015-block-scoping</a>.
+  </p>
+</blockquote>
+
 ## Installation
 
 ```sh
-$ npm install babel-plugin-check-es2015-constants
+$ npm install --save-dev babel-plugin-check-es2015-constants
 ```
 
 ## Usage

--- a/packages/babel-plugin-check-es2015-constants/README.md
+++ b/packages/babel-plugin-check-es2015-constants/README.md
@@ -2,13 +2,6 @@
 
 Validate ES2015 constants
 
-<blockquote class="babel-callout babel-callout-info">
-  <h4>Syntax only</h4>
-  <p>
-    This check will only validate consts. If you need it to compile down to `var` then you must also install and enable <a href="https://babeljs.io/docs/plugins/transform-es2015-block-scoping">transform-es2015-block-scoping</a>.
-  </p>
-</blockquote>
-
 ## Installation
 
 ```sh


### PR DESCRIPTION
| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Doc PR            | yes 

From babel/babel.github.io#997

I moved some description that has been made on babel.github.io's [check-es2015-constants.md](https://github.com/babel/babel.github.io/blob/master/docs/plugins/check-es2015-constants.md) to the package's README.md

I'm not sure if I should change the path to transform-es2015-block-scoping or not. With the old path, it will navigate to a non-existed page if you are in GitHub website.
