### PR TITLE
Revert babel-helper-builder-react-jsx change from #4988

### DIFF
--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -17,10 +17,6 @@ export default function (opts) {
     throw path.buildCodeFrameError("Namespace tags are not supported. ReactJSX is not XML.");
   };
 
-  visitor.JSXSpreadChild = function(path) {
-    throw path.buildCodeFrameError("Spread children are not supported.");
-  };
-
   visitor.JSXElement = {
     exit(path, file) {
       let callExpr = buildElementCall(path.get("openingElement"), file);

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/actual.js
@@ -1,1 +1,0 @@
-<div>{...children}</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Spread children are not supported."
-}


### PR DESCRIPTION
Reverting part of https://github.com/babel/babel/pull/4988 to avoid using a node type that may not be a known type. We can re-add this, but we should probably expose a way to check what node types are known to `babel-core` so that we don't trigger unknown node type errors.