### PR TITLE
Add babel-generator support for Import

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -113,6 +113,10 @@ export function CallExpression(node: Object) {
   this.token(")");
 }
 
+export function Import() {
+  this.word("import");
+}
+
 function buildYieldAwait(keyword: string) {
   return function (node: Object) {
     this.word(keyword);

--- a/packages/babel-generator/test/fixtures/types/Import/actual.js
+++ b/packages/babel-generator/test/fixtures/types/Import/actual.js
@@ -1,0 +1,1 @@
+import("module.js");

--- a/packages/babel-generator/test/fixtures/types/Import/expected.js
+++ b/packages/babel-generator/test/fixtures/types/Import/expected.js
@@ -1,0 +1,1 @@
+import("module.js");

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -35,6 +35,10 @@ defineType("BindExpression", {
   }
 });
 
+defineType("Import", {
+  aliases: ["Expression"]
+});
+
 defineType("Decorator", {
   visitor: ["expression"],
   fields: {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | Fixes #4944 
| License           | MIT
| Doc PR            | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds --> no
| Dependency Changes| no

<!-- Describe your changes below in as much detail as possible -->
This adds support to the `dynamic-import-syntax` for `babel-generator` and `babel-types`. 
