### PR TITLE
Fix broken repository url

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -2,7 +2,7 @@
   "name": "babel-plugin-transform-react-jsx",
   "version": "6.8.0",
   "description": "Turn JSX into React function calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jsx",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
   "license": "MIT",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | N/A
| Spec Compliancy?         | N/A
| Tests Added/Pass?        | N/A
| Fixed Tickets            | N/A
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | N/A

<!-- Describe your changes below in as much detail as possible -->

Fixing the repository url reference, got here from a 404 while on npm registry
https://www.npmjs.com/package/babel-plugin-transform-react-jsx