### PR TITLE
Use template, traverse, and types from context

### DIFF
--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-runtime": "^6.0.0",
-    "babel-traverse": "^6.18.0",
     "babel-types": "^6.18.0"
   }
 }

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-traverse": "^6.18.0",
     "babel-runtime": "^6.0.0",
     "babel-types": "^6.18.0",
     "babel-helper-hoist-variables": "^6.18.0"

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-traverse": "^6.18.0",
     "babel-runtime": "^6.0.0",
     "babel-types": "^6.18.0"
   }

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-runtime": "^6.0.0",
-    "babel-traverse": "^6.18.0",
     "babel-types": "^6.18.0",
     "babel-helper-bindify-decorators": "^6.18.0"
   }

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "babel-runtime": "^6.0.0",
     "babel-types": "^6.18.0",
-    "babel-traverse": "^6.18.0",
     "babel-helper-get-function-arity": "^6.18.0",
     "babel-template": "^6.8.0"
   }

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "babel-helper-optimise-call-expression": "^6.18.0",
     "babel-runtime": "^6.0.0",
-    "babel-traverse": "^6.18.0",
     "babel-messages": "^6.8.0",
     "babel-template": "^6.16.0",
     "babel-types": "^6.18.0"

--- a/packages/babel-plugin-transform-async-to-module-method/package.json
+++ b/packages/babel-plugin-transform-async-to-module-method/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "babel-plugin-syntax-async-functions": "^6.8.0",
     "babel-helper-remap-async-to-generator": "^6.16.0",
-    "babel-types": "^6.16.0",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-class-constructor-call/package.json
+++ b/packages/babel-plugin-transform-class-constructor-call/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-template": "^6.8.0",
     "babel-plugin-syntax-class-constructor-call": "^6.18.0",
     "babel-runtime": "^6.0.0"
   },

