### PR TITLE
Remove uses of lodash/compact

### DIFF
--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -1,5 +1,4 @@
 import toFastProperties from "to-fast-properties";
-import compact from "lodash/compact";
 import loClone from "lodash/clone";
 import uniq from "lodash/uniq";
 
@@ -398,7 +397,10 @@ export function inheritInnerComments(child: Object, parent: Object) {
 
 function _inheritComments(key, child, parent) {
   if (child && parent) {
-    child[key] = uniq(compact([].concat(child[key], parent[key])));
+    child[key] = uniq(
+      [].concat(child[key], parent[key])
+        .filter(Boolean)
+    );
   }
 }
 


### PR DESCRIPTION
Like lo-dash, we're just filtering falsey values: https://github.com/lodash/lodash/blob/85255da560a4f641c019573b901c2eb43729df6d/compact.js

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | X

<!-- Describe your changes below in as much detail as possible -->
