### PR TITLE
internal: don't run watch with the test env (skip building with code …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-dist: build
 
 watch: clean
 	rm -rf packages/*/lib
-	./node_modules/.bin/gulp watch
+	BABEL_ENV=development ./node_modules/.bin/gulp watch
 
 lint:
 	./node_modules/.bin/eslint packages/ --format=codeframe


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            |  no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

…coverage) [skip ci]

This is currently annoying in watch mode because the built files have coverage info 