### PR TITLE
Drop support for Node 0.12 :skull:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
 - '6'
 - '5'
 - '4'
-- '0.12'
 script: 
   - 'if [ -n "${LINT-}" ]; then make lint ; fi'
   - 'if [ -z "${LINT-}" ]; then make test-ci ; fi'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Feel free to check out the `#discussion`/`#development` channels on our [slack](
 
 **Note:** Versions `< 5.1.10` can't be built.
 
-Babel is built for node 0.10 and up but we develop using node 6. Make sure you are on npm 3.
+Babel is built for node 4 and up but we develop using node 6. Make sure you are on npm 3.
 
 You can check this with `node -v` and `npm -v`.
 


### PR DESCRIPTION
Node 0.12 end of life is coming soon: 2016-12-31. More info: [LTS schedule](https://github.com/nodejs/LTS)

Merge on Jan 1 😄

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | yes!
| Spec Compliancy?         | NA
| Tests Added/Pass?        | no
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no
