### PR TITLE
Remove uses of lodash/isRegExp

### DIFF
--- a/packages/babel-core/src/util.js
+++ b/packages/babel-core/src/util.js
@@ -2,7 +2,6 @@ import escapeRegExp from "lodash/escapeRegExp";
 import startsWith from "lodash/startsWith";
 import minimatch from "minimatch";
 import includes from "lodash/includes";
-import isRegExp from "lodash/isRegExp";
 import path from "path";
 import slash from "slash";
 
@@ -65,7 +64,7 @@ export function regexify(val: any): RegExp {
     return new RegExp(regex.source.slice(1, -1), "i");
   }
 
-  if (isRegExp(val)) {
+  if (_isRegExp(val)) {
     return val;
   }
 
@@ -141,4 +140,8 @@ function _shouldIgnore(pattern: Function | RegExp, filename: string) {
   } else {
     return pattern.test(filename);
   }
+}
+
+function _isRegExp(value: mixed): boolean {
+  return Object.prototype.toString.call(value) === "[object RegExp]";
 }

--- a/packages/babel-types/src/converters.js
+++ b/packages/babel-types/src/converters.js
@@ -1,5 +1,4 @@
 import isPlainObject from "lodash/isPlainObject";
-import isRegExp from "lodash/isRegExp";
 import type { Scope } from "babel-traverse";
 import * as t from "./index";
 
@@ -280,7 +279,7 @@ export function valueToNode(value: any): Object {
   }
 
   // regexes
-  if (isRegExp(value)) {
+  if (_isRegExp(value)) {
     const pattern = value.source;
     const flags = value.toString().match(/\/([a-z]+|)$/)[1];
     return t.regExpLiteral(pattern, flags);
@@ -307,4 +306,8 @@ export function valueToNode(value: any): Object {
   }
 
   throw new Error("don't know how to turn this value into a node");
+}
+
+function _isRegExp(value: mixed): boolean {
+  return Object.prototype.toString.call(value) === "[object RegExp]";
 }


### PR DESCRIPTION
Continuing the gradual reduction in lodash use. This is not exactly like lodash's [implementation](https://github.com/lodash/lodash/blob/85255da560a4f641c019573b901c2eb43729df6d/isRegExp.js). In Node it defers to `util.isRegExp`, which is cross-realm safe. In Browsers it does a `Object.prototype.toString.call(value) === '[object RegExp]'`. I'm fine with switching to the `toString` approach.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | X

<!-- Describe your changes below in as much detail as possible -->
