### PR TITLE
Avoid duplicating impure expressions in object rest destructuring

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/catch-clause/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/catch-clause/expected.js
@@ -2,16 +2,16 @@ try {} catch (_ref) {
   let a34 = babelHelpers.objectWithoutProperties(_ref, []);
 }
 try {} catch (_ref2) {
-  let { a1 } = _ref2;
-  let b1 = babelHelpers.objectWithoutProperties(_ref2, ["a1"]);
+  let { a1 } = _ref2,
+      b1 = babelHelpers.objectWithoutProperties(_ref2, ["a1"]);
 }
 try {} catch (_ref3) {
-  let { a2, b2 } = _ref3;
-  let c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
+  let { a2, b2 } = _ref3,
+      c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
 }
 try {} catch (_ref4) {
-  let { a2, b2, c2: { c3 } } = _ref4;
-  let c4 = babelHelpers.objectWithoutProperties(_ref4.c2, ["c3"]);
+  let { a2, b2, c2: { c3 } } = _ref4,
+      c4 = babelHelpers.objectWithoutProperties(_ref4.c2, ["c3"]);
 }
 
 // Unchanged

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/expected.js
@@ -1,7 +1,7 @@
 // ExportNamedDeclaration
-var { b } = asdf2;
+var { b } = asdf2,
+    c = babelHelpers.objectWithoutProperties(asdf2, ["b"]);
 // Skip
-var c = babelHelpers.objectWithoutProperties(asdf2, ["b"]);
 export { b, c };
 export var { bb, cc } = ads;
 export var [dd, ee] = ads;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x/expected.js
@@ -1,16 +1,16 @@
 // ForXStatement
 for (var _ref of []) {
-  var { a } = _ref;
-  var b = babelHelpers.objectWithoutProperties(_ref, ["a"]);
+  var { a } = _ref,
+      b = babelHelpers.objectWithoutProperties(_ref, ["a"]);
 }
 for (var _ref2 of []) {
-  var { a } = _ref2;
-  var b = babelHelpers.objectWithoutProperties(_ref2, ["a"]);
+  var { a } = _ref2,
+      b = babelHelpers.objectWithoutProperties(_ref2, ["a"]);
 }
 async function a() {
   for await (var _ref3 of []) {
-    var { a } = _ref3;
-    var b = babelHelpers.objectWithoutProperties(_ref3, ["a"]);
+    var { a } = _ref3,
+        b = babelHelpers.objectWithoutProperties(_ref3, ["a"]);
   }
 }
 

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
@@ -2,31 +2,31 @@ function a(_ref) {
   let a34 = babelHelpers.objectWithoutProperties(_ref, []);
 }
 function a2(_ref2) {
-  let { a1 } = _ref2;
-  let b1 = babelHelpers.objectWithoutProperties(_ref2, ["a1"]);
+  let { a1 } = _ref2,
+      b1 = babelHelpers.objectWithoutProperties(_ref2, ["a1"]);
 }
 function a3(_ref3) {
-  let { a2, b2 } = _ref3;
-  let c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
+  let { a2, b2 } = _ref3,
+      c2 = babelHelpers.objectWithoutProperties(_ref3, ["a2", "b2"]);
 }
 function a4(_ref4, _ref5) {
-  let { a5 } = _ref5;
-  let c5 = babelHelpers.objectWithoutProperties(_ref5, ["a5"]);
-  let { a3 } = _ref4;
-  let c3 = babelHelpers.objectWithoutProperties(_ref4, ["a3"]);
+  let { a5 } = _ref5,
+      c5 = babelHelpers.objectWithoutProperties(_ref5, ["a5"]);
+  let { a3 } = _ref4,
+      c3 = babelHelpers.objectWithoutProperties(_ref4, ["a3"]);
 }
 function a5(_ref6) {
-  let { a3, b2: { ba1 } } = _ref6;
-  let ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]),
+  let { a3, b2: { ba1 } } = _ref6,
+      ba2 = babelHelpers.objectWithoutProperties(_ref6.b2, ["ba1"]),
       c3 = babelHelpers.objectWithoutProperties(_ref6, ["a3", "b2"]);
 }
 function a6(_ref7) {
-  let { a3, b2: { ba1 } } = _ref7;
-  let ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, ["ba1"]);
+  let { a3, b2: { ba1 } } = _ref7,
+      ba2 = babelHelpers.objectWithoutProperties(_ref7.b2, ["ba1"]);
 }
 function a7(_ref8 = {}) {
-  let { a1 = 1 } = _ref8;
-  let b1 = babelHelpers.objectWithoutProperties(_ref8, ["a1"]);
+  let { a1 = 1 } = _ref8,
+      b1 = babelHelpers.objectWithoutProperties(_ref8, ["a1"]);
 }
 // Unchanged
 function b(a) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/expected.js
