### PR TITLE
Remove redundant NODE_ENV=test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ test-only:
 test: lint test-only
 
 test-ci:
-	NODE_ENV=test make bootstrap
+	make bootstrap
 	make test-only
 
 test-ci-coverage:
-	NODE_ENV=test BABEL_ENV=cov make bootstrap
+	BABEL_ENV=cov make bootstrap
 	./scripts/test-cov.sh
 	./node_modules/.bin/codecov -f coverage/coverage-final.json
 


### PR DESCRIPTION
`NODE_ENV=test` is exported by default in `Makefile`. Therefore, targets that set `NODE_ENV` to `test` are cleaned up.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         |
| Tests Added/Pass?        | no
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | no<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no 

<!-- Describe your changes below in as much detail as possible -->
