### PR TITLE
Remove unused define-map helper from computed-properties

### DIFF
--- a/packages/babel-plugin-transform-es2015-computed-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-computed-properties/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-helper-define-map": "^6.8.0",
     "babel-template": "^6.8.0",
     "babel-runtime": "^6.0.0"
   },


### PR DESCRIPTION
Noticed this while checking out https://github.com/babel/babel/pull/5038 and https://github.com/babel/babel/pull/5037