### PR TITLE
Move break constants to function scope

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -41,10 +41,9 @@ const buildExportAll = template(`
   });
 `);
 
-const THIS_BREAK_KEYS = ["FunctionExpression", "FunctionDeclaration", "ClassProperty",
-  "ClassMethod", "ObjectMethod"];
-
 export default function () {
+  const THIS_BREAK_KEYS = ["FunctionExpression", "FunctionDeclaration", "ClassProperty",
+    "ClassMethod", "ObjectMethod"];
   const REASSIGN_REMAP_SKIP = Symbol();
 
   const reassignmentVisitor = {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | NA
| Tests Added/Pass?        | no, yes
| Fixed Tickets            | NA
| License                  | MIT
| Doc PR                   | ?
| Dependency Changes       | no

I ran into an issue using babel-node with npm linked packages. We are writing our own npm packages and publish them untranspiled togheter with a .babelrc file. In our packages we use the es2015-modules-commonjs tranform and when linking and running the app with our packages we get `Cannot read property 'indexOf' of undefined` in `lib/index.js:120:55`.

After a quick debug i saw that `THIS_BREAK_KEYS` was undefined. Looking at the `lib/index` file, these constants are declared in the bottom of this file make them undefined at run-time (not sure why).

I'm not really sure how to tackle this problem since it's an effect of the transpiled code but by simply moving the contants to the function scope everything is working as expected and when transpiled, the contants are declared at the top of the scope. No other constants are declared outside of the function scope and REASSIGN_REMAP_SKIP is there so for me this solution seems legit

Prev transpiled code
```js
var THIS_BREAK_KEYS = ["FunctionExpression", "FunctionDeclaration", "ClassProperty", "ClassMethod", "ObjectMethod"];

module.exports = exports["default"];
```

Transpiled code
```js
exports.default = function () {
  var THIS_BREAK_KEYS = ["FunctionExpression", "FunctionDeclaration", "ClassProperty", "ClassMethod", "ObjectMethod"];
```

If you need any more info please let me know