### PR TITLE
Force transform-runtime to only work while file is a module.

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -250,6 +250,8 @@ export default class File extends Store {
   }
 
   addImport(source: string, imported: string, name?: string = imported): Object {
+    if (this.path.node.sourceType !== "module") throw new Error("Cannot insert an import into a script.");
+
     const alias = `${source}:${imported}`;
     let id = this.dynamicImportIds[alias];
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -131,23 +131,20 @@ export default function () {
 
     visitor: {
       ThisExpression(path, state) {
-        // If other plugins run after this plugin's Program#exit handler, we allow them to
-        // insert top-level `this` values. This allows the AMD and UMD plugins to
-        // function properly.
-        if (this.ranCommonJS) return;
+        if (state.opts.allowTopLevelThis === true) return;
 
-        if (
-          state.opts.allowTopLevelThis !== true &&
-          !path.findParent((path) => !path.is("shadow") &&
-          THIS_BREAK_KEYS.indexOf(path.type) >= 0)
-        ) {
+        const program = path.findParent((p) => p.isProgram());
+        if (program.node.sourceType !== "module") return;
+
+        if (!path.findParent((path) => !path.is("shadow") && THIS_BREAK_KEYS.indexOf(path.type) >= 0)) {
           path.replaceWith(t.identifier("undefined"));
         }
       },
 
       Program: {
         exit(path) {
-          this.ranCommonJS = true;
+          if (path.node.sourceType !== "module") return;
+          path.node.sourceType = "script";
 
           const strict = !!this.opts.strict;
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/actual.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/actual.js
@@ -1,2 +1,4 @@
 import foo from "bar";
 foo;
+
+export * from "foo";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/expected.js
@@ -1,5 +1,21 @@
 "use strict";
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require("foo");
+
+Object.keys(_foo).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return _foo[key];
+    }
+  });
+});
+
 var _bar = require("bar");
 
 var _bar2 = _interopRequireDefault(_bar);

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -86,6 +86,7 @@ function buildHelper(helperName) {
   var tree = t.program([
     t.exportDefaultDeclaration(helpers.get(helperName))
   ]);
+  tree.sourceType = "module";
 
   return babel.transformFromAst(tree, null, {
     presets: transformOpts.presets,


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | Y
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes #2877 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

Toggle `sourceType` on the AST to "script" (which we should have been doing for a long time but haven't), and then use that as a flag to disable `transform-runtime`. This means that if you insert something after Program#exit that would require a helper, it will not be transformed. I think that's reasonable because it should probably be up to the transform at that point to not insert stuff that will require a runtime helper.

Not sure there is a better way to do this, but if this does expose other edge cases, at least it is a step in the right direction.