### PR TITLE
Add syntax-dynamic-import to stage-3

### DIFF
--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -12,6 +12,7 @@
     "babel-plugin-transform-async-generator-functions": "^6.17.0",
     "babel-plugin-transform-async-to-generator": "^6.16.0",
     "babel-plugin-transform-exponentiation-operator": "^6.3.13",
-    "babel-plugin-transform-object-rest-spread": "^6.16.0"
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0"
   }
 }

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -3,6 +3,7 @@ import transformAsyncToGenerator from "babel-plugin-transform-async-to-generator
 import transformExponentiationOperator from "babel-plugin-transform-exponentiation-operator";
 import transformObjectRestSpread from "babel-plugin-transform-object-rest-spread";
 import transformAsyncGeneratorFunctions from "babel-plugin-transform-async-generator-functions";
+import syntaxDynamicImport from "babel-plugin-syntax-dynamic-import";
 
 export default {
   plugins: [
@@ -10,6 +11,7 @@ export default {
     transformAsyncToGenerator, // in ES2017 (remove as a breaking change)
     transformExponentiationOperator,  // in ES2016 (remove as a breaking change)
     transformAsyncGeneratorFunctions,
-    transformObjectRestSpread
+    transformObjectRestSpread,
+    syntaxDynamicImport
   ]
 };


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | no
| Fixed Tickets            | no <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | yes

I'm using webpack 2, and found `import()` is available~
http://babeljs.io/docs/plugins/syntax-dynamic-import/
But somehow stage-3 does not include it. So I made this pr.
http://babeljs.io/docs/plugins/preset-stage-3/
https://github.com/tc39/proposals