### PR TITLE
Ignore babel-register test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist
 /.package.json
 /packages/babel-runtime/core-js
 /packages/babel-runtime/helpers/*.js
+/packages/babel-register/test/.babel
 /packages/*/lib
 _babel.github.io
 /tests/.browser-build.js


### PR DESCRIPTION
Missed this in https://github.com/babel/babel/pull/5260, and matches fix in [`7.0` branch](https://github.com/babel/babel/blob/7.0/.gitignore#L17).