### PR TITLE
Load local copy of babel-cli when possible, fallback to global

### DIFF
--- a/packages/babel-cli/bin/babel.js
+++ b/packages/babel-cli/bin/babel.js
@@ -1,3 +1,22 @@
 #!/usr/bin/env node
 
-require("../lib/babel");
+const path       = require("path");
+const resolveCwd = require("resolve-cwd");
+const localCLI   = resolveCwd("babel-cli");
+
+function resolveLocalOrGlobalBinary () {
+  if (localCLI && path.relative(localCLI, __filename) !== "") {
+    if (process.stdout.isTTY) {
+      console.log("Using the locally installed Babel CLI");
+    }
+
+    const localBase = localCLI.replace("index.js", "");
+    return path.join(localBase, "bin/babel.js");
+  } else {
+    return "../lib/babel";
+  }
+}
+
+module.exports = resolveLocalOrGlobalBinary;
+
+require(resolveLocalOrGlobalBinary());

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -27,6 +27,7 @@
     "lodash": "^4.2.0",
     "output-file-sync": "^1.1.0",
     "path-is-absolute": "^1.0.0",
+    "resolve-cwd": "^1.0.0",
     "slash": "^1.0.0",
     "source-map": "^0.5.0",
     "v8flags": "^2.0.10"


### PR DESCRIPTION
Walk up the project and try to resolve a local copy of babel-cli, if there isn't one, load the global one

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | yes
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes #5091
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | added resolve-cwd

<!-- Describe your changes below in as much detail as possible -->
This PR gives the CLI the ability to invoke a local copy of babel-cli (if one exists) from within a project.

I've marked it as "Breaking Change" because it will change the behavior the CLI will have when invoked in projects that contain local copies of the cli.
~It's still a WIP so I added a DNM tag to the title until someone from the project can clarify a [couple of questions I have](https://github.com/babel/babel/issues/5091#issuecomment-275908684).~