### PR TITLE
Fix for-await printing

### DIFF
--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -87,13 +87,13 @@ const buildForXStatement = function (op) {
     if (op === "await") {
       this.word("await");
       this.space();
-      op = "of";
+      // do not attempt to change op here, as it will break subsequent for-await statements
     }
     this.token("(");
 
     this.print(node.left, node);
     this.space();
-    this.word(op);
+    this.word(op === "await" ? "of" : op);
     this.space();
     this.print(node.right, node);
     this.token(")");

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x/expected.js
@@ -18,11 +18,11 @@ async function a() {
 for ({ a } in {}) {}
 for ({ a } of []) {}
 async function a() {
-  for ({ a } of []) {}
+  for await ({ a } of []) {}
 }
 
 for (a in {}) {}
 for (a of []) {}
 async function a() {
-  for (a of []) {}
+  for await (a of []) {}
 }


### PR DESCRIPTION


| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  y
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | y
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

Only the first for-await was correctly re-printed as for-await all subsequent for-await statements
where printed as for-of as the variable op was changed inside the buildForXStatement during the first run.
