### PR TITLE
Static function call result comment does not match variable content [skip ci]

### DIFF
--- a/packages/babel-plugin-transform-class-properties/README.md
+++ b/packages/babel-plugin-transform-class-properties/README.md
@@ -15,7 +15,7 @@ Below is a class with four class properties which will be transformed.
     }
 
     //Static class properties
-    static staticProperty = "babeliscool";
+    static staticProperty = "babelIsCool";
     static staticFunction = function() {
       return Bork.staticProperty;
     }


### PR DESCRIPTION
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  |  no
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         |  no
| Tests Added/Pass?        | no
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | no

static staticProperty, defined in line 18, value is 'babeliscool' but comment on line 33 the given sample output is 'babelIsCool'. 
this commit fixes this inconsistency