### PR TITLE
Improve babel-generator's code coverage

### DIFF
--- a/packages/babel-generator/src/generators/modules.js
+++ b/packages/babel-generator/src/generators/modules.js
@@ -45,12 +45,6 @@ export function ExportAllDeclaration(node: Object) {
   this.word("export");
   this.space();
   this.token("*");
-  if (node.exported) {
-    this.space();
-    this.word("as");
-    this.space();
-    this.print(node.exported, node);
-  }
   this.space();
   this.word("from");
   this.space();

--- a/packages/babel-generator/test/fixtures/types/DoExpression/actual.js
+++ b/packages/babel-generator/test/fixtures/types/DoExpression/actual.js
@@ -1,0 +1,7 @@
+let a = do {
+  if (x > 10) {
+    'big';
+  } else {
+    'small';
+  }
+};

--- a/packages/babel-generator/test/fixtures/types/DoExpression/expected.js
+++ b/packages/babel-generator/test/fixtures/types/DoExpression/expected.js
@@ -1,0 +1,7 @@
+let a = do {
+  if (x > 10) {
+    'big';
+  } else {
+    'small';
+  }
+};

--- a/packages/babel-generator/test/fixtures/types/LogicalExpression/actual.js
+++ b/packages/babel-generator/test/fixtures/types/LogicalExpression/actual.js
@@ -1,0 +1,2 @@
+foo ||bar;
+(x => x)|| bar;

--- a/packages/babel-generator/test/fixtures/types/LogicalExpression/expected.js
+++ b/packages/babel-generator/test/fixtures/types/LogicalExpression/expected.js
@@ -1,0 +1,2 @@
+foo || bar;
+(x => x) || bar;


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | #5326
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
I worked on improvement `babel-generator`s code coverage: added a couple of tests, removed the code that does not meet spec (`ExportAllDeclaration` has no `exported` field, [proof](https://github.com/babel/babylon/blob/master/ast/spec.md#exportalldeclaration)) and I proposed to remove the obsolete code (https://github.com/babel/babel/pull/5317/commits/7e540cdcc9a31d42bef50ded1aa55c7244b17b25).

I see no reason to test [this code](https://codecov.io/gh/babel/babel/src/master/packages/babel-generator/src/generators/types.js#L10), it is [deleted](https://github.com/babel/babel/pull/5317/commits/7e540cdcc9a31d42bef50ded1aa55c7244b17b25) in 7.0.