### PR TITLE
[7.0] Add legacy-decorators to stage1. Fixes #5220

### DIFF
--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -9,6 +9,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-stage-2": "^6.22.0"
   }
 }

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -8,8 +8,8 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-preset-stage-2": "^6.22.0"
   }
 }

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -1,12 +1,14 @@
 import presetStage2 from "babel-preset-stage-2";
 
 import transformExportExtensions from "babel-plugin-transform-export-extensions";
+import transformDecoratorsLegacy from "babel-plugin-transform-decorators-legacy";
 
 export default {
   presets: [
     presetStage2
   ],
   plugins: [
-    transformExportExtensions
+    transformExportExtensions,
+    transformDecoratorsLegacy
   ]
 };

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -1,14 +1,14 @@
 import presetStage2 from "babel-preset-stage-2";
 
-import transformExportExtensions from "babel-plugin-transform-export-extensions";
 import transformDecoratorsLegacy from "babel-plugin-transform-decorators-legacy";
+import transformExportExtensions from "babel-plugin-transform-export-extensions";
 
 export default {
   presets: [
     presetStage2
   ],
   plugins: [
-    transformExportExtensions,
-    transformDecoratorsLegacy
+    transformDecoratorsLegacy,
+    transformExportExtensions
   ]
 };

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.22.0",
-    "babel-plugin-transform-decorators": "^6.22.0",
     "babel-plugin-transform-unicode-property-regex": "^2.0.0",
     "babel-preset-stage-3": "^6.22.0"
   }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -2,7 +2,6 @@ import presetStage3 from "babel-preset-stage-3";
 
 import syntaxDynamicImport from "babel-plugin-syntax-dynamic-import";
 import transformClassProperties from "babel-plugin-transform-class-properties";
-import transformDecorators from "babel-plugin-transform-decorators";
 import transformUnicodePropertyRegex from "babel-plugin-transform-unicode-property-regex";
 
 export default {
@@ -12,7 +11,6 @@ export default {
   plugins: [
     syntaxDynamicImport,
     transformClassProperties,
-    transformDecorators,
     transformUnicodePropertyRegex
   ]
 };


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  n
| Major: Breaking Change?  | y
| Minor: New Feature?      |  n
| Deprecations?            |  n
| Spec Compliancy?         |  y
| Tests Added/Pass?        | n
| Fixed Tickets            |  Fixes #5220 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       |  Added babel-plugin-transform-decorators-legacy.

<!-- Describe your changes below in as much detail as possible -->
