### PR TITLE
Use code not filename, fixes #4535 to allow using e.g. ts-node, but source maps still ignored; suggestion by @blakeembrey

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -44,7 +44,7 @@ function mtime(filename) {
   return +fs.statSync(filename).mtime;
 }
 
-function compile(filename) {
+function compile(code, filename) {
   let result;
 
   // merge in base options and resolve all the plugins and presets relative to this file
@@ -67,7 +67,7 @@ function compile(filename) {
   }
 
   if (!result) {
-    result = babel.transformFileSync(filename, extend(opts, {
+    result = babel.transform(code, extend(opts, {
       // Do not process config files since has already been done with the OptionManager
       // calls above and would introduce duplicates.
       babelrc: false,
@@ -94,8 +94,14 @@ function shouldIgnore(filename) {
   }
 }
 
-function loader(m, filename) {
-  m._compile(compile(filename), filename);
+function loader(m, filename, old) {
+  const _compile = m._compile;
+
+  m._compile = function (code, filename) {
+    return _compile.call(m, compile(code, filename), filename);
+  };
+
+  old(m, filename);
 }
 
 function registerExtension(ext) {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            | no
| Spec Compliancy?         | NA
| Tests Added/Pass?        | no, yes
| Fixed Tickets            | Fixes #4535 
| License                  | MIT
| Doc PR                   | ?
| Dependency Changes       | no

As described by @blakeembrey [here](https://github.com/TypeStrong/ts-node/issues/51#issuecomment-255219090), the require hook is changed to properly use the output of the previous  compiler instead of loading the file from disc (again).
I tested this change with 6.23.0 - and it's doing fine - as I was not able to use the dist build from 7.0 in my project. Automatic tests are passing, obviously, but babel-register does not test its behavior with regard to this.

Edit @xtuc: re-formatted table.