### PR TITLE
Add strict option to es2015 preset

### DIFF
--- a/packages/babel-preset-es2015/README.md
+++ b/packages/babel-preset-es2015/README.md
@@ -42,6 +42,12 @@ require("babel-core").transform("code", {
 
 Enable "loose" transformations for any plugins in this preset that allow them.
 
+### `strict`
+
+`boolean`, defaults to `false`.
+
+Enable "strict" transformations for any plugins in this preset that allow them.
+
 ### `modules`
 
 `"amd" | "umd" | "systemjs" | "commonjs" | false`, defaults to `"commonjs"`.

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -28,15 +28,18 @@ export default function (context, opts = {}) {
   let loose = false;
   let modules = "commonjs";
   let spec = false;
+  let strict = false;
 
   if (opts !== undefined) {
     if (opts.loose !== undefined) loose = opts.loose;
     if (opts.modules !== undefined) modules = opts.modules;
     if (opts.spec !== undefined) spec = opts.spec;
+    if (opts.strict !== undefined) strict = opts.strict;
   }
 
   if (typeof loose !== "boolean") throw new Error("Preset es2015 'loose' option must be a boolean.");
   if (typeof spec !== "boolean") throw new Error("Preset es2015 'spec' option must be a boolean.");
+  if (typeof strict !== "boolean") throw new Error("Preset es2015 'strict' option must be a boolean.");
   if (modules !== false && moduleTypes.indexOf(modules) === -1) {
     throw new Error("Preset es2015 'modules' option must be 'false' to indicate no modules\n" +
       "or a module type which be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'");
@@ -64,9 +67,9 @@ export default function (context, opts = {}) {
       [transformES2015Spread, optsLoose],
       transformES2015Parameters,
       [transformES2015Destructuring, optsLoose],
-      transformES2015BlockScoping,
+      [transformES2015BlockScoping, { "throwIfClosureRequired": strict }],
       transformES2015TypeofSymbol,
-      modules === "commonjs" && [transformES2015ModulesCommonJS, optsLoose],
+      modules === "commonjs" && [transformES2015ModulesCommonJS, { loose, strict: strict || undefined }],
       modules === "systemjs" && [transformES2015ModulesSystemJS, optsLoose],
       modules === "amd" && [transformES2015ModulesAMD, optsLoose],
       modules === "umd" && [transformES2015ModulesUMD, optsLoose],

--- a/packages/babel-preset-es2015/test/fixtures/option-strict-false/block-scoping/actual.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict-false/block-scoping/actual.js
@@ -1,0 +1,6 @@
+for (let i = 0; i < 5; i++) {
+  const l = i;
+  setTimeout(function() {
+    console.log(l);
+  }, 1);
+}

--- a/packages/babel-preset-es2015/test/fixtures/option-strict-false/block-scoping/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict-false/block-scoping/expected.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var _loop = function _loop(i) {
+  var l = i;
+  setTimeout(function () {
+    console.log(l);
+  }, 1);
+};
+
+for (var i = 0; i < 5; i++) {
+  _loop(i);
+}

--- a/packages/babel-preset-es2015/test/fixtures/option-strict-false/modules-commonjs/actual.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict-false/modules-commonjs/actual.js
@@ -1,0 +1,9 @@
+import foo from "foo";
+import { default as foo2 } from "foo";
+import { foo3 } from "foo";
+import * as foo4 from "foo";
+
+foo;
+foo2;
+foo3;
+foo3();

--- a/packages/babel-preset-es2015/test/fixtures/option-strict-false/modules-commonjs/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict-false/modules-commonjs/expected.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var _foo = require("foo");
+
+var foo4 = _interopRequireWildcard(_foo);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+foo4.default;
+foo4.default;
+_foo.foo3;
+(0, _foo.foo3)();

--- a/packages/babel-preset-es2015/test/fixtures/option-strict-false/options.json
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict-false/options.json
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["es2015", { "strict": false }]
+  ]
+}

--- a/packages/babel-preset-es2015/test/fixtures/option-strict/block-scoping/actual.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict/block-scoping/actual.js
@@ -1,0 +1,6 @@
+for (let i = 0; i < 5; i++) {
+  const l = i;
+  setTimeout(function() {
+    console.log(l);
+  }, 1);
+}

--- a/packages/babel-preset-es2015/test/fixtures/option-strict/block-scoping/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict/block-scoping/expected.js
@@ -1,0 +1,6 @@
+for (let i = 0; i < 5; i++) {
+  var l = i;
+  setTimeout(function() {
+    console.log(l);
+  }, 1);
+}

--- a/packages/babel-preset-es2015/test/fixtures/option-strict/block-scoping/options.json
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict/block-scoping/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Compiling let/const in this block would add a closure (throwIfClosureRequired)."
+}

--- a/packages/babel-preset-es2015/test/fixtures/option-strict/modules-commonjs/actual.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict/modules-commonjs/actual.js
@@ -1,0 +1,9 @@
+import foo from "foo";
+import { default as foo2 } from "foo";
+import { foo3 } from "foo";
+import * as foo4 from "foo";
+
+foo;
+foo2;
+foo3;
+foo3();

--- a/packages/babel-preset-es2015/test/fixtures/option-strict/modules-commonjs/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict/modules-commonjs/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var _foo = require("foo");
+
+_foo.default;
+_foo.default;
+_foo.foo3;
+(0, _foo.foo3)();

--- a/packages/babel-preset-es2015/test/fixtures/option-strict/options.json
+++ b/packages/babel-preset-es2015/test/fixtures/option-strict/options.json
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["es2015", { "strict": true }]
+  ]
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| License                  | MIT
| Dependency Changes       | no

I added the strict option for es2015 preset, which includes this setting for babel-plugin-transform-es2015-block-scoping and babel-plugin-transform-es2015-modules-commonjs. At this moment, there is no another way to enable this option for preset. I think it could be useful.