### PR TITLE
Fix broken repository link in package.json for babel-plugin-transform-react-display-name

### DIFF
--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -2,7 +2,7 @@
   "name": "babel-plugin-transform-react-display-name",
   "version": "6.22.0",
   "description": "Add displayName to React.createClass calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-display-name",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
   "license": "MIT",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
The repository link in the package.json of `babel-plugin-transform-react-display-name` was incorrect. This PR fixes it.
