### PR TITLE
JSXSpreadChildren

### DIFF
--- a/packages/babel-generator/src/generators/jsx.js
+++ b/packages/babel-generator/src/generators/jsx.js
@@ -35,6 +35,13 @@ export function JSXExpressionContainer(node: Object) {
   this.token("}");
 }
 
+export function JSXSpreadChild(node: Object) {
+  this.token("{");
+  this.token("...");
+  this.print(node.expression, node);
+  this.token("}");
+}
+
 export function JSXText(node: Object) {
   this.token(node.value);
 }

--- a/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/actual.js
+++ b/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/actual.js
@@ -1,0 +1,1 @@
+<div>{...this.props.children}</div>;

--- a/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/expected.js
+++ b/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/expected.js
@@ -1,0 +1,1 @@
+<div>{...this.props.children}</div>;

--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -17,6 +17,10 @@ export default function (opts) {
     throw path.buildCodeFrameError("Namespace tags are not supported. ReactJSX is not XML.");
   };
 
+  visitor.JSXSpreadChild = function(path) {
+    throw path.buildCodeFrameError("Spread children are not supported.");
+  };
+
   visitor.JSXElement = {
     exit(path, file) {
       let callExpr = buildElementCall(path.get("openingElement"), file);

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/actual.js
@@ -1,0 +1,1 @@
+<div>{...children}</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Spread children are not supported."
+}

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -67,7 +67,7 @@ defineType("JSXSpreadChild", {
       validate: assertNodeType("Expression")
     }
   }
-})
+});
 
 defineType("JSXIdentifier", {
   builder: ["name"],

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -39,7 +39,7 @@ defineType("JSXElement", {
     children: {
       validate: chain(
         assertValueType("array"),
-        assertEach(assertNodeType("JSXText", "JSXExpressionContainer", "JSXElement"))
+        assertEach(assertNodeType("JSXText", "JSXExpressionContainer", "JSXSpreadChild", "JSXElement"))
       )
     }
   }
@@ -58,6 +58,16 @@ defineType("JSXExpressionContainer", {
     }
   }
 });
+
+defineType("JSXSpreadChild", {
+  visitor: ["expression"],
+  aliases: ["JSX", "Immutable"],
+  fields: {
+    expression: {
+      validate: assertNodeType("Expression")
+    }
+  }
+})
 
 defineType("JSXIdentifier", {
   builder: ["name"],


### PR DESCRIPTION
| Q                 | A <!--(yes/no) -->
| ----------------- | ---
| Bug fix?          | No
| Breaking change?  | No
| New feature?      | Yes
| Deprecations?     | No
| Spec compliancy?  | Yes?
| Tests added/pass? | Yes
| Fixed tickets     | Fixes #3575
| License           | MIT
| Doc PR            | No
| Dependency Changes| N/A

Follow up to https://github.com/babel/babel/pull/3575, since that one seems to have stalled. Adds throwing when `transform-react-jsx` encounters a spread child.