### PR TITLE
fix: plugin-transform-object-rest-spread param with default value

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/actual.js
@@ -4,6 +4,7 @@ function a3({a2, b2, ...c2}) {}
 function a4({a3, ...c3}, {a5, ...c5}) {}
 function a5({a3, b2: { ba1, ...ba2 }, ...c3}) {}
 function a6({a3, b2: { ba1, ...ba2 } }) {}
+function a7({a1 = 1, ...b1} = {}) {}
 // Unchanged
 function b(a) {}
 function b2(a, ...b) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
@@ -24,6 +24,10 @@ function a6(_ref7) {
   let { a3, b2: { ba1 } } = _ref7;
   let ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, ["ba1"]);
 }
+function a7(_ref8 = {}) {
+  let { a1 = 1 } = _ref8;
+  let b1 = babelHelpers.objectWithoutProperties(_ref8, ["a1"]);
+}
 // Unchanged
 function b(a) {}
 function b2(a, ...b) {}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         | 
| Tests Added/Pass?        |  yes
| Fixed Tickets            | Fixes #4851 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | 

Fix when a parameter has a default object