### PR TITLE
Treat "await" as an invalid identifier

### DIFF
--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/await/actual.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/await/actual.js
@@ -1,0 +1,3 @@
+export {};
+
+var obj = { await: function () {} };

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/await/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/await/expected.js
@@ -1,0 +1,3 @@
+export {};
+
+var obj = { await: function _await() {} };

--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -169,6 +169,9 @@ export function isReferenced(node: Object, parent: Object): boolean {
 export function isValidIdentifier(name: string): boolean {
   if (typeof name !== "string" || esutils.keyword.isReservedWordES6(name, true)) {
     return false;
+  } else if (name === "await") {
+    // invalid in module, valid in script; better be safe (see #4952)
+    return false;
   } else {
     return esutils.keyword.isIdentifierNameES6(name);
   }

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -26,5 +26,9 @@ suite("validators", function () {
 
       assert(t.isNodesEquivalent(parse(program), parse(program2)) === false);
     });
+
+    it("rejects 'await' as an identifier", function () {
+      assert(t.isValidIdentifier("await") === false);
+    });
   });
 });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | Fixes #4952 , Fixes #4198 
| License           | MIT
| Doc PR            | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes | 

<!-- Describe your changes below in as much detail as possible -->

"await" is valid (outside `async` functions) as an identifier in the "script" parse goal, but [always invalid](https://tc39.github.io/ecma262/#prod-AwaitExpression) in the "module" parse goal. Prevents the transform from generating invalid code when used without a modules-to-script transform.

This does make the function name generated for `transform-es2015-function-name` not _ES2015_-compliant, however, but it is probably better than breaking ES2017. An alternative is to make `transform-es2015-function-name` not give the function a name if it would have been `await`; that way ES2015 engines could still infer the correct name.