--- a/packages/babel-plugin-transform-class-constructor-call/src/index.js
+++ b/packages/babel-plugin-transform-class-constructor-call/src/index.js
@@ -1,21 +1,19 @@
-import template from "babel-template";
-
-let buildWrapper = template(`
-  let CLASS_REF = CLASS;
-  var CALL_REF = CALL;
-  var WRAPPER_REF = function (...args) {
-    if (this instanceof WRAPPER_REF) {
-      return Reflect.construct(CLASS_REF, args);
-    } else {
-      return CALL_REF.apply(this, args);
-    }
-  };
-  WRAPPER_REF.__proto__ = CLASS_REF;
-  WRAPPER_REF;
-`);
-
-export default function ({ types: t }) {
+export default function ({ template, types: t }) {
   let ALREADY_VISITED = Symbol();
+
+  let buildWrapper = template(`
+    let CLASS_REF = CLASS;
+    var CALL_REF = CALL;
+    var WRAPPER_REF = function (...args) {
+      if (this instanceof WRAPPER_REF) {
+        return Reflect.construct(CLASS_REF, args);
+      } else {
+        return CALL_REF.apply(this, args);
+      }
+    };
+    WRAPPER_REF.__proto__ = CLASS_REF;
+    WRAPPER_REF;
+  `);
 
   function findConstructorCall(path): ?Object {
     let methods: Array<Object> = path.get("body.body");

--- a/packages/babel-plugin-transform-class-properties/package.json
+++ b/packages/babel-plugin-transform-class-properties/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "babel-helper-function-name": "^6.18.0",
     "babel-plugin-syntax-class-properties": "^6.8.0",
-    "babel-runtime": "^6.9.1",
-    "babel-template": "^6.15.0"
+    "babel-runtime": "^6.9.1"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.18.0"

--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -1,8 +1,7 @@
 /* eslint max-len: 0 */
 import nameFunction from "babel-helper-function-name";
-import template from "babel-template";
 
-export default function ({ types: t }) {
+export default function ({ template, types: t }) {
   let findBareSupers = {
     Super(path) {
       if (path.parentPath.isCallExpression({ callee: path.node })) {

--- a/packages/babel-plugin-transform-decorators/package.json
+++ b/packages/babel-plugin-transform-decorators/package.json
@@ -9,11 +9,9 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-types": "^6.13.0",
     "babel-helper-define-map": "^6.8.0",
     "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-helper-explode-class": "^6.8.0",
-    "babel-template": "^6.8.0",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -1,11 +1,10 @@
-import template from "babel-template";
 import explodeClass from "babel-helper-explode-class";
 
-let buildClassDecorator = template(`
-  CLASS_REF = DECORATOR(CLASS_REF) || CLASS_REF;
-`);
+export default function ({ template, types: t }) {
+  let buildClassDecorator = template(`
+    CLASS_REF = DECORATOR(CLASS_REF) || CLASS_REF;
+  `);
 
-export default function ({ types: t }) {
   function cleanDecorators(decorators) {
     return decorators.reverse().map((dec) => dec.expression);
   }

--- a/packages/babel-plugin-transform-es2015-computed-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-computed-properties/package.json
@@ -10,7 +10,6 @@
   ],
   "dependencies": {
     "babel-helper-define-map": "^6.8.0",
-    "babel-template": "^6.8.0",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es2015-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-es2015-duplicate-keys/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.0.0",
-    "babel-types": "^6.8.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.8.0"

--- a/packages/babel-plugin-transform-es2015-duplicate-keys/src/index.js
+++ b/packages/babel-plugin-transform-es2015-duplicate-keys/src/index.js
@@ -1,13 +1,11 @@
-import * as t from "babel-types";
-
-function getName(key) {
-  if (t.isIdentifier(key)) {
-    return key.name;
+export default function({ types: t }) {
+  function getName(key) {
+    if (t.isIdentifier(key)) {
+      return key.name;
+    }
+    return key.value.toString();
   }
-  return key.value.toString();
-}
 
-export default function() {
   return {
     visitor: {
       ObjectExpression(path) {

--- a/packages/babel-plugin-transform-es2015-function-name/package.json
+++ b/packages/babel-plugin-transform-es2015-function-name/package.json
@@ -10,7 +10,6 @@
   ],
   "dependencies": {
     "babel-helper-function-name": "^6.8.0",
-    "babel-types": "^6.9.0",
     "babel-runtime": "^6.9.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es2015-modules-amd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-    "babel-template": "^6.8.0",
     "babel-runtime": "^6.0.0"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -1,16 +1,14 @@
-import template from "babel-template";
+export default function ({ template, types: t }) {
+  let buildDefine = template(`
+    define(MODULE_NAME, [SOURCES], FACTORY);
+  `);
 
-let buildDefine = template(`
-  define(MODULE_NAME, [SOURCES], FACTORY);
-`);
+  let buildFactory = template(`
+    (function (PARAMS) {
+      BODY;
+    })
+  `);
 
-let buildFactory = template(`
-  (function (PARAMS) {
-    BODY;
-  })
-`);
-
-export default function ({ types: t }) {
   function isValidRequireCall(path) {
     if (!path.isCallExpression()) return false;
     if (!path.get("callee").isIdentifier({ name: "require" })) return false;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
@@ -6,9 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-types": "^6.18.0",
     "babel-runtime": "^6.0.0",
-    "babel-template": "^6.16.0",
     "babel-plugin-transform-strict-mode": "^6.18.0"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -1,52 +1,50 @@
 /* eslint max-len: 0 */
 
 import { basename, extname } from "path";
-import template from "babel-template";
-import * as t from "babel-types";
-
-let buildRequire = template(`
-  require($0);
-`);
-
-let buildExportsModuleDeclaration = template(`
-  Object.defineProperty(exports, "__esModule", {
-    value: true
-  });
-`);
-
-let buildExportsFrom = template(`
-  Object.defineProperty(exports, $0, {
-    enumerable: true,
-    get: function () {
-      return $1;
-    }
-  });
-`);
-
-let buildLooseExportsModuleDeclaration = template(`
-  exports.__esModule = true;
-`);
-
-let buildExportsAssignment = template(`
-  exports.$0 = $1;
-`);
-
-let buildExportAll = template(`
-  Object.keys(OBJECT).forEach(function (key) {
-    if (key === "default" || key === "__esModule") return;
-    Object.defineProperty(exports, key, {
-      enumerable: true,
-      get: function () {
-        return OBJECT[key];
-      }
-    });
-  });
-`);
 
 const THIS_BREAK_KEYS = ["FunctionExpression", "FunctionDeclaration", "ClassProperty", "ClassMethod", "ObjectMethod"];
 
-export default function () {
+export default function ({ template, types: t }) {
   let REASSIGN_REMAP_SKIP = Symbol();
+
+  let buildRequire = template(`
+    require($0);
+  `);
+
+  let buildExportsModuleDeclaration = template(`
+    Object.defineProperty(exports, "__esModule", {
+      value: true
+    });
+  `);
+
+  let buildExportsFrom = template(`
+    Object.defineProperty(exports, $0, {
+      enumerable: true,
+      get: function () {
+        return $1;
+      }
+    });
+  `);
+
+  let buildLooseExportsModuleDeclaration = template(`
+    exports.__esModule = true;
+  `);
+
+  let buildExportsAssignment = template(`
+    exports.$0 = $1;
+  `);
+
+  let buildExportAll = template(`
+    Object.keys(OBJECT).forEach(function (key) {
+      if (key === "default" || key === "__esModule") return;
+      Object.defineProperty(exports, key, {
+        enumerable: true,
+        get: function () {
+          return OBJECT[key];
+        }
+      });
+    });
+  `);
 
   let reassignmentVisitor = {
     ReferencedIdentifier(path) {

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-template": "^6.14.0",
     "babel-helper-hoist-variables": "^6.18.0",
     "babel-runtime": "^6.11.6"
   },

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -1,32 +1,30 @@
 /* eslint max-len: 0 */
 
 import hoistVariables from "babel-helper-hoist-variables";
-import template from "babel-template";
 
-let buildTemplate = template(`
-  SYSTEM_REGISTER(MODULE_NAME, [SOURCES], function (EXPORT_IDENTIFIER, CONTEXT_IDENTIFIER) {
-    "use strict";
-    BEFORE_BODY;
-    return {
-      setters: [SETTERS],
-      execute: function () {
-        BODY;
-      }
-    };
-  });
-`);
+export default function ({ template, types: t }) {
+  const TYPE_IMPORT = "Import";
 
-let buildExportAll = template(`
-  for (var KEY in TARGET) {
-    if (KEY !== "default" && KEY !== "__esModule") EXPORT_OBJ[KEY] = TARGET[KEY];
-  }
-`);
-
-
-const TYPE_IMPORT = "Import";
-
-export default function ({ types: t }) {
   let IGNORE_REASSIGNMENT_SYMBOL = Symbol();
+
+  let buildTemplate = template(`
+    SYSTEM_REGISTER(MODULE_NAME, [SOURCES], function (EXPORT_IDENTIFIER, CONTEXT_IDENTIFIER) {
+      "use strict";
+      BEFORE_BODY;
+      return {
+        setters: [SETTERS],
+        execute: function () {
+          BODY;
+        }
+      };
+    });
+  `);
+
+  let buildExportAll = template(`
+    for (var KEY in TARGET) {
+      if (KEY !== "default" && KEY !== "__esModule") EXPORT_OBJ[KEY] = TARGET[KEY];
+    }
+  `);
 
   let reassignmentVisitor = {
     "AssignmentExpression|UpdateExpression"(path) {

--- a/packages/babel-plugin-transform-es2015-modules-umd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-es2015-modules-amd": "^6.18.0",
-    "babel-template": "^6.8.0",
     "babel-runtime": "^6.0.0"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -1,32 +1,31 @@
 /* eslint max-len: 0 */
 
 import { basename, extname } from "path";
-import template from "babel-template";
 
-let buildPrerequisiteAssignment = template(`
-  GLOBAL_REFERENCE = GLOBAL_REFERENCE || {}
-`);
+export default function ({ template, types: t }) {
+  let buildPrerequisiteAssignment = template(`
+    GLOBAL_REFERENCE = GLOBAL_REFERENCE || {}
+  `);
 
-let buildGlobalExport = template(`
-  var mod = { exports: {} };
-  factory(BROWSER_ARGUMENTS);
-  PREREQUISITE_ASSIGNMENTS
-  GLOBAL_TO_ASSIGN = mod.exports;
-`);
+  let buildGlobalExport = template(`
+    var mod = { exports: {} };
+    factory(BROWSER_ARGUMENTS);
+    PREREQUISITE_ASSIGNMENTS
+    GLOBAL_TO_ASSIGN = mod.exports;
+  `);
 
-let buildWrapper = template(`
-  (function (global, factory) {
-    if (typeof define === "function" && define.amd) {
-      define(MODULE_NAME, AMD_ARGUMENTS, factory);
-    } else if (typeof exports !== "undefined") {
-      factory(COMMON_ARGUMENTS);
-    } else {
-      GLOBAL_EXPORT
-    }
-  })(this, FUNC);
-`);
+  let buildWrapper = template(`
+    (function (global, factory) {
+      if (typeof define === "function" && define.amd) {
+        define(MODULE_NAME, AMD_ARGUMENTS, factory);
+      } else if (typeof exports !== "undefined") {
+        factory(COMMON_ARGUMENTS);
+      } else {
+        GLOBAL_EXPORT
+      }
+    })(this, FUNC);
+  `);
 
-export default function ({ types: t }) {
   function isValidDefine(path) {
     if (!path.isExpressionStatement()) return;
 

--- a/packages/babel-plugin-transform-es2015-parameters/package.json
+++ b/packages/babel-plugin-transform-es2015-parameters/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-traverse": "^6.21.0",
     "babel-helper-call-delegate": "^6.18.0",
     "babel-helper-get-function-arity": "^6.18.0",
     "babel-template": "^6.16.0",

--- a/packages/babel-plugin-transform-es2015-parameters/src/index.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/index.js
@@ -1,13 +1,12 @@
 import type { NodePath } from "babel-traverse";
-import { visitors } from "babel-traverse";
 
 import * as destructuring from "./destructuring";
 import * as def from "./default";
 import * as rest from "./rest";
 
-export default function () {
+export default function ({ traverse }) {
   return {
-    visitor: visitors.merge([{
+    visitor: traverse.visitors.merge([{
       ArrowFunctionExpression(path) {
         // default/rest visitors require access to `arguments`
         let params: Array<NodePath> = path.get("params");

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-types": "^6.18.0",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
@@ -1,6 +1,4 @@
-import * as t from "babel-types";
-
-export default function () {
+export default function ({ types: t }) {
   return {
     visitor: {
       ObjectMethod(path) {

--- a/packages/babel-plugin-transform-es2015-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-es2015-sticky-regex/package.json
@@ -10,7 +10,6 @@
   ],
   "dependencies": {
     "babel-helper-regex": "^6.8.0",
-    "babel-types": "^6.8.0",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es2015-sticky-regex/src/index.js
+++ b/packages/babel-plugin-transform-es2015-sticky-regex/src/index.js
@@ -1,7 +1,6 @@
 import * as regex from "babel-helper-regex";
-import * as t from "babel-types";
 
-export default function () {
+export default function ({ types: t }) {
   return {
     visitor: {
       RegExpLiteral(path) {

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.0.0",
-    "babel-types": "^6.18.0"
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.18.0"

--- a/packages/babel-plugin-transform-strict-mode/src/index.js
+++ b/packages/babel-plugin-transform-strict-mode/src/index.js
@@ -1,6 +1,4 @@
-import * as t from "babel-types";
-
-export default function () {
+export default function ({ types: t }) {
   return {
     visitor: {
       Program(path, state) {


### PR DESCRIPTION
This PR simplifies the dependency graph of babel by using `babel-template`, `babel-traverse` and `babel-types` from `context` instead of importing them, and removes them as deps where they're not used. This change has no impact on the API, but should result in faster `npm` install times (less stuff to resolve & dedupe), as well as smaller install sizes for projects where these packages can't be deduped.

I didn't fix any of the `babel-helper` since that would require passing the deps some way – I'll tackle this after this PR goes though. Also didn't fix `babel-plugin-transform-es2015-block-scoping`, `babel-plugin-transform-es2015-classes` or `babel-plugin-transform-es2015-parameters`, because they would've required too many changes. I'll them in a separate PR.