### PR TITLE
Update babel-core options in README

### DIFF
--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -117,4 +117,4 @@ Following is a table of the options you can use:
 | `sourceMaps`             | `false`              | If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to `"both"` then a `map` property is returned as well as a source map comment appended. **This does not emit sourcemap files by itself!** To have sourcemaps emitted using the CLI, you must pass it the `--source-maps` option. |
 | `sourceMapTarget`        | `(filenameRelative)` | Set `file` on returned source map. |
 | `sourceRoot`             | `(moduleRoot)`       | The root from which all sources are relative. |
-| `wrapPluginVisitorMethod`| `null`               | An optional callback that can be used to wrap visitor methods. Called as `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.
+| `wrapPluginVisitorMethod`| `null`               | An optional callback that can be used to wrap visitor methods. **NOTE:** This is useful for things like introspection, and not really needed for implementing anything. Called as `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -86,35 +86,35 @@ Following is a table of the options you can use:
 
 | Option                   | Default              | Description                     |
 | ------------------------ | -------------------- | ------------------------------- |
+| `ast`                    | `true`               | Include the AST in the returned object |
+| `auxiliaryCommentAfter`  | `null`               | Attach a comment after all non-user injected code. |
+| `auxiliaryCommentBefore` | `null`               | Attach a comment before all non-user injected code. |
+| `code`                   | `true`               | Enable code generation |
+| `comments`               | `true`               | Output comments in generated output. |
+| `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >500KB. |
+| `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the environment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
+| `extends`                | `null`               | A path to an `.babelrc` file to extend |
 | `filename`               | `"unknown"`          | Filename for use in errors etc. |
 | `filenameRelative`       | `(filename)`         | Filename relative to `sourceRoot`. |
