### PR TITLE
Normalize options sections in docs [skip ci]

### DIFF
--- a/packages/babel-code-frame/README.md
+++ b/packages/babel-code-frame/README.md
@@ -35,9 +35,26 @@ If the column number is not known, you may pass `null` instead.
 
 ## Options
 
-name                   | type     | default         | description
------------------------|----------|-----------------|------------------------------------------------------
-highlightCode          | boolean  | `false`         | Syntax highlight the code as JavaScript for terminals
-linesAbove             | number   | 2               | The number of lines to show above the error
-linesBelow             | number   | 3               | The number of lines to show below the error
-forceColor             | boolean  | `false`         | Forcibly syntax highlight the code as JavaScript (for non-terminals); overrides highlightCode
+### `highlightCode`
+
+`boolean`, defaults to `false`.
+
+Toggles syntax highlighting the code as JavaScript for terminals.
+
+### `linesAbove`
+
+`number`, defaults to `2`.
+
+Adjust the number of lines to show above the error.
+
+### `linesBelow`
+
+`number`, defaults to `3`.
+
+Adjust the number of lines to show below the error.
+
+### `forceColor`
+
+`boolean`, defaults to `false`.
+
+Enable this to forcibly syntax highlight the code as JavaScript (for non-terminals); overrides `highlightCode`.

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -117,4 +117,5 @@ Following is a table of the options you can use:
 | `sourceMaps`             | `false`              | If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to `"both"` then a `map` property is returned as well as a source map comment appended. **This does not emit sourcemap files by itself!** To have sourcemaps emitted using the CLI, you must pass it the `--source-maps` option. |
 | `sourceMapTarget`        | `(filenameRelative)` | Set `file` on returned source map. |
 | `sourceRoot`             | `(moduleRoot)`       | The root from which all sources are relative. |
+| `sourceType`             | `"module"`           | Indicate the mode the code should be parsed in. Can be either "script" or "module". |
 | `wrapPluginVisitorMethod`| `null`               | An optional callback that can be used to wrap visitor methods. **NOTE:** This is useful for things like introspection, and not really needed for implementing anything. Called as `wrapPluginVisitorMethod(pluginAlias, visitorType, callback)`.

