### PR TITLE
Update CONTRIBUTING.md with new way to run coverage check [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ $ TEST_DEBUG=true make test
 To test the code coverage, use:
 
 ```sh
-$ make test-cov
+$ make test-ci-coverage
 ```
 
 #### Writing tests


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | none
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | no

CONTRIBUTING.md referred to an old and no longer used way to run the coverage check. I just updated it to reflect the current Makefile.
