### PR TITLE
Add option to block-scoping to throw on slow code

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/README.md
+++ b/packages/babel-plugin-transform-es2015-block-scoping/README.md
@@ -14,9 +14,23 @@ npm install --save-dev babel-plugin-transform-es2015-block-scoping
 
 **.babelrc**
 
+Without options:
+
 ```json
 {
   "plugins": ["transform-es2015-block-scoping"]
+}
+```
+
+With options:
+
+```json
+{
+  "plugins": [
+    ["transform-es2015-block-scoping", {
+      "throwIfClosureRequired": true
+    }]
+  ]
 }
 ```
 
@@ -33,3 +47,15 @@ require("babel-core").transform("code", {
   plugins: ["transform-es2015-block-scoping"]
 });
 ```
+
+## Options `throwIfClosureRequired`
+
+In cases such as the following it's impossible to rewrite let/const without adding an additional function and closure while transforming:
+
+```javascript
+for (let i = 0; i < 5; i++) {
+  setTimeout(() => console.log(i), 1);
+}
+```
+
+In extremely performance-sensitive code, this can be undesirable. If `"throwIfClosureRequired": true` is set, Babel throws when transforming these patterns instead of automatically adding an additional function.

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -362,6 +362,12 @@ class BlockScoping {
   }
 
   wrapClosure() {
+    if (this.file.opts.throwIfClosureRequired) {
+      throw this.blockPath.buildCodeFrameError(
+        "Compiling let/const in this block would add a closure " +
+        "(throwIfClosureRequired)."
+      );
+    }
     const block = this.block;
 
     const outsideRefs = this.outsideLetReferences;

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/for-const-closure/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/for-const-closure/actual.js
@@ -1,0 +1,6 @@
+for (let i = 0; i < 5; i++) {
+  const l = i;
+  setTimeout(function() {
+    console.log(l);
+  }, 1);
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/for-const-closure/options.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/for-const-closure/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Compiling let/const in this block would add a closure (throwIfClosureRequired)."
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/function/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/function/actual.js
@@ -1,0 +1,3 @@
+function test() {
+  let foo = "bar";
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/function/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/function/expected.js
@@ -1,0 +1,3 @@
+function test() {
+  var foo = "bar";
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/options.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-es2015-block-scoping", { "throwIfClosureRequired": true }], "syntax-jsx", "transform-react-jsx", "transform-es2015-block-scoped-functions", "transform-es2015-arrow-functions"]
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/superswitch/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/superswitch/actual.js
@@ -1,0 +1,16 @@
+function foo() {
+  switch (2) {
+    case 0: {
+      if (true) {
+        return;
+      }
+
+      const stuff = new Map();
+      const data = 0;
+      stuff.forEach(() => {
+        const d = data;
+      });
+      break;
+    }
+  }
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/superswitch/options.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/superswitch/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Compiling let/const in this block would add a closure (throwIfClosureRequired)."
+}


### PR DESCRIPTION
The let/const plugin can add closures where you don't expect them. This is undesirable in some perf-sensitive projects (ex: React). I added an option that throws whenever the plugin adds a function (as opposed to simply renaming variables when converting to var).

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | yes
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | yes
| Fixed Tickets            | <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