@@ -3,25 +3,24 @@ var x = babelHelpers.objectWithoutProperties(z, []);
 var a = babelHelpers.objectWithoutProperties({ a: 1 }, []);
 var x = babelHelpers.objectWithoutProperties(a.b, []);
 var x = babelHelpers.objectWithoutProperties(a(), []);
-
-var { x1 } = z;
-var y1 = babelHelpers.objectWithoutProperties(z, ["x1"]);
+var { x1 } = z,
+    y1 = babelHelpers.objectWithoutProperties(z, ["x1"]);
 x1++;
-var { [a]: b } = z;
-var c = babelHelpers.objectWithoutProperties(z, [a]);
-var { x1 } = z;
-var y1 = babelHelpers.objectWithoutProperties(z, ["x1"]);
-let { x2, y2 } = z;
-let z2 = babelHelpers.objectWithoutProperties(z, ["x2", "y2"]);
-const { w3, x3, y3 } = z;
+var { [a]: b } = z,
+    c = babelHelpers.objectWithoutProperties(z, [a]);
+var { x1 } = z,
+    y1 = babelHelpers.objectWithoutProperties(z, ["x1"]);
+let { x2, y2 } = z,
+    z2 = babelHelpers.objectWithoutProperties(z, ["x2", "y2"]);
+const { w3, x3, y3 } = z,
+      z4 = babelHelpers.objectWithoutProperties(z, ["w3", "x3", "y3"]);
 
-const z4 = babelHelpers.objectWithoutProperties(z, ["w3", "x3", "y3"]);
 let {
   x: { a: xa, [d]: f }
-} = complex;
-
-let asdf = babelHelpers.objectWithoutProperties(complex.x, ["a", d]),
+} = complex,
+    asdf = babelHelpers.objectWithoutProperties(complex.x, ["a", d]),
     d = babelHelpers.objectWithoutProperties(complex.y, []),
     g = babelHelpers.objectWithoutProperties(complex, ["x"]);
-let {} = z;
-let y4 = babelHelpers.objectWithoutProperties(z.x4, []);
+
+let {} = z,
+    y4 = babelHelpers.objectWithoutProperties(z.x4, []);

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-4904/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-4904/actual.js
@@ -1,0 +1,7 @@
+const { s, ...t } = foo();
+
+const { s: { q1, ...q2 }, ...q3 } = bar();
+
+const { a } = foo(({ b, ...c }) => {
+  console.log(b, c);
+});

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-4904/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-4904/expected.js
@@ -1,0 +1,18 @@
+const _foo = foo();
+
+const { s } = _foo;
+
+const t = babelHelpers.objectWithoutProperties(_foo, ["s"]);
+
+const _bar = bar();
+
+const { s: { q1 } } = _bar;
+
+const q2 = babelHelpers.objectWithoutProperties(_bar.s, ["q1"]);
+const q3 = babelHelpers.objectWithoutProperties(_bar, ["s"]);
+const { a } = foo((_ref) => {
+  let { b } = _ref;
+  let c = babelHelpers.objectWithoutProperties(_ref, ["b"]);
+
+  console.log(b, c);
+});

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-4904/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-4904/expected.js
@@ -1,18 +1,15 @@
-const _foo = foo();
+const _foo = foo(),
+      { s } = _foo,
+      t = babelHelpers.objectWithoutProperties(_foo, ["s"]);
 
