### PR TITLE
Optimize removal-hooks for ArrowFunctions

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -17,5 +17,8 @@
     "globals": "^9.0.0",
     "invariant": "^2.2.0",
     "lodash": "^4.2.0"
+  },
+  "devDependencies": {
+    "babel-generator": "^6.21.0"
   }
 }

--- a/packages/babel-traverse/src/path/lib/removal-hooks.js
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.js
@@ -6,13 +6,6 @@
 
 export let hooks = [
   function (self, parent) {
-    if (self.key === "body" && parent.isArrowFunctionExpression()) {
-      self.replaceWith(self.scope.buildUndefinedNode());
-      return true;
-    }
-  },
-
-  function (self, parent) {
     let removeParent = false;
 
     // while (NODE);
@@ -69,7 +62,7 @@ export let hooks = [
   function (self, parent) {
     if (
       (parent.isIfStatement() && (self.key === "consequent" || self.key === "alternate")) ||
-      (parent.isLoop() && self.key === "body")
+      (self.key === "body" && (parent.isLoop() || parent.isArrowFunctionExpression()))
     ) {
       self.replaceWith({
         type: "BlockStatement",

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -1,0 +1,34 @@
+import traverse from "../lib";
+import assert from "assert";
+import { parse } from "babylon";
+import generate from "babel-generator";
+
+function getPath(code) {
+  const ast = parse(code);
+  let path;
+  traverse(ast, {
+    Program: function (_path) {
+      path = _path;
+      _path.stop();
+    }
+  });
+
+  return path;
+}
+
+function generateCode(path) {
+  return generate(path.node).code;
+}
+
+describe("removal", function () {
+  describe("ArrowFunction", function () {
+    it("remove body", function () {
+      const rootPath = getPath("x = () => b;");
+      const path = rootPath.get("body")[0].get("expression").get("right");
+      const body = path.get("body");
+      body.remove();
+
+      assert.equal(generateCode(rootPath), "x = () => {};", "body should be replaced with BlockStatement");
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

When the body of an ArrowFunctionExpression is removed generate `() => {}` instead of `() => void 0`
