### PR TITLE
babel-code-frame: Upgrade to js-tokens@3

### DIFF
--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "chalk": "^1.1.0",
     "esutils": "^2.0.2",
-    "js-tokens": "^2.0.0"
+    "js-tokens": "^3.0.0"
   }
 }

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -1,4 +1,4 @@
-import jsTokens from "js-tokens";
+import jsTokens, {matchToToken} from "js-tokens";
 import esutils from "esutils";
 import Chalk from "chalk";
 
@@ -47,7 +47,7 @@ const BRACKET = /^[()\[\]{}]$/;
 
 function getTokenType(match) {
   let [offset, text] = match.slice(-2);
-  let token = jsTokens.matchToToken(match);
+  let token = matchToToken(match);
 
   if (token.type === "name") {
     if (esutils.keyword.isReservedWordES6(token.value)) {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no/yes
| Fixed Tickets            | none
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | js-tokens@2 → js-tokens@3

js-tokens@3 version brings a big [performance boost](https://github.com/lydell/js-tokens/blob/master/CHANGELOG.md#version-300-2017-01-11).