### PR TITLE
Remove old code used for backwards compatibility

### DIFF
--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -7,23 +7,3 @@ global._babelPolyfill = true;
 
 import "core-js/shim";
 import "regenerator-runtime/runtime";
-
-// Should be removed in the next major release:
-
-import "core-js/fn/regexp/escape";
-
-const DEFINE_PROPERTY = "defineProperty";
-function define(O, key, value) {
-  O[key] || Object[DEFINE_PROPERTY](O, key, {
-    writable:     true,
-    configurable: true,
-    value:        value
-  });
-}
-
-define(String.prototype, "padLeft", "".padStart);
-define(String.prototype, "padRight", "".padEnd);
-
-"pop,reverse,shift,keys,values,entries,indexOf,every,some,forEach,map,filter,find,findIndex,includes,join,slice,concat,push,splice,unshift,sort,lastIndexOf,reduce,reduceRight,copyWithin,fill".split(",").forEach(function(key) {
-  [][key] && define(Array, key, Function.call.bind([][key]));
-});


### PR DESCRIPTION
[7.0] Remove old code used for backwards compatibility in babel-polyfill #5121

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | yes
| Spec Compliancy?        | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | #5121
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

It was removed old code used for backwards compatibility in babel-polyfill as asked in #5121
