### PR TITLE
Replace lodash/assign with Object.assign

### DIFF
--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -2,7 +2,6 @@ import OptionManager from "./file/options/option-manager";
 import * as messages from "babel-messages";
 import Store from "../store";
 import traverse from "babel-traverse";
-import assign from "lodash/assign";
 import clone from "lodash/clone";
 
 const GLOBAL_VISITOR_PROPS = ["enter", "exit"];
@@ -12,7 +11,7 @@ export default class Plugin extends Store {
     super();
 
     this.initialized = false;
-    this.raw         = assign({}, plugin);
+    this.raw         = Object.assign({}, plugin);
     this.key         = this.take("name") || key;
 
     this.manipulateOptions = this.take("manipulateOptions");

--- a/packages/babel-template/src/index.js
+++ b/packages/babel-template/src/index.js
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import assign from "lodash/assign";
 import has from "lodash/has";
 import traverse from "babel-traverse";
 import * as babylon from "babylon";
@@ -23,7 +22,7 @@ export default function (code: string, opts?: Object): Function {
     }
   }
 
-  opts = assign({
+  opts = Object.assign({
     allowReturnOutsideFunction: true,
     allowSuperOutsideMethod: true,
     preserveComments: false,

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -4,7 +4,6 @@ import * as virtualTypes from "./lib/virtual-types";
 import buildDebug from "debug";
 import invariant from "invariant";
 import traverse from "../index";
-import assign from "lodash/assign";
 import Scope from "../scope";
 import * as t from "babel-types";
 import { path as pathCache } from "../cache";
@@ -164,7 +163,7 @@ export default class NodePath {
   }
 }
 
-assign(NodePath.prototype,
+Object.assign(NodePath.prototype,
   NodePath_ancestry,
   NodePath_inference,
   NodePath_replacement,


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  |  no
| Minor: New Feature?      |  no
| Deprecations?            | no
| Spec Compliancy?         | 
| Tests Added/Pass?        | no
| Fixed Tickets            | Fixes #5353 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

I have made the following changes with this PR:

- [x]  Search for imports of `lodash/assign` and its usages and change to use `Object.assign`
- [x]  Search for imports of `lodash` and usages (`lodsh.assign`) and change to use `Object.assign`
- [x]  In the packages where some lodash imports were removed due to the last two tasks, check if these usages were the last ones to use `lodash` and if so remove `lodash` dependency from package.json

Since the packages affected are using lodash in other places I didn't remove it from de dependencies in the file `package.json`.

I also run the tests for each package and they passed.