### PR TITLE
Add forceColor option to babel-code-frame

### DIFF
--- a/packages/babel-code-frame/README.md
+++ b/packages/babel-code-frame/README.md
@@ -40,3 +40,4 @@ name                   | type     | default         | description
 highlightCode          | boolean  | `false`         | Syntax highlight the code as JavaScript for terminals
 linesAbove             | number   | 2               | The number of lines to show above the error
 linesBelow             | number   | 3               | The number of lines to show below the error
+forceColor             | boolean  | `false`         | Forcibly syntax highlight the code as JavaScript (for non-terminals); overrides highlightCode

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -1,25 +1,27 @@
 import jsTokens from "js-tokens";
 import esutils from "esutils";
-import chalk from "chalk";
+import Chalk from "chalk";
 
 /**
  * Chalk styles for token types.
  */
 
-let defs = {
-  keyword:     chalk.cyan,
-  capitalized: chalk.yellow,
-  jsx_tag:     chalk.yellow,
-  punctuator:  chalk.yellow,
-  // bracket:  intentionally omitted.
-  number:      chalk.magenta,
-  string:      chalk.green,
-  regex:       chalk.magenta,
-  comment:     chalk.grey,
-  invalid:     chalk.white.bgRed.bold,
-  gutter:      chalk.grey,
-  marker:      chalk.red.bold,
-};
+function getDefs(chalk) {
+  return {
+    keyword:     chalk.cyan,
+    capitalized: chalk.yellow,
+    jsx_tag:     chalk.yellow,
+    punctuator:  chalk.yellow,
+    // bracket:  intentionally omitted.
+    number:      chalk.magenta,
+    string:      chalk.green,
+    regex:       chalk.magenta,
+    comment:     chalk.grey,
+    invalid:     chalk.white.bgRed.bold,
+    gutter:      chalk.grey,
+    marker:      chalk.red.bold,
+  };
+}
 
 /**
  * RegExp to test for newlines in terminal.
@@ -75,7 +77,7 @@ function getTokenType(match) {
  * Highlight `text`.
  */
 
-function highlight(text: string) {
+function highlight(defs: Object, text: string) {
   return text.replace(jsTokens, function (...args) {
     let type = getTokenType(args);
     let colorize = defs[type];
@@ -99,11 +101,16 @@ export default function (
 ): string {
   colNumber = Math.max(colNumber, 0);
 
-  let highlighted = opts.highlightCode && chalk.supportsColor;
+  let highlighted = (opts.highlightCode && Chalk.supportsColor) || opts.forceColor;
+  let chalk = Chalk;
+  if (opts.forceColor) {
+    chalk = new Chalk.constructor({ enabled: true });
+  }
   let maybeHighlight = (chalkFn, string) => {
     return highlighted ? chalkFn(string) : string;
   };
-  if (highlighted) rawLines = highlight(rawLines);
+  let defs = getDefs(chalk);
+  if (highlighted) rawLines = highlight(defs, rawLines);
 
   let linesAbove = opts.linesAbove || 2;
   let linesBelow = opts.linesBelow || 3;

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -186,4 +186,21 @@ describe("babel-code-frame", function () {
       "  8 | "
     ].join("\n"));
   });
+
+  it("opts.forceColor", function() {
+    let marker = chalk.red.bold;
+    let gutter = chalk.grey;
+
+    let rawLines = [
+      "",
+      "",
+      "",
+      ""
+    ].join("\n");
+    assert.equal(codeFrame(rawLines, 3, null, { linesAbove: 1, linesBelow: 1, forceColor: true }), chalk.reset([
+      " " + gutter(" 2 | "),
+      marker(">") + gutter(" 3 | "),
+      " " + gutter(" 4 | ")
+    ].join("\n")));
+  });
 });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

Added a `forceColor` option to babel-code-frame.

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | N
| Breaking change?  | N
| New feature?      | Y
| Deprecations?     | N
| Spec compliancy?  | N/A
| Tests added/pass? | N/Y
| Fixed tickets     | #4912 <!-- rm the quotes to link the issues -->
| License           | MIT
| Doc PR            | N/A
| Dependency Changes| N/A

<!-- Describe your changes below in as much detail as possible -->

