### PR TITLE
Remove babel-runtime from packages' dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,5 +72,4 @@ bootstrap:
 	./node_modules/.bin/lerna bootstrap
 	make build
 	cd packages/babel-runtime; \
-	npm install; \
 	node scripts/build-dist.js

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,14 @@ machine:
     version:
       6
 
+dependencies:
+  pre:
+    - curl -o- -L https://yarnpkg.com/install.sh | bash
+  cache_directories:
+    - ~/.yarn-cache
+  override:
+    - yarn
+
 test:
   override:
     - make test-ci

--- a/lerna.json
+++ b/lerna.json
@@ -13,9 +13,6 @@
       "tag: internal": ":house: Internal"
     }
   },
-  "bootstrapConfig": {
-    "ignore": "babel-runtime"
-  },
   "publishConfig": {
     "ignore": [
       "*.md",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.0.0",
     "babel-register": "^6.14.0",
-    "babel-runtime": "^6.0.0",
     "browserify": "^13.1.1",
     "bundle-collapser": "^1.2.1",
     "chai": "^3.5.0",
@@ -58,7 +57,6 @@
       "stage-0"
     ],
     "plugins": [
-      "transform-runtime",
       "transform-class-properties",
       "transform-flow-strip-types"
     ],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-plugin-istanbul": "^2.0.1",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-flow-strip-types": "^6.3.13",
-    "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.0.0",
     "babel-register": "^6.14.0",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -19,7 +19,6 @@
     "babel-core": "^6.22.1",
     "babel-register": "^6.22.0",
     "babel-polyfill": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "commander": "^2.8.1",
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^1.0.0",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -31,7 +31,6 @@
     "babel-helpers": "^6.22.0",
     "babel-messages": "^6.22.0",
     "babel-template": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-register": "^6.22.0",
     "babel-traverse": "^6.22.1",
     "babel-types": "^6.22.0",

--- a/packages/babel-core/src/store.js
+++ b/packages/babel-core/src/store.js
@@ -1,22 +1,24 @@
-export default class Store extends Map {
+export default class Store {
   constructor() {
-    super();
-    this.dynamicData = {};
+    this._map = new Map();
+    this._map.dynamicData = {};
   }
 
-  dynamicData: Object;
-
   setDynamic(key, fn) {
-    this.dynamicData[key] = fn;
+    this._map.dynamicData[key] = fn;
+  }
+
+  set(key: string, val) {
+    this._map.set(key, val);
   }
 
   get(key: string): any {
-    if (this.has(key)) {
-      return super.get(key);
+    if (this._map.has(key)) {
+      return this._map.get(key);
     } else {
-      if (Object.prototype.hasOwnProperty.call(this.dynamicData, key)) {
-        const val =  this.dynamicData[key]();
-        this.set(key, val);
+      if (Object.prototype.hasOwnProperty.call(this._map.dynamicData, key)) {
+        const val =  this._map.dynamicData[key]();
+        this._map.set(key, val);
         return val;
       }
     }

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -12,7 +12,6 @@
   ],
   "dependencies": {
     "babel-messages": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0",
     "detect-indent": "^4.0.0",
     "jsesc": "^1.3.0",

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-traverse": "^6.22.0",
     "babel-types": "^6.22.0"
   }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-helper-explode-assignable-expression": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   }
 }

--- a/packages/babel-helper-builder-conditional-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-conditional-assignment-operator-visitor/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-helper-explode-assignable-expression": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   }
 }

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0",
     "esutils": "^2.0.0",
     "lodash": "^4.2.0"

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-traverse": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0",
     "babel-helper-hoist-variables": "^6.22.0"
   }

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "lodash": "^4.2.0",
     "babel-types": "^6.22.0",
     "babel-helper-function-name": "^6.22.0"

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-traverse": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   }
 }

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-traverse": "^6.22.0",
     "babel-types": "^6.22.0",
     "babel-helper-bindify-decorators": "^6.22.0"

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -7,7 +7,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "lodash": "^4.2.0",
     "try-resolve": "^1.0.0"
   }

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0",
     "babel-traverse": "^6.22.0",
     "babel-helper-get-function-arity": "^6.22.0",

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   }
 }

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   }
 }

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   }
 }

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-helper-transform-fixture-test-runner": "^6.22.0"
   }
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "lodash": "^4.2.0",
     "babel-types": "^6.22.0"
   }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-template": "^6.22.0",
     "babel-types": "^6.22.0",
     "babel-traverse": "^6.22.0",

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-helper-optimise-call-expression": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-traverse": "^6.22.0",
     "babel-messages": "^6.22.0",
     "babel-template": "^6.22.0",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-core": "^6.22.0",
     "babel-polyfill": "^6.22.0",
     "babel-helper-fixtures": "^6.22.0",

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helpers",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-template": "^6.22.0"
   }
 }

