### PR TITLE
babel-helper-transform-fixture-test-runner: pass require as a global

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -65,11 +65,12 @@ function run(task) {
 
   if (execCode) {
     let execOpts = getOpts(exec);
+    let execDirName = path.dirname(exec.loc);
     result = babel.transform(execCode, execOpts);
     execCode = result.code;
 
     try {
-      resultExec = runExec(execOpts, execCode);
+      resultExec = runExec(execOpts, execCode, execDirName);
     } catch (err) {
       err.message = exec.loc + ": " + err.message;
       err.message += codeFrame(execCode);
@@ -110,7 +111,7 @@ function run(task) {
   }
 }
 
-function runExec(opts, execCode) {
+function runExec(opts, execCode, execDirname) {
   let sandbox = {
     ...helpers,
     babelHelpers,
@@ -118,7 +119,9 @@ function runExec(opts, execCode) {
     transform: babel.transform,
     opts,
     exports: {},
-    require
+    require(id) {
+      return require(id[0] === "." ? path.resolve(execDirname, id) : id);
+    }
   };
 
   let fn = new Function(...Object.keys(sandbox), execCode);

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -118,6 +118,7 @@ function runExec(opts, execCode) {
     transform: babel.transform,
     opts,
     exports: {},
+    require
   };
 
   let fn = new Function(...Object.keys(sandbox), execCode);

--- a/packages/babel-plugin-syntax-trailing-function-commas/test/fixtures/trailing-function-commas/test-exec-require/exec.js
+++ b/packages/babel-plugin-syntax-trailing-function-commas/test/fixtures/trailing-function-commas/test-exec-require/exec.js
@@ -1,0 +1,4 @@
+// builtin module
+require("path");
+// relative module
+require("../../../../lib");


### PR DESCRIPTION
This is for:

Issue: https://github.com/babel/babel-preset-env/issues/72
PR: https://github.com/babel/babel-preset-env/pull/95

can also just do a specific branch in the meantime