### PR TITLE
[doc] Fix: comments in usage w/ options

### DIFF
--- a/packages/babel-plugin-transform-runtime/README.md
+++ b/packages/babel-plugin-transform-runtime/README.md
@@ -50,7 +50,7 @@ Without options:
 
 With options:
 
-```json
+```js
 {
   "plugins": [
     ["transform-runtime", {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no 
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         |  no
| Tests Added/Pass?        | no
| Fixed Tickets            | -
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | no

Just a small code styling in the `babel-plugin-transform-runtime` README. With `js` instead of `json`, as code styling, the json object is still highlighted as it should be, but the comments are not red anymore.

<!-- Describe your changes below in as much detail as possible -->