--- a/packages/babel-plugin-transform-class-properties/README.md
+++ b/packages/babel-plugin-transform-class-properties/README.md
@@ -76,7 +76,11 @@ require("babel-core").transform("code", {
 
 ## Options
 
-* `spec` -  Class properties are compiled to use `Object.defineProperty. Static fields are now defined even if they are not initialized
+### `spec`
+
+`boolean`, defaults to `false`.
+
+Class properties are compiled to use `Object.defineProperty`. Static fields are now defined even if they are not initialized.
 
 ## References
 

--- a/packages/babel-plugin-transform-es2015-arrow-functions/README.md
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/README.md
@@ -73,7 +73,7 @@ Without options:
 
 With options:
 
-```json 
+```json
 {
   "plugins": [
     ["transform-es2015-arrow-functions", { "spec": true }]
@@ -97,4 +97,8 @@ require("babel-core").transform("code", {
 
 ## Options
 
-* `spec` - This option wraps the generated function in `.bind(this)` and keeps uses of `this` inside the function as-is, instead of using a renamed `this`. It also adds a runtime check to ensure the functions are not instantiated.
+### `spec`
+
+`boolean`, defaults to `false`.
+
+This option wraps the generated function in `.bind(this)` and keeps uses of `this` inside the function as-is, instead of using a renamed `this`. It also adds a runtime check to ensure the functions are not instantiated.

--- a/packages/babel-plugin-transform-es2015-classes/README.md
+++ b/packages/babel-plugin-transform-es2015-classes/README.md
@@ -50,7 +50,11 @@ require("babel-core").transform("code", {
 });
 ```
 
-## Options `loose`
+## Options
+
+### `loose`
+
+`boolean`, defaults to `false`.
 
 #### Method enumerability
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/README.md
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/README.md
@@ -62,7 +62,11 @@ require("babel-core").transform("code", {
 });
 ```
 
-## Options `loose`
+## Options
+
+### `loose`
+
+`boolean`, defaults to `false`.
 
 As per the spec, `import` and `export` are only allowed to be used at the top
 level. When in loose mode these are allowed to be used anywhere.

--- a/packages/babel-plugin-transform-es2015-spread/README.md
+++ b/packages/babel-plugin-transform-es2015-spread/README.md
@@ -80,4 +80,8 @@ require("babel-core").transform("code", {
 
 ## Options
 
-* `loose` - All iterables are assumed to be arrays.
+### `loose`
+
+`boolean`, defaults to `false`.
+
+In loose mode, **all** iterables are assumed to be arrays.

--- a/packages/babel-plugin-transform-es2015-template-literals/README.md
+++ b/packages/babel-plugin-transform-es2015-template-literals/README.md
@@ -62,10 +62,15 @@ require("babel-core").transform("code", {
 ## Options
 
 ### `loose`
+
+`boolean`, defaults to `false`.
+
 In loose mode, tagged template literal objects aren't frozen.
 
-
 ### `spec`
+
+`boolean`, defaults to `false`.
+
 This option wraps all template literal expressions with `String`. See [babel/babel#1065](https://github.com/babel/babel/issues/1065) for more info.
 
 **In**

--- a/packages/babel-plugin-transform-react-jsx/README.md
+++ b/packages/babel-plugin-transform-react-jsx/README.md
@@ -95,6 +95,16 @@ require("babel-core").transform("code", {
 
 ## Options
 
-* `pragma` - Replace the function used when compiling JSX expressions (Defaults to `React.createElement`).
-  - Note that the `@jsx React.DOM` pragma has been deprecated as of React v0.12
-* `useBuiltIns` - When spreading props, use Object.assign instead of Babel's extend helper (Disabled by default).
+### `pragma`
+
+`string`, defaults to `React.createElement`.
+
+Replace the function used when compiling JSX expressions.
+
+Note that the `@jsx React.DOM` pragma has been deprecated as of React v0.12
+
+### `useBuiltIns`
+
+`boolean`, defaults to `false`.
+
+When spreading props, use `Object.assign` directly instead of Babel's extend helper.

--- a/packages/babel-preset-es2015/README.md
+++ b/packages/babel-preset-es2015/README.md
@@ -36,30 +36,22 @@ require("babel-core").transform("code", {
 
 ## Options
 
-* `loose` - Enable "loose" transformations for any plugins in this preset that allow them (Disabled by default).
-* `modules` - Enable transformation of ES6 module syntax to another module type (Enabled by default to `"commonjs"`).
-  * Can be `false` to not transform modules, or one of `["amd", "umd", "systemjs", "commonjs"]`
-* `spec` - Enable "spec" transformations for any plugins in this preset that allow them (Disabled by default)
+### `loose`
 
-```js
-{
-  presets: [
-    ["es2015", { "loose": true }]
-  ]
-}
-{
-  presets: [
-    ["es2015", { "modules": false }]
-  ]
-}
-{
-  presets: [
-    ["es2015", { "loose": true, "modules": false }]
-  ]
-}
-{
-  presets: [
-    ["es2015", { "spec": true }]
-  ]
-}
-```
+`boolean`, defaults to `false`.
+
+Enable "loose" transformations for any plugins in this preset that allow them.
+
+### `modules`
+
+`"amd" | "umd" | "systemjs" | "commonjs" | false`, defaults to `"commonjs"`.
+
+Enable transformation of ES6 module syntax to another module type.
+
+Setting this to `false` will not transform modules.
+
+### `spec`
+
+`boolean`, defaults to `false`.
+
+Enable "spec" transformations for any plugins in this preset that allow them.

--- a/packages/babel-preset-latest/README.md
+++ b/packages/babel-preset-latest/README.md
@@ -38,21 +38,21 @@ require("babel-core").transform("code", {
 
 ### `es2015`
 
-`boolean`, defaults to `false`.
+`boolean`, defaults to `true`.
 
-Toggles including plugins from the [es2015 preset](/docs/plugins/preset-es2015/).
+Toggles including plugins from the [es2015 preset](https://babeljs.io/docs/plugins/preset-es2015/).
 
 ```js
 {
   "presets": [
     ["latest", {
-      "es2015": false // defaults to true
+      "es2015": false
     }]
   ]
 }
 ```
 
-You can also pass options down to the `es2015` preset. This also works for the other preset options.
+You can also pass options down to the `es2015` preset.
 
 ```js
 {
@@ -66,14 +66,16 @@ You can also pass options down to the `es2015` preset. This also works for the o
 }
 ```
 
+**Note:** This also works for the other preset-year options below.
+
 ### `es2016`
 
-`boolean`, defaults to `false`.
+`boolean`, defaults to `true`.
 
-Toggles including from the [es2016 preset](/docs/plugins/preset-es2016/).
+Toggles including plugins from the [es2016 preset](https://babeljs.io/docs/plugins/preset-es2016/).
 
 ### `es2017`
 
-`boolean`, defaults to `false`.
+`boolean`, defaults to `true`.
 
-Toggles including plugins from the [es2017 preset](/docs/plugins/preset-es2017/).
+Toggles including plugins from the [es2017 preset](https://babeljs.io/docs/plugins/preset-es2017/).

--- a/packages/babel-preset-latest/README.md
+++ b/packages/babel-preset-latest/README.md
@@ -36,9 +36,11 @@ require("babel-core").transform("code", {
 
 ### Options
 
-- `es2015`: Optionally not run any plugins from this preset (defaults to true)
-- `es2016`: Optionally not run any plugins from this preset (defaults to true)
-- `es2017`: Optionally not run any plugins from this preset (defaults to true)
+### `es2015`
+
+`boolean`, defaults to `false`.
+
+Toggles including plugins from the [es2015 preset](/docs/plugins/preset-es2015/).
 
 ```js
 {
@@ -50,16 +52,28 @@ require("babel-core").transform("code", {
 }
 ```
 
-You can also pass options down to the `es2015` preset.
+You can also pass options down to the `es2015` preset. This also works for the other preset options.
 
 ```js
 {
   "presets": [
     ["latest", {
       "es2015": {
-        "modules": false 
+        "modules": false
       }
     }]
   ]
 }
 ```
+
+### `es2016`
+
+`boolean`, defaults to `false`.
+
+Toggles including from the [es2016 preset](/docs/plugins/preset-es2016/).
+
+### `es2017`
+
+`boolean`, defaults to `false`.
+
+Toggles including plugins from the [es2017 preset](/docs/plugins/preset-es2017/).


### PR DESCRIPTION
* Normalizes all the remaining options sections except for `babel-core` and `babel-generator`, the consistency will let us parse/manipulate/lint these sections for the website.

* Fixes a bug with missing closing quote in [babel-plugin-transform-class-properties](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-class-properties/README.md#options)

* Adds `sourceType` to `babel-core` options (fixes https://github.com/babel/babel.github.io/issues/1151)