### PR TITLE
Switch decorators-legacy to decorators in the Stage 1 Preset (#5318)

### DIFF
--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-decorators": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-preset-stage-2": "^6.22.0"
   }

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -1,6 +1,6 @@
 import presetStage2 from "babel-preset-stage-2";
 
-import transformDecoratorsLegacy from "babel-plugin-transform-decorators-legacy";
+import transformDecorators from "babel-plugin-transform-decorators";
 import transformExportExtensions from "babel-plugin-transform-export-extensions";
 
 export default {
@@ -8,7 +8,7 @@ export default {
     presetStage2
   ],
   plugins: [
-    transformDecoratorsLegacy,
+    transformDecorators,
     transformExportExtensions
   ]
 };


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | Fixes #5318  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Just remove the `-legacy` in two places and rename one variable.
