### PR TITLE
Remove binding class declaration in its own scope.

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -149,14 +149,6 @@ const collectorVisitor = {
     scope.getBlockParent().registerDeclaration(path);
   },
 
-  ClassDeclaration(path) {
-    const id = path.node.id;
-    if (!id) return;
-
-    const name = id.name;
-    path.scope.bindings[name] = path.scope.getBinding(name);
-  },
-
   Block(path) {
     const paths = path.get("body");
     for (const bodyPath of (paths: Array)) {

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -60,5 +60,16 @@ describe("scope", function () {
         _foo2: { }
       `).scope.generateUid("foo"), "_foo3");
     });
+
+    test("class declarations should have only one binding - fix issue #5156", () => {
+      assert.strictEqual(
+        !!getPath("class A {}").scope.bindings.A,
+        true
+      );
+      assert.strictEqual(
+        getPath("class A {}").get("body.0").scope.bindings.A,
+        undefined
+      );
+    });
   });
 });


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | not sure
| Minor: New Feature?      | no
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes #5156
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

Removes ClassDeclaration binding in the scope of the classDeclaration. It is already present in the scope containing the declaration. 
