### PR TITLE
Strip Flow's new shorthand import-type specifiers

### DIFF
--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-annotations/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-annotations/actual.js
@@ -97,5 +97,9 @@ import type2, { foo3 } from "bar";
 import type * as namespace from "bar";
 export type { foo };
 export type { foo2 } from "bar";
+import {type T} from "foo";
+import {type T2, V1} from "foo";
+import {typeof V2} from "foo";
+import {typeof V3, V4} from "foo";
 export interface foo5 { p: number }
 export interface foo6<T> { p: T }

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-annotations/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-type-annotations/expected.js
@@ -90,3 +90,8 @@ var identity;
 
 import type from "foo";
 import type2, { foo3 } from "bar";
+
+import "foo";
+import { V1 } from "foo";
+import "foo";
+import { V4 } from "foo";

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -12,7 +12,7 @@
     "babel-messages": "^6.8.0",
     "babel-runtime": "^6.20.0",
     "babel-types": "^6.21.0",
-    "babylon": "^6.11.0",
+    "babylon": "^6.15.0",
     "debug": "^2.2.0",
     "globals": "^9.0.0",
     "invariant": "^2.2.0",

--- a/packages/babel-traverse/src/path/lib/virtual-types.js
+++ b/packages/babel-traverse/src/path/lib/virtual-types.js
@@ -113,6 +113,8 @@ export let Flow = {
       return node.importKind === "type" || node.importKind === "typeof";
     } else if (t.isExportDeclaration(node)) {
       return node.exportKind === "type";
+    } else if (t.isImportSpecifier(node)) {
+      return node.importKind === "type" || node.importKind === "typeof";
     } else {
       return false;
     }

--- a/packages/babel-traverse/src/path/lib/virtual-types.js
+++ b/packages/babel-traverse/src/path/lib/virtual-types.js
@@ -105,7 +105,7 @@ export let Pure = {
 };
 
 export let Flow = {
-  types: ["Flow", "ImportDeclaration", "ExportDeclaration"],
+  types: ["Flow", "ImportDeclaration", "ImportSpecifier", "ExportDeclaration"],
   checkPath({ node }: NodePath): boolean {
     if (t.isFlow(node)) {
       return true;


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Deprecations?            | N
| Spec Compliancy?         | Y
| Tests Added/Pass?        | Y
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

This is just https://github.com/babel/babel/pull/5035 with a fixup commit for bumping babylon in the babel-traverse package.json and the test fix mentioned in https://github.com/babel/babel/pull/5035#discussion_r96040900. You can squash my commit out of the history.