### PR TITLE
[7.0] List babylon plugins instead of * in babel-generator tests

### DIFF
--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -306,7 +306,19 @@ suites.forEach(function (testSuite) {
         if (actualCode) {
           const actualAst = parse(actualCode, {
             filename: actual.loc,
-            plugins: ["*"],
+            plugins: [
+              "asyncGenerators",
+              "classProperties",
+              "decorators",
+              "doExpressions",
+              "dynamicImport",
+              "exportExtensions",
+              "flow",
+              "functionBind",
+              "functionSent",
+              "jsx",
+              "objectRestSpread",
+            ],
             strictMode: false,
             sourceType: "module",
           });


### PR DESCRIPTION
Matches the [removal of '*' in the plugin option](https://github.com/babel/babylon/issues/296) in babylon, and fixes running tests with babylon 7 (as seen in https://github.com/babel/babel/pull/5199)