### PR TITLE
Remove unnecessary spaces around template element

### DIFF
--- a/packages/babel-generator/src/generators/template-literals.js
+++ b/packages/babel-generator/src/generators/template-literals.js
@@ -9,9 +9,7 @@ export function TemplateElement(node: Object, parent: Object) {
 
   let value = (isFirst ? "`" : "}") + node.value.raw + (isLast ? "`" : "${");
 
-  if (!isFirst) this.space();
   this.token(value);
-  if (!isLast) this.space();
 }
 
 export function TemplateLiteral(node: Object) {

--- a/packages/babel-generator/test/fixtures/harmony-edgecase/templates-indentation/expected.js
+++ b/packages/babel-generator/test/fixtures/harmony-edgecase/templates-indentation/expected.js
@@ -1,15 +1,15 @@
 function multilineTemplate() {
   return `I'm done reconfoobling
-${ 'the energy motron' }
-      ${ '...or whatever' }`;
+${'the energy motron'}
+      ${'...or whatever'}`;
 }
 
 {
   const foo = `spam
 and eggs!`;
 
-  const bar = `${ 4 + 2 }`;
+  const bar = `${4 + 2}`;
 
   const hello = `Hello
-${ 'world' }`;
+${'world'}`;
 }

--- a/packages/babel-generator/test/fixtures/harmony-edgecase/templates/expected.js
+++ b/packages/babel-generator/test/fixtures/harmony-edgecase/templates/expected.js
@@ -15,17 +15,17 @@ Is the order a rabbit?
 `;
 
 var middles = `
-Is the order ${ order }?
+Is the order ${order}?
 `;
 
 var middles = `
-Is the order ${ order }?
+Is the order ${order}?
 `;
 
 var middles = `
-1. ${ cocoa }
-2. ${ chino }
-3. ${ rize }
-4. ${ syaro }
-5. ${ chiya }
+1. ${cocoa}
+2. ${chino}
+3. ${rize}
+4. ${syaro}
+5. ${chiya}
 `;

--- a/packages/babel-generator/test/fixtures/types/TemplateLiteral-TaggedTemplateExpression-TemplateElement/expected.js
+++ b/packages/babel-generator/test/fixtures/types/TemplateLiteral-TaggedTemplateExpression-TemplateElement/expected.js
@@ -3,7 +3,7 @@ html`<b></b>`;
 `multi
   lines`;
 
-`test ${ interpolation } test`;
+`test ${interpolation} test`;
 
 `foob
 

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4403/expected.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4403/expected.js
@@ -1,3 +1,3 @@
 var a, b;
-var _ref = `${ b++ }`;
+var _ref = `${b++}`;
 a[_ref] = Math.pow(a[_ref], 1)


### PR DESCRIPTION
Like was discussed in Slack chat with @ljharb and @hzoo spaces was added with no particular reason.

https://babeljs.slack.com/archives/discussion/p1481744017001806

I'm still not sure if everything here is correct (for example source maps)

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | probably yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | not sure
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 
