### PR TITLE
[7.0] No path is absolute

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -26,7 +26,6 @@
     "glob": "^7.0.0",
     "lodash": "^4.2.0",
     "output-file-sync": "^1.1.0",
-    "path-is-absolute": "^1.0.0",
     "slash": "^1.0.0",
     "source-map": "^0.5.0",
     "v8flags": "^2.0.10"

--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -1,4 +1,3 @@
-import pathIsAbsolute from "path-is-absolute";
 import commander from "commander";
 import Module from "module";
 import { inspect } from "util";
@@ -123,7 +122,7 @@ if (program.eval || program.print) {
 
     // make the filename absolute
     const filename = args[0];
-    if (!pathIsAbsolute(filename)) args[0] = path.join(process.cwd(), filename);
+    if (!path.isAbsolute(filename)) args[0] = path.join(process.cwd(), filename);
 
     // add back on node and concat the sliced args
     process.argv = ["node"].concat(args);

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -41,7 +41,6 @@
     "json5": "^0.5.0",
     "lodash": "^4.2.0",
     "minimatch": "^3.0.2",
-    "path-is-absolute": "^1.0.0",
     "private": "^0.1.6",
     "slash": "^1.0.0",
     "source-map": "^0.5.0"

--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -2,7 +2,6 @@
 import type Logger from "../logger";
 import resolve from "../../../helpers/resolve";
 import json5 from "json5";
-import isAbsolute from "path-is-absolute";
 import path from "path";
 import fs from "fs";
 
@@ -50,7 +49,7 @@ class ConfigChainBuilder {
   findConfigs(loc) {
     if (!loc) return;
 
-    if (!isAbsolute(loc)) {
+    if (!path.isAbsolute(loc)) {
       loc = path.join(process.cwd(), loc);
     }
 


### PR DESCRIPTION
`path-is-absolute` is a ponyfill for Node's v0.11.2 `path.isAbsolute`. Since Node v4 is now the minimally supported version, we can drop `path-is-absolute`.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | X
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
