### PR TITLE
Add support for DOTFILES_PATH environment variable

### DIFF
--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -10,6 +10,7 @@ let existsCache = {};
 let jsonCache   = {};
 
 const BABELIGNORE_FILENAME = ".babelignore";
+const DOTFILES_PATH        = process.env.DOTFILES_PATH || "";
 const BABELRC_FILENAME     = ".babelrc";
 const PACKAGE_FILENAME     = "package.json";
 
@@ -59,7 +60,7 @@ class ConfigChainBuilder {
 
     while (loc !== (loc = path.dirname(loc))) {
       if (!foundConfig) {
-        let configLoc = path.join(loc, BABELRC_FILENAME);
+        let configLoc = path.join(loc, DOTFILES_PATH, BABELRC_FILENAME);
         if (exists(configLoc)) {
           this.addConfig(configLoc);
           foundConfig = true;


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      |  yes
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

The purpose of this edit is to provide a commonly accepted environment variable used by the JavaScript/npm scripts where to look for their dotfiles (config files).

This is an attempt to resolve the problem with the high number of "dotfiles" stored in the root directory of the projects.

I don't expect this PR to be merged, but I wanted to raise attention to the problem and see if you have feedbacks.
