### PR TITLE
Seperate version env cache files

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -2,8 +2,11 @@ import path from "path";
 import fs from "fs";
 import { sync as mkdirpSync } from "mkdirp";
 import homeOrTmp from "home-or-tmp";
+import * as babel from "babel-core";
 
-const FILENAME: string = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json");
+const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+
+const FILENAME: string = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, `.babel.${babel.version}${env ? `.${env}` : ""}.json`);
 let data: Object = {};
 
 /**

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -4,9 +4,8 @@ import { sync as mkdirpSync } from "mkdirp";
 import homeOrTmp from "home-or-tmp";
 import * as babel from "babel-core";
 
-const env = process.env.BABEL_ENV || process.env.NODE_ENV;
-
-const FILENAME: string = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, `.babel.${babel.version}${env ? `.${env}` : ""}.json`);
+const DEFAULT_FILENAME = path.join(homeOrTmp, `.babel.${babel.version}.${babel.getEnv()}.json`);
+const FILENAME: string = process.env.BABEL_CACHE_PATH || DEFAULT_FILENAME;
 let data: Object = {};
 
 /**


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  ?
| Major: Breaking Change?  |  ?
| Minor: New Feature?      |  ?
| Deprecations?            |  N
| Spec Compliancy?         |  N
| Tests Added/Pass?        |  N
| License                  | MIT

Because cache entries are keyed on babel version and environment, there's no point in storing different combinations in the same file, because you'll never use the portions of the cache generated with different combinations. For instance, if you use BABEL_ENV values 'node' and 'test', you'll have to load a cache that's twice as big as you'll possibly use.