--- a/packages/babel-messages/package.json
+++ b/packages/babel-messages/package.json
@@ -6,8 +6,5 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-messages",
-  "main": "lib/index.js",
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  }
+  "main": "lib/index.js"
 }

--- a/packages/babel-plugin-check-es2015-constants/package.json
+++ b/packages/babel-plugin-check-es2015-constants/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-async-functions/package.json
+++ b/packages/babel-plugin-transform-async-functions/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-plugin-syntax-async-functions": "^6.8.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-async-functions": "^6.8.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-async-generator-functions/package.json
+++ b/packages/babel-plugin-transform-async-generator-functions/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-remap-async-to-generator": "^6.22.0",
-    "babel-plugin-syntax-async-generators": "^6.5.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-async-generators": "^6.5.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-remap-async-to-generator": "^6.22.0",
-    "babel-plugin-syntax-async-functions": "^6.8.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-async-functions": "^6.8.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-async-to-module-method/package.json
+++ b/packages/babel-plugin-transform-async-to-module-method/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "babel-plugin-syntax-async-functions": "^6.8.0",
     "babel-helper-remap-async-to-generator": "^6.22.0",
-    "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-types": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-class-properties/package.json
+++ b/packages/babel-plugin-transform-class-properties/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "babel-helper-function-name": "^6.22.0",
     "babel-plugin-syntax-class-properties": "^6.8.0",
-    "babel-runtime": "^6.22.0",
     "babel-template": "^6.22.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-decorators/package.json
+++ b/packages/babel-plugin-transform-decorators/package.json
@@ -12,8 +12,7 @@
     "babel-types": "^6.22.0",
     "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-helper-explode-class": "^6.22.0",
-    "babel-template": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-template": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-do-expressions/package.json
+++ b/packages/babel-plugin-transform-do-expressions/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-plugin-syntax-do-expressions": "^6.8.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-do-expressions": "^6.8.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-es2015-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-es2015-block-scoped-functions/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-block-scoping/package.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/package.json
@@ -9,8 +9,7 @@
     "babel-traverse": "^6.22.0",
     "babel-types": "^6.22.0",
     "babel-template": "^6.22.0",
-    "lodash": "^4.2.0",
-    "babel-runtime": "^6.22.0"
+    "lodash": "^4.2.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-classes/package.json
+++ b/packages/babel-plugin-transform-es2015-classes/package.json
@@ -13,7 +13,6 @@
     "babel-traverse": "^6.22.0",
     "babel-helper-define-map": "^6.22.0",
     "babel-messages": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-es2015-computed-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-computed-properties/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-template": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-template": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-es2015-destructuring/package.json
+++ b/packages/babel-plugin-transform-es2015-destructuring/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-es2015-duplicate-keys/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es2015-for-of/package.json
+++ b/packages/babel-plugin-transform-es2015-for-of/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-function-name/package.json
+++ b/packages/babel-plugin-transform-es2015-function-name/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-function-name": "^6.22.0",
-    "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-types": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-es2015-instanceof/package.json
+++ b/packages/babel-plugin-transform-es2015-instanceof/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-literals/package.json
+++ b/packages/babel-plugin-transform-es2015-literals/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-modules-amd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/package.json
@@ -7,8 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
-    "babel-template": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-template": "^6.22.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-template": "^6.22.0",
     "babel-plugin-transform-strict-mode": "^6.22.0"
   },

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/package.json
@@ -7,8 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-template": "^6.22.0",
-    "babel-helper-hoist-variables": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-helper-hoist-variables": "^6.22.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-modules-umd/package.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/package.json
@@ -7,8 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-    "babel-template": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-template": "^6.22.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-object-super/package.json
+++ b/packages/babel-plugin-transform-es2015-object-super/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-helper-replace-supers": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-helper-replace-supers": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-es2015-parameters/package.json
+++ b/packages/babel-plugin-transform-es2015-parameters/package.json
@@ -10,8 +10,7 @@
     "babel-helper-call-delegate": "^6.22.0",
     "babel-helper-get-function-arity": "^6.22.0",
     "babel-template": "^6.22.0",
