### PR TITLE
Break out of argument processing properly.

### DIFF
--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -103,7 +103,7 @@ if (program.eval || program.print) {
 
     let i = 0;
     let ignoreNext = false;
-    args.forEach(function (arg, i2) {
+    args.some(function (arg, i2) {
       if (ignoreNext) {
         ignoreNext = false;
         return;
@@ -116,7 +116,7 @@ if (program.eval || program.print) {
         }
       } else {
         i = i2;
-        return false;
+        return true;
       }
     });
     args = args.slice(i);


### PR DESCRIPTION

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes #5161
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

This was refactored from `_.each` to `.forEach` in https://github.com/babel/babel/pull/5042/files#diff-39007a4e7a98596984e03c626b2eedc8R106 and our tests didn't catch that it used Lodash's special `return false` to break out of the loop. cc @zertosh 