### PR TITLE
checks if babel is installed globally and displays correct cli message

### DIFF
--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
+import isGlobal from "is-global"
+
+const globalMessage = isGlobal() ? ' -g' : '';
 
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +
   "\n" +
-  "    npm uninstall babel\n" +
-  "    npm install babel-cli\n" +
+  "    npm uninstall" + globalMessage + " babel\n" +
+  "    npm install" + globalMessage + " babel-cli\n" +
   "\n" +
   "See http://babeljs.io/docs/usage/cli/ for setup instructions.");
 process.exit(1);

--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const globalMessage = process.env._.includes(process.cwd()) ? "" : " -g";
+const globalMessage = process.env._.includes("/node_modules/.bin/babel") ? "" : " -g";
 
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +

--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -6,7 +6,7 @@ const globalMessage = isGlobal() ? " -g" : "";
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +
   "\n" +
-  "    npm uninstall" + globalMessage + " babel-cli\n" +
+  "    npm uninstall" + globalMessage + " babel\n" +
   "    npm install --save-dev babel-cli\n" +
   "\n" +
   "See http://babeljs.io/docs/usage/cli/ for setup instructions.");

--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-import isGlobal from "is-global"
+const isGlobal = require("is-global");
 
-const globalMessage = isGlobal() ? ' -g' : '';
+const globalMessage = isGlobal() ? " -g" : "";
 
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +
   "\n" +
   "    npm uninstall" + globalMessage + " babel\n" +
-  "    npm install" + globalMessage + " babel-cli\n" +
+  "    npm install --save-dev babel-cli\n" +
   "\n" +
   "See http://babeljs.io/docs/usage/cli/ for setup instructions.");
 process.exit(1);

--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -6,7 +6,7 @@ const globalMessage = isGlobal() ? " -g" : "";
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +
   "\n" +
-  "    npm uninstall" + globalMessage + " babel\n" +
+  "    npm uninstall" + globalMessage + " babel-cli\n" +
   "    npm install --save-dev babel-cli\n" +
   "\n" +
   "See http://babeljs.io/docs/usage/cli/ for setup instructions.");

--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-const isGlobal = require("is-global");
-
-const globalMessage = isGlobal() ? " -g" : "";
+const globalMessage = process.env._.includes(process.cwd()) ? "" : " -g";
 
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +

--- a/packages/babel/cli.js
+++ b/packages/babel/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-const globalMessage = process.env._.includes("/node_modules/.bin/babel") ? "" : " -g";
+const path = require("path");
+const globalMessage = path.dirname(process.execPath) === path.dirname(process.env._ || "") ? " -g" : "";
 
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +
   "Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.\n" +

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -7,10 +7,8 @@
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel",
   "bin": {
-    "babel": "./cli.js",
-    "babel-node": "./cli.js",
-    "babel-external-helpers": "./cli.js"
-  },
-  "dependencies": {},
-  "devDependencies": {}
+    "babel": "./lib/cli.js",
+    "babel-node": "./lib/cli.js",
+    "babel-external-helpers": "./lib/cli.js"
+  }
 }

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -10,5 +10,8 @@
     "babel": "./cli.js",
     "babel-node": "./cli.js",
     "babel-external-helpers": "./cli.js"
+  },
+  "dependencies": {
+    "is-global": "^0.1.0"
   }
 }

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -11,7 +11,6 @@
     "babel-node": "./cli.js",
     "babel-external-helpers": "./cli.js"
   },
-  "dependencies": {
-    "is-global": "^0.1.0"
-  }
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/packages/babel/src/cli.js
+++ b/packages/babel/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-const path = require("path");
+import path from "path";
+
 const globalMessage = path.dirname(process.execPath) === path.dirname(process.env._ || "") ? " -g" : "";
 
 console.error("You have mistakenly installed the `babel` package, which is a no-op in Babel 6.\n" +


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  |  no
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         |  ?
| Tests Added/Pass?        |  no
| Fixed Tickets            |  Fixes #5228
| License                  | MIT
| Doc PR                   | no 
| Dependency Changes       | yes, just to the babel module.  

I've added the [is-globa](https://github.com/gagle/node-is-global)l dependency to ensure this also works on windows. I check against isGlobal to determine if the process is executed globally or from the node module. 

This was difficult to reproduce locally. I tried using `npm link` to test but that undermines the local check.
