### PR TITLE
Fix PathHoister hoisting JSX member expressions on "this".

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/actual.js
@@ -1,0 +1,4 @@
+function render() {
+  this.component = "div";
+  return () => <this.component />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-constant/expected.js
@@ -1,0 +1,7 @@
+function render() {
+  this.component = "div";
+
+  var _ref = <this.component />;
+
+  return () => _ref;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/actual.js
@@ -1,0 +1,5 @@
+class Component extends React.Component {
+  subComponent = () => <span>Sub Component</span>
+
+  render = () => <this.subComponent />
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/expected.js
@@ -1,0 +1,12 @@
+var _ref = <span>Sub Component</span>;
+
+class Component extends React.Component {
+  constructor(...args) {
+    var _temp;
+
+    var _ref2 = <this.subComponent />;
+
+    return _temp = super(...args), this.subComponent = () => _ref, this.render = () => _ref2, _temp;
+  }
+
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-jsx", "transform-react-constant-elements", "transform-class-properties"]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/actual.js
@@ -1,0 +1,6 @@
+const els = {
+  subComponent: () => <span>Sub Component</span>
+};
+class Component extends React.Component {
+  render = () => <els.subComponent />
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/expected.js
@@ -1,0 +1,16 @@
+var _ref = <span>Sub Component</span>;
+
+const els = {
+  subComponent: () => _ref
+};
+
+var _ref2 = <els.subComponent />;
+
+class Component extends React.Component {
+  constructor(...args) {
+    var _temp;
+
+    return _temp = super(...args), this.render = () => _ref2, _temp;
+  }
+
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-jsx", "transform-react-constant-elements", "transform-class-properties"]
+}


### PR DESCRIPTION

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | #4397 
| License                  | MIT


The PathHoister ignored member references on `this`, causing it to potentially hoist an expression above its function scope.

This patch tells the hoister to watch for `this`, and if seen, mark the nearest non-arrow function scope as the upper limit for hoistng.

This fixes #4397 and is an alternative to #4787.