### PR TITLE
Add test for passing arguments to babel-node (#5163)

### DIFF
--- a/packages/babel-cli/test/fixtures/babel-node/arguments/in-files/bar.js
+++ b/packages/babel-cli/test/fixtures/babel-node/arguments/in-files/bar.js
@@ -1,0 +1,1 @@
+console.log(process.argv[2]);

--- a/packages/babel-cli/test/fixtures/babel-node/arguments/options.json
+++ b/packages/babel-cli/test/fixtures/babel-node/arguments/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["bar", "foo"],
+  "stdout": "foo"
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  N
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            |  
| Spec Compliancy?         | 
| Tests Added/Pass?        | Y
| Fixed Tickets            | close #5163
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

This PR is adding a test for passing arguments to babel-node which is addressed by #5162 . I checked it pass the test case and it is failed when I revert the changes of #5162 .

I not sure the test folder name is properly because it's my first PR on babel. Let me know if I miss something.