### PR TITLE
Remove REPL link transform-flow-strip-types doc

### DIFF
--- a/packages/babel-plugin-transform-flow-strip-types/README.md
+++ b/packages/babel-plugin-transform-flow-strip-types/README.md
@@ -16,9 +16,6 @@ function foo(one: any, two: number, three?): string {}
 function foo(one, two, three) {}
 ```
 
-[Try in REPL](http://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=react&code=function%20foo(one%3A%20any%2C%20two%3A%20number%2C%20three%3F)%3A%20string%20%7B%7D&experimental=false&loose=false&spec=false&playground=false&stage=0
-)
-
 ## Installation
 
 ```sh


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | yes<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

Since the REPL link is automatically added in code blocks, we can remove it.