### PR TITLE
Add `/.test` and `/src` to `babel-plugin-transform-regenerator` `.npm…

### DIFF
--- a/packages/babel-plugin-transform-regenerator/.npmignore
+++ b/packages/babel-plugin-transform-regenerator/.npmignore
@@ -1,2 +1,4 @@
 /node_modules
 /test
+/.test
+/src


### PR DESCRIPTION
`src` didn't seem to be bundled with [other packages](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-object-assign/.npmignore#L3), but let me know if `babel-plugin-transform-regenerator` is a special case.