### PR TITLE
Fix 'o' is undefined in example code

### DIFF
--- a/packages/babel-plugin-transform-es2015-spread/README.md
+++ b/packages/babel-plugin-transform-es2015-spread/README.md
@@ -11,7 +11,7 @@ var a = ['a', 'b', 'c'];
 var b = [...a, 'foo'];
 
 var c = { foo: 'bar', baz: 42 };
-var d = {...o, a: 2};
+var d = {...c, a: 2};
 ```
 
 **Out**
@@ -33,7 +33,7 @@ var a = [ 'a', 'b', 'c' ];
 var b = [].concat(a, [ 'foo' ]);
 
 var c = { foo: 'bar', baz: 42 };
-var d = _extends({}, o, { a: 2 });
+var d = _extends({}, c, { a: 2 });
 ```
 
 ## Installation


### PR DESCRIPTION
Fixed a reference to an undefined variable in the documentations example code.
