### PR TITLE
[skip ci]transform-react-constant-elements hoists Composite Components

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/README.md
+++ b/packages/babel-plugin-transform-react-constant-elements/README.md
@@ -37,12 +37,6 @@ const Hr = () => {
   <div ref={node => this.node = node} />
   ```
 
-- **Composite Components**
-
-  ```js
-  const ComponentA = () => <div><MyCustomComponent /></div>;
-  ```
-
 ## Installation
 
 ```sh


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  |  no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | yes<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

According to my test, `babel-plugin-transform-react-constant-elements` hoists Composite Components.
The following is a repro repo.

https://gist.github.com/koba04/1f8ac9785606da700f95e823ce87a9fe

This PR is fixed for the documentation, but should I fix the behavior?