### PR TITLE
Revert "Upgrade lerna to current beta."

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.37",
+  "lerna": "2.0.0-beta.23",
   "version": "6.22.2",
   "changelog": {
     "repo": "babel/babel",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",
-    "lerna": "2.0.0-beta.37",
+    "lerna": "2.0.0-beta.23",
     "lerna-changelog": "^0.2.0",
     "lodash": "^4.2.0",
     "mocha": "^3.0.0",


### PR DESCRIPTION
Reverts babel/babel#5300

Alas, The new beta does not support Node 0.12.