### PR TITLE
fixed issue where multiline JSXElement does not wrap with ()

### DIFF
--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -46,6 +46,20 @@ export function ObjectExpression(node: Object, parent: Object, printStack: Array
   return isFirstInStatement(printStack, { considerArrow: true });
 }
 
+const isMultiLine = (n) => {
+  const { loc:{ start, end } } = n;
+  return start.line < end.line;
+};
+
+
+export function JSXElement(node: Object, parent: Object): boolean {
+
+  return (
+    t.isReturnStatement(parent) ||
+    t.isArrowFunctionExpression(parent)
+  ) && isMultiLine(node);
+}
+
 export function Binary(node: Object, parent: Object): boolean {
   if ((t.isCallExpression(parent) || t.isNewExpression(parent)) && parent.callee === node) {
     return true;

--- a/packages/babel-generator/test/'
+++ b/packages/babel-generator/test/'
@@ -1,0 +1,3 @@
+const FunctionalElement = _ => (<div>
+  someText
+</div>)

--- a/packages/babel-generator/test/fixtures/parentheses/arrow-function-jsx/actual.js
+++ b/packages/babel-generator/test/fixtures/parentheses/arrow-function-jsx/actual.js
@@ -1,0 +1,3 @@
+const FunctionalElement = _ => (<div>
+  someText
+</div>);

--- a/packages/babel-generator/test/fixtures/parentheses/arrow-function-jsx/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/arrow-function-jsx/expected.js
@@ -1,0 +1,3 @@
+const FunctionalElement = _ => (<div>
+  someText
+</div>);

--- a/packages/babel-generator/test/fixtures/parentheses/return-expression-jsx/actual.js
+++ b/packages/babel-generator/test/fixtures/parentheses/return-expression-jsx/actual.js
@@ -1,0 +1,8 @@
+const modifyName = name => name + ' modified ';
+
+const Element = ({ name: input }) => {
+  const name = modifyName(input);
+  return (<div>
+    {name}
+  </div>);
+};

--- a/packages/babel-generator/test/fixtures/parentheses/return-expression-jsx/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/return-expression-jsx/expected.js
@@ -1,0 +1,8 @@
+const modifyName = name => name + ' modified ';
+
+const Element = ({ name: input }) => {
+  const name = modifyName(input);
+  return (<div>
+    {name}
+  </div>);
+};

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/children/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/children/expected.js
@@ -2,8 +2,8 @@ var _ref = <span />;
 
 var Foo = React.createClass({
   render: function () {
-    return <div className={this.props.className}>
+    return (<div className={this.props.className}>
       {_ref}
-    </div>;
+    </div>);
   }
 });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  |  no
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         |  no
| Tests Added/Pass?        | yes
| Fixed Tickets            |  Not Yet Reported
| License                  | MIT
| Doc PR                   |  No
| Dependency Changes       |  No

<!-- Describe your changes below in as much detail as possible -->

Babel-generator does not properly wrap multi-lined JSXElement in parenthesis after `ReturnExpression` or `ArrowExpression` . I was using babel libs for codemod and found this issue. I actually had to modify a test in another package to get all the tests passing. I didn't find anything in the contribution guide with regards to breaking other packages test while fixing a bug so i just fixed it anyways. This is actually my first time contributing. Let me know if there are problems. I'd be glad to fix them

