### PR TITLE
Fix getBindingIdentifiers in babel-types

### DIFF
--- a/packages/babel-types/src/retrievers.js
+++ b/packages/babel-types/src/retrievers.js
@@ -29,8 +29,8 @@ export function getBindingIdentifiers(
     }
 
     if (t.isExportDeclaration(id)) {
-      if (t.isDeclaration(node.declaration)) {
-        search.push(node.declaration);
+      if (t.isDeclaration(id.declaration)) {
+        search.push(id.declaration);
       }
       continue;
     }

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -3,7 +3,7 @@ import assert from "assert";
 import { parse } from "babylon";
 
 function getBody(program) {
-  return parse(program).program.body;
+  return parse(program, {sourceType: "module"}).program.body;
 }
 
 describe("retrievers", function () {
@@ -17,6 +17,11 @@ describe("retrievers", function () {
       const program = "var foo = 1; function bar() { var baz = 2; }";
       const ids = t.getBindingIdentifiers(getBody(program));
       assert.deepEqual(Object.keys(ids), ["bar", "foo"]);
+    });
+    it("export named declarations", function () {
+      const program = "export const foo = 'foo';";
+      const ids = t.getBindingIdentifiers(getBody(program));
+      assert.deepEqual(Object.keys(ids), ["foo"]);
     });
   });
 });

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -1,0 +1,22 @@
+import * as t from "../lib";
+import assert from "assert";
+import { parse } from "babylon";
+
+function getBody(program) {
+  return parse(program).program.body;
+}
+
+describe("retrievers", function () {
+  describe("getBindingIdentifiers", function () {
+    it("variable declarations", function () {
+      const program = "var a = 1; let b = 2; const c = 3;";
+      const ids = t.getBindingIdentifiers(getBody(program));
+      assert.deepEqual(Object.keys(ids), ["a", "b", "c"]);
+    });
+    it("function declarations", function () {
+      const program = "var foo = 1; function bar() { var baz = 2; }";
+      const ids = t.getBindingIdentifiers(getBody(program));
+      assert.deepEqual(Object.keys(ids), ["bar", "foo"]);
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

Summary of changes:
- Added passing tests for `t.getBindingIdentifiers` (the first two tests)
- Added a test which should pass, but fails without the fix in this PR (the third test)
- Fixed logic in `t.getBindingIdentifiers` regarding handling of ExportDeclarations

The correct logic (which is added in this PR) is currently in reflected in the [equivalent implementation of `getBindingIdentifierPaths` function in babel-traverse](https://github.com/babel/babel/blob/796c6c07632f93b15e7481cca42b2751e1129205/packages/babel-traverse/src/path/family.js#L154):
```js
// …
    if (id.isExportDeclaration()) {
      const declaration = id.get("declaration");
      if (declaration.isDeclaration()) {
        search.push(declaration);
      }
      continue;
    }
// …
```
