### PR TITLE
Update transform-object-rest-spread's README from babel.github.io [skip ci]

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/README.md
+++ b/packages/babel-plugin-transform-object-rest-spread/README.md
@@ -1,15 +1,22 @@
 # babel-plugin-transform-object-rest-spread
 
-Compile object rest and spread to ES5
+> This plugin allows Babel to transform rest properties for object destructuring assignment and spread properties for object literals.
+
+## Example
 
 ```js
-// source
-z = { x, ...y };
+// Rest properties
+let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
+console.log(x); // 1
+console.log(y); // 2
+console.log(z); // { a: 3, b: 4 }
 
-// compiled
-_extends = Object.assign || function(target) { ... }
-z = _extends({ x }, y);
+// Spread properties
+let n = { x, y, ...z };
+console.log(n); // { x: 1, y: 2, a: 3, b: 4 }
 ```
+
+[Try in REPL](/repl/#?evaluate=true&presets=es2015%2Cstage-0&code=%2F%2F%20Rest%20properties%0Alet%20%7B%20x%2C%20y%2C%20...z%20%7D%20%3D%20%7B%20x%3A%201%2C%20y%3A%202%2C%20a%3A%203%2C%20b%3A%204%20%7D%3B%0Aconsole.log(x)%3B%20%2F%2F%201%0Aconsole.log(y)%3B%20%2F%2F%202%0Aconsole.log(z)%3B%20%2F%2F%20%7B%20a%3A%203%2C%20b%3A%204%20%7D%0A%0A%2F%2F%20Spread%20properties%0Alet%20n%20%3D%20%7B%20x%2C%20y%2C%20...z%20%7D%3B%0Aconsole.log(n)%3B%20%2F%2F%20%7B%20x%3A%201%2C%20y%3A%202%2C%20a%3A%203%2C%20b%3A%204%20%7D)
 
 ## Installation
 
@@ -61,3 +68,8 @@ require("babel-core").transform("code", {
   plugins: ["transform-object-rest-spread"]
 });
 ```
+
+## References
+
+* [Proposal: Object Rest/Spread Properties for ECMAScript](https://github.com/sebmarkbage/ecmascript-rest-spread)
+* [Spec](https://github.com/sebmarkbage/ecmascript-rest-spread/blob/master/Spec.md)

--- a/packages/babel-plugin-transform-object-rest-spread/README.md
+++ b/packages/babel-plugin-transform-object-rest-spread/README.md
@@ -16,7 +16,7 @@ let n = { x, y, ...z };
 console.log(n); // { x: 1, y: 2, a: 3, b: 4 }
 ```
 
-[Try in REPL](/repl/#?evaluate=true&presets=es2015%2Cstage-0&code=%2F%2F%20Rest%20properties%0Alet%20%7B%20x%2C%20y%2C%20...z%20%7D%20%3D%20%7B%20x%3A%201%2C%20y%3A%202%2C%20a%3A%203%2C%20b%3A%204%20%7D%3B%0Aconsole.log(x)%3B%20%2F%2F%201%0Aconsole.log(y)%3B%20%2F%2F%202%0Aconsole.log(z)%3B%20%2F%2F%20%7B%20a%3A%203%2C%20b%3A%204%20%7D%0A%0A%2F%2F%20Spread%20properties%0Alet%20n%20%3D%20%7B%20x%2C%20y%2C%20...z%20%7D%3B%0Aconsole.log(n)%3B%20%2F%2F%20%7B%20x%3A%201%2C%20y%3A%202%2C%20a%3A%203%2C%20b%3A%204%20%7D)
+[Try in REPL](https://babeljs.io/repl/#?evaluate=true&presets=es2015%2Cstage-0&code=%2F%2F%20Rest%20properties%0Alet%20%7B%20x%2C%20y%2C%20...z%20%7D%20%3D%20%7B%20x%3A%201%2C%20y%3A%202%2C%20a%3A%203%2C%20b%3A%204%20%7D%3B%0Aconsole.log(x)%3B%20%2F%2F%201%0Aconsole.log(y)%3B%20%2F%2F%202%0Aconsole.log(z)%3B%20%2F%2F%20%7B%20a%3A%203%2C%20b%3A%204%20%7D%0A%0A%2F%2F%20Spread%20properties%0Alet%20n%20%3D%20%7B%20x%2C%20y%2C%20...z%20%7D%3B%0Aconsole.log(n)%3B%20%2F%2F%20%7B%20x%3A%201%2C%20y%3A%202%2C%20a%3A%203%2C%20b%3A%204%20%7D)
 
 ## Installation
 
@@ -72,4 +72,4 @@ require("babel-core").transform("code", {
 ## References
 
 * [Proposal: Object Rest/Spread Properties for ECMAScript](https://github.com/sebmarkbage/ecmascript-rest-spread)
-* [Spec](https://github.com/sebmarkbage/ecmascript-rest-spread/blob/master/Spec.md)
+* [Spec](http://sebmarkbage.github.io/ecmascript-rest-spread)


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Doc PR            | yes<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->

<!-- Describe your changes below in as much detail as possible -->

Sync `transform-object-rest-spread`'s README with [the one on babel.github.io](https://github.com/babel/babel.github.io/blob/master/docs/plugins/transform-object-rest-spread.md)

I removed the quote which mentions babel/babel#4755 because it's already fixed, and I fixed some broken links as well (REPL link can't be navigated from GitHub and Spec link was gone).