### PR TITLE
codegen performance: use trim instead of lodash/trimEnd

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -17,7 +17,8 @@
     "detect-indent": "^4.0.0",
     "jsesc": "^1.3.0",
     "lodash": "^4.2.0",
-    "source-map": "^0.5.0"
+    "source-map": "^0.5.0",
+    "trim-right": "^1.0.1"
   },
   "devDependencies": {
     "babel-helper-fixtures": "^6.22.0",

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -87,7 +87,7 @@ export default class Buffer {
   _trimEnd(str: string): string {
     let trimTarget = str.length;
     const whitespace = /\s/;
-    while (trimTarget > 0 && str[trimTarget - 1].match(whitespace)) {
+    while (trimTarget > 0 && whitespace.test(str[trimTarget - 1])) {
       trimTarget--;
     }
     return str.slice(0, trimTarget);

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -39,7 +39,9 @@ export default class Buffer {
 
     const map = this._map;
     const result = {
-      code: this._trimEnd(this._buf.join("")),
+      // Whatever trim is used here should not execute a regex against the
+      // source string since it may be arbitrarily large after all transformations
+      code: this._buf.join("").trimRight(),
       map: null,
       rawMappings: map && map.getRawMappings(),
     };
@@ -82,15 +84,6 @@ export default class Buffer {
 
     const { line, column, filename, identifierName } = this._sourcePosition;
     this._queue.unshift([str, line, column, identifierName, filename]);
-  }
-
-  _trimEnd(str: string): string {
-    let trimTarget = str.length;
-    const whitespace = /\s/;
-    while (trimTarget > 0 && whitespace.test(str[trimTarget - 1])) {
-      trimTarget--;
-    }
-    return str.slice(0, trimTarget);
   }
 
   _flush(): void {

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,5 +1,4 @@
 import type SourceMap from "./source-map";
-import trimEnd from "lodash/trimEnd";
 
 const SPACES_RE = /^[ \t]+$/;
 
@@ -40,7 +39,7 @@ export default class Buffer {
 
     const map = this._map;
     const result = {
-      code: trimEnd(this._buf.join("")),
+      code: this._trimEnd(this._buf.join("")),
       map: null,
       rawMappings: map && map.getRawMappings(),
     };
@@ -83,6 +82,15 @@ export default class Buffer {
 
     const { line, column, filename, identifierName } = this._sourcePosition;
     this._queue.unshift([str, line, column, identifierName, filename]);
+  }
+
+  _trimEnd(str: string): string {
+    let trimTarget = str.length;
+    const whitespace = /\s/;
+    while (trimTarget > 0 && str[trimTarget - 1].match(whitespace)) {
+      trimTarget--;
+    }
+    return str.slice(0, trimTarget);
   }
 
   _flush(): void {

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,4 +1,5 @@
 import type SourceMap from "./source-map";
+import trimRight from "trim-right";
 
 const SPACES_RE = /^[ \t]+$/;
 
@@ -41,7 +42,7 @@ export default class Buffer {
     const result = {
       // Whatever trim is used here should not execute a regex against the
       // source string since it may be arbitrarily large after all transformations
-      code: this._buf.join("").trimRight(),
+      code: trimRight(this._buf.join("")),
       map: null,
       rawMappings: map && map.getRawMappings(),
     };


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | #5081
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

lodash/trimEnd executes a regex against potentially massive strings which can freeze node. Instead find out how much we need to trim off character by character, then slice it off all at once

Fixes #5081

Benchmark:
```js
import Buffer from './buffer';

const buf = new Buffer();
const str = 'x \n \t\n '.repeat(1000000); //string length of 7 million chars

for (let index = 0; index < 20; index++) {
    const time = process.hrtime();
    const result = buf._trimEnd(str);
    const diff = process.hrtime(time);
    const timeNS = diff[0] * 1e9 + diff[1];
    const timeMS = timeNS / 1000000;
    console.log(`${timeMS} ms`);
}
```

Result, first with lodash, then with local implementation:
```
bash-3.2$ node lib/perftest
106.521502 ms
111.613859 ms
110.619436 ms
108.626456 ms
106.573851 ms
118.773115 ms
115.758886 ms
114.970173 ms
113.741202 ms
112.46398 ms
111.008178 ms
113.651342 ms
113.615203 ms
116.468036 ms
109.902413 ms
105.105529 ms
118.988414 ms
119.775734 ms
116.280489 ms
115.562662 ms
bash-3.2$ node lib/perftest
5.051242 ms
0.066738 ms
0.066952 ms
0.010192 ms
0.00808 ms
0.013173 ms
0.006453 ms
0.005716 ms
0.011435 ms
0.004782 ms
0.004849 ms
0.005258 ms
0.004975 ms
0.009258 ms
0.004691 ms
0.004398 ms
0.008326 ms
0.004975 ms
0.249306 ms
0.006354 ms
```