### PR TITLE
docs: fix do expressions JSX example

### DIFF
--- a/packages/babel-plugin-transform-do-expressions/README.md
+++ b/packages/babel-plugin-transform-do-expressions/README.md
@@ -47,8 +47,6 @@ let a = do {
 };
 ```
 
-[Try in REPL](http://babeljs.io/repl/#?evaluate=true&presets=es2015%2Cstage-0&code=let%20x%20%3D%20100%3B%0Alet%20y%20%3D%2020%3B%0A%0Alet%20a%20%3D%20do%20%7B%0A%20%20if(x%20%3E%2010)%20%7B%0A%20%20%20%20if(y%20%3E%2020)%20%7B%0A%20%20%20%20%20%20'big%20x%2C%20big%20y'%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20'big%20x%2C%20small%20y'%3B%0A%20%20%20%20%7D%0A%20%20%7D%20else%20%7B%0A%20%20%20%20if(y%20%3E%2010)%20%7B%0A%20%20%20%20%20%20'small%20x%2C%20big%20y'%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20'small%20x%2C%20small%20y'%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%3B%0A%0Aconsole.log(a)%3B)
-
 ## Example
 
 ### In JSX

--- a/packages/babel-plugin-transform-do-expressions/README.md
+++ b/packages/babel-plugin-transform-do-expressions/README.md
@@ -75,8 +75,8 @@ const Component = props =>
   <div className='myComponent'>
     {do {
       if(color === 'blue') { <BlueComponent/>; }
-      if(color === 'red') { <RedComponent/>; }
-      if(color === 'green') { <GreenComponent/>; }
+      else if(color === 'red') { <RedComponent/>; }
+      else if(color === 'green') { <GreenComponent/>; }
     }}
   </div>
 ;


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  |  no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | no

Correcting the use of a do statement which without `if...else if...else if` generates comma separated expressions (returning only the result of the last one).
