### PR TITLE
Config caching

### DIFF
--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -8,6 +8,7 @@ import fs from "fs";
 
 const existsCache = {};
 const configCache = {};
+const ignoreCache = {};
 
 const BABELIGNORE_FILENAME = ".babelignore";
 const BABELRC_FILENAME     = ".babelrc";
@@ -84,12 +85,14 @@ class ConfigChainBuilder {
   }
 
   addIgnoreConfig(loc) {
-    const file  = fs.readFileSync(loc, "utf8");
-    let lines = file.split("\n");
-
-    lines = lines
-      .map((line) => line.replace(/#(.*?)$/, "").trim())
-      .filter((line) => !!line);
+    let lines = ignoreCache[loc];
+    if (!lines) {
+      const file  = fs.readFileSync(loc, "utf8");
+      lines = file.split("\n")
+        .map((line) => line.replace(/#(.*?)$/, "").trim())
+        .filter((line) => !!line);
+      ignoreCache[loc] = lines;
+    }
 
     if (lines.length) {
       this.mergeConfig({

--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -7,7 +7,7 @@ import path from "path";
 import fs from "fs";
 
 const existsCache = {};
-const jsonCache   = {};
+const configCache = {};
 
 const BABELIGNORE_FILENAME = ".babelignore";
 const BABELRC_FILENAME     = ".babelrc";
@@ -107,16 +107,17 @@ class ConfigChainBuilder {
 
     this.resolvedConfigs.push(loc);
 
-    const content = fs.readFileSync(loc, "utf8");
-    let options;
-
-    try {
-      options = jsonCache[content] = jsonCache[content] || json.parse(content);
-      if (key) options = options[key];
-    } catch (err) {
-      err.message = `${loc}: Error while parsing JSON - ${err.message}`;
-      throw err;
+    let options = configCache[loc];
+    if (!options) {
+      try {
+        configCache[loc] = options = json.parse(fs.readFileSync(loc, "utf8"));
+      } catch (err) {
+        err.message = `${loc}: Error while parsing JSON - ${err.message}`;
+        throw err;
+      }
     }
+
+    if (key) options = options[key];
 
     this.mergeConfig({
       options,


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      | yes (kinda)
| Deprecations?            | no
| Spec Compliancy?         | 
| Tests Added/Pass?        | no/pass
| Fixed Tickets            | Improves #3511
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

I've been debugging some build slowness issues with [Node's `--trace-sync-io` flag](https://github.com/nodejs/node/pull/1707) and I noticed `build-config-chain.js` ends up re-re-re-reading the same configuration file(s) over and over again, and as it's using sync IO, the Node.js event loop gets blocked.

This PR adds filename-keyed in-memory caching for configuration (`package.json`/`.babelrc`) and ignore (`.babelignore`) files.

This *should* be backwards-compatible, aside from processes which modify or create Babel configuration or ignore files during the lifetime of the builder process. I think that's a corner case not worth worrying too much about.

## Performance impact

For the build I'm debugging, this seems to remove some 1,500 sync call warnings:
```
$ grep "sync API" babel*txt | cut -f 1 -d: | sort | uniq -c
10625 babel-post-patch.txt
11980 babel-pre-patch.txt
```
Most of the remaining sync call warnings are from `babel-loader`, for which there's a similar PR (https://github.com/babel/babel-loader/pull/375).

To be somewhat more exact using [summarize-sync-io](https://github.com/akx/summarize-sync-io), Babel used to do
```
$ node summarize-sync-io.js < babel-pre-patch.txt  | grep babel-core
###########....       1542 fs.fstatSync by babel-core/lib/transformation/file/options/build-config-chain.js:addConfig
###########....       1542 fs.readSync by babel-core/lib/transformation/file/options/build-config-chain.js:addConfig
###########....       1542 fs.openSync by babel-core/lib/transformation/file/options/build-config-chain.js:addConfig
###............        263 fs.existsSync by babel-core/lib/transformation/file/options/build-config-chain.js:exists
#..............         14 fs.lstatSync by babel-core/lib/helpers/resolve.js:exports.default
```

and with this patch, it does
```
$ node summarize-sync-io.js < babel-post-patch.txt  | grep babel-core
###############        263 fs.existsSync by babel-core/lib/transformation/file/options/build-config-chain.js:exists
###............         32 fs.readSync by babel-core/lib/transformation/file/options/build-config-chain.js:addConfig
###............         32 fs.openSync by babel-core/lib/transformation/file/options/build-config-chain.js:addConfig
###............         32 fs.fstatSync by babel-core/lib/transformation/file/options/build-config-chain.js:addConfig
##.............         14 fs.lstatSync by babel-core/lib/helpers/resolve.js:exports.default
```

for this particular build. :)

As for memory usage impact, I expect it to be negligible -- adding eslintignore files to the cache has to be _peanuts_ all considered.