### PR TITLE
[7.0] Remove the unneeded Pipeline class.

### DIFF
--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -27,13 +27,8 @@ export function Plugin(alias) {
   throw new Error(`The (${alias}) Babel 5 plugin is being run with Babel 6.`);
 }
 
-import Pipeline from "./transformation/pipeline";
-export { Pipeline };
-
-const pipeline = new Pipeline;
-export const analyse = pipeline.analyse.bind(pipeline);
-export const transform = pipeline.transform.bind(pipeline);
-export const transformFromAst = pipeline.transformFromAst.bind(pipeline);
+import { transform, analyse, transformFromAst } from "./transformation/pipeline";
+export { transform, analyse, transformFromAst };
 
 export function transformFile(filename: string, opts?: Object, callback: Function) {
   if (typeof opts === "function") {

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -4,7 +4,6 @@ import getHelper from "babel-helpers";
 import * as metadataVisitor from "./metadata";
 import convertSourceMap from "convert-source-map";
 import OptionManager from "./options/option-manager";
-import type Pipeline from "../pipeline";
 import PluginPass from "../plugin-pass";
 import { NodePath, Hub, Scope } from "babel-traverse";
 import sourceMap from "source-map";
@@ -42,10 +41,8 @@ const errorVisitor = {
 };
 
 export default class File extends Store {
-  constructor(opts: Object = {}, pipeline: Pipeline) {
+  constructor(opts: Object = {}) {
     super();
-
-    this.pipeline = pipeline;
 
     this.log  = new Logger(this, opts.filename || "unknown");
     this.opts = this.initOptions(opts);
@@ -105,7 +102,6 @@ export default class File extends Store {
 
   pluginVisitors: Array<Object>;
   pluginPasses: Array<PluginPass>;
-  pipeline: Pipeline;
   parserOpts: BabelParserOptions;
   log: Logger;
   opts: Object;
@@ -136,7 +132,7 @@ export default class File extends Store {
   }
 
   initOptions(opts) {
-    opts = new OptionManager(this.log, this.pipeline).init(opts);
+    opts = new OptionManager(this.log).init(opts);
 
     if (opts.inputSourceMap) {
       opts.sourceMaps = true;

--- a/packages/babel-core/src/transformation/pipeline.js
+++ b/packages/babel-core/src/transformation/pipeline.js
@@ -3,48 +3,31 @@ import normalizeAst from "../helpers/normalize-ast";
 import Plugin from "./plugin";
 import File from "./file";
 
-export default class Pipeline {
-  lint(code: string, opts?: Object = {}): BabelFileResult {
-    opts.code = false;
-    opts.mode = "lint";
-    return this.transform(code, opts);
+export function analyse(code: string, opts: Object = {}, visitor?: Object): ?BabelFileMetadata {
+  opts.code = false;
+  if (visitor) {
+    opts.plugins = opts.plugins || [];
+    opts.plugins.push(new Plugin({ visitor }));
   }
+  return transform(code, opts).metadata;
+}
 
-  pretransform(code: string, opts?: Object): BabelFileResult {
-    const file = new File(opts, this);
-    return file.wrap(code, function () {
-      file.addCode(code);
-      file.parseCode(code);
-      return file;
-    });
-  }
+export function transform(code: string, opts?: Object): BabelFileResult {
+  const file = new File(opts);
+  return file.wrap(code, function () {
+    file.addCode(code);
+    file.parseCode(code);
+    return file.transform();
+  });
+}
 
-  transform(code: string, opts?: Object): BabelFileResult {
-    const file = new File(opts, this);
-    return file.wrap(code, function () {
-      file.addCode(code);
-      file.parseCode(code);
-      return file.transform();
-    });
-  }
+export function transformFromAst(ast: Object, code: string, opts: Object): BabelFileResult {
+  ast = normalizeAst(ast);
 
-  analyse(code: string, opts: Object = {}, visitor?: Object): ?BabelFileMetadata {
-    opts.code = false;
-    if (visitor) {
-      opts.plugins = opts.plugins || [];
-      opts.plugins.push(new Plugin({ visitor }));
-    }
-    return this.transform(code, opts).metadata;
-  }
-
-  transformFromAst(ast: Object, code: string, opts: Object): BabelFileResult {
-    ast = normalizeAst(ast);
-
-    const file = new File(opts, this);
-    return file.wrap(code, function () {
-      file.addCode(code);
-      file.addAst(ast);
-      return file.transform();
-    });
-  }
+  const file = new File(opts);
+  return file.wrap(code, function () {
+    file.addCode(code);
+    file.addAst(ast);
+    return file.transform();
+  });
 }


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  N
| Major: Breaking Change?  | Y, barely
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

I'm trying to remove things from the public API that aren't actually needed for public use. The official APIs for this are already available on the overall `babel-core` import, there isn't any reason to expose this class too.

I removed `pretransform` and `lint` because they don't seem to do anything useful. If we want to keep them, we should expose them like `transform` and `analyze` and such instead of using a class.

