### PR TITLE
Added vue to extensions

### DIFF
--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -24,7 +24,7 @@ export function canCompile(filename: string, altExts?: Array<string>): boolean {
  * Default set of compilable extensions.
  */
 
-canCompile.EXTENSIONS = [".js", ".jsx", ".es6", ".es"];
+canCompile.EXTENSIONS = [".js", ".jsx", ".es6", ".es", ".vue"];
 
 /**
  * Create an array from any value, splitting strings by ",".

--- a/packages/babel-core/test/util.js
+++ b/packages/babel-core/test/util.js
@@ -20,6 +20,10 @@ describe("util", function () {
     assert.ok(util.canCompile("/test.jsx"));
     assert.ok(util.canCompile("/scripts/test.jsx"));
 
+    assert.ok(util.canCompile("test.vue"));
+    assert.ok(util.canCompile("/test.vue"));
+    assert.ok(util.canCompile("/scripts/test.vue"));
+
     assert.ok(!util.canCompile("test"));
     assert.ok(!util.canCompile("test.css"));
     assert.ok(!util.canCompile("/test.css"));


### PR DESCRIPTION
Babelify tests files to be compiled. The only available are ".js", ".jsx", ".es6", ".es". Without the proper transpilation, I don't get the vue files in the istanbul report generated by babel-plugin-istanbul.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes?
| Tests Added/Pass?        | yes
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