-const { s } = _foo;
+const _bar = bar(),
+      { s: { q1 } } = _bar,
+      q2 = babelHelpers.objectWithoutProperties(_bar.s, ["q1"]),
+      q3 = babelHelpers.objectWithoutProperties(_bar, ["s"]);
 
-const t = babelHelpers.objectWithoutProperties(_foo, ["s"]);
-
-const _bar = bar();
-
-const { s: { q1 } } = _bar;
-
-const q2 = babelHelpers.objectWithoutProperties(_bar.s, ["q1"]);
-const q3 = babelHelpers.objectWithoutProperties(_bar, ["s"]);
 const { a } = foo((_ref) => {
-  let { b } = _ref;
-  let c = babelHelpers.objectWithoutProperties(_ref, ["b"]);
+  let { b } = _ref,
+      c = babelHelpers.objectWithoutProperties(_ref, ["b"]);
 
   console.log(b, c);
 });

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-5151/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-5151/actual.js
@@ -1,0 +1,10 @@
+const { x, ...y } = a,
+  z = foo(y);
+
+const { ...s } = r,
+  t = foo(s);
+
+// ordering is preserved
+var l = foo(),
+    { m: { n, ...o }, ...p } = bar(),
+    q = baz();

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-5151/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/gh-5151/expected.js
@@ -1,0 +1,14 @@
+const { x } = a,
+      y = babelHelpers.objectWithoutProperties(a, ["x"]),
+      z = foo(y);
+
+const s = babelHelpers.objectWithoutProperties(r, []),
+      t = foo(s);
+
+// ordering is preserved
+var l = foo(),
+    _bar = bar(),
+    { m: { n } } = _bar,
+    o = babelHelpers.objectWithoutProperties(_bar.m, ["n"]),
+    p = babelHelpers.objectWithoutProperties(_bar, ["m"]),
+    q = baz();

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/options.json
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/regression/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-object-rest-spread",
+    "external-helpers"
+  ]
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        |  yes
| Fixed Tickets            | fixes #4904
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

There were two main issues here (fixed in the first commit):

1.  `path.traverse` was called instead of `path.get("id").traverse` in the `VariableDeclarator` visitor. This means that in `const { a } = foo(({ ...x }) => {/* ... */})`, the visitor visiting `{ a } = ...` would traverse down to the `...x` `RestProperty`, causing unexpected behaviour.

1. The `VariableDeclarator`'s `init` expression was duplicated directly, which is unsafe if it may have side effects, e.g. in `const { x, ...y } = foo();`

Edit: I found a few more (~~will push fixes to this branch~~ fixed in the second commit)

1. Variables may be reordered incorrectly ([repl](https://babeljs.io/repl/#?babili=false&evaluate=false&lineWrap=false&presets=stage-0&experimental=true&loose=false&spec=false&code=const%20%7B%20x%2C%20...y%20%7D%20%3D%20a%2C%0A%20%20%20%20%20%20z%20%3D%20foo(y)%3B%0A)), e.g.
```js
const { x, ...y } = a,
      z = foo(y);
```
becomes
```js
const { x } = a,
      z = foo(y);

const y = _objectWithoutProperties(a, ["x"]);
```

1. The entire `VariableDeclaration` is removed when all properties are rest properties, killing any other variables ([repl](https://babeljs.io/repl/#?babili=false&evaluate=false&lineWrap=false&presets=stage-0&experimental=true&loose=false&spec=false&code=const%20%7B%20...y%20%7D%20%3D%20a%2C%0A%20%20%20%20%20%20z%20%3D%20foo(y)%3B%0A)), e.g.
```js
const { ...y } = a,
      z = foo(y);
```
becomes
```js
const y = _objectWithoutProperties(a, []);
```