### PR TITLE
Add strict option

### DIFF
--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -36,15 +36,18 @@ function preset(context, opts = {}) {
   let loose = false;
   let modules = "commonjs";
   let spec = false;
+  let strict = true;
 
   if (opts !== undefined) {
     if (opts.loose !== undefined) loose = opts.loose;
     if (opts.modules !== undefined) modules = opts.modules;
     if (opts.spec !== undefined) spec = opts.spec;
+    if (opts.strict !== undefined) strict = opts.strict;
   }
 
   if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
   if (typeof spec !== "boolean") throw new Error("Preset es2015 'spec' option must be a boolean.");
+  if (typeof strict !== "boolean") throw new Error("Preset es2015 'strict' option must be a boolean.");
   if (modules !== false && moduleTypes.indexOf(modules) === -1) {
     throw new Error("Preset es2015 'modules' option must be 'false' to indicate no modules\n" +
       "or a module type which be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'");
@@ -74,7 +77,7 @@ function preset(context, opts = {}) {
       [transformES2015Destructuring, optsLoose],
       transformES2015BlockScoping,
       transformES2015TypeofSymbol,
-      modules === "commonjs" && [transformES2015ModulesCommonJS, optsLoose],
+      modules === "commonjs" && [transformES2015ModulesCommonJS, { loose, strict }],
       modules === "systemjs" && [transformES2015ModulesSystemJS, optsLoose],
       modules === "amd" && [transformES2015ModulesAMD, optsLoose],
       modules === "umd" && [transformES2015ModulesUMD, optsLoose],


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no 
| Minor: New Feature?      |  yes
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| License                  | MIT
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
I've added the strict option in order to disable the default "use strict" mode used in the more external eval function. The reason for this is the dependency of this module over the babel-plugin-transform-es2015-modules-commonjs whose depend on babel-plugin-transform-strict-mode.

Actually there is no way to pass the strict option from the es2015 preset down to the commonjs plugin and for this reason was born this modules babel-preset-es2015-without-strict whose only scope is to prevent the use of the strict mode. I don't want use the babel-preset-es2015-without-strict because it can be not aligned with the official one so I think that could be good have this option exposed.
