### PR TITLE
Fix React constant element bugs

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -305,14 +305,14 @@ class BlockScoping {
       this.remap();
     }
 
-    this.updateScopeInfo();
+    this.updateScopeInfo(needsClosure);
 
     if (this.loopLabel && !t.isLabeledStatement(this.loopParent)) {
       return t.labeledStatement(this.loopLabel, this.loop);
     }
   }
 
-  updateScopeInfo() {
+  updateScopeInfo(wrappedInClosure) {
     let scope = this.scope;
     let parentScope = scope.getFunctionParent();
     let letRefs = this.letReferences;
@@ -323,7 +323,12 @@ class BlockScoping {
       if (!binding) continue;
       if (binding.kind === "let" || binding.kind === "const") {
         binding.kind = "var";
-        scope.moveBindingTo(ref.name, parentScope);
+
+        if (wrappedInClosure) {
+          scope.removeBinding(ref.name);
+        } else {
+          scope.moveBindingTo(ref.name, parentScope);
+        }
       }
     }
   }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/actual.js
@@ -1,0 +1,11 @@
+function render() {
+  const bar = "bar", renderFoo = () => <foo bar={bar} />;
+
+  return renderFoo();
+}
+
+function render() {
+  const bar = "bar", renderFoo = () => <foo bar={bar} baz={baz} />, baz = "baz";
+
+  return renderFoo();
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-declaration/expected.js
@@ -1,0 +1,15 @@
+function render() {
+  const bar = "bar",
+        _ref = <foo bar={bar} />,
+        renderFoo = () => _ref;
+
+  return renderFoo();
+}
+
+function render() {
+  const bar = "bar",
+        renderFoo = () => <foo bar={bar} baz={baz} />,
+        baz = "baz";
+
+  return renderFoo();
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-block-scoped-variables/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-block-scoped-variables/actual.js
@@ -1,0 +1,11 @@
+function render(flag) {
+  if (flag) {
+    let bar = "bar";
+
+    [].map(() => bar);
+
+    return <foo bar={bar} />;
+  }
+
+  return null;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-block-scoped-variables/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-block-scoped-variables/expected.js
@@ -1,0 +1,17 @@
+function render(flag) {
+  if (flag) {
+    var _ret = function () {
+      var bar = "bar";
+
+      [].map(() => bar);
+
+      return {
+        v: <foo bar={bar} />
+      };
+    }();
+
+    if (typeof _ret === "object") return _ret.v;
+  }
+
+  return null;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-block-scoped-variables/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-block-scoped-variables/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "syntax-jsx",
+    "transform-es2015-block-scoping",
+    "transform-react-constant-elements"
+  ]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | Fixes #4419, Fixes #4804
| License           | MIT
| Doc PR            | no
| Dependency Changes| no

There were a couple known issues where `transform-react-constant-elements` was hoisting the constant element too far. This addresses those and adds regression tests.

Excerpts from the commit messages are below:
- When block scoped variables caused the block to be wrapped in a closure, the variable `bindings` remained in parent function scope, which caused the JSX element to be hoisted out of the closure.
- When multiple declarators are present in a declaration, we want to insert the constant element inside the declaration rather than placing it before because it may rely on a declarator inside that same declaration.

