### PR TITLE
Fix loose for-of with label

### DIFF
--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -135,9 +135,8 @@ export default function ({ messages, template, types: t }) {
   };
 
   function loose(path, file) {
-    const { node, scope } = path;
-
-    const left = node.left;
+    const { node, scope, parent } = path;
+    const { left } = node;
     let declar, id;
 
     if (t.isIdentifier(left) || t.isPattern(left) || t.isMemberExpression(left)) {
@@ -171,11 +170,18 @@ export default function ({ messages, template, types: t }) {
     }
 
     //
+    const isLabeledParent = t.isLabeledStatement(parent);
+    let labeled;
+
+    if (isLabeledParent) {
+      labeled = t.labeledStatement(parent.label, loop);
+    }
 
     return {
-      declar: declar,
-      node:   loop,
-      loop:   loop
+      replaceParent: isLabeledParent,
+      declar:        declar,
+      node:          labeled || loop,
+      loop:          loop
     };
   }
 

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/loose/nested-label-for-of/actual.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/loose/nested-label-for-of/actual.js
@@ -1,0 +1,5 @@
+b: for (let c of d()) {
+  for (let e of f()) {
+    continue b;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-for-of/test/fixtures/loose/nested-label-for-of/expected.js
+++ b/packages/babel-plugin-transform-es2015-for-of/test/fixtures/loose/nested-label-for-of/expected.js
@@ -1,0 +1,31 @@
+b: for (var _iterator = d(), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+  var _ref;
+
+  if (_isArray) {
+    if (_i >= _iterator.length) break;
+    _ref = _iterator[_i++];
+  } else {
+    _i = _iterator.next();
+    if (_i.done) break;
+    _ref = _i.value;
+  }
+
+  let c = _ref;
+
+  for (var _iterator2 = f(), _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
+    var _ref2;
+
+    if (_isArray2) {
+      if (_i2 >= _iterator2.length) break;
+      _ref2 = _iterator2[_i2++];
+    } else {
+      _i2 = _iterator2.next();
+      if (_i2.done) break;
+      _ref2 = _i2.value;
+    }
+
+    let e = _ref2;
+
+    continue b;
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes?
| Tests Added/Pass?        | Yes
| Fixed Tickets            | N/A
| License                  | MIT
| Doc PR                   | N/A
| Dependency Changes       | N/A

Transforming a for-of with a label in loose mode was dropping the label. 💩