-    "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-types": "^6.22.0"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-types": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-es2015-spread/package.json
+++ b/packages/babel-plugin-transform-es2015-spread/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-es2015-sticky-regex/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "babel-helper-regex": "^6.22.0",
-    "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-types": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-es2015-template-literals/package.json
+++ b/packages/babel-plugin-transform-es2015-template-literals/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es2015-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/package.json
@@ -10,7 +10,6 @@
   ],
   "dependencies": {
     "babel-helper-regex": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "regexpu-core": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-es3-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-es3-member-expression-literals/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es3-property-literals/package.json
+++ b/packages/babel-plugin-transform-es3-property-literals/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-es5-property-mutators/package.json
+++ b/packages/babel-plugin-transform-es5-property-mutators/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-helper-define-map": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-helper-define-map": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-eval/package.json
+++ b/packages/babel-plugin-transform-eval/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-    "babel-helper-builder-binary-assignment-operator-visitor": "^6.22.0",
-    "babel-runtime": "^6.22.0"
+    "babel-helper-builder-binary-assignment-operator-visitor": "^6.22.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-export-extensions/package.json
+++ b/packages/babel-plugin-transform-export-extensions/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-plugin-syntax-export-extensions": "^6.8.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-export-extensions": "^6.8.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-plugin-syntax-flow": "^6.8.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-plugin-syntax-flow": "^6.18.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-function-bind/package.json
+++ b/packages/babel-plugin-transform-function-bind/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-plugin-syntax-function-bind": "^6.8.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-function-bind": "^6.8.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -9,9 +9,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-object-rest-spread/package.json
+++ b/packages/babel-plugin-transform-object-rest-spread/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-    "babel-runtime": "^6.22.0"
+    "babel-plugin-syntax-object-rest-spread": "^6.8.0"
   },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "lodash": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-helper-builder-react-jsx": "^6.22.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-plugin-syntax-jsx": "^6.8.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-plugin-syntax-jsx": "^6.8.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-helper-builder-react-jsx": "^6.22.0",
     "babel-plugin-syntax-jsx": "^6.8.0"
   },

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.22.0"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "^6.22.0"
   }

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-undeclared-variables-check/package.json
+++ b/packages/babel-plugin-undeclared-variables-check/package.json
@@ -9,7 +9,6 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "leven": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -9,7 +9,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "core-js": "^2.4.0",
-    "babel-runtime": "^6.22.0",
     "regenerator-runtime": "^0.10.0"
   }
 }

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -9,7 +9,6 @@
   "browser": "lib/browser.js",
   "dependencies": {
     "babel-core": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "core-js": "^2.4.0",
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -32,16 +32,6 @@ function relative(filename) {
   return __dirname + "/../" + filename;
 }
 
-function readFile(filename, shouldDefaultify) {
-  var file = fs.readFileSync(require.resolve(filename), "utf8");
-
-  if (shouldDefaultify) {
-    file += "\n" + defaultify("module.exports") + "\n";
-  }
-
-  return file;
-}
-
 function defaultify(name) {
   return 'module.exports = { "default": ' + name + ', __esModule: true };';
 }
@@ -63,15 +53,15 @@ var transformOpts = {
 
   plugins: [
     require("../../babel-plugin-transform-runtime"),
-    [require("../../babel-plugin-transform-es2015-modules-commonjs"), {loose: true, strict: false}]
+    [require("../../babel-plugin-transform-es2015-modules-commonjs"), { loose: true, strict: false }]
   ]
 };
 
 function buildRuntimeRewritePlugin(relativePath, helperName) {
   return {
-    pre: function (file){
+    pre: function (file) {
       var original = file.get("helperGenerator");
-      file.set("helperGenerator", function(name){
+      file.set("helperGenerator", function(name) {
         // make sure that helpers won't insert circular references to themselves
         if (name === helperName) return;
 
@@ -90,13 +80,6 @@ function buildRuntimeRewritePlugin(relativePath, helperName) {
       }
     }
   };
-}
-
-function selfContainify(path, code) {
-  return babel.transform(code, {
-    presets: transformOpts.presets,
-    plugins: transformOpts.plugins.concat([buildRuntimeRewritePlugin(path, null)])
-  }).code;
 }
 
 function buildHelper(helperName) {

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -11,7 +11,6 @@
     "babylon": "^6.11.0",
     "babel-traverse": "^6.22.0",
     "babel-types": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "lodash": "^4.2.0"
   }
 }

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "babel-code-frame": "^6.22.0",
     "babel-messages": "^6.22.0",
-    "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0",
     "babylon": "^6.15.0",
     "debug": "^2.2.0",

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-types",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.22.0",
     "esutils": "^2.0.2",
     "lodash": "^4.2.0",
     "to-fast-properties": "^1.0.1"


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | yes
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes #5118
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

Worked with @hzoo to remove babel-runtime in preparation for dropping Node < 4 in Babel 7.0.

Updated `packages/babel-runtime/scripts/build-dist.js` to fix some ESLint warnings and remove dead code.
