### PR TITLE
Deopt evaluation of undefined with a local binding. Fix #5204

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -181,11 +181,11 @@ export function evaluate(): { confident: boolean; value: any } {
         return binding.value;
       } else {
         if (node.name === "undefined") {
-          return undefined;
+          return binding ? deopt(binding.path) : undefined;
         } else if (node.name === "Infinity") {
-          return Infinity;
+          return binding ? deopt(binding.path) : Infinity;
         } else if (node.name === "NaN") {
-          return NaN;
+          return binding ? deopt(binding.path) : NaN;
         }
 
         const resolved = path.resolve();

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -98,4 +98,22 @@ describe("evaluation", function () {
       false
     );
   });
+
+  it("should evaluate undefined, NaN and Infinity", () => {
+    assert.strictEqual(getPath("undefined").get("body.0.expression").evaluate().confident, true);
+    assert.strictEqual(getPath("NaN").get("body.0.expression").evaluate().confident, true);
+    assert.strictEqual(getPath("Infinity").get("body.0.expression").evaluate().confident, true);
+  });
+
+  it("should deopt redefined primitives - undefined, NaN and Infinity", () => {
+    const eval_undef = getPath("let undefined; undefined;").get("body.1.expression").evaluate();
+    const eval_nan = getPath("let NaN; NaN;").get("body.1.expression").evaluate();
+    const eval_inf = getPath("let Infinity; Infinity;").get("body.1.expression").evaluate();
+    assert.strictEqual(eval_undef.confident, false);
+    assert.strictEqual(eval_nan.confident, false);
+    assert.strictEqual(eval_inf.confident, false);
+
+    assert.strictEqual(eval_undef.deopt.type, "VariableDeclarator");
+    assert.strictEqual(eval_undef.deopt.parentPath.node.kind, "let");
+  });
 });


### PR DESCRIPTION

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | 
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5204
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

undefined, NaN, Infinity with local bindings - deopt during path.evaluate.
