### PR TITLE
Correctly convert MemberExpressions with require() to AMD/UMD

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -25,6 +25,10 @@ export default function ({ types: t }) {
     return true;
   }
 
+  function hasProgramScope(path) {
+    return path.scope.getProgramParent() === path.scope;
+  }
+
   const amdVisitor = {
     ReferencedIdentifier({ node, scope }) {
       if (node.name === "exports" && !scope.getBinding("exports")) {
@@ -38,6 +42,10 @@ export default function ({ types: t }) {
 
     CallExpression(path) {
       if (!isValidRequireCall(path)) return;
+      if (!hasProgramScope(path)) {
+        this.hasRequire = true;
+        return;
+      }
       this.bareSources.push(path.node.arguments[0]);
       path.remove();
     },
@@ -46,6 +54,10 @@ export default function ({ types: t }) {
       const object = path.get("object");
 
       if (!isValidRequireCall(object)) return;
+      if (!hasProgramScope(path)) {
+        this.hasRequire = true;
+        return;
+      }
 
       const source = object.node.arguments[0];
       const id = path.scope.generateUidIdentifier(source.value);
@@ -61,6 +73,10 @@ export default function ({ types: t }) {
 
       const init = path.get("init");
       if (!isValidRequireCall(init)) return;
+      if (!hasProgramScope(path)) {
+        this.hasRequire = true;
+        return;
+      }
 
       const source = init.node.arguments[0];
       this.sourceNames[source.value] = true;
@@ -83,6 +99,7 @@ export default function ({ types: t }) {
 
       this.hasExports = false;
       this.hasModule = false;
+      this.hasRequire = false;
     },
 
     visitor: {
@@ -102,6 +119,11 @@ export default function ({ types: t }) {
 
           let moduleName = this.getModuleName();
           if (moduleName) moduleName = t.stringLiteral(moduleName);
+
+          if (this.hasRequire) {
+            sources.unshift(t.stringLiteral("require"));
+            params.unshift(t.identifier("require"));
+          }
 
           if (this.hasExports) {
             sources.unshift(t.stringLiteral("exports"));

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -42,6 +42,19 @@ export default function ({ types: t }) {
       path.remove();
     },
 
+    MemberExpression(path) {
+      const object = path.get("object");
+
+      if (!isValidRequireCall(object)) return;
+
+      const source = object.node.arguments[0];
+      const id = path.scope.generateUidIdentifier(source.value);
+      this.sourceNames[source.value] = true;
+      this.sources.push([id, source]);
+
+      object.replaceWith(id);
+    },
+
     VariableDeclarator(path) {
       const id = path.get("id");
       if (!id.isIdentifier()) return;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/actual.js
@@ -1,7 +1,7 @@
 const _module = "test";
+let _module1 = require("foo").bar;
 
 function foo () {
-  let _module1 = require("foo").bar;
   require("module").test();
 }
 

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/actual.js
@@ -1,0 +1,7 @@
+const _module = "test";
+
+function foo () {
+  let _module1 = require("foo").bar;
+  require("module").test();
+}
+

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/expected.js
@@ -1,0 +1,10 @@
+define(["foo", "module"], function (_foo, _module2) {
+  "use strict";
+
+  const _module = "test";
+
+  function foo() {
+    let _module1 = _foo.bar;
+    _module2.test();
+  }
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/expected.js
@@ -1,10 +1,10 @@
-define(["foo", "module"], function (_foo, _module2) {
+define(["require", "foo"], function (require, _foo) {
   "use strict";
 
   const _module = "test";
+  let _module1 = _foo.bar;
 
   function foo() {
-    let _module1 = _foo.bar;
-    _module2.test();
+    require("module").test();
   }
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/issue-4281/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-modules-amd"]
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | n
| Tests Added/Pass?        | y
| Fixed Tickets            | Fixes #4281 Fixes babel/babel-loader#373
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

MemberExpressions with `require()` where transformed incorrectly.

```js
require('test').a;
```

In this code the CallExpression was removed resulting in this code:

```js
.a;
```

which is invalid and therefore the validation throw an exception as seen in #4281.

The fix correctly handles MemberExpressions and replaces the CallExpression with an identifier to the amd import.
