### PR TITLE
Remove node 0.10 support (CI)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-machine:
-  node:
-    version:
-      0.10.46
-
-test:
-  override:
-    - make test-ci

--- a/doc/design/compiler-environment-support.md
+++ b/doc/design/compiler-environment-support.md
@@ -7,7 +7,7 @@
 The Babel compiler is **only** supported in these environments:
 
  - Modern browsers such as Chrome, Firefox, Safari, Edge etc.
- - Node 4
+ - Node.js 4 and upper versions
 
 ## Unsupported environments
 
@@ -17,7 +17,6 @@ to:
  - Rhino
  - Nashorn
  - Internet Explorer
- - ...
 
 **NOTE:** If Babel works in any of the unsupported environments, it is purely
 coincidental and has no bearing on future compatibility. Use at your own risk.

--- a/doc/design/compiler-environment-support.md
+++ b/doc/design/compiler-environment-support.md
@@ -2,12 +2,12 @@
 
 **NOTE:** Compiler support does not dictate the runtime requirements of compiled code.
 
-## Supported environments
+## Officially supported environments
 
 The Babel compiler is **only** supported in these environments:
 
  - Modern browsers such as Chrome, Firefox, Safari, Edge etc.
- - Node 0.10+
+ - Node 4
 
 ## Unsupported environments
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | yes
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | Fixes #4315
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Related to #5025 (Drop support for Node 0.12 :skull:)

Dropping support is a breaking change, it will require a major release of Babel.