### PR TITLE
Add another con 😞

### DIFF
--- a/doc/design/monorepo.md
+++ b/doc/design/monorepo.md
@@ -22,6 +22,7 @@ This is quite taboo but let's look at the pros and cons:
  * Codebase looks more intimidating.
  * Repo is bigger in size.
  * Lower ranking in [npms](https://npms.io/) results. At least until [npms-io/npms-analyzer#83](https://github.com/npms-io/npms-analyzer/issues/83) is fixed.
+ * ???
 
 ## This is dumb! Nobody in open source does this!
 

--- a/doc/design/monorepo.md
+++ b/doc/design/monorepo.md
@@ -21,7 +21,7 @@ This is quite taboo but let's look at the pros and cons:
 
  * Codebase looks more intimidating.
  * Repo is bigger in size.
- * ???
+ * Lower ranking in [npms](https://npms.io/) results. At least until [npms-io/npms-analyzer#83](https://github.com/npms-io/npms-analyzer/issues/83) is fixed.
 
 ## This is dumb! Nobody in open source does this!
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | N/A
| Tests added/pass? | N/A
| Fixed tickets     | N/A
| License           | MIT
| Doc PR            | yes
| Dependency Changes| no

<!-- Describe your changes below in as much detail as possible -->

Add another con against the usage of monorepos:
Lower ranking in [npms](https://npms.io/) results. At least until [npms-io/npms-analyzer#83](https://github.com/npms-io/npms-analyzer/issues/83) is fixed.

Monorepos aren’t indexed equally because the API Responses from monorepos differs to the response from »normal« repos.

Compare the following two responses.

+ »normal« repo
  + https://api.npms.io/v2/package/generator-http-fake-backend
+ Monorepo
  + https://api.npms.io/v2/package/generator-react-server

The `github` object is missing in case of monorepos.
This object contains properties like `starsCount`, `forksCount`, `contributors`, `statuses` and `issues` which influence all aspects of the npms ranking algorithm. See https://npms.io/about. 


