### PR TITLE
Rename NumericLiteralTypeAnnotation to NumberLiteralTypeAnnotation

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -632,8 +632,8 @@ declare class BabelNodeNullableTypeAnnotation extends BabelNode {
   typeAnnotation: any;
 }
 
-declare class BabelNodeNumericLiteralTypeAnnotation extends BabelNode {
-  type: "NumericLiteralTypeAnnotation";
+declare class BabelNodeNumberLiteralTypeAnnotation extends BabelNode {
+  type: "NumberLiteralTypeAnnotation";
 }
 
 declare class BabelNodeNumberTypeAnnotation extends BabelNode {
@@ -873,7 +873,7 @@ type BabelNodeClass = BabelNodeClassDeclaration | BabelNodeClassExpression;
 type BabelNodeModuleDeclaration = BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeImportDeclaration;
 type BabelNodeExportDeclaration = BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration;
 type BabelNodeModuleSpecifier = BabelNodeExportSpecifier | BabelNodeImportDefaultSpecifier | BabelNodeImportNamespaceSpecifier | BabelNodeImportSpecifier | BabelNodeExportDefaultSpecifier | BabelNodeExportNamespaceSpecifier;
-type BabelNodeFlow = BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeClassImplements | BabelNodeClassProperty | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeExistentialTypeParam | BabelNodeFunctionTypeAnnotation | BabelNodeFunctionTypeParam | BabelNodeGenericTypeAnnotation | BabelNodeInterfaceExtends | BabelNodeInterfaceDeclaration | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumericLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeTypeAlias | BabelNodeTypeAnnotation | BabelNodeTypeCastExpression | BabelNodeTypeParameterDeclaration | BabelNodeTypeParameterInstantiation | BabelNodeObjectTypeAnnotation | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeQualifiedTypeIdentifier | BabelNodeUnionTypeAnnotation | BabelNodeVoidTypeAnnotation;
+type BabelNodeFlow = BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeClassImplements | BabelNodeClassProperty | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeExistentialTypeParam | BabelNodeFunctionTypeAnnotation | BabelNodeFunctionTypeParam | BabelNodeGenericTypeAnnotation | BabelNodeInterfaceExtends | BabelNodeInterfaceDeclaration | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumberLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeTypeAlias | BabelNodeTypeAnnotation | BabelNodeTypeCastExpression | BabelNodeTypeParameterDeclaration | BabelNodeTypeParameterInstantiation | BabelNodeObjectTypeAnnotation | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeQualifiedTypeIdentifier | BabelNodeUnionTypeAnnotation | BabelNodeVoidTypeAnnotation;
 type BabelNodeFlowBaseAnnotation = BabelNodeAnyTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeVoidTypeAnnotation;
 type BabelNodeFlowDeclaration = BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias;
 type BabelNodeJSX = BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXExpressionContainer | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName | BabelNodeJSXOpeningElement | BabelNodeJSXSpreadAttribute | BabelNodeJSXText;
@@ -974,7 +974,7 @@ declare module "babel-types" {
   declare function intersectionTypeAnnotation(types: any): BabelNodeIntersectionTypeAnnotation;
   declare function mixedTypeAnnotation(): BabelNodeMixedTypeAnnotation;
   declare function nullableTypeAnnotation(typeAnnotation: any): BabelNodeNullableTypeAnnotation;
-  declare function numericLiteralTypeAnnotation(): BabelNodeNumericLiteralTypeAnnotation;
+  declare function numberLiteralTypeAnnotation(): BabelNodeNumberLiteralTypeAnnotation;
   declare function numberTypeAnnotation(): BabelNodeNumberTypeAnnotation;
   declare function stringLiteralTypeAnnotation(): BabelNodeStringLiteralTypeAnnotation;
   declare function stringTypeAnnotation(): BabelNodeStringTypeAnnotation;
@@ -1110,7 +1110,7 @@ declare module "babel-types" {
   declare function isIntersectionTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isMixedTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isNullableTypeAnnotation(node: Object, opts?: Object): boolean;
-  declare function isNumericLiteralTypeAnnotation(node: Object, opts?: Object): boolean;
+  declare function isNumberLiteralTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isNumberTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isStringLiteralTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isStringTypeAnnotation(node: Object, opts?: Object): boolean;

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -185,7 +185,7 @@ export function NullableTypeAnnotation(node: Object) {
 }
 
 export {
-  NumericLiteral as NumericLiteralTypeAnnotation,
+  NumericLiteral as NumberLiteralTypeAnnotation,
   StringLiteral as StringLiteralTypeAnnotation,
 } from "./types";
 

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -1295,12 +1295,12 @@ Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
 ---
 
-### numericLiteralTypeAnnotation
+### numberLiteralTypeAnnotation
 ```javascript
-t.numericLiteralTypeAnnotation()
+t.numberLiteralTypeAnnotation()
 ```
 
-See also `t.isNumericLiteralTypeAnnotation(node, opts)` and `t.assertNumericLiteralTypeAnnotation(node, opts)`.
+See also `t.isNumberLiteralTypeAnnotation(node, opts)` and `t.assertNumberLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -179,7 +179,7 @@ defineType("NullableTypeAnnotation", {
   }
 });
 
-defineType("NumericLiteralTypeAnnotation", {
+defineType("NumberLiteralTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | yes
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | flow
| Tests Added/Pass?        | yes
| Fixed Tickets            |  https://github.com/babel/babylon/issues/329
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

Flow uses `NumberLiteralTypeAnnotation`, this PR along with https://github.com/babel/babylon/pull/332 bring babel and babylon inline.