-| `presets`                | `[]`                 | List of [presets](/docs/plugins/#presets) (a set of plugins) to load and use. |
-| `plugins`                | `[]`                 | List of [plugins](/docs/plugins/) to load and use. |
-| `parserOpts`             | `{}`                 | An object containing the options to be passed down to the babel parser, babylon |
 | `generatorOpts`          | `{}`                 | An object containing the options to be passed down to the babel code generator, babel-generator |
-| `highlightCode`          | `true`               | ANSI highlight syntax error code frames |
-| `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
-| `ignore`                 | `null`               | Opposite to the `only` option. `ignore` is disregarded if `only` is specified. |
-| `auxiliaryCommentBefore` | `null`               | Attach a comment before all non-user injected code. |
-| `auxiliaryCommentAfter`  | `null`               | Attach a comment after all non-user injected code. |
-| `sourceMaps`             | `false`              | If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to `"both"` then a `map` property is returned as well as a source map comment appended. **This does not emit sourcemap files by itself!** To have sourcemaps emitted using the CLI, you must pass it the `--source-maps` option. |
-| `inputSourceMap`         | `null`               | A source map object that the output source map will be based on. |
-| `sourceMapTarget`        | `(filenameRelative)` | Set `file` on returned source map. |
-| `sourceFileName`         | `(filenameRelative)` | Set `sources[0]` on returned source map. |
-| `sourceRoot`             | `(moduleRoot)`       | The root from which all sources are relative. |
-| `moduleRoot`             | `(sourceRoot)`       | Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. |
-| `moduleIds`              | `false`              | If truthy, insert an explicit id for modules. By default, all modules are anonymous. (Not available for `common` modules) |
-| `moduleId`               | `null`               | Specify a custom name for module ids. |
 | `getModuleId`            | `null`               | Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`. If falsy value is returned then the generated module id is used. |
-| `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
-| `code`                   | `true`               | Enable code generation |
-| `no-babelrc`             | [CLI flag](http://babeljs.io/docs/usage/cli/#ignoring-babelrc) | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI. |
-| `ast`                    | `true`               | Include the AST in the returned object |
-| `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >500KB. |
+| `highlightCode`          | `true`               | ANSI highlight syntax error code frames |
+| `ignore`                 | `null`               | Opposite to the `only` option. `ignore` is disregarded if `only` is specified. |
+| `inputSourceMap`         | `null`               | A source map object that the output source map will be based on. |
 | `minified`               | `false`              | Should the output be minified (not printing last semicolons in blocks, printing literal string values instead of escaped ones, stripping `()` from `new` when safe) |
-| `comments`               | `true`               | Output comments in generated output. |
-| `shouldPrintComment`     | `null`               | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |
-| `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the environment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
+| `moduleId`               | `null`               | Specify a custom name for module ids. |
+| `moduleIds`              | `false`              | If truthy, insert an explicit id for modules. By default, all modules are anonymous. (Not available for `common` modules) |
+| `moduleRoot`             | `(sourceRoot)`       | Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. |
+| `no-babelrc`             | [CLI flag](http://babeljs.io/docs/usage/cli/#ignoring-babelrc) | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI. |
+| `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
+| `parserOpts`             | `{}`                 | An object containing the options to be passed down to the babel parser, babylon |
+| `plugins`                | `[]`                 | List of [plugins](/docs/plugins/) to load and use. |
+| `presets`                | `[]`                 | List of [presets](/docs/plugins/#presets) (a set of plugins) to load and use. |
 | `retainLines`            | `false`              | Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. (**NOTE:** This will not retain the columns) |
-| `extends`                | `null`               | A path to an `.babelrc` file to extend |
+| `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
+| `shouldPrintComment`     | `null`               | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |
+| `sourceFileName`         | `(filenameRelative)` | Set `sources[0]` on returned source map. |
+| `sourceMaps`             | `false`              | If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to `"both"` then a `map` property is returned as well as a source map comment appended. **This does not emit sourcemap files by itself!** To have sourcemaps emitted using the CLI, you must pass it the `--source-maps` option. |
+| `sourceMapTarget`        | `(filenameRelative)` | Set `file` on returned source map. |
+| `sourceRoot`             | `(moduleRoot)`       | The root from which all sources are relative. |
 | `wrapPluginVisitorMethod`| `null`               | An optional callback that can be used to wrap visitor methods. Called as `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -96,7 +96,7 @@ Following is a table of the options you can use:
 | `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
 | `ignore`                 | `null`               | Opposite to the `only` option. `ignore` is disregarded if `only` is specified. |
 | `auxiliaryCommentBefore` | `null`               | Attach a comment before all non-user injected code. |
-| `auxiliaryCommentAfter`  | `null`                | Attach a comment after all non-user injected code. |
+| `auxiliaryCommentAfter`  | `null`               | Attach a comment after all non-user injected code. |
 | `sourceMaps`             | `false`              | If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to `"both"` then a `map` property is returned as well as a source map comment appended. **This does not emit sourcemap files by itself!** To have sourcemaps emitted using the CLI, you must pass it the `--source-maps` option. |
 | `inputSourceMap`         | `null`               | A source map object that the output source map will be based on. |
 | `sourceMapTarget`        | `(filenameRelative)` | Set `file` on returned source map. |
@@ -113,8 +113,8 @@ Following is a table of the options you can use:
 | `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >500KB. |
 | `minified`               | `false`              | Should the output be minified (not printing last semicolons in blocks, printing literal string values instead of escaped ones, stripping `()` from `new` when safe) |
 | `comments`               | `true`               | Output comments in generated output. |
-| `shouldPrintComment`     | `null`                 | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |
-| `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
+| `shouldPrintComment`     | `null`               | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |
+| `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the environment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
 | `retainLines`            | `false`              | Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. (**NOTE:** This will not retain the columns) |
 | `extends`                | `null`               | A path to an `.babelrc` file to extend |
 | `wrapPluginVisitorMethod`| `null`               | An optional callback that can be used to wrap visitor methods. Called as `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -117,3 +117,4 @@ Following is a table of the options you can use:
 | `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
 | `retainLines`            | `false`              | Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. (**NOTE:** This will not retain the columns) |
 | `extends`                | `null`               | A path to an `.babelrc` file to extend |
+| `wrapPluginVisitorMethod`| `null`               | An optional callback that can be used to wrap visitor methods. Called as `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.


### PR DESCRIPTION
While working on something completely unrelated I noticed we never documented the `wrapPluginVisitorMethod ` option from https://github.com/babel/babel/pull/3659.

Also, I alpha-sorted the options to make it easier to find what you're looking for, but another option might be to group them, and then sort?