### PR TITLE
Bump `detect-indent` for `babel-generator`.

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -14,7 +14,7 @@
     "babel-messages": "^6.22.0",
     "babel-runtime": "^6.22.0",
     "babel-types": "^6.22.0",
-    "detect-indent": "^4.0.0",
+    "detect-indent": "^5.0.0",
     "jsesc": "^1.3.0",
     "lodash": "^4.2.0",
     "source-map": "^0.5.0"


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No (for `babel@7.0.0`)
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | No
| Fixed Tickets            | N/A
| License                  | MIT
| Doc PR                   | No
| Dependency Changes       | Yes

<!-- Describe your changes below in as much detail as possible -->
Bumps `detect-indent` from `^4.0.0` to `^5.0.0`.  `5.0.0` drops the `repeating` package, which depended on `is-finite`, which depended on `number-is-nan`.