### PR TITLE
Handle FunctionDeclarations in ExportDefaultDeclaration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ packages/*/node_modules
 packages/*/lib
 packages/*/dist
 packages/*/test/fixtures
+packages/*/test/tmp
 vendor
 _babel.github.io
 Gulpfile.js

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -145,6 +145,15 @@ function plainFunction(path: NodePath, callId: Object) {
     ]);
     declar._blockHoist = true;
 
+    if (path.parentPath.isExportDefaultDeclaration()) {
+      // change the path type so that replaceWith() does not wrap
+      // the identifier into an expressionStatement
+      path.type = "FunctionExpression";
+      path.parentPath.insertBefore(declar);
+      path.replaceWith(t.identifier(asyncFnId.name));
+      return;
+    }
+
     path.replaceWith(declar);
   } else {
     const retFunction = container.body.body[1].argument;

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -148,9 +148,17 @@ function plainFunction(path: NodePath, callId: Object) {
     if (path.parentPath.isExportDefaultDeclaration()) {
       // change the path type so that replaceWith() does not wrap
       // the identifier into an expressionStatement
-      path.type = "FunctionExpression";
       path.parentPath.insertBefore(declar);
-      path.replaceWith(t.identifier(asyncFnId.name));
+      path.parentPath.replaceWith(
+        t.exportNamedDeclaration(null,
+          [
+            t.exportSpecifier(
+              t.identifier(asyncFnId.name),
+              t.identifier("default")
+            )
+          ]
+        )
+      );
       return;
     }
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-arrow-export/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-arrow-export/actual.js
@@ -1,0 +1,1 @@
+export default async () => { return await foo(); }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-arrow-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-arrow-export/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = babelHelpers.asyncToGenerator(function* () {
+  return yield foo();
+});

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-export/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-export/actual.js
@@ -1,0 +1,1 @@
+export default async function myFunc() {}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/.default-export/expected.js
@@ -1,0 +1,15 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+let myFunc = (() => {
+  var _ref = babelHelpers.asyncToGenerator(function* () {});
+
+  return function myFunc() {
+    return _ref.apply(this, arguments);
+  };
+})();
+
+exports.default = myFunc;


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  y
| Major: Breaking Change?  |  n
| Minor: New Feature?      |  n
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes babel/babylon#374
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

This fix works with all babylon version independent if babel/babylon#377 is merged.

~The fix is a little bit weird, because I have to set the path.type to an FunctionExpression in order to make replaceWith() not to wrap the identifier into an expressionStatement.~

The test output differs if using babylon with babel/babylon#377 or without. So the tests are disabled but already cover the case with the PR.