### PR TITLE
allow for custom caches

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -2,9 +2,23 @@ import path from "path";
 import fs from "fs";
 import { sync as mkdirpSync } from "mkdirp";
 import homeOrTmp from "home-or-tmp";
+import * as babel from "babel-core";
 
 const FILENAME: string = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json");
 let data: Object = {};
+
+/**
+ * Create a key from transform options.
+ */
+
+export function key(opts) {
+  let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
+
+  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  if (env) cacheKey += `:${env}`;
+
+  return cacheKey;
+}
 
 /**
  * Write stringified cache to disk.
@@ -34,8 +48,6 @@ export function save() {
  */
 
 export function load() {
-  if (process.env.BABEL_DISABLE_CACHE) return;
-
   process.on("exit", save);
   process.nextTick(save);
 
@@ -52,6 +64,10 @@ export function load() {
  * Retrieve data from cache.
  */
 
-export function get(): Object {
-  return data;
+export function get(opts): Object {
+  return data[key(opts)];
+}
+
+export function set(opts, value) {
+  data[key(opts)] = value;
 }

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -34,13 +34,14 @@ function resetCache() {
 describe("babel register", () => {
 
   describe("cache", () => {
-    let load, get, save;
+    let key, load, get, save;
 
     beforeEach(() => {
       // Since lib/cache is a singleton we need to fully reload it
       decache("../lib/cache");
       const cache = require("../lib/cache");
 
+      key = cache.key;
       load = cache.load;
       get = cache.get;
       save = cache.save;
@@ -50,35 +51,32 @@ describe("babel register", () => {
     after(resetCache);
 
     it("should load and get cached data", () => {
-      writeCache({ foo: "bar" });
+      writeCache({ [key("foo")]: "bar" });
 
       load();
 
-      expect(get()).to.be.an("object");
-      expect(get()).to.deep.equal({ foo: "bar" });
+      expect(get("foo")).to.be.a("string");
+      expect(get("foo")).to.equal("bar");
     });
 
-    it("should load and get an object with no cached data", () => {
+    it("should load and get with no cached data", () => {
       load();
 
-      expect(get()).to.be.an("object");
-      expect(get()).to.deep.equal({});
+      expect(get("foo")).to.be.undefined;
     });
 
-    it("should load and get an object with invalid cached data", () => {
+    it("should load and get with invalid cached data", () => {
       writeCache("foobar");
 
       load();
 
-      expect(get()).to.be.an("object");
-      expect(get()).to.deep.equal({});
+      expect(get("foo")).to.be.undefined;
     });
 
     it("should create the cache on save", () => {
       save();
 
       expect(fs.existsSync(testCacheFilename)).to.be.true;
-      expect(get()).to.deep.equal({});
     });
   });
 });


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  N
| Major: Breaking Change?  |  N
| Minor: New Feature?      |  Y
| Deprecations?            |  N
| Spec Compliancy?         |  Y
| Tests Added/Pass?        |  N/Y
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | N
| Dependency Changes       |  

<!-- Describe your changes below in as much detail as possible -->

This change adds support for providing a custom cache to babel-register. A cache must provide get/set functions. The bulk of this PR splits the existing cache functionality into a noop cache (in the case of `cache: false` or  `BABEL_DISABLE_CACHE`) and the default caching functionality. Turning the cache on and off is now just a matter of toggling between cache implementations (one of which just has noop `get`/`set` functions). ~~The cache was implemented as a class, which now uses a constructor in lieu of `load`, and takes a key for `get`/`set` rather than just returning the entire cache.~~

~~Load is no longer part of the cache interface because the consumers of babel-register can initialize their custom cache themselves if necessary, but also because its not always necessary (For instance a cache implementation that stored each compilation in a different file).~~

I could also break this into a cache rewrite PR and then a tiny PR on top of it that allows the custom cache.
