### PR TITLE
Run new lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,11 @@
 {
   "extends": "babel",
   "rules": {
+    "comma-dangle": ["error", "always-multiline"],
+    "curly": ["error", "multi-line"],
+    "func-call-spacing": "error",
+    "key-spacing": "error",
+    "no-multi-spaces": "error"
   },
   "env": {
     "node": true,

--- a/packages/babel-cli/src/_babel-node.js
+++ b/packages/babel-cli/src/_babel-node.js
@@ -29,10 +29,10 @@ program.parse(process.argv);
 
 register({
   extensions: program.extensions,
-  ignore:     program.ignore,
-  only:       program.only,
-  plugins:    program.plugins,
-  presets:    program.presets,
+  ignore: program.ignore,
+  only: program.only,
+  plugins: program.plugins,
+  presets: program.presets,
 });
 
 //
@@ -55,8 +55,8 @@ const replPlugin = ({ types: t }) => ({
       // If the executed code doesn't evaluate to a value,
       // prevent implicit strict mode from printing 'use strict'.
       path.pushContainer("body", t.expressionStatement(t.identifier("undefined")));
-    }
-  }
+    },
+  },
 });
 
 //
@@ -68,11 +68,11 @@ const _eval = function (code, filename) {
   code = babel.transform(code, {
     filename: filename,
     presets: program.presets,
-    plugins: (program.plugins || []).concat([replPlugin])
+    plugins: (program.plugins || []).concat([replPlugin]),
   }).code;
 
   return vm.runInThisContext(code, {
-    filename: filename
+    filename: filename,
   });
 };
 
@@ -85,10 +85,10 @@ if (program.eval || program.print) {
 
   const module = new Module(global.__filename);
   module.filename = global.__filename;
-  module.paths    = Module._nodeModulePaths(global.__dirname);
+  module.paths = Module._nodeModulePaths(global.__dirname);
 
   global.exports = module.exports;
-  global.module  = module;
+  global.module = module;
   global.require = module.require.bind(module);
 
   const result = _eval(code, global.__filename);
@@ -141,7 +141,7 @@ function replStart() {
     input: process.stdin,
     output: process.stdout,
     eval: replEval,
-    useGlobal: true
+    useGlobal: true,
   });
 }
 

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -14,7 +14,7 @@ let userArgs;
 // separate node arguments from script arguments
 const argSeparator = babelArgs.indexOf("--");
 if (argSeparator > -1) {
-  userArgs  = babelArgs.slice(argSeparator); // including the  --
+  userArgs = babelArgs.slice(argSeparator); // including the  --
   babelArgs = babelArgs.slice(0, argSeparator);
 }
 

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -14,7 +14,7 @@ export default function (commander, filenames) {
 
     const data = util.compile(src, {
       sourceFileName: slash(path.relative(dest + "/..", src)),
-      sourceMapTarget: path.basename(relative)
+      sourceMapTarget: path.basename(relative),
     });
     if (!commander.copyFiles && data.ignored) return;
 
@@ -74,7 +74,7 @@ export default function (commander, filenames) {
         awaitWriteFinish: {
           stabilityThreshold: 50,
           pollInterval: 10,
-        }
+        },
       });
 
       ["add", "change"].forEach(function (type) {

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -1,5 +1,5 @@
 import convertSourceMap from "convert-source-map";
-import sourceMap  from "source-map";
+import sourceMap from "source-map";
 import slash from "slash";
 import path from "path";
 import fs from "fs";
@@ -16,7 +16,7 @@ export default function (commander, filenames, opts) {
   const buildResult = function () {
     const map = new sourceMap.SourceMapGenerator({
       file: path.basename(commander.outFile || "") || "stdout",
-      sourceRoot: opts.sourceRoot
+      sourceRoot: opts.sourceRoot,
     });
 
     let code = "";
@@ -64,7 +64,7 @@ export default function (commander, filenames, opts) {
 
     return {
       map: map,
-      code: code
+      code: code,
     };
   };
 
@@ -156,7 +156,7 @@ export default function (commander, filenames, opts) {
         awaitWriteFinish: {
           stabilityThreshold: 50,
           pollInterval: 10,
-        }
+        },
       }).on("all", function (type, filename) {
         if (util.shouldIgnore(filename) || !util.canCompile(filename, commander.extensions)) return;
 

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import fs        from "fs";
+import fs from "fs";
 import commander from "commander";
 import kebabCase from "lodash/kebabCase";
 import { options, util, version } from "babel-core";
-import uniq      from "lodash/uniq";
-import glob      from "glob";
+import uniq from "lodash/uniq";
+import glob from "glob";
 
 import dirCommand from "./dir";
 import fileCommand from "./file";

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,21 +1,21 @@
-const includes       = require("lodash/includes");
-const readdir        = require("fs-readdir-recursive");
-const helper         = require("babel-helper-fixtures");
-const assert         = require("assert");
-const rimraf         = require("rimraf");
+const includes = require("lodash/includes");
+const readdir = require("fs-readdir-recursive");
+const helper = require("babel-helper-fixtures");
+const assert = require("assert");
+const rimraf = require("rimraf");
 const outputFileSync = require("output-file-sync");
-const child          = require("child_process");
-const merge          = require("lodash/merge");
-const path           = require("path");
-const chai           = require("chai");
-const fs             = require("fs");
+const child = require("child_process");
+const merge = require("lodash/merge");
+const path = require("path");
+const chai = require("chai");
+const fs = require("fs");
 
 const fixtureLoc = path.join(__dirname, "fixtures");
 const tmpLoc = path.join(__dirname, "tmp");
 
 const presetLocs = [
   path.join(__dirname, "../../babel-preset-es2015"),
-  path.join(__dirname, "../../babel-preset-react")
+  path.join(__dirname, "../../babel-preset-react"),
 ].join(",");
 
 const pluginLocs = [
@@ -150,7 +150,7 @@ fs.readdirSync(fixtureLoc).forEach(function (binName) {
       const testLoc = path.join(suiteLoc, testName);
 
       const opts = {
-        args: []
+        args: [],
       };
 
       const optionsLoc = path.join(testLoc, "options.json");
@@ -166,7 +166,7 @@ fs.readdirSync(fixtureLoc).forEach(function (binName) {
       });
 
       opts.outFiles = readDir(path.join(testLoc, "out-files"));
-      opts.inFiles  = readDir(path.join(testLoc, "in-files"));
+      opts.inFiles = readDir(path.join(testLoc, "in-files"));
 
       const babelrcLoc = path.join(testLoc, ".babelrc");
       if (fs.existsSync(babelrcLoc)) {

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -8,18 +8,18 @@ import Chalk from "chalk";
 
 function getDefs(chalk) {
   return {
-    keyword:     chalk.cyan,
+    keyword: chalk.cyan,
     capitalized: chalk.yellow,
-    jsx_tag:     chalk.yellow,
-    punctuator:  chalk.yellow,
+    jsx_tag: chalk.yellow,
+    punctuator: chalk.yellow,
     // bracket:  intentionally omitted.
-    number:      chalk.magenta,
-    string:      chalk.green,
-    regex:       chalk.magenta,
-    comment:     chalk.grey,
-    invalid:     chalk.white.bgRed.bold,
-    gutter:      chalk.grey,
-    marker:      chalk.red.bold,
+    number: chalk.magenta,
+    string: chalk.green,
+    regex: chalk.magenta,
+    comment: chalk.grey,
+    invalid: chalk.white.bgRed.bold,
+    gutter: chalk.grey,
+    marker: chalk.red.bold,
   };
 }
 
@@ -117,7 +117,7 @@ export default function (
 
   const lines = rawLines.split(NEWLINE);
   let start = Math.max(lineNumber - (linesAbove + 1), 0);
-  let end   = Math.min(lines.length, lineNumber + linesBelow);
+  let end = Math.min(lines.length, lineNumber + linesBelow);
 
   if (!lineNumber && !colNumber) {
     start = 0;
@@ -138,14 +138,14 @@ export default function (
           "\n ",
           maybeHighlight(defs.gutter, gutter.replace(/\d/g, " ")),
           markerSpacing,
-          maybeHighlight(defs.marker, "^")
+          maybeHighlight(defs.marker, "^"),
         ].join("");
       }
       return [
         maybeHighlight(defs.marker, ">"),
         maybeHighlight(defs.gutter, gutter),
         line,
-        markerLine
+        markerLine,
       ].join("");
     } else {
       return ` ${maybeHighlight(defs.gutter, gutter)}${line}`;

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -55,7 +55,7 @@ describe("babel-code-frame", function () {
       "",
       "function sum(a, b) {",
       "  return a + b",
-      "}"
+      "}",
     ].join("\n");
     assert.equal(codeFrame(rawLines, 7, 2), [
       "   5 |  * @param b Number",
@@ -80,7 +80,7 @@ describe("babel-code-frame", function () {
       "",
       "function sum(a, b) {",
       "  return a + b",
-      "}"
+      "}",
     ].join("\n");
     assert.equal(codeFrame(rawLines, 6, 2), [
       "  4 |  * @param a Number",
@@ -130,7 +130,7 @@ describe("babel-code-frame", function () {
       "",
       "function sum(a, b) {",
       "  return a + b",
-      "}"
+      "}",
     ].join("\n");
     assert.equal(codeFrame(rawLines, 7, 2, { linesAbove: 1 }), [
       "   6 |  * @returns Number",
@@ -154,14 +154,14 @@ describe("babel-code-frame", function () {
       "",
       "function sum(a, b) {",
       "  return a + b",
-      "}"
+      "}",
     ].join("\n");
     assert.equal(codeFrame(rawLines, 7, 2, { linesBelow: 1 }), [
       "  5 |  * @param b Number",
       "  6 |  * @returns Number",
       "> 7 |  */",
       "    |  ^",
-      "  8 | "
+      "  8 | ",
     ].join("\n"));
   });
 
@@ -177,13 +177,13 @@ describe("babel-code-frame", function () {
       "",
       "function sum(a, b) {",
       "  return a + b",
-      "}"
+      "}",
     ].join("\n");
     assert.equal(codeFrame(rawLines, 7, 2, { linesAbove: 1, linesBelow: 1 }), [
       "  6 |  * @returns Number",
       "> 7 |  */",
       "    |  ^",
-      "  8 | "
+      "  8 | ",
     ].join("\n"));
   });
 
@@ -195,13 +195,13 @@ describe("babel-code-frame", function () {
       "",
       "",
       "",
-      ""
+      "",
     ].join("\n");
     assert.equal(codeFrame(rawLines, 3, null, { linesAbove: 1, linesBelow: 1, forceColor: true }),
       chalk.reset([
         " " + gutter(" 2 | "),
         marker(">") + gutter(" 3 | "),
-        " " + gutter(" 4 | ")
+        " " + gutter(" 4 | "),
       ].join("\n"))
     );
   });

--- a/packages/babel-core/src/store.js
+++ b/packages/babel-core/src/store.js
@@ -17,7 +17,7 @@ export default class Store {
       return this._map.get(key);
     } else {
       if (Object.prototype.hasOwnProperty.call(this._map.dynamicData, key)) {
-        const val =  this._map.dynamicData[key]();
+        const val = this._map.dynamicData[key]();
         this._map.set(key, val);
         return val;
       }

--- a/packages/babel-core/src/tools/build-external-helpers.js
+++ b/packages/babel-core/src/tools/build-external-helpers.js
@@ -19,9 +19,9 @@ const buildUmdWrapper = template(`
 `);
 
 function buildGlobal(namespace, builder) {
-  const body      = [];
+  const body = [];
   const container = t.functionExpression(null, [t.identifier("global")], t.blockStatement(body));
-  const tree      = t.program([
+  const tree = t.program([
     t.expressionStatement(t.callExpression(container, [helpers.get("selfGlobal")]))]);
 
   body.push(t.variableDeclaration("var", [
@@ -29,7 +29,7 @@ function buildGlobal(namespace, builder) {
       namespace,
       t.assignmentExpression("=", t.memberExpression(t.identifier("global"), namespace),
         t.objectExpression([]))
-    )
+    ),
   ]));
 
   builder(body);
@@ -40,7 +40,7 @@ function buildGlobal(namespace, builder) {
 function buildUmd(namespace, builder) {
   const body = [];
   body.push(t.variableDeclaration("var", [
-    t.variableDeclarator(namespace, t.identifier("global"))
+    t.variableDeclarator(namespace, t.identifier("global")),
   ]));
 
   builder(body);
@@ -48,23 +48,23 @@ function buildUmd(namespace, builder) {
   return t.program([
     buildUmdWrapper({
       FACTORY_PARAMETERS: t.identifier("global"),
-      BROWSER_ARGUMENTS:  t.assignmentExpression(
+      BROWSER_ARGUMENTS: t.assignmentExpression(
         "=",
         t.memberExpression(t.identifier("root"), namespace),
         t.objectExpression([])
       ),
-      COMMON_ARGUMENTS:   t.identifier("exports"),
-      AMD_ARGUMENTS:      t.arrayExpression([t.stringLiteral("exports")]),
-      FACTORY_BODY:       body,
-      UMD_ROOT:           t.identifier("this")
-    })
+      COMMON_ARGUMENTS: t.identifier("exports"),
+      AMD_ARGUMENTS: t.arrayExpression([t.stringLiteral("exports")]),
+      FACTORY_BODY: body,
+      UMD_ROOT: t.identifier("this"),
+    }),
   ]);
 }
 
 function buildVar(namespace, builder) {
   const body = [];
   body.push(t.variableDeclaration("var", [
-    t.variableDeclarator(namespace, t.objectExpression([]))
+    t.variableDeclarator(namespace, t.objectExpression([])),
   ]));
   builder(body);
   body.push(t.expressionStatement(namespace));
@@ -95,8 +95,8 @@ export default function (
 
   const build = {
     global: buildGlobal,
-    umd:    buildUmd,
-    var:    buildVar,
+    umd: buildUmd,
+    var: buildVar,
   }[outputType];
 
   if (build) {

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -14,7 +14,7 @@ import traverse from "babel-traverse";
 import Logger from "./logger";
 import Store from "../../store";
 import { parse } from "babylon";
-import * as util from  "../../util";
+import * as util from "../../util";
 import path from "path";
 import * as t from "babel-types";
 
@@ -27,7 +27,7 @@ const shebangRegex = /^#!.*/;
 
 const INTERNAL_PLUGINS = [
   [blockHoistPlugin],
-  [shadowFunctionsPlugin]
+  [shadowFunctionsPlugin],
 ];
 
 const errorVisitor = {
@@ -37,20 +37,20 @@ const errorVisitor = {
       state.loc = loc;
       path.stop();
     }
-  }
+  },
 };
 
 export default class File extends Store {
   constructor(opts: Object = {}) {
     super();
 
-    this.log  = new Logger(this, opts.filename || "unknown");
+    this.log = new Logger(this, opts.filename || "unknown");
     this.opts = this.initOptions(opts);
 
     this.parserOpts = {
-      sourceType:     this.opts.sourceType,
+      sourceType: this.opts.sourceType,
       sourceFileName: this.opts.filename,
-      plugins:        []
+      plugins: [],
     };
 
     this.pluginVisitors = [];
@@ -78,21 +78,21 @@ export default class File extends Store {
         imports: [],
         exports: {
           exported: [],
-          specifiers: []
-        }
-      }
+          specifiers: [],
+        },
+      },
     };
 
     this.dynamicImportTypes = {};
-    this.dynamicImportIds   = {};
-    this.dynamicImports     = [];
-    this.declarations       = {};
-    this.usedHelpers        = {};
+    this.dynamicImportIds = {};
+    this.dynamicImports = [];
+    this.declarations = {};
+    this.usedHelpers = {};
 
     this.path = null;
-    this.ast  = {};
+    this.ast = {};
 
-    this.code    = "";
+    this.code = "";
     this.shebang = "";
 
     this.hub = new Hub(this);
@@ -149,22 +149,22 @@ export default class File extends Store {
     if (opts.only) opts.only = util.arrayify(opts.only, util.regexify);
 
     defaults(opts, {
-      moduleRoot: opts.sourceRoot
+      moduleRoot: opts.sourceRoot,
     });
 
     defaults(opts, {
-      sourceRoot: opts.moduleRoot
+      sourceRoot: opts.moduleRoot,
     });
 
     defaults(opts, {
-      filenameRelative: opts.filename
+      filenameRelative: opts.filename,
     });
 
     const basenameRelative = path.basename(opts.filenameRelative);
 
     defaults(opts, {
-      sourceFileName:   basenameRelative,
-      sourceMapTarget:  basenameRelative
+      sourceFileName: basenameRelative,
+      sourceMapTarget: basenameRelative,
     });
 
     return opts;
@@ -282,7 +282,7 @@ export default class File extends Store {
     }
 
     const generator = this.get("helperGenerator");
-    const runtime   = this.get("helpersNamespace");
+    const runtime = this.get("helpersNamespace");
     if (generator) {
       const res = generator(name);
       if (res) return res;
@@ -304,7 +304,7 @@ export default class File extends Store {
       this.scope.push({
         id: uid,
         init: ref,
-        unique: true
+        unique: true,
       });
     }
 
@@ -334,7 +334,7 @@ export default class File extends Store {
     this.scope.push({
       id: uid,
       init: init,
-      _blockHoist: 1.9 // This ensures that we don't fail if not using function expression helpers
+      _blockHoist: 1.9, // This ensures that we don't fail if not using function expression helpers
     });
     return uid;
   }
@@ -365,12 +365,12 @@ export default class File extends Store {
     const inputMap = this.opts.inputSourceMap;
 
     if (inputMap) {
-      const inputMapConsumer   = new sourceMap.SourceMapConsumer(inputMap);
-      const outputMapConsumer  = new sourceMap.SourceMapConsumer(map);
+      const inputMapConsumer = new sourceMap.SourceMapConsumer(inputMap);
+      const outputMapConsumer = new sourceMap.SourceMapConsumer(map);
 
       const mergedGenerator = new sourceMap.SourceMapGenerator({
         file: inputMapConsumer.file,
-        sourceRoot: inputMapConsumer.sourceRoot
+        sourceRoot: inputMapConsumer.sourceRoot,
       });
 
       // This assumes the output map always has a single source, since Babel always compiles a
@@ -381,7 +381,7 @@ export default class File extends Store {
         const generatedPosition = outputMapConsumer.generatedPositionFor({
           line: mapping.generatedLine,
           column: mapping.generatedColumn,
-          source: source
+          source: source,
         });
         if (generatedPosition.column != null) {
           mergedGenerator.addMapping({
@@ -389,10 +389,10 @@ export default class File extends Store {
 
             original: mapping.source == null ? null : {
               line: mapping.originalLine,
-              column: mapping.originalColumn
+              column: mapping.originalColumn,
             },
 
-            generated: generatedPosition
+            generated: generatedPosition,
           });
         }
       });
@@ -429,7 +429,7 @@ export default class File extends Store {
         parserOpts.parser = {
           parse(source) {
             return parse(source, parserOpts);
-          }
+          },
         };
       }
     }
@@ -446,10 +446,10 @@ export default class File extends Store {
       parentPath: null,
       parent: ast,
       container: ast,
-      key: "program"
+      key: "program",
     }).setContext();
     this.scope = this.path.scope;
-    this.ast   = ast;
+    this.ast = ast;
     this.getMetadata();
   }
 
@@ -568,11 +568,11 @@ export default class File extends Store {
   makeResult({ code, map, ast, ignored }: BabelFileResult): BabelFileResult {
     const result = {
       metadata: null,
-      options:  this.opts,
-      ignored:  !!ignored,
-      code:     null,
-      ast:      null,
-      map:      map || null
+      options: this.opts,
+      ignored: !!ignored,
+      code: null,
+      ast: null,
+      map: map || null,
     };
 
     if (this.opts.code) {
@@ -592,7 +592,7 @@ export default class File extends Store {
 
   generate(): BabelFileResult {
     const opts = this.opts;
-    const ast  = this.ast;
+    const ast = this.ast;
 
     const result: BabelFileResult = { ast };
     if (!opts.code) return this.makeResult(result);
@@ -618,7 +618,7 @@ export default class File extends Store {
     const _result = gen(ast, opts.generatorOpts ? Object.assign(opts, opts.generatorOpts) : opts,
       this.code);
     result.code = _result.code;
-    result.map  = _result.map;
+    result.map = _result.map;
 
     this.log.debug("Generation end");
 

--- a/packages/babel-core/src/transformation/file/logger.js
+++ b/packages/babel-core/src/transformation/file/logger.js
@@ -9,7 +9,7 @@ const seenDeprecatedMessages = [];
 export default class Logger {
   constructor(file: File, filename: string) {
     this.filename = filename;
-    this.file     = file;
+    this.file = file;
   }
 
   filename: string;

--- a/packages/babel-core/src/transformation/file/metadata.js
+++ b/packages/babel-core/src/transformation/file/metadata.js
@@ -6,7 +6,7 @@ export const ModuleDeclaration = {
     if (node.source) {
       node.source.value = file.resolveModuleSource(node.source.value);
     }
-  }
+  },
 };
 
 export const ImportDeclaration = {
@@ -18,7 +18,7 @@ export const ImportDeclaration = {
     file.metadata.modules.imports.push({
       source: node.source.value,
       imported,
-      specifiers
+      specifiers,
     });
 
     for (const specifier of (path.get("specifiers"): Array<Object>)) {
@@ -29,7 +29,7 @@ export const ImportDeclaration = {
         specifiers.push({
           kind: "named",
           imported: "default",
-          local
+          local,
         });
       }
 
@@ -39,7 +39,7 @@ export const ImportDeclaration = {
         specifiers.push({
           kind: "named",
           imported: importedName,
-          local
+          local,
         });
       }
 
@@ -47,11 +47,11 @@ export const ImportDeclaration = {
         imported.push("*");
         specifiers.push({
           kind: "namespace",
-          local
+          local,
         });
       }
     }
-  }
+  },
 };
 
 export function ExportDeclaration(path, file) {
@@ -71,7 +71,7 @@ export function ExportDeclaration(path, file) {
       exports.specifiers.push({
         kind: "local",
         local: name,
-        exported: path.isExportDefaultDeclaration() ? "default" : name
+        exported: path.isExportDefaultDeclaration() ? "default" : name,
       });
     }
   }
@@ -87,7 +87,7 @@ export function ExportDeclaration(path, file) {
           kind: "external",
           local: exported,
           exported,
-          source
+          source,
         });
       }
 
@@ -96,7 +96,7 @@ export function ExportDeclaration(path, file) {
         exports.specifiers.push({
           kind: "external-namespace",
           exported,
-          source
+          source,
         });
       }
 
@@ -110,7 +110,7 @@ export function ExportDeclaration(path, file) {
           kind: "external",
           local: local.name,
           exported,
-          source
+          source,
         });
       }
 
@@ -120,7 +120,7 @@ export function ExportDeclaration(path, file) {
         exports.specifiers.push({
           kind: "local",
           local: local.name,
-          exported
+          exported,
         });
       }
     }
@@ -130,7 +130,7 @@ export function ExportDeclaration(path, file) {
   if (path.isExportAllDeclaration()) {
     exports.specifiers.push({
       kind: "external-all",
-      source
+      source,
     });
   }
 }

--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -6,11 +6,11 @@ import path from "path";
 import fs from "fs";
 
 const existsCache = {};
-const jsonCache   = {};
+const jsonCache = {};
 
 const BABELIGNORE_FILENAME = ".babelignore";
-const BABELRC_FILENAME     = ".babelrc";
-const PACKAGE_FILENAME     = "package.json";
+const BABELRC_FILENAME = ".babelrc";
+const PACKAGE_FILENAME = "package.json";
 
 function exists(filename) {
   const cached = existsCache[filename];
@@ -33,7 +33,7 @@ export default function buildConfigChain(opts: Object = {}, log?: Logger) {
   builder.mergeConfig({
     options: opts,
     alias: "base",
-    dirname: filename && path.dirname(filename)
+    dirname: filename && path.dirname(filename),
   });
 
   return builder.configs;
@@ -83,7 +83,7 @@ class ConfigChainBuilder {
   }
 
   addIgnoreConfig(loc) {
-    const file  = fs.readFileSync(loc, "utf8");
+    const file = fs.readFileSync(loc, "utf8");
     let lines = file.split("\n");
 
     lines = lines
@@ -94,7 +94,7 @@ class ConfigChainBuilder {
       this.mergeConfig({
         options: { ignore: lines },
         alias: loc,
-        dirname: path.dirname(loc)
+        dirname: path.dirname(loc),
       });
     }
   }
@@ -120,7 +120,7 @@ class ConfigChainBuilder {
     this.mergeConfig({
       options,
       alias: loc,
-      dirname: path.dirname(loc)
+      dirname: path.dirname(loc),
     });
 
     return !!options;
@@ -130,7 +130,7 @@ class ConfigChainBuilder {
     options,
     alias,
     loc,
-    dirname
+    dirname,
   }) {
     if (!options) {
       return false;
@@ -156,7 +156,7 @@ class ConfigChainBuilder {
       options,
       alias,
       loc,
-      dirname
+      dirname,
     });
 
     // env
@@ -170,7 +170,7 @@ class ConfigChainBuilder {
     this.mergeConfig({
       options: envOpts,
       alias: `${alias}.env.${envKey}`,
-      dirname: dirname
+      dirname: dirname,
     });
   }
 }

--- a/packages/babel-core/src/transformation/file/options/config.js
+++ b/packages/babel-core/src/transformation/file/options/config.js
@@ -5,191 +5,191 @@ export default {
     type: "filename",
     description: "filename to use when reading from stdin - this will be used in source-maps, errors etc",
     default: "unknown",
-    shorthand: "f"
+    shorthand: "f",
   },
 
   filenameRelative: {
     hidden: true,
-    type: "string"
+    type: "string",
   },
 
   inputSourceMap: {
-    hidden: true
+    hidden: true,
   },
 
   env: {
     hidden: true,
-    default: {}
+    default: {},
   },
 
   mode: {
     description: "",
-    hidden: true
+    hidden: true,
   },
 
   retainLines: {
     type: "boolean",
     default: false,
-    description: "retain line numbers - will result in really ugly code"
+    description: "retain line numbers - will result in really ugly code",
   },
 
   highlightCode: {
     description: "enable/disable ANSI syntax highlighting of code frames (on by default)",
     type: "boolean",
-    default: true
+    default: true,
   },
 
   suppressDeprecationMessages: {
     type: "boolean",
     default: false,
-    hidden: true
+    hidden: true,
   },
 
   presets: {
     type: "list",
     description: "",
-    default: []
+    default: [],
   },
 
   plugins: {
     type: "list",
     default: [],
-    description: ""
+    description: "",
   },
 
   ignore: {
     type: "list",
     description: "list of glob paths to **not** compile",
-    default: []
+    default: [],
   },
 
   only: {
     type: "list",
-    description: "list of glob paths to **only** compile"
+    description: "list of glob paths to **only** compile",
   },
 
   code: {
     hidden: true,
     default: true,
-    type: "boolean"
+    type: "boolean",
   },
 
   metadata: {
     hidden: true,
     default: true,
-    type: "boolean"
+    type: "boolean",
   },
 
   ast: {
     hidden: true,
     default: true,
-    type: "boolean"
+    type: "boolean",
   },
 
   extends: {
     type: "string",
-    hidden: true
+    hidden: true,
   },
 
   comments: {
     type: "boolean",
     default: true,
-    description: "write comments to generated output (true by default)"
+    description: "write comments to generated output (true by default)",
   },
 
   shouldPrintComment: {
     hidden: true,
-    description: "optional callback to control whether a comment should be inserted, when this is used the comments option is ignored"
+    description: "optional callback to control whether a comment should be inserted, when this is used the comments option is ignored",
   },
 
   wrapPluginVisitorMethod: {
     hidden: true,
-    description: "optional callback to wrap all visitor methods"
+    description: "optional callback to wrap all visitor methods",
   },
 
   compact: {
     type: "booleanString",
     default: "auto",
-    description: "do not include superfluous whitespace characters and line terminators [true|false|auto]"
+    description: "do not include superfluous whitespace characters and line terminators [true|false|auto]",
   },
 
   minified: {
     type: "boolean",
     default: false,
-    description: "save as much bytes when printing [true|false]"
+    description: "save as much bytes when printing [true|false]",
   },
 
   sourceMap: {
     alias: "sourceMaps",
-    hidden: true
+    hidden: true,
   },
 
   sourceMaps: {
     type: "booleanString",
     description: "[true|false|inline]",
     default: false,
-    shorthand: "s"
+    shorthand: "s",
   },
 
   sourceMapTarget: {
     type: "string",
-    description: "set `file` on returned source map"
+    description: "set `file` on returned source map",
   },
 
   sourceFileName: {
     type: "string",
-    description: "set `sources[0]` on returned source map"
+    description: "set `sources[0]` on returned source map",
   },
 
   sourceRoot: {
     type: "filename",
-    description: "the root from which all sources are relative"
+    description: "the root from which all sources are relative",
   },
 
   babelrc: {
     description: "Whether or not to look up .babelrc and .babelignore files",
     type: "boolean",
-    default: true
+    default: true,
   },
 
   sourceType: {
     description: "",
-    default: "module"
+    default: "module",
   },
 
   auxiliaryCommentBefore: {
     type: "string",
-    description: "print a comment before any injected non-user code"
+    description: "print a comment before any injected non-user code",
   },
 
   auxiliaryCommentAfter: {
     type: "string",
-    description: "print a comment after any injected non-user code"
+    description: "print a comment after any injected non-user code",
   },
 
   resolveModuleSource: {
-    hidden: true
+    hidden: true,
   },
 
   getModuleId: {
-    hidden: true
+    hidden: true,
   },
 
   moduleRoot: {
     type: "filename",
-    description: "optional prefix for the AMD module formatter that will be prepend to the filename on module definitions"
+    description: "optional prefix for the AMD module formatter that will be prepend to the filename on module definitions",
   },
 
   moduleIds: {
     type: "boolean",
     default: false,
     shorthand: "M",
-    description: "insert an explicit id for modules"
+    description: "insert an explicit id for modules",
   },
 
   moduleId: {
     description: "specify a custom name for module ids",
-    type: "string"
+    type: "string",
   },
 
   passPerPreset: {
@@ -202,12 +202,12 @@ export default {
   // Deprecate top level parserOpts
   parserOpts: {
     description: "Options to pass into the parser, or to change parsers (parserOpts.parser)",
-    default: false
+    default: false,
   },
 
   // Deprecate top level generatorOpts
   generatorOpts: {
     description: "Options to pass into the generator, or to change generators (generatorOpts.generator)",
-    default: false
-  }
+    default: false,
+  },
 };

--- a/packages/babel-core/src/transformation/file/options/option-manager.js
+++ b/packages/babel-core/src/transformation/file/options/option-manager.js
@@ -67,7 +67,7 @@ export default class OptionManager {
       const plugin = new Plugin(obj, alias);
       OptionManager.memoisedPlugins.push({
         container: fn,
-        plugin: plugin
+        plugin: plugin,
       });
       return plugin;
     } else {
@@ -151,7 +151,7 @@ export default class OptionManager {
     extending: extendingOpts,
     alias,
     loc,
-    dirname
+    dirname,
   }: MergeOptions) {
     alias = alias || "foreign";
     if (!rawOpts) return;
@@ -208,7 +208,7 @@ export default class OptionManager {
             extending: preset,
             alias: presetLoc,
             loc: presetLoc,
-            dirname: dirname
+            dirname: dirname,
           });
         });
       } else {
@@ -238,7 +238,7 @@ export default class OptionManager {
         options: presetOpts,
         alias: presetLoc,
         loc: presetLoc,
-        dirname: path.dirname(presetLoc || "")
+        dirname: path.dirname(presetLoc || ""),
       });
     });
   }
@@ -318,7 +318,7 @@ export default class OptionManager {
 
     for (const key in config) {
       const option = config[key];
-      const val    = opts[key];
+      const val = opts[key];
 
       // optional
       if (!val && option.optional) continue;

--- a/packages/babel-core/src/transformation/file/options/removed.js
+++ b/packages/babel-core/src/transformation/file/options/removed.js
@@ -2,34 +2,34 @@
 
 export default {
   "auxiliaryComment": {
-    "message": "Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`"
+    "message": "Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`",
   },
   "blacklist": {
-    "message": "Put the specific transforms you want in the `plugins` option"
+    "message": "Put the specific transforms you want in the `plugins` option",
   },
   "breakConfig": {
-    "message": "This is not a necessary option in Babel 6"
+    "message": "This is not a necessary option in Babel 6",
   },
   "experimental": {
-    "message": "Put the specific transforms you want in the `plugins` option"
+    "message": "Put the specific transforms you want in the `plugins` option",
   },
   "externalHelpers": {
-    "message": "Use the `external-helpers` plugin instead. Check out http://babeljs.io/docs/plugins/external-helpers/"
+    "message": "Use the `external-helpers` plugin instead. Check out http://babeljs.io/docs/plugins/external-helpers/",
   },
   "extra": {
-    "message": ""
+    "message": "",
   },
   "jsxPragma": {
-    "message": "use the `pragma` option in the `react-jsx` plugin . Check out http://babeljs.io/docs/plugins/transform-react-jsx/"
+    "message": "use the `pragma` option in the `react-jsx` plugin . Check out http://babeljs.io/docs/plugins/transform-react-jsx/",
   },
   // "keepModuleIdExtensions": {
   //   "message": ""
   // },
   "loose": {
-    "message": "Specify the `loose` option for the relevant plugin you are using or use a preset that sets the option."
+    "message": "Specify the `loose` option for the relevant plugin you are using or use a preset that sets the option.",
   },
   "metadataUsedHelpers": {
-    "message": "Not required anymore as this is enabled by default"
+    "message": "Not required anymore as this is enabled by default",
   },
   "modules": {
     "message": "Use the corresponding module transform plugin in the `plugins` option. Check out http://babeljs.io/docs/plugins/#modules",
@@ -38,15 +38,15 @@ export default {
     "message": "Use the `react-jsx` and `flow-strip-types` plugins to support JSX and Flow. Also check out the react preset http://babeljs.io/docs/plugins/preset-react/",
   },
   "optional": {
-    "message": "Put the specific transforms you want in the `plugins` option"
+    "message": "Put the specific transforms you want in the `plugins` option",
   },
   "sourceMapName": {
-    "message": "Use the `sourceMapTarget` option"
+    "message": "Use the `sourceMapTarget` option",
   },
   "stage": {
-    "message": "Check out the corresponding stage-x presets http://babeljs.io/docs/plugins/#presets"
+    "message": "Check out the corresponding stage-x presets http://babeljs.io/docs/plugins/#presets",
   },
   "whitelist": {
-    "message": "Put the specific transforms you want in the `plugins` option"
-  }
+    "message": "Put the specific transforms you want in the `plugins` option",
+  },
 };

--- a/packages/babel-core/src/transformation/internal-plugins/block-hoist.js
+++ b/packages/babel-core/src/transformation/internal-plugins/block-hoist.js
@@ -36,7 +36,7 @@ export default new Plugin({
           // Higher priorities should move toward the top.
           return -1 * priority;
         });
-      }
-    }
-  }
+      },
+    },
+  },
 });

--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -12,7 +12,7 @@ const superVisitor = {
     node[SUPER_THIS_BOUND] = true;
 
     path.replaceWith(t.assignmentExpression("=", this.id, node));
-  }
+  },
 };
 
 export default new Plugin({
@@ -27,8 +27,8 @@ export default new Plugin({
       if (path.node.name === "arguments") {
         remap(path, "arguments");
       }
-    }
-  }
+    },
+  },
 });
 
 function shouldShadow(path, shadowPath) {
@@ -94,7 +94,7 @@ function remap(path, key) {
   const cached = fnPath.getData(key);
   if (cached) return path.replaceWith(cached);
 
-  const id   = path.scope.generateUidIdentifier(key);
+  const id = path.scope.generateUidIdentifier(key);
 
   fnPath.setData(key, id);
 

--- a/packages/babel-core/src/transformation/plugin-pass.js
+++ b/packages/babel-core/src/transformation/plugin-pass.js
@@ -6,9 +6,9 @@ export default class PluginPass extends Store {
   constructor(file: File, plugin: Plugin, options: Object = {}) {
     super();
     this.plugin = plugin;
-    this.key    = plugin.key;
-    this.file   = file;
-    this.opts   = options;
+    this.key = plugin.key;
+    this.file = file;
+    this.opts = options;
   }
 
   key: string;

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -11,13 +11,13 @@ export default class Plugin extends Store {
     super();
 
     this.initialized = false;
-    this.raw         = Object.assign({}, plugin);
-    this.key         = this.take("name") || key;
+    this.raw = Object.assign({}, plugin);
+    this.key = this.take("name") || key;
 
     this.manipulateOptions = this.take("manipulateOptions");
-    this.post              = this.take("post");
-    this.pre               = this.take("pre");
-    this.visitor           = this.normaliseVisitor(clone(this.take("visitor")) || {});
+    this.post = this.take("post");
+    this.pre = this.take("pre");
+    this.visitor = this.normaliseVisitor(clone(this.take("visitor")) || {});
   }
 
   initialized: boolean;

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -18,7 +18,7 @@ function transformAsync(code, opts) {
   return {
     then: function (resolve) {
       resolve(babel.transform(code, opts));
-    }
+    },
   };
 }
 
@@ -29,7 +29,7 @@ describe("parser and generator options", function() {
     },
     print: function(ast) {
       return generator(ast);
-    }
+    },
   };
 
   function newTransform(string) {
@@ -37,11 +37,11 @@ describe("parser and generator options", function() {
       parserOpts: {
         parser: recast.parse,
         plugins: ["flow"],
-        allowImportExportEverywhere: true
+        allowImportExportEverywhere: true,
       },
       generatorOpts: {
-        generator: recast.print
-      }
+        generator: recast.print,
+      },
     });
   }
 
@@ -56,8 +56,8 @@ describe("parser and generator options", function() {
 
     assert.deepEqual(newTransform(experimental).ast, babel.transform(experimental, {
       parserOpts: {
-        plugins: ["flow"]
-      }
+        plugins: ["flow"],
+      },
     }).ast);
     assert.equal(newTransform(experimental).code, experimental);
 
@@ -65,18 +65,18 @@ describe("parser and generator options", function() {
       return babel.transform(string, {
         plugins: [__dirname + "/../../babel-plugin-syntax-flow"],
         parserOpts: {
-          parser: recast.parse
+          parser: recast.parse,
         },
         generatorOpts: {
-          generator: recast.print
-        }
+          generator: recast.print,
+        },
       });
     }
 
     assert.deepEqual(newTransformWithPlugins(experimental).ast, babel.transform(experimental, {
       parserOpts: {
-        plugins: ["flow"]
-      }
+        plugins: ["flow"],
+      },
     }).ast);
     assert.equal(newTransformWithPlugins(experimental).code, experimental);
   });
@@ -86,8 +86,8 @@ describe("parser and generator options", function() {
 
     assert.notEqual(newTransform(experimental).ast, babel.transform(experimental, {
       parserOpts: {
-        allowImportExportEverywhere: true
-      }
+        allowImportExportEverywhere: true,
+      },
     }).ast);
     assert.equal(newTransform(experimental).code, experimental);
   });
@@ -102,15 +102,15 @@ describe("api", function () {
         visitor: {
           Program: function (path) {
             path.mark("category", "foobar");
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).marked[0].message, "foobar");
 
     assert.equal(babel.analyse("foobar;", {}, {
       Program: function (path) {
         path.mark("category", "foobar");
-      }
+      },
     }).marked[0].message, "foobar");
   });
 
@@ -138,7 +138,7 @@ describe("api", function () {
     return assert.throws(
       function () {
         babel.transform("", {
-          plugins: [__dirname + "/../../babel-plugin-syntax-jsx", false]
+          plugins: [__dirname + "/../../babel-plugin-syntax-jsx", false],
         });
       },
       /TypeError: Falsy value found in plugins/
@@ -148,7 +148,7 @@ describe("api", function () {
   it("options merge backwards", function () {
     return transformAsync("", {
       presets: [__dirname + "/../../babel-preset-es2015"],
-      plugins: [__dirname + "/../../babel-plugin-syntax-jsx"]
+      plugins: [__dirname + "/../../babel-plugin-syntax-jsx"],
     }).then(function (result) {
       assert.ok(result.options.plugins[0][0].manipulateOptions.toString().indexOf("jsx") >= 0);
     });
@@ -177,9 +177,9 @@ describe("api", function () {
         visitor: {
           "Program|Identifier": function () {
             calledRaw++;
-          }
-        }
-      })]
+          },
+        },
+      })],
     });
 
     assert.equal(calledRaw, 4);
@@ -212,10 +212,10 @@ describe("api", function () {
                       // In case of `passPerPreset` being `true`, the
                       // alias node should still exist.
                       aliasBaseType = alias.right.type; // NumberTypeAnnotation
-                    }
-                  }
-                })
-              ]
+                    },
+                  },
+                }),
+              ],
             };
           },
 
@@ -228,9 +228,9 @@ describe("api", function () {
               plugins: [
                 require(__dirname + "/../../babel-plugin-syntax-flow"),
                 require(__dirname + "/../../babel-plugin-transform-flow-strip-types"),
-              ]
+              ],
             };
-          }
+          },
         ],
       });
     }
@@ -246,7 +246,7 @@ describe("api", function () {
       "",
       "var x = function x(y) {",
       "  return y;",
-      "};"
+      "};",
     ].join("\n"), result.code);
 
     // 2. passPerPreset: false
@@ -262,7 +262,7 @@ describe("api", function () {
       "",
       "var x = function x(y) {",
       "  return y;",
-      "};"
+      "};",
     ].join("\n"), result.code);
 
   });
@@ -276,10 +276,10 @@ describe("api", function () {
       "  _classCallCheck(this, Foo);",
       "};",
       "",
-      "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0ZG91dCJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztJQUFNLEdBQUcsWUFBSCxHQUFHO3dCQUFILEdBQUciLCJmaWxlIjoidW5kZWZpbmVkIiwic291cmNlc0NvbnRlbnQiOlsiY2xhc3MgRm9vIHt9XG4iXX0="
+      "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0ZG91dCJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztJQUFNLEdBQUcsWUFBSCxHQUFHO3dCQUFILEdBQUciLCJmaWxlIjoidW5kZWZpbmVkIiwic291cmNlc0NvbnRlbnQiOlsiY2xhc3MgRm9vIHt9XG4iXX0=",
       /* eslint-enable max-len */
     ].join("\n"), {
-      sourceMap: true
+      sourceMap: true,
     });
 
     assert.deepEqual([
@@ -291,19 +291,19 @@ describe("api", function () {
       "",
       "let Foo = function Foo() {",
       "  _classCallCheck(this, Foo);",
-      "};"
+      "};",
     ].join("\n"), result.code);
 
     const consumer = new sourceMap.SourceMapConsumer(result.map);
 
     assert.deepEqual(consumer.originalPositionFor({
       line: 7,
-      column: 4
+      column: 4,
     }), {
       name: null,
       source: "stdout",
       line: 1,
-      column: 6
+      column: 6,
     });
   });
 
@@ -330,10 +330,10 @@ describe("api", function () {
             Program: function (path) {
               path.unshiftContainer("body", t.expressionStatement(t.identifier("start")));
               path.pushContainer("body", t.expressionStatement(t.identifier("end")));
-            }
-          }
+            },
+          },
         };
-      }]
+      }],
     }).then(function (result) {
       assert.equal(result.code,
         "/*before*/start;\n/*after*/class Foo {}\n/*before*/end;\n/*after*/");
@@ -350,8 +350,8 @@ describe("api", function () {
           specifiers: [{
             kind: "named",
             imported: "externalName",
-            local: "localName"
-          }]
+            local: "localName",
+          }],
         });
       }),
 
@@ -361,8 +361,8 @@ describe("api", function () {
           imported: ["*"],
           specifiers: [{
             kind: "namespace",
-            local: "localName2"
-          }]
+            local: "localName2",
+          }],
         });
       }),
 
@@ -373,15 +373,15 @@ describe("api", function () {
           specifiers: [{
             kind: "named",
             imported: "default",
-            local: "localName3"
-          }]
+            local: "localName3",
+          }],
         });
       }),
 
       transformAsync("import localName from \"./array\";", {
         resolveModuleSource: function() {
           return "override-source";
-        }
+        },
       }).then(function (result) {
         assert.deepEqual(result.metadata.modules.imports, [
           {
@@ -391,15 +391,15 @@ describe("api", function () {
               {
                 "kind": "named",
                 "imported": "default",
-                "local": "localName"
-              }
-            ]
-          }
+                "local": "localName",
+              },
+            ],
+          },
         ]);
       }),
 
       transformAsync("export * as externalName1 from \"external\";", {
-        plugins: [require("../../babel-plugin-syntax-export-extensions")]
+        plugins: [require("../../babel-plugin-syntax-export-extensions")],
       }).then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
           exported: ["externalName1"],
@@ -407,12 +407,12 @@ describe("api", function () {
             kind: "external-namespace",
             exported: "externalName1",
             source: "external",
-          }]
+          }],
         });
       }),
 
       transformAsync("export externalName2 from \"external\";", {
-        plugins: [require("../../babel-plugin-syntax-export-extensions")]
+        plugins: [require("../../babel-plugin-syntax-export-extensions")],
       }).then(function (result) {
         assert.deepEqual(result.metadata.modules.exports, {
           exported: ["externalName2"],
@@ -420,8 +420,8 @@ describe("api", function () {
             kind: "external",
             local: "externalName2",
             exported: "externalName2",
-            source: "external"
-          }]
+            source: "external",
+          }],
         });
       }),
 
@@ -431,8 +431,8 @@ describe("api", function () {
           specifiers: [{
             kind: "local",
             local: "namedFunction",
-            exported: "namedFunction"
-          }]
+            exported: "namedFunction",
+          }],
         });
       }),
 
@@ -442,8 +442,8 @@ describe("api", function () {
           specifiers: [{
             kind: "local",
             local: "foo",
-            exported: "foo"
-          }]
+            exported: "foo",
+          }],
         });
       }),
 
@@ -453,8 +453,8 @@ describe("api", function () {
           specifiers: [{
             kind: "local",
             local: "localName",
-            exported: "externalName3"
-          }]
+            exported: "externalName3",
+          }],
         });
       }),
 
@@ -465,8 +465,8 @@ describe("api", function () {
             kind: "external",
             local: "externalName4",
             exported: "externalName4",
-            source: "external"
-          }]
+            source: "external",
+          }],
         });
       }),
 
@@ -475,8 +475,8 @@ describe("api", function () {
           exported: [],
           specifiers: [{
             kind: "external-all",
-            source: "external"
-          }]
+            source: "external",
+          }],
         });
       }),
 
@@ -486,10 +486,10 @@ describe("api", function () {
           specifiers: [{
             kind: "local",
             local: "defaultFunction",
-            exported: "default"
-          }]
+            exported: "default",
+          }],
         });
-      })
+      }),
     ]);
   });
 
@@ -497,18 +497,18 @@ describe("api", function () {
     return Promise.all([
       transformAsync("", {
         ignore: "node_modules",
-        filename: "/foo/node_modules/bar"
+        filename: "/foo/node_modules/bar",
       }).then(assertIgnored),
 
       transformAsync("", {
         ignore: "foo/node_modules",
-        filename: "/foo/node_modules/bar"
+        filename: "/foo/node_modules/bar",
       }).then(assertIgnored),
 
       transformAsync("", {
         ignore: "foo/node_modules/*.bar",
-        filename: "/foo/node_modules/foo.bar"
-      }).then(assertIgnored)
+        filename: "/foo/node_modules/foo.bar",
+      }).then(assertIgnored),
     ]);
   });
 
@@ -516,33 +516,33 @@ describe("api", function () {
     return Promise.all([
       transformAsync("", {
         only: "node_modules",
-        filename: "/foo/node_modules/bar"
+        filename: "/foo/node_modules/bar",
       }).then(assertNotIgnored),
 
       transformAsync("", {
         only: "foo/node_modules",
-        filename: "/foo/node_modules/bar"
+        filename: "/foo/node_modules/bar",
       }).then(assertNotIgnored),
 
       transformAsync("", {
         only: "foo/node_modules/*.bar",
-        filename: "/foo/node_modules/foo.bar"
+        filename: "/foo/node_modules/foo.bar",
       }).then(assertNotIgnored),
 
       transformAsync("", {
         only: "node_modules",
-        filename: "/foo/node_module/bar"
+        filename: "/foo/node_module/bar",
       }).then(assertIgnored),
 
       transformAsync("", {
         only: "foo/node_modules",
-        filename: "/bar/node_modules/foo"
+        filename: "/bar/node_modules/foo",
       }).then(assertIgnored),
 
       transformAsync("", {
         only: "foo/node_modules/*.bar",
-        filename: "/foo/node_modules/bar.foo"
-      }).then(assertIgnored)
+        filename: "/foo/node_modules/bar.foo",
+      }).then(assertIgnored),
     ]);
   });
 
@@ -565,8 +565,8 @@ describe("api", function () {
     it("default", function () {
       const result = babel.transform("foo;", {
         env: {
-          development: { code: false }
-        }
+          development: { code: false },
+        },
       });
 
       assert.equal(result.code, undefined);
@@ -576,8 +576,8 @@ describe("api", function () {
       process.env.BABEL_ENV = "foo";
       const result = babel.transform("foo;", {
         env: {
-          foo: { code: false }
-        }
+          foo: { code: false },
+        },
       });
       assert.equal(result.code, undefined);
     });
@@ -586,8 +586,8 @@ describe("api", function () {
       process.env.NODE_ENV = "foo";
       const result = babel.transform("foo;", {
         env: {
-          foo: { code: false }
-        }
+          foo: { code: false },
+        },
       });
       assert.equal(result.code, undefined);
     });
@@ -602,7 +602,7 @@ describe("api", function () {
     return transformAsync(actual, {
       resolveModuleSource: function (originalSource) {
         return "resolved/" + originalSource;
-      }
+      },
     }).then(function (result) {
       assert.equal(result.code.trim(), expected);
     });

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -29,48 +29,48 @@ describe("buildConfigChain", function () {
 
   it("dir1", function () {
     const chain = buildConfigChain({
-      filename: fixture("dir1", "src.js")
+      filename: fixture("dir1", "src.js"),
     });
 
     const expected = [
       {
         options: {
           plugins: [
-            "extended"
-          ]
+            "extended",
+          ],
         },
         alias: fixture("extended.babelrc.json"),
         loc: fixture("extended.babelrc.json"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
           plugins: [
-            "root"
-          ]
+            "root",
+          ],
         },
         alias: fixture(".babelrc"),
         loc: fixture(".babelrc"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
           ignore: [
-            "root-ignore"
-          ]
+            "root-ignore",
+          ],
         },
         alias: fixture(".babelignore"),
         loc: fixture(".babelignore"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
-          filename: fixture("dir1", "src.js")
+          filename: fixture("dir1", "src.js"),
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("dir1")
-      }
+        dirname: fixture("dir1"),
+      },
     ];
 
     assert.deepEqual(chain, expected);
@@ -78,38 +78,38 @@ describe("buildConfigChain", function () {
 
   it("dir2", function () {
     const chain = buildConfigChain({
-      filename: fixture("dir2", "src.js")
+      filename: fixture("dir2", "src.js"),
     });
 
     const expected = [
       {
         options: {
           plugins: [
-            "dir2"
-          ]
+            "dir2",
+          ],
         },
         alias: fixture("dir2", ".babelrc"),
         loc: fixture("dir2", ".babelrc"),
-        dirname: fixture("dir2")
+        dirname: fixture("dir2"),
       },
       {
         options: {
           ignore: [
-            "root-ignore"
-          ]
+            "root-ignore",
+          ],
         },
         alias: fixture(".babelignore"),
         loc: fixture(".babelignore"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
-          filename: fixture("dir2", "src.js")
+          filename: fixture("dir2", "src.js"),
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("dir2")
-      }
+        dirname: fixture("dir2"),
+      },
     ];
 
     assert.deepEqual(chain, expected);
@@ -117,38 +117,38 @@ describe("buildConfigChain", function () {
 
   it("env - base", function () {
     const chain = buildConfigChain({
-      filename: fixture("env", "src.js")
+      filename: fixture("env", "src.js"),
     });
 
     const expected = [
       {
         options: {
           plugins: [
-            "env-base"
-          ]
+            "env-base",
+          ],
         },
         alias: fixture("env", ".babelrc"),
         loc: fixture("env", ".babelrc"),
-        dirname: fixture("env")
+        dirname: fixture("env"),
       },
       {
         options: {
           ignore: [
-            "root-ignore"
-          ]
+            "root-ignore",
+          ],
         },
         alias: fixture(".babelignore"),
         loc: fixture(".babelignore"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
-          filename: fixture("env", "src.js")
+          filename: fixture("env", "src.js"),
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("env")
-      }
+        dirname: fixture("env"),
+      },
     ];
 
     assert.deepEqual(chain, expected);
@@ -158,48 +158,48 @@ describe("buildConfigChain", function () {
     process.env.NODE_ENV = "foo";
 
     const chain = buildConfigChain({
-      filename: fixture("env", "src.js")
+      filename: fixture("env", "src.js"),
     });
 
     const expected = [
       {
         options: {
           plugins: [
-            "env-base"
-          ]
+            "env-base",
+          ],
         },
         alias: fixture("env", ".babelrc"),
         loc: fixture("env", ".babelrc"),
-        dirname: fixture("env")
+        dirname: fixture("env"),
       },
       {
         options: {
           plugins: [
-            "env-foo"
-          ]
+            "env-foo",
+          ],
         },
         alias: fixture("env", ".babelrc.env.foo"),
         loc: fixture("env", ".babelrc.env.foo"),
-        dirname: fixture("env")
+        dirname: fixture("env"),
       },
       {
         options: {
           ignore: [
-            "root-ignore"
-          ]
+            "root-ignore",
+          ],
         },
         alias: fixture(".babelignore"),
         loc: fixture(".babelignore"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
-          filename: fixture("env", "src.js")
+          filename: fixture("env", "src.js"),
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("env")
-      }
+        dirname: fixture("env"),
+      },
     ];
 
     assert.deepEqual(chain, expected);
@@ -210,48 +210,48 @@ describe("buildConfigChain", function () {
     process.env.NODE_ENV = "bar";
 
     const chain = buildConfigChain({
-      filename: fixture("env", "src.js")
+      filename: fixture("env", "src.js"),
     });
 
     const expected = [
       {
         options: {
           plugins: [
-            "env-base"
-          ]
+            "env-base",
+          ],
         },
         alias: fixture("env", ".babelrc"),
         loc: fixture("env", ".babelrc"),
-        dirname: fixture("env")
+        dirname: fixture("env"),
       },
       {
         options: {
           plugins: [
-            "env-bar"
-          ]
+            "env-bar",
+          ],
         },
         alias: fixture("env", ".babelrc.env.bar"),
         loc: fixture("env", ".babelrc.env.bar"),
-        dirname: fixture("env")
+        dirname: fixture("env"),
       },
       {
         options: {
           ignore: [
-            "root-ignore"
-          ]
+            "root-ignore",
+          ],
         },
         alias: fixture(".babelignore"),
         loc: fixture(".babelignore"),
-        dirname: fixture()
+        dirname: fixture(),
       },
       {
         options: {
-          filename: fixture("env", "src.js")
+          filename: fixture("env", "src.js"),
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("env")
-      }
+        dirname: fixture("env"),
+      },
     ];
 
     assert.deepEqual(chain, expected);
@@ -262,34 +262,34 @@ describe("buildConfigChain", function () {
     process.env.NODE_ENV = "foo";
 
     const chain = buildConfigChain({
-      filename: fixture("pkg", "src.js")
+      filename: fixture("pkg", "src.js"),
     });
 
     const expected = [
       {
         options: {
-          plugins: ["pkg-plugin"]
+          plugins: ["pkg-plugin"],
         },
         alias: fixture("pkg", "package.json"),
         loc: fixture("pkg", "package.json"),
-        dirname: fixture("pkg")
+        dirname: fixture("pkg"),
       },
       {
         options: {
-          ignore: ["pkg-ignore"]
+          ignore: ["pkg-ignore"],
         },
         alias: fixture("pkg", ".babelignore"),
         loc: fixture("pkg", ".babelignore"),
-        dirname: fixture("pkg")
+        dirname: fixture("pkg"),
       },
       {
         options: {
-          filename: fixture("pkg", "src.js")
+          filename: fixture("pkg", "src.js"),
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("pkg")
-      }
+        dirname: fixture("pkg"),
+      },
     ];
 
     assert.deepEqual(chain, expected);

--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -14,7 +14,7 @@ describe("evaluation", function () {
       };
 
       traverse(parse(code, {
-        plugins: ["*"]
+        plugins: ["*"],
       }), visitor);
     });
   }

--- a/packages/babel-core/test/get-possible-preset-names.js
+++ b/packages/babel-core/test/get-possible-preset-names.js
@@ -10,13 +10,13 @@ describe("getPossiblePresetNames", function () {
     assert.deepEqual(getPossiblePresetNames("@babel/es2015"), [
       "babel-preset-@babel/es2015",
       "@babel/es2015",
-      "@babel/babel-preset-es2015"
+      "@babel/babel-preset-es2015",
     ]);
 
     assert.deepEqual(getPossiblePresetNames("@babel/react/optimizations"), [
       "babel-preset-@babel/react/optimizations",
       "@babel/react/optimizations",
-      "@babel/babel-preset-react/optimizations"
+      "@babel/babel-preset-react/optimizations",
     ]);
   });
 });

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -19,7 +19,7 @@ describe("option-manager", () => {
         () => {
           const opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
-            "randomOption": true
+            "randomOption": true,
           });
         },
         /Unknown option: base.randomOption/
@@ -32,7 +32,7 @@ describe("option-manager", () => {
           const opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
             "auxiliaryComment": true,
-            "blacklist": true
+            "blacklist": true,
           });
         },
         // eslint-disable-next-line max-len
@@ -45,7 +45,7 @@ describe("option-manager", () => {
         () => {
           const opt = new OptionManager(new Logger(null, "unknown"));
           opt.init({
-            "presets": [path.join(__dirname, "fixtures/option-manager/not-a-preset")]
+            "presets": [path.join(__dirname, "fixtures/option-manager/not-a-preset")],
           });
         },
         /While processing preset: .*option-manager(?:\/|\\\\)not-a-preset\.js/
@@ -58,7 +58,7 @@ describe("option-manager", () => {
       it(name, function () {
         const opt = new OptionManager(new Logger(null, "unknown"));
         const options = opt.init({
-          "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)]
+          "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)],
         });
 
         assert.equal(true, Array.isArray(options.plugins));
@@ -70,7 +70,7 @@ describe("option-manager", () => {
       it(name, function () {
         const opt = new OptionManager(new Logger(null, "unknown"));
         assert.throws(() => opt.init({
-          "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)]
+          "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)],
         }), msg);
       });
     }

--- a/packages/babel-core/test/path.js
+++ b/packages/babel-core/test/path.js
@@ -11,9 +11,9 @@ describe("traversal path", function () {
         visitor: {
           FunctionDeclaration: function (path) {
             path.replaceWithSourceString("console.whatever()");
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("console.whatever();");
@@ -32,13 +32,13 @@ describe("traversal path", function () {
                 type: "ReturnStatement",
                 argument: {
                   type: "BooleanLiteral",
-                  value: true
-                }
-              }]
+                  value: true,
+                },
+              }],
             });
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("var fn = () => {\n  return true;\n};");
@@ -53,11 +53,11 @@ describe("traversal path", function () {
           ArrowFunctionExpression: function (path) {
             path.get("body").replaceWith({
               type: "BooleanLiteral",
-              value: true
+              value: true,
             });
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("var fn = () => true;");
@@ -77,13 +77,13 @@ describe("traversal path", function () {
                 type: "VariableDeclarator",
                 id: {
                   type: "Identifier",
-                  name: "KEY"
-                }
-              }]
+                  name: "KEY",
+                },
+              }],
             });
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("for (var KEY in right);");
@@ -98,11 +98,11 @@ describe("traversal path", function () {
           ForInStatement: function (path) {
             path.get("left").replaceWith({
               type: "Identifier",
-              name: "KEY"
+              name: "KEY",
             });
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("for (KEY in right);");
@@ -122,13 +122,13 @@ describe("traversal path", function () {
                 type: "VariableDeclarator",
                 id: {
                   type: "Identifier",
-                  name: "KEY"
-                }
-              }]
+                  name: "KEY",
+                },
+              }],
             });
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("for (var KEY;;);");
@@ -143,11 +143,11 @@ describe("traversal path", function () {
           ForStatement: function (path) {
             path.get("init").replaceWith({
               type: "Identifier",
-              name: "KEY"
+              name: "KEY",
             });
-          }
-        }
-      })]
+          },
+        },
+      })],
     }).code;
 
     chai.expect(actualCode).to.be.equal("for (KEY;;);");

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -188,7 +188,7 @@ export function BindExpression(node: Object) {
 
 export {
   AssignmentExpression as BinaryExpression,
-  AssignmentExpression as LogicalExpression
+  AssignmentExpression as LogicalExpression,
 };
 
 export function MemberExpression(node: Object) {

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -280,7 +280,7 @@ export function ObjectTypeAnnotation(node: Object) {
           this.token(",");
           this.space();
         }
-      }
+      },
     });
 
     this.space();

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -7,7 +7,7 @@ export function _params(node: Object) {
     iterator: (node) => {
       if (node.optional) this.token("?");
       this.print(node.typeAnnotation, node);
-    }
+    },
   });
   this.token(")");
 
@@ -18,7 +18,7 @@ export function _params(node: Object) {
 
 export function _method(node: Object) {
   const kind = node.kind;
-  const key  = node.key;
+  const key = node.key;
 
   if (kind === "method" || kind === "init") {
     if (node.generator) {

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -133,9 +133,9 @@ function buildLabelStatement(prefix, key = "label") {
 }
 
 export const ContinueStatement = buildLabelStatement("continue");
-export const ReturnStatement   = buildLabelStatement("return", "argument");
-export const BreakStatement    = buildLabelStatement("break");
-export const ThrowStatement    = buildLabelStatement("throw", "argument");
+export const ReturnStatement = buildLabelStatement("return", "argument");
+export const BreakStatement = buildLabelStatement("break");
+export const ThrowStatement = buildLabelStatement("throw", "argument");
 
 export function LabeledStatement(node: Object) {
   this.print(node.label, node);
@@ -190,7 +190,7 @@ export function SwitchStatement(node: Object) {
     indent: true,
     addNewlines(leading, cas) {
       if (!leading && node.cases[node.cases.length - 1] === cas) return -1;
-    }
+    },
   });
 
   this.token("}");

--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -69,7 +69,7 @@ export function ObjectProperty(node: Object) {
 
 export function ArrayExpression(node: Object) {
   const elems = node.elements;
-  const len   = elems.length;
+  const len = elems.length;
 
   this.token("[");
   this.printInnerComments(node);
@@ -129,7 +129,7 @@ export function StringLiteral(node: Object, parent: Object) {
   // ensure the output is ASCII-safe
   const opts = {
     quotes: t.isJSX(parent) ? "double" : this.format.quotes,
-    wrap: true
+    wrap: true,
   };
   if (this.format.jsonCompatibleStrings) {
     opts.json = true;

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -63,8 +63,8 @@ function normalizeOptions(code, opts, tokens): Format {
     indent: {
       adjustMultilineComment: true,
       style: style,
-      base: 0
-    }
+      base: 0,
+    },
   };
 
   if (format.minified) {
@@ -102,7 +102,7 @@ function findCommonStringDelimiter(code, tokens) {
 
   const occurences = {
     single: 0,
-    double: 0
+    double: 0,
   };
 
   let checked = 0;

--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -24,7 +24,7 @@ const PRECEDENCE = {
   "*": 9,
   "/": 9,
   "%": 9,
-  "**": 10
+  "**": 10,
 };
 
 export function NullableTypeAnnotation(node: Object, parent: Object): boolean {
@@ -64,7 +64,7 @@ export function Binary(node: Object, parent: Object): boolean {
   }
 
   if (t.isBinary(parent)) {
-    const parentOp  = parent.operator;
+    const parentOp = parent.operator;
     const parentPos = PRECEDENCE[parentOp];
 
     const nodeOp = node.operator;
@@ -220,7 +220,7 @@ export function AssignmentExpression(node: Object): boolean {
 // in statement.
 function isFirstInStatement(printStack: Array<Object>, {
     considerArrow = false,
-    considerDefaultExports = false
+    considerDefaultExports = false,
   } = {}): boolean {
   let i = printStack.length - 1;
   let node = printStack[i];

--- a/packages/babel-generator/src/node/whitespace.js
+++ b/packages/babel-generator/src/node/whitespace.js
@@ -71,7 +71,7 @@ export const nodes = {
     if ((state.hasCall && state.hasHelper) || state.hasFunction) {
       return {
         before: state.hasFunction,
-        after: true
+        after: true,
       };
     }
   },
@@ -82,7 +82,7 @@ export const nodes = {
 
   SwitchCase(node: Object, parent: Object): ?WhitespaceObject {
     return {
-      before: node.consequent.length || parent.cases[0] === node
+      before: node.consequent.length || parent.cases[0] === node,
     };
   },
 
@@ -93,7 +93,7 @@ export const nodes = {
   LogicalExpression(node: Object): ?WhitespaceObject {
     if (t.isFunction(node.left) || t.isFunction(node.right)) {
       return {
-        after: true
+        after: true,
       };
     }
   },
@@ -105,7 +105,7 @@ export const nodes = {
   Literal(node: Object): ?WhitespaceObject {
     if (node.value === "use strict") {
       return {
-        after: true
+        after: true,
       };
     }
   },
@@ -118,7 +118,7 @@ export const nodes = {
     if (t.isFunction(node.callee) || isHelper(node)) {
       return {
         before: true,
-        after: true
+        after: true,
       };
     }
   },
@@ -140,7 +140,7 @@ export const nodes = {
       if (enabled) {
         return {
           before: true,
-          after: true
+          after: true,
         };
       }
     }
@@ -154,10 +154,10 @@ export const nodes = {
     if (t.isBlockStatement(node.consequent)) {
       return {
         before: true,
-        after: true
+        after: true,
       };
     }
-  }
+  },
 };
 
 /**
@@ -169,7 +169,7 @@ nodes.ObjectTypeProperty =
 nodes.ObjectMethod = function (node: Object, parent): ?WhitespaceObject {
   if (parent.properties[0] === node) {
     return {
-      before: true
+      before: true,
     };
   }
 };
@@ -202,7 +202,7 @@ export const list = {
 
   ObjectExpression(node: Object): Array<Object> {
     return node.properties;
-  }
+  },
 };
 
 /**
@@ -215,7 +215,7 @@ export const list = {
   ["Loop", true],
   ["LabeledStatement", true],
   ["SwitchStatement", true],
-  ["TryStatement", true]
+  ["TryStatement", true],
 ].forEach(function ([type, amounts]) {
   if (typeof amounts === "boolean") {
     amounts = { after: amounts, before: amounts };

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -295,7 +295,7 @@ export default class Printer {
 
   startTerminatorless(): Object {
     return this._parenPushNewlineState = {
-      printed: false
+      printed: false,
     };
   }
 
@@ -370,7 +370,7 @@ export default class Printer {
     if (comment) {
       this._printComment({
         type: "CommentBlock",
-        value: comment
+        value: comment,
       });
     }
   }
@@ -383,7 +383,7 @@ export default class Printer {
     if (comment) {
       this._printComment({
         type: "CommentBlock",
-        value: comment
+        value: comment,
       });
     }
   }

--- a/packages/babel-generator/src/whitespace.js
+++ b/packages/babel-generator/src/whitespace.js
@@ -5,7 +5,7 @@
 export default class Whitespace {
   constructor(tokens) {
     this.tokens = tokens;
-    this.used   = {};
+    this.used = {};
   }
 
   /**
@@ -59,7 +59,7 @@ export default class Whitespace {
     if (!endToken || !endToken.loc) return 0;
 
     const start = startToken ? startToken.loc.end.line : 1;
-    const end   = endToken.loc.start.line;
+    const end = endToken.loc.start.line;
     let lines = 0;
 
     for (let line = start; line < end; line++) {

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -24,7 +24,7 @@ describe("generation", function () {
   it("multiple sources", function () {
     const sources = {
       "a.js": "function hi (msg) { console.log(msg); }\n",
-      "b.js": "hi('hello');\n"
+      "b.js": "hi('hello');\n",
     };
     const parsed = Object.keys(sources).reduce(function (_parsed, filename) {
       _parsed[filename] = parse(sources[filename], { sourceFilename: filename });
@@ -36,8 +36,8 @@ describe("generation", function () {
       "program": {
         "type": "Program",
         "sourceType": "module",
-        "body": [].concat(parsed["a.js"].program.body, parsed["b.js"].program.body)
-      }
+        "body": [].concat(parsed["a.js"].program.body, parsed["b.js"].program.body),
+      },
     };
 
     const generated = generate(combinedAst, { sourceMaps: true }, sources);
@@ -54,8 +54,8 @@ describe("generation", function () {
       ],
       sourcesContent: [
         "function hi (msg) { console.log(msg); }\n",
-        "hi('hello');\n"
-      ]
+        "hi('hello');\n",
+      ],
     }, "sourcemap was incorrectly generated");
 
     chai.expect(generated.rawMappings).to.deep.equal([
@@ -144,7 +144,7 @@ describe("generation", function () {
     const generated = generate(ast, {
       filename: "inline",
       sourceFileName: "inline",
-      sourceMaps: true
+      sourceMaps: true,
     }, code);
 
     chai.expect(generated.map).to.deep.equal({
@@ -152,7 +152,7 @@ describe("generation", function () {
       sources: ["inline"],
       names: ["foo", "bar" ],
       mappings: "AAAA,SAASA,IAAT,GAAe;AAAEC;AAAM",
-      sourcesContent: [ "function foo() { bar; }\n" ]
+      sourcesContent: [ "function foo() { bar; }\n" ],
     }, "sourcemap was incorrectly generated");
 
     chai.expect(generated.rawMappings).to.deep.equal([
@@ -240,7 +240,7 @@ describe("programmatic generation", function() {
     assert.equal(output, [
       "{",
       "  \"use strict\";",
-      "}"
+      "}",
     ].join("\n"));
   });
 

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
@@ -22,7 +22,7 @@ export default function (opts: {
     const expr = path.node.expression;
     if (!isAssignment(expr)) return;
 
-    const nodes    = [];
+    const nodes = [];
     const exploded = explode(expr.left, nodes, file, path.scope, true);
 
     nodes.push(t.expressionStatement(
@@ -36,7 +36,7 @@ export default function (opts: {
     const { node, scope } = path;
     if (!isAssignment(node)) return;
 
-    const nodes    = [];
+    const nodes = [];
     const exploded = explode(node.left, nodes, file, scope);
     nodes.push(buildAssignment(exploded.ref, opts.build(exploded.uid, node.right)));
     path.replaceWithMultiple(nodes);

--- a/packages/babel-helper-builder-conditional-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-conditional-assignment-operator-visitor/src/index.js
@@ -35,7 +35,7 @@ export default function (
     const node = path.node;
     if (!opts.is(node, file)) return;
 
-    const nodes    = [];
+    const nodes = [];
     const exploded = explode(node.left, nodes, file, path.scope);
 
     nodes.push(t.logicalExpression(

--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -28,7 +28,7 @@ export default function (opts) {
       }
 
       path.replaceWith(t.inherits(callExpr, path.node));
-    }
+    },
   };
 
   return visitor;
@@ -92,7 +92,7 @@ export default function (opts) {
     const state: ElementState = {
       tagExpr: tagExpr,
       tagName: tagName,
-      args:    args
+      args: args,
     };
 
     if (opts.pre) {

--- a/packages/babel-helper-call-delegate/src/index.js
+++ b/packages/babel-helper-call-delegate/src/index.js
@@ -15,7 +15,7 @@ const visitor = {
 
   Function(path) {
     path.skip();
-  }
+  },
 };
 
 export default function (path: NodePath, scope = path.scope) {
@@ -23,14 +23,14 @@ export default function (path: NodePath, scope = path.scope) {
   const container = t.functionExpression(null, [], node.body, node.generator, node.async);
 
   let callee = container;
-  let args   = [];
+  let args = [];
 
   // todo: only hoist if necessary
   hoistVariables(path, (id) => scope.push({ id }));
 
   const state = {
     foundThis: false,
-    foundArguments: false
+    foundArguments: false,
   };
 
   path.traverse(visitor, state);

--- a/packages/babel-helper-explode-assignable-expression/src/index.js
+++ b/packages/babel-helper-explode-assignable-expression/src/index.js
@@ -33,7 +33,7 @@ function getObjRef(node, nodes, file, scope) {
 
   const temp = scope.generateUidIdentifierBasedOnNode(ref);
   nodes.push(t.variableDeclaration("var", [
-    t.variableDeclarator(temp, ref)
+    t.variableDeclarator(temp, ref),
   ]));
   return temp;
 }
@@ -45,7 +45,7 @@ function getPropRef(node, nodes, file, scope) {
 
   const temp = scope.generateUidIdentifierBasedOnNode(prop);
   nodes.push(t.variableDeclaration("var", [
-    t.variableDeclarator(temp, prop)
+    t.variableDeclarator(temp, prop),
   ]));
   return temp;
 }
@@ -80,6 +80,6 @@ export default function (
 
   return {
     uid: uid,
-    ref: ref
+    ref: ref,
   };
 }

--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -64,7 +64,7 @@ export default function get(entryLoc): Array<Suite> {
       options: clone(rootOpts),
       tests: [],
       title: humanize(suiteName),
-      filename: entryLoc + "/" + suiteName
+      filename: entryLoc + "/" + suiteName,
     };
 
     assertDirectory(suite.filename);
@@ -80,11 +80,11 @@ export default function get(entryLoc): Array<Suite> {
     function push(taskName, taskDir) {
       const actualLocAlias = suiteName + "/" + taskName + "/actual.js";
       let expectLocAlias = suiteName + "/" + taskName + "/expected.js";
-      const execLocAlias   = suiteName + "/" + taskName + "/exec.js";
+      const execLocAlias = suiteName + "/" + taskName + "/exec.js";
 
       const actualLoc = taskDir + "/actual.js";
       let expectLoc = taskDir + "/expected.js";
-      let execLoc   = taskDir + "/exec.js";
+      let execLoc = taskDir + "/exec.js";
 
       if (fs.statSync(taskDir).isFile()) {
         const ext = path.extname(taskDir);
@@ -121,8 +121,8 @@ export default function get(entryLoc): Array<Suite> {
         expect: {
           loc: expectLoc,
           code: readFile(expectLoc),
-          filename: expectLocAlias
-        }
+          filename: expectLocAlias,
+        },
       };
 
       // traceur checks

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -42,7 +42,7 @@ const visitor = {
 
     state.selfReference = true;
     path.stop();
-  }
+  },
 };
 
 function wrap(state, method, id, scope) {
@@ -60,7 +60,7 @@ function wrap(state, method, id, scope) {
       const template = build({
         FUNCTION: method,
         FUNCTION_ID: id,
-        FUNCTION_KEY: scope.generateUidIdentifier(id.name)
+        FUNCTION_KEY: scope.generateUidIdentifier(id.name),
       }).expression;
       template.callee._skipModulesRemap = true;
 
@@ -82,10 +82,10 @@ function wrap(state, method, id, scope) {
 function visit(node, name, scope) {
   const state = {
     selfAssignment: false,
-    selfReference:  false,
-    outerDeclar:    scope.getBindingIdentifier(name),
-    references:     [],
-    name:           name
+    selfReference: false,
+    outerDeclar: scope.getBindingIdentifier(name),
+    references: [],
+    name: name,
   };
 
   // check to see if we have a local binding of the id we're setting inside of

--- a/packages/babel-helper-hoist-variables/src/index.js
+++ b/packages/babel-helper-hoist-variables/src/index.js
@@ -37,7 +37,7 @@ const visitor = {
     } else {
       path.replaceWithMultiple(nodes);
     }
-  }
+  },
 };
 
 export default function (path, emit: Function, kind: "var" | "let" = "var") {

--- a/packages/babel-helper-remap-async-to-generator/src/for-await.js
+++ b/packages/babel-helper-remap-async-to-generator/src/for-await.js
@@ -51,7 +51,7 @@ const forAwaitVisitor = {
     if (t.isIdentifier(callee) && callee.name === "AWAIT" && !replacements.AWAIT) {
       path.replaceWith(path.node.arguments[0]);
     }
-  }
+  },
 };
 
 export default function (path, helpers) {
@@ -68,7 +68,7 @@ export default function (path, helpers) {
   } else if (t.isVariableDeclaration(left)) {
     // for await (let i of test)
     declar = t.variableDeclaration(left.kind, [
-      t.variableDeclarator(left.declarations[0].id, stepValue)
+      t.variableDeclarator(left.declarations[0].id, stepValue),
     ]);
   }
 
@@ -83,7 +83,7 @@ export default function (path, helpers) {
     OBJECT: node.right,
     STEP_VALUE: stepValue,
     STEP_KEY: stepKey,
-    AWAIT: helpers.wrapAwait
+    AWAIT: helpers.wrapAwait,
   });
 
   // remove generator function wrapper
@@ -101,6 +101,6 @@ export default function (path, helpers) {
     replaceParent: isLabeledParent,
     node: template,
     declar,
-    loop
+    loop,
   };
 }

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -47,7 +47,7 @@ const awaitVisitor = {
 
     const build = rewriteForAwait(path, {
       getAsyncIterator: file.addHelper("asyncIterator"),
-      wrapAwait
+      wrapAwait,
     });
 
     const { declar, loop } = build;
@@ -73,7 +73,7 @@ const awaitVisitor = {
     } else {
       path.replaceWithMultiple(build.node);
     }
-  }
+  },
 
 };
 
@@ -89,7 +89,7 @@ function classOrObjectMethod(path: NodePath, callId: Object) {
     t.returnStatement(t.callExpression(
       t.callExpression(callId, [container]),
       []
-    ))
+    )),
   ];
 
   // Regardless of whether or not the wrapped function is a an async method
@@ -142,7 +142,7 @@ function plainFunction(path: NodePath, callId: Object) {
       t.variableDeclarator(
         t.identifier(asyncFnId.name),
         t.callExpression(container, [])
-      )
+      ),
     ]);
     declar._blockHoist = true;
 
@@ -156,7 +156,7 @@ function plainFunction(path: NodePath, callId: Object) {
             t.exportSpecifier(
               t.identifier(asyncFnId.name),
               t.identifier("default")
-            )
+            ),
           ]
         )
       );
@@ -170,7 +170,7 @@ function plainFunction(path: NodePath, callId: Object) {
       nameFunction({
         node: retFunction,
         parent: path.parent,
-        scope: path.scope
+        scope: path.scope,
       });
     }
 
@@ -192,7 +192,7 @@ export default function (path: NodePath, file: Object, helpers: Object) {
   }
   path.traverse(awaitVisitor, {
     file,
-    wrapAwait: helpers.wrapAwait
+    wrapAwait: helpers.wrapAwait,
   });
 
   if (path.isClassMethod() || path.isObjectMethod()) {

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -38,7 +38,7 @@ function getPrototypeOfExpression(objectRef, isStatic) {
     t.callExpression(
       t.memberExpression(t.identifier("Object"), t.identifier("getPrototypeOf")),
       [
-        targetRef
+        targetRef,
       ]
     ),
   );
@@ -90,26 +90,26 @@ const visitor = {
         path.replaceWith(result);
       }
     }
-  }
+  },
 };
 
 export default class ReplaceSupers {
   constructor(opts: Object, inClass?: boolean = false) {
     this.forceSuperMemoisation = opts.forceSuperMemoisation;
-    this.methodPath            = opts.methodPath;
-    this.methodNode            = opts.methodNode;
-    this.superRef              = opts.superRef;
-    this.isStatic              = opts.isStatic;
-    this.hasSuper              = false;
-    this.inClass               = inClass;
-    this.isLoose               = opts.isLoose;
-    this.scope                 = this.methodPath.scope;
-    this.file                  = opts.file;
-    this.opts                  = opts;
+    this.methodPath = opts.methodPath;
+    this.methodNode = opts.methodNode;
+    this.superRef = opts.superRef;
+    this.isStatic = opts.isStatic;
+    this.hasSuper = false;
+    this.inClass = inClass;
+    this.isLoose = opts.isLoose;
+    this.scope = this.methodPath.scope;
+    this.file = opts.file;
+    this.opts = opts;
 
     this.bareSupers = [];
-    this.returns    = [];
-    this.thises     = [];
+    this.returns = [];
+    this.thises = [];
   }
 
   forceSuperMemoisation: boolean;
@@ -154,7 +154,7 @@ export default class ReplaceSupers {
         getPrototypeOfExpression(this.getObjectRef(), this.isStatic),
         isComputed ? property : t.stringLiteral(property.name),
         value,
-        t.thisExpression()
+        t.thisExpression(),
       ]
     );
   }
@@ -174,7 +174,7 @@ export default class ReplaceSupers {
       [
         getPrototypeOfExpression(this.getObjectRef(), this.isStatic),
         isComputed ? property : t.stringLiteral(property.name),
-        t.thisExpression()
+        t.thisExpression(),
       ]
     );
   }
@@ -185,7 +185,7 @@ export default class ReplaceSupers {
 
   getLooseSuperProperty(id: Object, parent: Object) {
     const methodNode = this.methodNode;
-    const superRef   = this.superRef || t.identifier("Function");
+    const superRef = this.superRef || t.identifier("Function");
 
     if (parent.property === id) {
       return;
@@ -224,10 +224,10 @@ export default class ReplaceSupers {
       ref = ref || path.scope.generateUidIdentifier("ref");
       return [
         t.variableDeclaration("var", [
-          t.variableDeclarator(ref, node.left)
+          t.variableDeclarator(ref, node.left),
         ]),
         t.expressionStatement(t.assignmentExpression("=", node.left,
-          t.binaryExpression(node.operator[0], ref, node.right)))
+          t.binaryExpression(node.operator[0], ref, node.right))),
       ];
     }
   }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -118,8 +118,8 @@ function wrapPackagesArray(type, names, optionsDir) {
 function run(task) {
   const actual = task.actual;
   const expect = task.expect;
-  const exec   = task.exec;
-  const opts   = task.options;
+  const exec = task.exec;
+  const opts = task.options;
   const optionsDir = task.optionsDir;
 
   function getOpts(self) {
@@ -218,8 +218,8 @@ export default function (
 
           defaults(task.options, {
             filenameRelative: task.expect.filename,
-            sourceFileName:   task.actual.filename,
-            sourceMapTarget:  task.expect.filename,
+            sourceFileName: task.actual.filename,
+            sourceMapTarget: task.expect.filename,
             suppressDeprecationMessages: true,
             babelrc: false,
             sourceMap: !!(task.sourceMappings || task.sourceMap),

--- a/packages/babel-messages/src/index.js
+++ b/packages/babel-messages/src/index.js
@@ -40,7 +40,7 @@ export const MESSAGES = {
   pluginNotObject: "Plugin $2 specified in $1 was expected to return an object when invoked but returned $3",
   pluginNotFunction: "Plugin $2 specified in $1 was expected to return a function but returned $3",
   pluginUnknown: "Unknown plugin $1 specified in $2 at $3, attempted to resolve relative to $4",
-  pluginInvalidProperty: "Plugin $2 specified in $1 provided an invalid property of $3"
+  pluginInvalidProperty: "Plugin $2 specified in $1 provided an invalid property of $3",
 };
 
 /**

--- a/packages/babel-plugin-check-es2015-constants/src/index.js
+++ b/packages/babel-plugin-check-es2015-constants/src/index.js
@@ -11,6 +11,6 @@ export default function ({ messages }) {
           }
         }
       },
-    }
+    },
   };
 }

--- a/packages/babel-plugin-external-helpers/src/index.js
+++ b/packages/babel-plugin-external-helpers/src/index.js
@@ -2,6 +2,6 @@ export default function ({ types: t }) {
   return {
     pre(file) {
       file.set("helpersNamespace", t.identifier("babelHelpers"));
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-async-functions/src/index.js
+++ b/packages/babel-plugin-syntax-async-functions/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("asyncFunctions");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-async-generators/src/index.js
+++ b/packages/babel-plugin-syntax-async-generators/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("asyncGenerators");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-class-properties/src/index.js
+++ b/packages/babel-plugin-syntax-class-properties/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("classProperties");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("decorators");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-do-expressions/src/index.js
+++ b/packages/babel-plugin-syntax-do-expressions/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("doExpressions");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-dynamic-import/src/index.js
+++ b/packages/babel-plugin-syntax-dynamic-import/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("dynamicImport");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-syntax-exponentiation-operator/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("exponentiationOperator");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-export-extensions/src/index.js
+++ b/packages/babel-plugin-syntax-export-extensions/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("exportExtensions");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-flow/src/index.js
+++ b/packages/babel-plugin-syntax-flow/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("flow");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-function-bind/src/index.js
+++ b/packages/babel-plugin-syntax-function-bind/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("functionBind");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-function-sent/src/index.js
+++ b/packages/babel-plugin-syntax-function-sent/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("functionSent");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-jsx/src/index.js
+++ b/packages/babel-plugin-syntax-jsx/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-syntax-object-rest-spread/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("objectRestSpread");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-syntax-trailing-function-commas/src/index.js
+++ b/packages/babel-plugin-syntax-trailing-function-commas/src/index.js
@@ -2,6 +2,6 @@ export default function () {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("trailingFunctionCommas");
-    }
+    },
   };
 }

--- a/packages/babel-plugin-transform-async-generator-functions/src/index.js
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.js
@@ -12,9 +12,9 @@ export default function ({ types: t }) {
       const callee = state.addHelper("asyncGeneratorDelegate");
       node.argument = t.callExpression(callee, [
         t.callExpression(state.addHelper("asyncIterator"), [node.argument]),
-        t.memberExpression(state.addHelper("asyncGenerator"), t.identifier("await"))
+        t.memberExpression(state.addHelper("asyncGenerator"), t.identifier("await")),
       ]);
-    }
+    },
   };
 
   return {
@@ -29,9 +29,9 @@ export default function ({ types: t }) {
           wrapAsync: t.memberExpression(
             state.addHelper("asyncGenerator"), t.identifier("wrap")),
           wrapAwait: t.memberExpression(
-            state.addHelper("asyncGenerator"), t.identifier("await"))
+            state.addHelper("asyncGenerator"), t.identifier("await")),
         });
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-async-to-generator/src/index.js
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.js
@@ -10,9 +10,9 @@ export default function () {
         if (!path.node.async || path.node.generator) return;
 
         remapAsyncToGenerator(path, state.file, {
-          wrapAsync: state.addHelper("asyncToGenerator")
+          wrapAsync: state.addHelper("asyncToGenerator"),
         });
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-async-to-module-method/src/index.js
+++ b/packages/babel-plugin-transform-async-to-module-method/src/index.js
@@ -10,9 +10,9 @@ export default function () {
         if (!path.node.async || path.node.generator) return;
 
         remapAsyncToGenerator(path, state.file, {
-          wrapAsync: state.addImport(state.opts.module, state.opts.method)
+          wrapAsync: state.addImport(state.opts.module, state.opts.method),
         });
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -8,7 +8,7 @@ export default function ({ types: t }) {
       if (path.parentPath.isCallExpression({ callee: path.node })) {
         this.push(path.parentPath);
       }
-    }
+    },
   };
 
   const referenceVisitor = {
@@ -17,7 +17,7 @@ export default function ({ types: t }) {
         this.collision = true;
         path.skip();
       }
-    }
+    },
   };
 
   const buildObjectDefineProperty = template(`
@@ -32,7 +32,7 @@ export default function ({ types: t }) {
   const buildClassPropertySpec = (ref, { key, value, computed }) => buildObjectDefineProperty({
     REF: ref,
     KEY: (t.isIdentifier(key) && !computed) ? t.stringLiteral(key.name) : key,
-    VALUE: value ? value : t.identifier("undefined")
+    VALUE: value ? value : t.identifier("undefined"),
   });
 
   const buildClassPropertyNonSpec = (ref, { key, value, computed }) => t.expressionStatement(
@@ -111,7 +111,7 @@ export default function ({ types: t }) {
 
           const collisionState = {
             collision: false,
-            scope: constructor.scope
+            scope: constructor.scope,
           };
 
           for (const prop of props) {
@@ -126,14 +126,14 @@ export default function ({ types: t }) {
               t.variableDeclarator(
                 initialisePropsRef,
                 t.functionExpression(null, [], t.blockStatement(instanceBody))
-              )
+              ),
             ]));
 
             instanceBody = [
               t.expressionStatement(
                 t.callExpression(t.memberExpression(initialisePropsRef, t.identifier("call")), [
                   t.thisExpression()])
-              )
+              ),
             ];
           }
 
@@ -180,7 +180,7 @@ export default function ({ types: t }) {
         if (members.some((member) => member.isClassProperty())) {
           path.ensureBlock();
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -302,7 +302,7 @@ export default function({ types: t }) {
         const ref = node.id || path.scope.generateUidIdentifier("class");
 
         path.replaceWith(t.variableDeclaration("let", [
-          t.variableDeclarator(ref, t.toExpression(node))
+          t.variableDeclarator(ref, t.toExpression(node)),
         ]));
       },
       ClassExpression(path, state) {
@@ -337,6 +337,6 @@ export default function({ types: t }) {
           path.get("right.arguments")[1].node,
         ]));
       },
-    }
+    },
   };
 }

--- a/packages/babel-plugin-transform-do-expressions/src/index.js
+++ b/packages/babel-plugin-transform-do-expressions/src/index.js
@@ -12,7 +12,7 @@ export default function () {
         } else {
           path.replaceWith(path.scope.buildUndefinedNode());
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-arrow-functions/src/index.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/src/index.js
@@ -18,7 +18,7 @@ export default function ({ types: t }) {
             "body",
             t.expressionStatement(t.callExpression(state.addHelper("newArrowCheck"), [
               t.thisExpression(),
-              boundThis
+              boundThis,
             ]))
           );
 
@@ -29,7 +29,7 @@ export default function ({ types: t }) {
         } else {
           path.arrowFunctionToShadowed();
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-block-scoped-functions/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoped-functions/src/index.js
@@ -7,7 +7,7 @@ export default function ({ types: t }) {
       if (!path.isFunctionDeclaration()) continue;
 
       const declar = t.variableDeclaration("let", [
-        t.variableDeclarator(func.id, t.toExpression(func))
+        t.variableDeclarator(func.id, t.toExpression(func)),
       ]);
 
       // hoist it up above everything else
@@ -24,7 +24,7 @@ export default function ({ types: t }) {
     visitor: {
       BlockStatement(path) {
         const { node, parent } = path;
-        if (t.isFunction(parent, { body: node })  || t.isExportDeclaration(parent)) {
+        if (t.isFunction(parent, { body: node }) || t.isExportDeclaration(parent)) {
           return;
         }
 
@@ -33,7 +33,7 @@ export default function ({ types: t }) {
 
       SwitchCase(path) {
         statementList("consequent", path);
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -60,8 +60,8 @@ export default function () {
           const blockScoping = new BlockScoping(null, path, path.parent, path.scope, file);
           blockScoping.run();
         }
-      }
-    }
+      },
+    },
   };
 }
 
@@ -128,7 +128,7 @@ const letReferenceBlockVisitor = traverse.visitors.merge([{
       path.traverse(letReferenceFunctionVisitor, state);
     }
     return path.skip();
-  }
+  },
 }, tdzVisitor]);
 
 const letReferenceFunctionVisitor = traverse.visitors.merge([{
@@ -144,7 +144,7 @@ const letReferenceFunctionVisitor = traverse.visitors.merge([{
     if (localBinding && localBinding !== ref) return;
 
     state.closurify = true;
-  }
+  },
 }, tdzVisitor]);
 
 const hoistVarDeclarationsVisitor = {
@@ -170,13 +170,13 @@ const hoistVarDeclarationsVisitor = {
     } else if (path.isFunction()) {
       return path.skip();
     }
-  }
+  },
 };
 
 const loopLabelVisitor = {
   LabeledStatement({ node }, state) {
     state.innerLabels.push(node.label.name);
-  }
+  },
 };
 
 const continuationVisitor = {
@@ -188,7 +188,7 @@ const continuationVisitor = {
         state.reassignments[name] = true;
       }
     }
-  }
+  },
 };
 
 function loopNodeTo(node) {
@@ -255,7 +255,7 @@ const loopVisitor = {
     if (path.isReturnStatement()) {
       state.hasReturn = true;
       replace = t.objectExpression([
-        t.objectProperty(t.identifier("v"), node.argument || scope.buildUndefinedNode())
+        t.objectProperty(t.identifier("v"), node.argument || scope.buildUndefinedNode()),
       ]);
     }
 
@@ -265,28 +265,28 @@ const loopVisitor = {
       path.skip();
       path.replaceWith(t.inherits(replace, node));
     }
-  }
+  },
 };
 
 class BlockScoping {
   constructor(loopPath?: NodePath, blockPath: NodePath, parent: Object, scope: Scope, file: File) {
     this.parent = parent;
-    this.scope  = scope;
-    this.file   = file;
+    this.scope = scope;
+    this.file = file;
 
     this.blockPath = blockPath;
-    this.block     = blockPath.node;
+    this.block = blockPath.node;
 
     this.outsideLetReferences = Object.create(null);
-    this.hasLetReferences     = false;
-    this.letReferences        = Object.create(null);
-    this.body                 = [];
+    this.hasLetReferences = false;
+    this.letReferences = Object.create(null);
+    this.body = [];
 
     if (loopPath) {
       this.loopParent = loopPath.parent;
-      this.loopLabel  = t.isLabeledStatement(this.loopParent) && this.loopParent.label;
-      this.loopPath   = loopPath;
-      this.loop       = loopPath.node;
+      this.loopLabel = t.isLabeledStatement(this.loopParent) && this.loopParent.label;
+      this.loopPath = loopPath;
+      this.loop = loopPath.node;
     }
   }
 
@@ -345,8 +345,8 @@ class BlockScoping {
   }
 
   remap() {
-    const letRefs   = this.letReferences;
-    const scope     = this.scope;
+    const letRefs = this.letReferences;
+    const scope = this.scope;
 
     // alright, so since we aren't wrapping this block in a closure
     // we have to check if any of our let variables collide with
@@ -364,10 +364,10 @@ class BlockScoping {
         // the enclosing scope (e.g. loop or catch statement), so we should handle both
         // individually
         if (scope.hasOwnBinding(key))
-          scope.rename(ref.name);
+          {scope.rename(ref.name);}
 
         if (this.blockPath.scope.hasOwnBinding(key))
-          this.blockPath.scope.rename(ref.name);
+          {this.blockPath.scope.rename(ref.name);}
       }
     }
   }
@@ -409,7 +409,7 @@ class BlockScoping {
 
     // turn outsideLetReferences into an array
     const params = values(outsideRefs);
-    const args   = values(outsideRefs);
+    const args = values(outsideRefs);
 
     const isSwitch = this.blockPath.isSwitchStatement();
 
@@ -426,13 +426,13 @@ class BlockScoping {
     if (this.loop) {
       ref = this.scope.generateUidIdentifier("loop");
       this.loopPath.insertBefore(t.variableDeclaration("var", [
-        t.variableDeclarator(ref, fn)
+        t.variableDeclarator(ref, fn),
       ]));
     }
 
     // build a call and a unique id that we can assign the return value to
     let call = t.callExpression(ref, args);
-    const ret  = this.scope.generateUidIdentifier("ret");
+    const ret = this.scope.generateUidIdentifier("ret");
 
     // handle generators
     const hasYield = traverse.hasType(fn.body, this.scope, "YieldExpression", t.FUNCTION_TYPES);
@@ -479,7 +479,7 @@ class BlockScoping {
   addContinuations(fn) {
     const state = {
       reassignments: {},
-      outsideReferences: this.outsideLetReferences
+      outsideReferences: this.outsideLetReferences,
     };
 
     this.scope.traverse(fn, continuationVisitor, state);
@@ -561,9 +561,9 @@ class BlockScoping {
 
     const state = {
       letReferences: this.letReferences,
-      closurify:     false,
-      file:          this.file,
-      loopDepth:     0,
+      closurify: false,
+      file: this.file,
+      loopDepth: 0,
     };
 
     const loopOrFunctionParent = this.blockPath.find(
@@ -592,13 +592,13 @@ class BlockScoping {
   checkLoop(): Object {
     const state = {
       hasBreakContinue: false,
-      ignoreLabeless:   false,
-      inSwitchCase:     false,
-      innerLabels:      [],
-      hasReturn:        false,
-      isLoop:           !!this.loop,
-      map:              {},
-      LOOP_IGNORE:      Symbol()
+      ignoreLabeless: false,
+      inSwitchCase: false,
+      innerLabels: [],
+      hasReturn: false,
+      isLoop: !!this.loop,
+      map: {},
+      LOOP_IGNORE: Symbol(),
     };
 
     this.blockPath.traverse(loopLabelVisitor, state);
@@ -647,7 +647,7 @@ class BlockScoping {
     const body = this.body;
 
     body.push(t.variableDeclaration("var", [
-      t.variableDeclarator(ret, call)
+      t.variableDeclarator(ret, call),
     ]));
 
     let retCheck;
@@ -657,7 +657,7 @@ class BlockScoping {
     if (has.hasReturn) {
       // typeof ret === "object"
       retCheck = buildRetCheck({
-        RETURN: ret
+        RETURN: ret,
       });
     }
 

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/tdz.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/tdz.js
@@ -58,7 +58,7 @@ export const visitor = {
     } else if (status === "outside") {
       path.replaceWith(t.throwStatement(t.inherits(
         t.newExpression(t.identifier("ReferenceError"), [
-          t.stringLiteral(`${node.name} is not defined - temporal dead zone`)
+          t.stringLiteral(`${node.name} is not defined - temporal dead zone`),
         ]),
         node
       )));
@@ -88,6 +88,6 @@ export const visitor = {
         nodes.push(node);
         path.replaceWithMultiple(nodes.map(t.expressionStatement));
       }
-    }
-  }
+    },
+  },
 };

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -26,7 +26,7 @@ export default function ({ types: t }) {
         const ref = node.id || path.scope.generateUidIdentifier("class");
 
         path.replaceWith(t.variableDeclaration("let", [
-          t.variableDeclarator(ref, t.toExpression(node))
+          t.variableDeclarator(ref, t.toExpression(node)),
         ]));
       },
 
@@ -43,7 +43,7 @@ export default function ({ types: t }) {
         if (state.opts.loose) Constructor = LooseTransformer;
 
         path.replaceWith(new Constructor(path, state.file).run());
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-classes/src/loose.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/loose.js
@@ -23,7 +23,7 @@ export default class LooseClassTransformer extends VanillaTransformer {
         func = nameFunction({
           node: func,
           id: key,
-          scope
+          scope,
         });
       }
 

--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -21,7 +21,7 @@ const noMethodVisitor = {
 
   Method(path) {
     path.skip();
-  }
+  },
 };
 
 const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
@@ -43,7 +43,7 @@ const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
           throw path.buildCodeFrameError("super() is only allowed in a derived constructor");
         }
       }
-    }
+    },
   },
 
   ThisExpression(path) {
@@ -52,36 +52,36 @@ const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
         throw path.buildCodeFrameError("'this' is not allowed before super()");
       }
     }
-  }
+  },
 }]);
 
 const findThisesVisitor = visitors.merge([noMethodVisitor, {
   ThisExpression(path) {
     this.superThises.push(path);
-  }
+  },
 }]);
 
 export default class ClassTransformer {
   constructor(path: NodePath, file) {
     this.parent = path.parent;
-    this.scope  = path.scope;
-    this.node   = path.node;
-    this.path   = path;
-    this.file   = file;
+    this.scope = path.scope;
+    this.node = path.node;
+    this.path = path;
+    this.file = file;
 
     this.clearDescriptors();
 
     this.instancePropBody = [];
     this.instancePropRefs = {};
-    this.staticPropBody   = [];
-    this.body             = [];
+    this.staticPropBody = [];
+    this.body = [];
 
-    this.bareSuperAfter   = [];
-    this.bareSupers       = [];
+    this.bareSuperAfter = [];
+    this.bareSupers = [];
 
     this.pushedConstructor = false;
-    this.pushedInherits    = false;
-    this.isLoose           = false;
+    this.pushedInherits = false;
+    this.isLoose = false;
 
     this.superThises = [];
 
@@ -98,13 +98,13 @@ export default class ClassTransformer {
 
   run() {
     let superName = this.superName;
-    const file      = this.file;
-    let body      = this.body;
+    const file = this.file;
+    let body = this.body;
 
     //
 
     const constructorBody = this.constructorBody = t.blockStatement([]);
-    this.constructor    = this.buildConstructor();
+    this.constructor = this.buildConstructor();
 
     //
 
@@ -128,7 +128,7 @@ export default class ClassTransformer {
     constructorBody.body.unshift(t.expressionStatement(t.callExpression(
       file.addHelper("classCallCheck"), [
         t.thisExpression(),
-        this.classRef
+        this.classRef,
       ]
     )));
 
@@ -248,14 +248,14 @@ export default class ClassTransformer {
 
         const replaceSupers = new ReplaceSupers({
           forceSuperMemoisation: isConstructor,
-          methodPath:            path,
-          methodNode:            node,
-          objectRef:             this.classRef,
-          superRef:              this.superName,
-          isStatic:              node.static,
-          isLoose:               this.isLoose,
-          scope:                 this.scope,
-          file:                  this.file
+          methodPath: path,
+          methodNode: node,
+          objectRef: this.classRef,
+          superRef: this.superName,
+          isStatic: node.static,
+          isLoose: this.isLoose,
+          scope: this.scope,
+          file: this.file,
         }, true);
 
         replaceSupers.replace();
@@ -271,10 +271,10 @@ export default class ClassTransformer {
 
   clearDescriptors() {
     this.hasInstanceDescriptors = false;
-    this.hasStaticDescriptors   = false;
+    this.hasStaticDescriptors = false;
 
     this.instanceMutatorMap = {};
-    this.staticMutatorMap   = {};
+    this.staticMutatorMap = {};
   }
 
   pushDescriptors() {
@@ -337,7 +337,7 @@ export default class ClassTransformer {
 
   buildObjectAssignment(id) {
     return t.variableDeclaration("var", [
-      t.variableDeclarator(id, t.objectExpression([]))
+      t.variableDeclarator(id, t.objectExpression([])),
     ]);
   }
 
@@ -400,10 +400,10 @@ export default class ClassTransformer {
     } else {
       bareSuper.replaceWithMultiple([
         t.variableDeclaration("var", [
-          t.variableDeclarator(thisRef, call)
+          t.variableDeclarator(thisRef, call),
         ]),
         ...bareSuperAfter,
-        t.expressionStatement(thisRef)
+        t.expressionStatement(thisRef),
       ]);
     }
 
@@ -462,7 +462,7 @@ export default class ClassTransformer {
         const ref = returnPath.scope.generateDeclaredUidIdentifier("ret");
         returnPath.get("argument").replaceWithMultiple([
           t.assignmentExpression("=", ref, returnPath.node.argument),
-          wrapReturn(ref)
+          wrapReturn(ref),
         ]);
       } else {
         returnPath.get("argument").replaceWith(wrapReturn());
@@ -504,13 +504,13 @@ export default class ClassTransformer {
     const construct = this.constructor;
 
     this.userConstructorPath = path;
-    this.userConstructor     = method;
-    this.hasConstructor      = true;
+    this.userConstructor = method;
+    this.hasConstructor = true;
 
     t.inheritsComments(construct, method);
 
     construct._ignoreUserWhitespace = true;
-    construct.params                = method.params;
+    construct.params = method.params;
 
     t.inherits(construct.body, method.body);
     construct.body.directives = method.body.directives;

--- a/packages/babel-plugin-transform-es2015-computed-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/src/index.js
@@ -39,7 +39,7 @@ export default function ({ types: t, template }) {
       MUTATOR_MAP_REF: getMutatorId(),
       KEY: key,
       VALUE: getValue(prop),
-      KIND: t.identifier(prop.kind)
+      KIND: t.identifier(prop.kind),
     }));
   }
 
@@ -68,14 +68,14 @@ export default function ({ types: t, template }) {
           return t.callExpression(state.addHelper("defineProperty"), [
             info.initPropExpression,
             key,
-            getValue(prop)
+            getValue(prop),
           ]);
         } else {
           body.push(t.expressionStatement(
             t.callExpression(state.addHelper("defineProperty"), [
               objId,
               key,
-              getValue(prop)
+              getValue(prop),
             ])
           ));
         }
@@ -119,7 +119,7 @@ export default function ({ types: t, template }) {
           const body = [];
 
           body.push(t.variableDeclaration("var", [
-            t.variableDeclarator(objId, initPropExpression)
+            t.variableDeclarator(objId, initPropExpression),
           ]));
 
           let callback = spec;
@@ -132,7 +132,7 @@ export default function ({ types: t, template }) {
               mutatorRef = scope.generateUidIdentifier("mutatorMap");
 
               body.push(t.variableDeclaration("var", [
-                t.variableDeclarator(mutatorRef, t.objectExpression([]))
+                t.variableDeclarator(mutatorRef, t.objectExpression([])),
               ]));
             }
 
@@ -162,8 +162,8 @@ export default function ({ types: t, template }) {
             body.push(t.expressionStatement(objId));
             path.replaceWithMultiple(body);
           }
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/src/index.js
@@ -32,18 +32,18 @@ export default function ({ types: t }) {
         state.deopt = true;
         path.stop();
       }
-    }
+    },
   };
 
   class DestructuringTransformer {
     constructor(opts) {
       this.blockHoist = opts.blockHoist;
-      this.operator   = opts.operator;
-      this.arrays     = {};
-      this.nodes      = opts.nodes || [];
-      this.scope      = opts.scope;
-      this.file       = opts.file;
-      this.kind       = opts.kind;
+      this.operator = opts.operator;
+      this.arrays = {};
+      this.nodes = opts.nodes || [];
+      this.scope = opts.scope;
+      this.file = opts.file;
+      this.kind = opts.kind;
     }
 
     buildVariableAssignment(id, init) {
@@ -56,7 +56,7 @@ export default function ({ types: t }) {
         node = t.expressionStatement(t.assignmentExpression(op, id, init));
       } else {
         node = t.variableDeclaration(this.kind, [
-          t.variableDeclarator(id, init)
+          t.variableDeclarator(id, init),
         ]);
       }
 
@@ -67,7 +67,7 @@ export default function ({ types: t }) {
 
     buildVariableDeclaration(id, init) {
       const declar = t.variableDeclaration("var", [
-        t.variableDeclarator(id, init)
+        t.variableDeclarator(id, init),
       ]);
       declar._blockHoist = this.blockHoist;
       return declar;
@@ -100,7 +100,7 @@ export default function ({ types: t }) {
       const tempValueRef = this.scope.generateUidIdentifierBasedOnNode(valueRef);
 
       const declar = t.variableDeclaration("var", [
-        t.variableDeclarator(tempValueRef, valueRef)
+        t.variableDeclarator(tempValueRef, valueRef),
       ]);
       declar._blockHoist = this.blockHoist;
       this.nodes.push(declar);
@@ -160,7 +160,7 @@ export default function ({ types: t }) {
       if (t.isLiteral(prop.key)) prop.computed = true;
 
       const pattern = prop.value;
-      const objRef  = t.memberExpression(propRef, prop.key, prop.computed);
+      const objRef = t.memberExpression(propRef, prop.key, prop.computed);
 
       if (t.isPattern(pattern)) {
         this.push(pattern, objRef);
@@ -359,13 +359,13 @@ export default function ({ types: t }) {
           const temp = scope.generateUidIdentifier("ref");
 
           node.left = t.variableDeclaration("var", [
-            t.variableDeclarator(temp)
+            t.variableDeclarator(temp),
           ]);
 
           path.ensureBlock();
 
           node.body.body.unshift(t.variableDeclaration("var", [
-            t.variableDeclarator(left, temp)
+            t.variableDeclarator(left, temp),
           ]));
 
           return;
@@ -378,7 +378,7 @@ export default function ({ types: t }) {
 
         const key = scope.generateUidIdentifier("ref");
         node.left = t.variableDeclaration(left.kind, [
-          t.variableDeclarator(key, null)
+          t.variableDeclarator(key, null),
         ]);
 
         const nodes = [];
@@ -387,7 +387,7 @@ export default function ({ types: t }) {
           kind: left.kind,
           file: file,
           scope: scope,
-          nodes: nodes
+          nodes: nodes,
         });
 
         destructuring.init(pattern, key);
@@ -411,7 +411,7 @@ export default function ({ types: t }) {
           kind: "let",
           file: file,
           scope: scope,
-          nodes: nodes
+          nodes: nodes,
         });
         destructuring.init(pattern, ref);
 
@@ -428,7 +428,7 @@ export default function ({ types: t }) {
           operator: node.operator,
           file: file,
           scope: scope,
-          nodes: nodes
+          nodes: nodes,
         });
 
         let ref;
@@ -436,7 +436,7 @@ export default function ({ types: t }) {
           ref = scope.generateUidIdentifierBasedOnNode(node.right, "ref");
 
           nodes.push(t.variableDeclaration("var", [
-            t.variableDeclarator(ref, node.right)
+            t.variableDeclarator(ref, node.right),
           ]));
 
           if (t.isArrayExpression(node.right)) {
@@ -466,14 +466,14 @@ export default function ({ types: t }) {
           declar = node.declarations[i];
 
           const patternId = declar.init;
-          const pattern   = declar.id;
+          const pattern = declar.id;
 
           const destructuring = new DestructuringTransformer({
             blockHoist: node._blockHoist,
-            nodes:      nodes,
-            scope:      scope,
-            kind:       node.kind,
-            file:       file
+            nodes: nodes,
+            scope: scope,
+            kind: node.kind,
+            file: file,
           });
 
           if (t.isPattern(pattern)) {
@@ -522,7 +522,7 @@ export default function ({ types: t }) {
         } else {
           path.replaceWithMultiple(nodesOut);
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-duplicate-keys/src/index.js
+++ b/packages/babel-plugin-transform-es2015-duplicate-keys/src/index.js
@@ -56,7 +56,7 @@ export default function() {
             prop.key = t.stringLiteral(name);
           }
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -53,7 +53,7 @@ export default function ({ messages, template, types: t }) {
     if (!t.isIdentifier(right) || !scope.hasBinding(right.name)) {
       const uid = scope.generateUidIdentifier("arr");
       nodes.push(t.variableDeclaration("var", [
-        t.variableDeclarator(uid, right)
+        t.variableDeclarator(uid, right),
       ]));
       right = uid;
     }
@@ -62,8 +62,8 @@ export default function ({ messages, template, types: t }) {
 
     let loop = buildForOfArray({
       BODY: node.body,
-      KEY:  iterationKey,
-      ARR:  right
+      KEY: iterationKey,
+      ARR: right,
     });
 
     t.inherits(loop, node);
@@ -105,10 +105,10 @@ export default function ({ messages, template, types: t }) {
         if (state.opts.loose) callback = loose;
 
         const { node } = path;
-        const build  = callback(path, state);
+        const build = callback(path, state);
         const declar = build.declar;
-        const loop   = build.loop;
-        const block  = loop.body;
+        const loop = build.loop;
+        const block = loop.body;
 
         // ensure that it's a block so we can take all its statements
         path.ensureBlock();
@@ -130,8 +130,8 @@ export default function ({ messages, template, types: t }) {
         } else {
           path.replaceWithMultiple(build.node);
         }
-      }
-    }
+      },
+    },
   };
 
   function loose(path, file) {
@@ -146,21 +146,21 @@ export default function ({ messages, template, types: t }) {
       // for (let i of test)
       id = scope.generateUidIdentifier("ref");
       declar = t.variableDeclaration(left.kind, [
-        t.variableDeclarator(left.declarations[0].id, id)
+        t.variableDeclarator(left.declarations[0].id, id),
       ]);
     } else {
       throw file.buildCodeFrameError(left, messages.get("unknownForHead", left.type));
     }
 
     const iteratorKey = scope.generateUidIdentifier("iterator");
-    const isArrayKey  = scope.generateUidIdentifier("isArray");
+    const isArrayKey = scope.generateUidIdentifier("isArray");
 
     const loop = buildForOfLoose({
-      LOOP_OBJECT:  iteratorKey,
-      IS_ARRAY:     isArrayKey,
-      OBJECT:       node.right,
-      INDEX:        scope.generateUidIdentifier("i"),
-      ID:           id
+      LOOP_OBJECT: iteratorKey,
+      IS_ARRAY: isArrayKey,
+      OBJECT: node.right,
+      INDEX: scope.generateUidIdentifier("i"),
+      ID: id,
     });
 
     if (!declar) {
@@ -179,9 +179,9 @@ export default function ({ messages, template, types: t }) {
 
     return {
       replaceParent: isLabeledParent,
-      declar:        declar,
-      node:          labeled || loop,
-      loop:          loop
+      declar: declar,
+      node: labeled || loop,
+      loop: loop,
     };
   }
 
@@ -190,7 +190,7 @@ export default function ({ messages, template, types: t }) {
     const left = node.left;
     let declar;
 
-    const stepKey   = scope.generateUidIdentifier("step");
+    const stepKey = scope.generateUidIdentifier("step");
     const stepValue = t.memberExpression(stepKey, t.identifier("value"));
 
     if (t.isIdentifier(left) || t.isPattern(left) || t.isMemberExpression(left)) {
@@ -199,7 +199,7 @@ export default function ({ messages, template, types: t }) {
     } else if (t.isVariableDeclaration(left)) {
       // for (let i of test)
       declar = t.variableDeclaration(left.kind, [
-        t.variableDeclarator(left.declarations[0].id, stepValue)
+        t.variableDeclarator(left.declarations[0].id, stepValue),
       ]);
     } else {
       throw file.buildCodeFrameError(left, messages.get("unknownForHead", left.type));
@@ -211,12 +211,12 @@ export default function ({ messages, template, types: t }) {
 
     const template = buildForOf({
       ITERATOR_HAD_ERROR_KEY: scope.generateUidIdentifier("didIteratorError"),
-      ITERATOR_COMPLETION:    scope.generateUidIdentifier("iteratorNormalCompletion"),
-      ITERATOR_ERROR_KEY:     scope.generateUidIdentifier("iteratorError"),
-      ITERATOR_KEY:           iteratorKey,
-      STEP_KEY:               stepKey,
-      OBJECT:                 node.right,
-      BODY:                   null
+      ITERATOR_COMPLETION: scope.generateUidIdentifier("iteratorNormalCompletion"),
+      ITERATOR_ERROR_KEY: scope.generateUidIdentifier("iteratorError"),
+      ITERATOR_KEY: iteratorKey,
+      STEP_KEY: stepKey,
+      OBJECT: node.right,
+      BODY: null,
     });
 
     const isLabeledParent = t.isLabeledStatement(parent);
@@ -232,9 +232,9 @@ export default function ({ messages, template, types: t }) {
 
     return {
       replaceParent: isLabeledParent,
-      declar:        declar,
-      loop:          loop,
-      node:          template
+      declar: declar,
+      loop: loop,
+      node: template,
     };
   }
 }

--- a/packages/babel-plugin-transform-es2015-function-name/src/index.js
+++ b/packages/babel-plugin-transform-es2015-function-name/src/index.js
@@ -9,7 +9,7 @@ export default function () {
             const replacement = nameFunction(path);
             if (replacement) path.replaceWith(replacement);
           }
-        }
+        },
       },
 
       ObjectProperty(path) {
@@ -18,7 +18,7 @@ export default function () {
           const newNode = nameFunction(value);
           if (newNode) value.replaceWith(newNode);
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-instanceof/src/index.js
+++ b/packages/babel-plugin-transform-es2015-instanceof/src/index.js
@@ -6,7 +6,7 @@ export default function ({ types: t }) {
         if (node.operator === "instanceof") {
           path.replaceWith(t.callExpression(this.addHelper("instanceof"), [node.left, node.right]));
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-literals/src/index.js
@@ -13,7 +13,7 @@ export default function () {
         if (node.extra && /\\[u]/gi.test(node.extra.raw)) {
           node.extra = undefined;
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -55,7 +55,7 @@ export default function ({ types: t }) {
       this.sources.push([id.node, source]);
 
       path.remove();
-    }
+    },
   };
 
   return {
@@ -104,7 +104,7 @@ export default function ({ types: t }) {
           const { node } = path;
           const factory = buildFactory({
             PARAMS: params,
-            BODY: node.body
+            BODY: node.body,
           });
           factory.expression.body.directives = node.directives;
           node.directives = [];
@@ -112,10 +112,10 @@ export default function ({ types: t }) {
           node.body = [buildDefine({
             MODULE_NAME: moduleName,
             SOURCES: sources,
-            FACTORY: factory
+            FACTORY: factory,
           })];
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -124,7 +124,7 @@ export default function () {
       nodes.push(t.binaryExpression(operator, arg.node, t.numericLiteral(1)));
 
       path.replaceWithMultiple(t.sequenceExpression(nodes));
-    }
+    },
   };
 
   return {
@@ -182,7 +182,7 @@ export default function () {
             const varDecl = t.variableDeclaration("var", [
               t.variableDeclarator(ref, buildRequire(
                 t.stringLiteral(source)
-              ).expression)
+              ).expression),
             ]);
 
             // Copy location from the original import statement for sourcemap
@@ -260,7 +260,7 @@ export default function () {
                   addTo(exports, id.name, defNode);
                   path.replaceWithMultiple([
                     declaration.node,
-                    buildExportsAssignment(defNode, id)
+                    buildExportsAssignment(defNode, id),
                   ]);
                 } else {
                   path.replaceWith(buildExportsAssignment(defNode, t.toExpression(declaration.node)));
@@ -291,7 +291,7 @@ export default function () {
                   addTo(exports, id.name, id);
                   path.replaceWithMultiple([
                     declaration.node,
-                    buildExportsAssignment(id, id)
+                    buildExportsAssignment(id, id),
                   ]);
                   nonHoistedExportNames[id.name] = true;
                 } else if (declaration.isVariableDeclaration()) {
@@ -353,7 +353,7 @@ export default function () {
               path.replaceWithMultiple(nodes);
             } else if (path.isExportAllDeclaration()) {
               const exportNode = buildExportAll({
-                OBJECT: addRequire(path.node.source.value, path.node._blockHoist)
+                OBJECT: addRequire(path.node.source.value, path.node._blockHoist),
               });
               exportNode.loc = path.node.loc;
               topNodes.push(exportNode);
@@ -381,7 +381,7 @@ export default function () {
                           this.addHelper("interopRequireWildcard"),
                           [uid]
                         )
-                      )
+                      ),
                     ]);
 
                     if (maxBlockHoist > 0) {
@@ -411,7 +411,7 @@ export default function () {
                             this.addHelper("interopRequireDefault"),
                             [uid]
                           )
-                        )
+                        ),
                       ]);
 
                       if (maxBlockHoist > 0) {
@@ -480,8 +480,8 @@ export default function () {
             exports,
             requeueInParent: (newPath) => path.requeue(newPath),
           });
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/esmodule-flag.js
@@ -10,7 +10,7 @@ test("Re-export doesn't overwrite __esModule flag", function () {
 
   const context = {
     module: {
-      exports: {}
+      exports: {},
     },
     require: function (id) {
       if (id === "./dep") return depStub;

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -50,11 +50,11 @@ export default function ({ types: t }) {
       let isPostUpdateExpression = path.isUpdateExpression() && !node.prefix;
       if (isPostUpdateExpression) {
         if (node.operator === "++")
-          node = t.binaryExpression("+", node.argument, t.numericLiteral(1));
+          {node = t.binaryExpression("+", node.argument, t.numericLiteral(1));}
         else if (node.operator === "--")
-          node = t.binaryExpression("-", node.argument, t.numericLiteral(1));
+          {node = t.binaryExpression("-", node.argument, t.numericLiteral(1));}
         else
-          isPostUpdateExpression = false;
+          {isPostUpdateExpression = false;}
       }
 
       for (const exportedName of exportedNames) {
@@ -62,10 +62,10 @@ export default function ({ types: t }) {
       }
 
       if (isPostUpdateExpression)
-        node = t.sequenceExpression([node, path.node]);
+        {node = t.sequenceExpression([node, path.node]);}
 
       path.replaceWith(node);
-    }
+    },
   };
 
   return {
@@ -244,7 +244,7 @@ export default function ({ types: t }) {
               const exportObjRef = path.scope.generateUidIdentifier("exportObj");
 
               setterBody.push(t.variableDeclaration("var", [
-                t.variableDeclarator(exportObjRef, t.objectExpression([]))
+                t.variableDeclarator(exportObjRef, t.objectExpression([])),
               ]));
 
               for (const node of specifiers.exports) {
@@ -252,7 +252,7 @@ export default function ({ types: t }) {
                   setterBody.push(buildExportAll({
                     KEY: path.scope.generateUidIdentifier("key"),
                     EXPORT_OBJ: exportObjRef,
-                    TARGET: target
+                    TARGET: target,
                   }));
                 } else if (t.isExportSpecifier(node)) {
                   setterBody.push(t.expressionStatement(
@@ -287,7 +287,7 @@ export default function ({ types: t }) {
           path.traverse(reassignmentVisitor, {
             exports: exportNames,
             buildCall: buildExportCall,
-            scope: path.scope
+            scope: path.scope,
           });
 
           for (const path of removedPaths) {
@@ -304,11 +304,11 @@ export default function ({ types: t }) {
               SOURCES: sources,
               BODY: path.node.body,
               EXPORT_IDENTIFIER: exportIdent,
-              CONTEXT_IDENTIFIER: contextIdent
-            })
+              CONTEXT_IDENTIFIER: contextIdent,
+            }),
           ];
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -121,7 +121,7 @@ export default function ({ types: t }) {
           const globalExport = buildGlobalExport({
             BROWSER_ARGUMENTS: browserArgs,
             PREREQUISITE_ASSIGNMENTS: prerequisiteAssignments,
-            GLOBAL_TO_ASSIGN: globalToAssign
+            GLOBAL_TO_ASSIGN: globalToAssign,
           });
 
           last.replaceWith(buildWrapper({
@@ -129,10 +129,10 @@ export default function ({ types: t }) {
             AMD_ARGUMENTS: amdArgs,
             COMMON_ARGUMENTS: commonArgs,
             GLOBAL_EXPORT: globalExport,
-            FUNC: func
+            FUNC: func,
           }));
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-object-super/src/index.js
+++ b/packages/babel-plugin-transform-es2015-object-super/src/index.js
@@ -4,11 +4,11 @@ export default function ({ types: t }) {
   function Property(path, node, scope, getObjectRef, file) {
     const replaceSupers = new ReplaceSupers({
       getObjectRef: getObjectRef,
-      methodNode:   node,
-      methodPath:   path,
-      isStatic:     true,
-      scope:        scope,
-      file:         file
+      methodNode: node,
+      methodPath: path,
+      isStatic: true,
+      scope: scope,
+      file: file,
     });
 
     replaceSupers.replace();
@@ -40,8 +40,8 @@ export default function ({ types: t }) {
             path.scope.push({ id: objectRef });
             path.replaceWith(t.assignmentExpression("=", objectRef, path.node));
           }
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-parameters/src/default.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/default.js
@@ -40,7 +40,7 @@ const iifeVisitor = {
   Scope(path) {
     // different bindings
     path.skip();
-  }
+  },
 };
 
 export const visitor = {
@@ -53,7 +53,7 @@ export const visitor = {
 
     const state = {
       iife: false,
-      scope: scope
+      scope: scope,
     };
 
     const body = [];
@@ -67,8 +67,8 @@ export const visitor = {
       const defNode = buildDefaultParam({
         VARIABLE_NAME: left,
         DEFAULT_VALUE: right,
-        ARGUMENT_KEY:  t.numericLiteral(i),
-        ARGUMENTS:     argsIdentifier
+        ARGUMENT_KEY: t.numericLiteral(i),
+        ARGUMENTS: argsIdentifier,
       });
       defNode._blockHoist = node.params.length - i;
       body.push(defNode);
@@ -90,7 +90,7 @@ export const visitor = {
         continue;
       }
 
-      const left  = param.get("left");
+      const left = param.get("left");
       const right = param.get("right");
 
       //
@@ -134,5 +134,5 @@ export const visitor = {
     } else {
       path.get("body").unshiftContainer("body", body);
     }
-  }
+  },
 };

--- a/packages/babel-plugin-transform-es2015-parameters/src/destructuring.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/destructuring.js
@@ -15,7 +15,7 @@ export const visitor = {
         const uid = path.scope.generateUidIdentifier("ref");
 
         const declar = t.variableDeclaration("let", [
-          t.variableDeclarator(param.node, uid)
+          t.variableDeclarator(param.node, uid),
         ]);
         declar._blockHoist = outputParamsLength - i;
 
@@ -25,5 +25,5 @@ export const visitor = {
         param.replaceWith(uid);
       }
     }
-  }
+  },
 };

--- a/packages/babel-plugin-transform-es2015-parameters/src/index.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/index.js
@@ -17,7 +17,7 @@ export default function () {
             break;
           }
         }
-      }
-    }, destructuring.visitor, rest.visitor, def.visitor])
+      },
+    }, destructuring.visitor, rest.visitor, def.visitor]),
   };
 }

--- a/packages/babel-plugin-transform-es2015-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/rest.js
@@ -153,7 +153,7 @@ const memberExpressionOptimisationVisitor = {
     if (node.name === state.name) {
       state.deopted = true;
     }
-  }
+  },
 };
 function hasRest(node) {
   return t.isRestElement(node.params[node.params.length - 1]);
@@ -178,7 +178,7 @@ function optimiseIndexGetter(path, argsId, offset) {
     path.parentPath.replaceWith(restIndexImpure({
       ARGUMENTS: argsId,
       INDEX: index,
-      REF: temp
+      REF: temp,
     }));
   } else {
     path.parentPath.replaceWith(restIndex({
@@ -214,10 +214,10 @@ export const visitor = {
     // check and optimise for extremely common cases
     const state = {
       references: [],
-      offset:     node.params.length,
+      offset: node.params.length,
 
       argumentsNode: argsId,
-      outerBinding:  scope.getBindingIdentifier(rest.name),
+      outerBinding: scope.getBindingIdentifier(rest.name),
 
       // candidate member expressions we could optimise if there are no other references
       candidates: [],
@@ -295,10 +295,10 @@ export const visitor = {
       ARGUMENTS: argsId,
       ARRAY_KEY: arrKey,
       ARRAY_LEN: arrLen,
-      START:     start,
-      ARRAY:     rest,
-      KEY:       key,
-      LEN:       len,
+      START: start,
+      ARRAY: rest,
+      KEY: key,
+      LEN: len,
     });
 
     if (state.deopted) {
@@ -322,5 +322,5 @@ export const visitor = {
 
       target.insertBefore(loop);
     }
-  }
+  },
 };

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
@@ -21,7 +21,7 @@ export default function () {
         if (node.shorthand) {
           node.shorthand = false;
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-spread/src/index.js
+++ b/packages/babel-plugin-transform-es2015-spread/src/index.js
@@ -136,7 +136,7 @@ export default function ({ types: t }) {
           ),
           []
         ));
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-sticky-regex/src/index.js
+++ b/packages/babel-plugin-transform-es2015-sticky-regex/src/index.js
@@ -10,9 +10,9 @@ export default function () {
 
         path.replaceWith(t.newExpression(t.identifier("RegExp"), [
           t.stringLiteral(node.pattern),
-          t.stringLiteral(node.flags)
+          t.stringLiteral(node.flags),
         ]));
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -12,10 +12,10 @@ export default function ({ types: t }) {
       TaggedTemplateExpression(path, state) {
         const { node } = path;
         const quasi = node.quasi;
-        let args  = [];
+        let args = [];
 
         let strings = [];
-        let raw     = [];
+        let raw = [];
 
         for (const elem of (quasi.quasis: Array)) {
           strings.push(t.stringLiteral(elem.value.cooked));
@@ -46,7 +46,7 @@ export default function ({ types: t }) {
 
           const expr = expressions.shift();
           if (expr) {
-            if (state.opts.spec && !expr.isBaseType("string") && !expr.isBaseType("number"))  {
+            if (state.opts.spec && !expr.isBaseType("string") && !expr.isBaseType("number")) {
               nodes.push(t.callExpression(t.identifier("String"), [expr.node]));
             } else {
               nodes.push(expr.node);
@@ -74,7 +74,7 @@ export default function ({ types: t }) {
         } else {
           path.replaceWith(nodes[0]);
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
@@ -46,7 +46,7 @@ export default function ({ types: t }) {
             path.replaceWith(call);
           }
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es2015-unicode-regex/src/index.js
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/src/index.js
@@ -8,7 +8,7 @@ export default function () {
         if (!regex.is(node, "u")) return;
         node.pattern = rewritePattern(node.pattern, node.flags);
         regex.pullFlag(node, "u");
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es3-member-expression-literals/src/index.js
+++ b/packages/babel-plugin-transform-es3-member-expression-literals/src/index.js
@@ -9,8 +9,8 @@ export default function ({ types: t }) {
             node.property = t.stringLiteral(prop.name);
             node.computed = true;
           }
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es3-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-es3-property-literals/src/index.js
@@ -8,8 +8,8 @@ export default function ({ types: t }) {
             // default: "bar" -> "default": "bar"
             node.key = t.stringLiteral(key.name);
           }
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-es5-property-mutators/src/index.js
+++ b/packages/babel-plugin-transform-es5-property-mutators/src/index.js
@@ -29,7 +29,7 @@ export default function ({ types: t }) {
           t.memberExpression(t.identifier("Object"), t.identifier("defineProperties")),
           [node, defineMap.toDefineObject(mutatorMap)]
         ));
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-eval/src/index.js
+++ b/packages/babel-plugin-transform-eval/src/index.js
@@ -13,7 +13,7 @@ export default function ({ parse, traverse }) {
           traverse.removeProperties(ast);
           return ast.program;
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/src/index.js
@@ -10,7 +10,7 @@ export default function ({ types: t }) {
 
       build(left, right) {
         return t.callExpression(t.memberExpression(t.identifier("Math"), t.identifier("pow")), [left, right]);
-      }
-    })
+      },
+    }),
   };
 }

--- a/packages/babel-plugin-transform-export-extensions/src/index.js
+++ b/packages/babel-plugin-transform-export-extensions/src/index.js
@@ -35,7 +35,7 @@ export default function ({ types: t }) {
           nodes.push(node);
         }
         path.replaceWithMultiple(nodes);
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -35,14 +35,14 @@ export default function ({ types: t }) {
       AssignmentPattern: {
         exit({ node }) {
           node.left.optional = false;
-        }
+        },
       },
 
       // strip optional property from function params - facebook/fbjs#17
       Function: {
         exit({ node }) {
           node.params.forEach((param) => param.optional = false);
-        }
+        },
       },
 
       // support for `class X { foo: string }` - #4622
@@ -67,7 +67,7 @@ export default function ({ types: t }) {
           return;
         }
         wrapInFlowComment(path, parent);
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -59,7 +59,7 @@ export default function ({ types: t }) {
           node = node.expression;
         } while (t.isTypeCastExpression(node));
         path.replaceWith(node);
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-function-bind/src/index.js
+++ b/packages/babel-plugin-transform-function-bind/src/index.js
@@ -22,7 +22,7 @@ export default function ({ types: t }) {
     if (bind.object) {
       bind.callee = t.sequenceExpression([
         t.assignmentExpression("=", tempId, bind.object),
-        bind.callee
+        bind.callee,
       ]);
     } else {
       bind.callee.object = t.assignmentExpression("=", tempId, bind.callee.object);
@@ -47,7 +47,7 @@ export default function ({ types: t }) {
         const { node, scope } = path;
         const context = inferBindContext(node, scope);
         path.replaceWith(t.callExpression(t.memberExpression(node.callee, t.identifier("bind")), [context]));
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-jscript/src/index.js
+++ b/packages/babel-plugin-transform-jscript/src/index.js
@@ -10,12 +10,12 @@ export default function ({ types: t }) {
           path.replaceWith(t.callExpression(
             t.functionExpression(null, [], t.blockStatement([
               t.toStatement(node),
-              t.returnStatement(node.id)
+              t.returnStatement(node.id),
             ])),
             []
           ));
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-object-assign/src/index.js
+++ b/packages/babel-plugin-transform-object-assign/src/index.js
@@ -5,7 +5,7 @@ export default function () {
         if (path.get("callee").matchesPattern("Object.assign")) {
           path.node.callee = file.addHelper("extends");
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -7,7 +7,7 @@ export default function ({ types: t }) {
       RestElement() {
         foundRestElement = true;
         path.stop();
-      }
+      },
     });
     return foundRestElement;
   }
@@ -38,9 +38,9 @@ export default function ({ types: t }) {
       t.callExpression(
         file.addHelper("objectWithoutProperties"), [
           objRef,
-          t.arrayExpression(keys)
+          t.arrayExpression(keys),
         ]
-      )
+      ),
     ];
   }
 
@@ -54,7 +54,7 @@ export default function ({ types: t }) {
       const uid = parentPath.scope.generateUidIdentifier("ref");
 
       const declar = t.variableDeclaration("let", [
-        t.variableDeclarator(paramPath.node, uid)
+        t.variableDeclarator(paramPath.node, uid),
       ]);
       declar._blockHoist = i ? numParams - i : 1;
 
@@ -138,9 +138,9 @@ export default function ({ types: t }) {
                 (path) => path.isObjectProperty() || path.isVariableDeclarator()
               ).remove();
             }
-          }
+          },
         }, {
-          originalPath: path
+          originalPath: path,
         });
       },
       // taken from transform-es2015-destructuring/src/index.js#visitor
@@ -179,7 +179,7 @@ export default function ({ types: t }) {
             ref = path.scope.generateUidIdentifierBasedOnNode(path.node.right, "ref");
 
             nodes.push(t.variableDeclaration("var", [
-              t.variableDeclarator(ref, path.node.right)
+              t.variableDeclarator(ref, path.node.right),
             ]));
           }
 
@@ -216,13 +216,13 @@ export default function ({ types: t }) {
           const temp = scope.generateUidIdentifier("ref");
 
           node.left = t.variableDeclaration("var", [
-            t.variableDeclarator(temp)
+            t.variableDeclarator(temp),
           ]);
 
           path.ensureBlock();
 
           node.body.body.unshift(t.variableDeclaration("var", [
-            t.variableDeclarator(left, temp)
+            t.variableDeclarator(left, temp),
           ]));
 
           return;
@@ -235,14 +235,14 @@ export default function ({ types: t }) {
 
         const key = scope.generateUidIdentifier("ref");
         node.left = t.variableDeclaration(left.kind, [
-          t.variableDeclarator(key, null)
+          t.variableDeclarator(key, null),
         ]);
 
         path.ensureBlock();
 
         node.body.body.unshift(
           t.variableDeclaration(node.left.kind, [
-            t.variableDeclarator(pattern, key)
+            t.variableDeclarator(pattern, key),
           ])
         );
       },
@@ -285,7 +285,7 @@ export default function ({ types: t }) {
           file.addHelper("extends");
 
         path.replaceWith(t.callExpression(helper, args));
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.js
@@ -5,7 +5,7 @@ export default function () {
         if (path.get("callee").matchesPattern("Object.setPrototypeOf")) {
           path.node.callee = file.addHelper("defaults");
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-proto-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-proto-to-assign/src/index.js
@@ -21,8 +21,8 @@ export default function ({ types: t }) {
         if (!isProtoAssignmentExpression(path.node)) return;
 
         const nodes = [];
-        const left  = path.node.left.object;
-        const temp  = path.scope.maybeGenerateMemoised(left);
+        const left = path.node.left.object;
+        const temp = path.scope.maybeGenerateMemoised(left);
 
         if (temp) nodes.push(t.expressionStatement(t.assignmentExpression("=", temp, left)));
         nodes.push(buildDefaultsCallExpression(path.node, temp || left, file));
@@ -56,7 +56,7 @@ export default function ({ types: t }) {
           if (node.properties.length) args.push(node);
           path.replaceWith(t.callExpression(file.addHelper("extends"), args));
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -44,7 +44,7 @@ export default function ({ types: t }) {
         }
         stop();
       }
-    }
+    },
   };
 
   return {
@@ -60,7 +60,7 @@ export default function ({ types: t }) {
         } else {
           path.node._hoisted = true;
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -88,7 +88,7 @@ export default function ({ types: t }) {
         if (t.isIdentifier(id)) {
           addDisplayName(id.name, node);
         }
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -29,9 +29,9 @@ export default function ({ types: t }) {
         if (hasRefOrSpread(open.attributes)) return;
 
         // init
-        const props       = t.objectExpression([]);
-        let key         = null;
-        let type        = open.name;
+        const props = t.objectExpression([]);
+        let key = null;
+        let type = open.name;
 
         if (t.isJSXIdentifier(type) && t.react.isCompatTag(type.name)) {
           type = t.stringLiteral(type.name);
@@ -63,7 +63,7 @@ export default function ({ types: t }) {
 
         const el = t.callExpression(file.addHelper("jsx"), args);
         path.replaceWith(el);
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-plugin-transform-react-jsx-compat/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-compat/src/index.js
@@ -22,7 +22,7 @@ export default function ({ types: t }) {
             state.args
           );
         }
-      }
-    })
+      },
+    }),
   };
 }

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.js
@@ -21,10 +21,10 @@ export default function ({ types: t }) {
       const trace = t.thisExpression();
 
       node.attributes.push(t.jSXAttribute(id, t.jSXExpressionContainer(trace)));
-    }
+    },
   };
 
   return {
-    visitor
+    visitor,
   };
 }

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -56,10 +56,10 @@ export default function ({ types: t }) {
 
       const trace = makeTrace(state.fileNameIdentifier, location.start.line);
       attributes.push(t.jSXAttribute(id, t.jSXExpressionContainer(trace)));
-    }
+    },
   };
 
   return {
-    visitor
+    visitor,
   };
 }

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -7,7 +7,7 @@ export default function ({ types: t }) {
   const visitor = helper({
     pre(state) {
       const tagName = state.tagName;
-      const args    = state.args;
+      const args = state.args;
       if (t.react.isCompatTag(tagName)) {
         args.push(t.stringLiteral(tagName));
       } else {
@@ -17,7 +17,7 @@ export default function ({ types: t }) {
 
     post(state, pass) {
       state.callee = pass.get("jsxIdentifier")();
-    }
+    },
   });
 
   visitor.Program = function (path, state) {
@@ -47,6 +47,6 @@ export default function ({ types: t }) {
 
   return {
     inherits: jsx,
-    visitor
+    visitor,
   };
 }

--- a/packages/babel-plugin-transform-runtime/src/definitions.js
+++ b/packages/babel-plugin-transform-runtime/src/definitions.js
@@ -9,7 +9,7 @@ export default {
     Observable: "observable",
     setImmediate: "set-immediate",
     clearImmediate: "clear-immediate",
-    asap: "asap"
+    asap: "asap",
     //parseFloat: "parse-float", // temporary disabled
     //parseInt: "parse-int" // temporary disabled
   },
@@ -38,11 +38,11 @@ export default {
       some: "array/some",
       sort: "array/sort",
       splice: "array/splice",
-      values: "array/values"
+      values: "array/values",
     },
 
     JSON: {
-      stringify: "json/stringify"
+      stringify: "json/stringify",
     },
 
     Object: {
@@ -65,7 +65,7 @@ export default {
       preventExtensions: "object/prevent-extensions",
       seal: "object/seal",
       setPrototypeOf: "object/set-prototype-of",
-      values: "object/values"
+      values: "object/values",
     },
 
     Math: {
@@ -89,7 +89,7 @@ export default {
       iaddh: "math/iaddh",
       isubh: "math/isubh",
       imulh: "math/imulh",
-      umulh: "math/umulh"
+      umulh: "math/umulh",
     },
 
     Symbol: {
@@ -105,7 +105,7 @@ export default {
       split: "symbol/split",
       toPrimitive: "symbol/to-primitive",
       toStringTag: "symbol/to-string-tag",
-      unscopables: "symbol/unscopables"
+      unscopables: "symbol/unscopables",
     },
 
     String: {
@@ -124,7 +124,7 @@ export default {
       trimLeft: "string/trim-left",
       trimRight: "string/trim-right",
       trimStart: "string/trim-start",
-      trimEnd: "string/trim-end"
+      trimEnd: "string/trim-end",
     },
 
     Number: {
@@ -136,7 +136,7 @@ export default {
       MAX_SAFE_INTEGER: "number/max-safe-integer",
       MIN_SAFE_INTEGER: "number/min-safe-integer",
       parseFloat: "number/parse-float",
-      parseInt: "number/parse-int"
+      parseInt: "number/parse-int",
     },
 
     Reflect: {
@@ -161,11 +161,11 @@ export default {
       getOwnMetadataKeys: "reflect/get-own-metadata-keys",
       hasMetadata: "reflect/has-metadata",
       hasOwnMetadata: "reflect/has-own-metadata",
-      metadata: "reflect/metadata"
+      metadata: "reflect/metadata",
     },
 
     System: {
-      global: "system/global"
+      global: "system/global",
     },
 
     Date: {
@@ -175,6 +175,6 @@ export default {
     Function: {
       // Warning: /virtual/ method - prototype, not static, version
       //bind: "function/virtual/bind" // temporary disabled
-    }
-  }
+    },
+  },
 };

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -147,9 +147,9 @@ export default function ({ types: t }) {
             node.property,
             node.computed
           ));
-        }
-      }
-    }
+        },
+      },
+    },
   };
 }
 

--- a/packages/babel-plugin-transform-strict-mode/src/index.js
+++ b/packages/babel-plugin-transform-strict-mode/src/index.js
@@ -13,7 +13,7 @@ export default function () {
         }
 
         path.unshiftContainer("directives", t.directive(t.directiveLiteral("use strict")));
-      }
-    }
+      },
+    },
   };
 }

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -70,7 +70,7 @@ export default function (context, opts = {}) {
       modules === "systemjs" && [transformES2015ModulesSystemJS, optsLoose],
       modules === "amd" && [transformES2015ModulesAMD, optsLoose],
       modules === "umd" && [transformES2015ModulesUMD, optsLoose],
-      [transformRegenerator, { async: false, asyncGenerators: false }]
-    ].filter(Boolean) // filter out falsy values
+      [transformRegenerator, { async: false, asyncGenerators: false }],
+    ].filter(Boolean), // filter out falsy values
   };
 }

--- a/packages/babel-preset-es2015/test/traceur.js
+++ b/packages/babel-preset-es2015/test/traceur.js
@@ -76,7 +76,7 @@ runner(`${__dirname}/fixtures/traceur`, "traceur", {
 
     // TODO
     "Syntax/StrictKeywordsInPattern",
-  ]
+  ],
 }, {
 
 }, function (opts, task) {

--- a/packages/babel-preset-es2016/src/index.js
+++ b/packages/babel-preset-es2016/src/index.js
@@ -3,7 +3,7 @@ import transformExponentiationOperator from "babel-plugin-transform-exponentiati
 export default function () {
   return {
     plugins: [
-      transformExponentiationOperator
-    ]
+      transformExponentiationOperator,
+    ],
   };
 }

--- a/packages/babel-preset-es2017/src/index.js
+++ b/packages/babel-preset-es2017/src/index.js
@@ -5,7 +5,7 @@ export default function () {
   return {
     plugins: [
       syntaxTrailingFunctionCommas,
-      transformAsyncToGenerator
-    ]
+      transformAsyncToGenerator,
+    ],
   };
 }

--- a/packages/babel-preset-flow/src/index.js
+++ b/packages/babel-preset-flow/src/index.js
@@ -3,7 +3,7 @@ import transformFlowStripTypes from "babel-plugin-transform-flow-strip-types";
 export default function () {
   return {
     plugins: [
-      transformFlowStripTypes
-    ]
+      transformFlowStripTypes,
+    ],
   };
 }

--- a/packages/babel-preset-latest/src/index.js
+++ b/packages/babel-preset-latest/src/index.js
@@ -7,7 +7,7 @@ export default function (context, opts = {}) {
     presets: [
       opts.es2015 !== false && [presetES2015, opts.es2015],
       opts.es2016 !== false && presetES2016,
-      opts.es2017 !== false && presetES2017
-    ].filter(Boolean) // filter out falsy values
+      opts.es2017 !== false && presetES2017,
+    ].filter(Boolean), // filter out falsy values
   };
 }

--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -10,20 +10,20 @@ import transformReactDisplayName from "babel-plugin-transform-react-display-name
 export default function () {
   return {
     presets: [
-      presetFlow
+      presetFlow,
     ],
     plugins: [
       transformReactJSX,
       transformSyntaxJSX,
-      transformReactDisplayName
+      transformReactDisplayName,
     ],
     env: {
       development: {
         plugins: [
           // transformReactJSXSource,
           // transformReactJSXSelf
-        ]
-      }
-    }
+        ],
+      },
+    },
   };
 }

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -6,11 +6,11 @@ import transformFunctionBind from "babel-plugin-transform-function-bind";
 export default function () {
   return {
     presets: [
-      presetStage1
+      presetStage1,
     ],
     plugins: [
       transformDoExpressions,
-      transformFunctionBind
-    ]
+      transformFunctionBind,
+    ],
   };
 }

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -6,11 +6,11 @@ import transformExportExtensions from "babel-plugin-transform-export-extensions"
 export default function () {
   return {
     presets: [
-      presetStage2
+      presetStage2,
     ],
     plugins: [
       transformDecorators,
-      transformExportExtensions
-    ]
+      transformExportExtensions,
+    ],
   };
 }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -7,12 +7,12 @@ import transformUnicodePropertyRegex from "babel-plugin-transform-unicode-proper
 export default function () {
   return {
     presets: [
-      presetStage3
+      presetStage3,
     ],
     plugins: [
       syntaxDynamicImport,
       transformClassProperties,
-      transformUnicodePropertyRegex
-    ]
+      transformUnicodePropertyRegex,
+    ],
   };
 }

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -5,7 +5,7 @@ export default function () {
   return {
     plugins: [
       transformAsyncGeneratorFunctions,
-      transformObjectRestSpread
-    ]
+      transformObjectRestSpread,
+    ],
   };
 }

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -9,18 +9,18 @@ import path from "path";
 
 sourceMapSupport.install({
   handleUncaughtExceptions: false,
-  environment : "node",
+  environment: "node",
   retrieveSourceMap(source) {
     const map = maps && maps[source];
     if (map) {
       return {
         url: null,
-        map: map
+        map: map,
       };
     } else {
       return null;
     }
-  }
+  },
 });
 
 registerCache.load();
@@ -31,8 +31,8 @@ const transformOpts = {};
 let ignore;
 let only;
 
-let oldHandlers   = {};
-const maps          = {};
+let oldHandlers = {};
+const maps = {};
 
 const cwd = process.cwd();
 
@@ -72,7 +72,7 @@ function compile(filename) {
       // calls above and would introduce duplicates.
       babelrc: false,
       sourceMaps: "both",
-      ast: false
+      ast: false,
     }));
   }
 

--- a/packages/babel-template/src/index.js
+++ b/packages/babel-template/src/index.js
@@ -106,6 +106,6 @@ const templateVisitor = {
 
   exit({ node }) {
     if (!node.loc)
-      traverse.clearNode(node);
-  }
+      {traverse.clearNode(node);}
+  },
 };

--- a/packages/babel-traverse/src/context.js
+++ b/packages/babel-traverse/src/context.js
@@ -6,9 +6,9 @@ const testing = process.env.NODE_ENV === "test";
 export default class TraversalContext {
   constructor(scope, opts, state, parentPath) {
     this.parentPath = parentPath;
-    this.scope      = scope;
-    this.state      = state;
-    this.opts       = opts;
+    this.scope = scope;
+    this.state = state;
+    this.opts = opts;
   }
 
   parentPath: NodePath;
@@ -47,7 +47,7 @@ export default class TraversalContext {
       parent: node,
       container: obj,
       key: key,
-      listKey
+      listKey,
     });
   }
 
@@ -85,7 +85,7 @@ export default class TraversalContext {
   visitSingle(node, key): boolean {
     if (this.shouldVisit(node[key])) {
       return this.visitQueue([
-        this.create(node, node, key)
+        this.create(node, node, key),
       ]);
     } else {
       return false;

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -36,8 +36,8 @@ traverse.verify = visitors.verify;
 traverse.explode = visitors.explode;
 
 traverse.NodePath = require("./path");
-traverse.Scope    = require("./scope");
-traverse.Hub      = require("./hub");
+traverse.Scope = require("./scope");
+traverse.Hub = require("./hub");
 
 traverse.cheap = function (node, enter) {
   return t.traverseFast(node, enter);
@@ -92,13 +92,13 @@ traverse.hasType = function (
   if (tree.type === type) return true;
 
   const state = {
-    has:  false,
-    type: type
+    has: false,
+    type: type,
   };
 
   traverse(tree, {
     blacklist: blacklistTypes,
-    enter: hasBlacklistedType
+    enter: hasBlacklistedType,
   }, scope, state);
 
   return state.has;

--- a/packages/babel-traverse/src/path/comments.js
+++ b/packages/babel-traverse/src/path/comments.js
@@ -12,7 +12,7 @@ export function shareCommentsWithSiblings() {
   if (!node) return;
 
   const trailing = node.trailingComments;
-  const leading  = node.leadingComments;
+  const leading = node.leadingComments;
   if (!trailing && !leading) return;
 
   let prev = this.getSibling(this.key - 1);
@@ -28,7 +28,7 @@ export function shareCommentsWithSiblings() {
 export function addComment(type, content, line?) {
   this.addComments(type, [{
     type: line ? "CommentLine" : "CommentBlock",
-    value: content
+    value: content,
   }]);
 }
 

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -105,13 +105,13 @@ export function setScope() {
 export function setContext(context) {
   this.shouldSkip = false;
   this.shouldStop = false;
-  this.removed    = false;
-  this.skipKeys   = {};
+  this.removed = false;
+  this.skipKeys = {};
 
   if (context) {
     this.context = context;
-    this.state   = context.state;
-    this.opts    = context.opts;
+    this.state = context.state;
+    this.opts = context.opts;
   }
 
   this.setScope();
@@ -193,8 +193,8 @@ export function pushContext(context) {
 }
 
 export function setup(parentPath, container, listKey, key) {
-  this.inList    = !!listKey;
-  this.listKey   = listKey;
+  this.inList = !!listKey;
+  this.listKey = listKey;
   this.parentKey = listKey || key;
   this.container = container;
 
@@ -203,7 +203,7 @@ export function setup(parentPath, container, listKey, key) {
 }
 
 export function setKey(key) {
-  this.key  = key;
+  this.key = key;
   this.node = this.container[this.key];
   this.type = this.node && this.node.type;
 }

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -58,8 +58,8 @@ export function evaluate(): { confident: boolean; value: any } {
   if (!confident) value = undefined;
   return {
     confident: confident,
-    deopt:     deoptPath,
-    value:     value
+    deopt: deoptPath,
+    value: value,
   };
 
   // we wrap the _evaluate method so we can track `seen` nodes, we push an item

--- a/packages/babel-traverse/src/path/family.js
+++ b/packages/babel-traverse/src/path/family.js
@@ -63,7 +63,7 @@ export function getSibling(key): NodePath {
     parent: this.parent,
     container: this.container,
     listKey: this.listKey,
-    key: key
+    key: key,
   });
 }
 
@@ -108,7 +108,7 @@ export function get(key: string, context?: boolean | TraversalContext): NodePath
 }
 
 export function _getKey(key, context?) {
-  const node      = this.node;
+  const node = this.node;
   const container = node[key];
 
   if (Array.isArray(container)) {
@@ -119,7 +119,7 @@ export function _getKey(key, context?) {
         parentPath: this,
         parent: node,
         container: container,
-        key: i
+        key: i,
       }).setContext(context);
     });
   } else {
@@ -127,7 +127,7 @@ export function _getKey(key, context?) {
       parentPath: this,
       parent: node,
       container: node,
-      key: key
+      key: key,
     }).setContext(context);
   }
 }

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -137,7 +137,7 @@ export default class NodePath {
     this.hub.file.metadata.marked.push({
       type,
       message,
-      loc: this.node.loc
+      loc: this.node.loc,
     });
   }
 

--- a/packages/babel-traverse/src/path/inference/index.js
+++ b/packages/babel-traverse/src/path/inference/index.js
@@ -24,7 +24,7 @@ export function _getTypeAnnotation(): ?Object {
   if (!node) {
     // handle initializerless variables, add in checks for loop initializers too
     if (this.key === "init" && this.parentPath.isVariableDeclarator()) {
-      const declar       = this.parentPath.parentPath;
+      const declar = this.parentPath.parentPath;
       const declarParent = declar.parentPath;
 
       // for (let NODE in bar) {}

--- a/packages/babel-traverse/src/path/inference/inferer-reference.js
+++ b/packages/babel-traverse/src/path/inference/inferer-reference.js
@@ -101,7 +101,7 @@ function inferAnnotationFromBinaryExpression(name, path) {
   const operator = path.node.operator;
 
   const right = path.get("right").resolve();
-  const left  = path.get("left").resolve();
+  const left = path.get("left").resolve();
 
   let target;
   if (left.isIdentifier({ name })) {
@@ -167,7 +167,7 @@ function getConditionalAnnotation(path, name) {
   const ifStatement = getParentConditionalPath(path);
   if (!ifStatement) return;
 
-  const test  = ifStatement.get("test");
+  const test = ifStatement.get("test");
   const paths = [test];
   const types = [];
 
@@ -188,7 +188,7 @@ function getConditionalAnnotation(path, name) {
   if (types.length) {
     return {
       typeAnnotation: t.createUnionTypeAnnotation(types),
-      ifStatement
+      ifStatement,
     };
   } else {
     return getConditionalAnnotation(ifStatement, name);

--- a/packages/babel-traverse/src/path/inference/inferers.js
+++ b/packages/babel-traverse/src/path/inference/inferers.js
@@ -52,7 +52,7 @@ export function BinaryExpression(node) {
     return t.booleanTypeAnnotation();
   } else if (operator === "+") {
     const right = this.get("right");
-    const left  = this.get("left");
+    const left = this.get("left");
 
     if (left.isBaseType("number") && right.isBaseType("number")) {
       // both numbers so this will be a number
@@ -65,7 +65,7 @@ export function BinaryExpression(node) {
     // unsure if left and right are strings or numbers so stay on the safe side
     return t.unionTypeAnnotation([
       t.stringTypeAnnotation(),
-      t.numberTypeAnnotation()
+      t.numberTypeAnnotation(),
     ]);
   }
 }
@@ -73,14 +73,14 @@ export function BinaryExpression(node) {
 export function LogicalExpression() {
   return t.createUnionTypeAnnotation([
     this.get("left").getTypeAnnotation(),
-    this.get("right").getTypeAnnotation()
+    this.get("right").getTypeAnnotation(),
   ]);
 }
 
 export function ConditionalExpression() {
   return t.createUnionTypeAnnotation([
     this.get("consequent").getTypeAnnotation(),
-    this.get("alternate").getTypeAnnotation()
+    this.get("alternate").getTypeAnnotation(),
   ]);
 }
 
@@ -142,7 +142,7 @@ export {
   Func as ArrowFunctionExpression,
   Func as FunctionDeclaration,
   Func as ClassExpression,
-  Func as ClassDeclaration
+  Func as ClassDeclaration,
 };
 
 export function CallExpression() {

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -271,7 +271,7 @@ export function _guessExecutionStatusRelativeTo(target) {
   const targetPaths = target.getAncestry();
   if (targetPaths.indexOf(this) >= 0) return "after";
 
-  const selfPaths   = this.getAncestry();
+  const selfPaths = this.getAncestry();
 
   // get ancestor where the branches intersect
   let commonPath;
@@ -291,7 +291,7 @@ export function _guessExecutionStatusRelativeTo(target) {
 
   // get the relationship paths that associate these nodes to their common ancestor
   const targetRelationship = targetPaths[targetIndex - 1];
-  const selfRelationship   = selfPaths[selfIndex - 1];
+  const selfRelationship = selfPaths[selfIndex - 1];
   if (!targetRelationship || !selfRelationship) {
     return "before";
   }
@@ -303,7 +303,7 @@ export function _guessExecutionStatusRelativeTo(target) {
 
   // otherwise we're associated by a parent node, check which key comes before the other
   const targetKeyPosition = t.VISITOR_KEYS[targetRelationship.type].indexOf(targetRelationship.key);
-  const selfKeyPosition   = t.VISITOR_KEYS[selfRelationship.type].indexOf(selfRelationship.key);
+  const selfKeyPosition = t.VISITOR_KEYS[selfRelationship.type].indexOf(selfRelationship.key);
   return targetKeyPosition > selfKeyPosition ? "before" : "after";
 }
 

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -32,7 +32,7 @@ const referenceVisitor = {
     if (binding !== state.scope.getBinding(path.node.name)) return;
 
     state.bindings[path.node.name] = binding;
-  }
+  },
 };
 
 export default class PathHoister {
@@ -40,15 +40,15 @@ export default class PathHoister {
     // Storage for scopes we can't hoist above.
     this.breakOnScopePaths = [];
     // Storage for bindings that may affect what path we can hoist to.
-    this.bindings          = {};
+    this.bindings = {};
     // Storage for eligible scopes.
-    this.scopes            = [];
+    this.scopes = [];
     // Our original scope and path.
-    this.scope             = scope;
-    this.path              = path;
+    this.scope = scope;
+    this.path = path;
     // By default, we attach as far up as we can; but if we're trying
     // to avoid referencing a binding, we may have to go after.
-    this.attachAfter       = false;
+    this.attachAfter = false;
   }
 
   // A scope is compatible if all required bindings are reachable.
@@ -160,7 +160,7 @@ export default class PathHoister {
         (path.isVariableDeclarator() &&
           path.parentPath.node !== null &&
           path.parentPath.node.declarations.length > 1))
-        return path;
+        {return path;}
     } while ((path = path.parentPath));
   }
 
@@ -198,7 +198,7 @@ export default class PathHoister {
 
     const insertFn = this.attachAfter ? "insertAfter" : "insertBefore";
     attachTo[insertFn]([
-      attachTo.isVariableDeclarator() ? declarator : t.variableDeclaration("var", [declarator])
+      attachTo.isVariableDeclarator() ? declarator : t.variableDeclaration("var", [declarator]),
     ]);
 
     const parent = this.path.parentPath;

--- a/packages/babel-traverse/src/path/lib/removal-hooks.js
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.js
@@ -67,9 +67,9 @@ export const hooks = [
     ) {
       self.replaceWith({
         type: "BlockStatement",
-        body: []
+        body: [],
       });
       return true;
     }
-  }
+  },
 ];

--- a/packages/babel-traverse/src/path/lib/virtual-types.js
+++ b/packages/babel-traverse/src/path/lib/virtual-types.js
@@ -16,21 +16,21 @@ export const ReferencedIdentifier = {
 
     // check if node is referenced
     return t.isReferenced(node, parent);
-  }
+  },
 };
 
 export const ReferencedMemberExpression = {
   types: ["MemberExpression"],
   checkPath({ node, parent }) {
     return t.isMemberExpression(node) && t.isReferenced(node, parent);
-  }
+  },
 };
 
 export const BindingIdentifier = {
   types: ["Identifier"],
   checkPath({ node, parent }: NodePath): boolean {
     return t.isIdentifier(node) && t.isBinding(node, parent);
-  }
+  },
 };
 
 export const Statement = {
@@ -46,7 +46,7 @@ export const Statement = {
     } else {
       return false;
     }
-  }
+  },
 };
 
 export const Expression = {
@@ -57,51 +57,51 @@ export const Expression = {
     } else {
       return t.isExpression(path.node);
     }
-  }
+  },
 };
 
 export const Scope = {
   types: ["Scopable"],
   checkPath(path) {
     return t.isScope(path.node, path.parent);
-  }
+  },
 };
 
 export const Referenced = {
   checkPath(path: NodePath): boolean {
     return t.isReferenced(path.node, path.parent);
-  }
+  },
 };
 
 export const BlockScoped = {
   checkPath(path: NodePath): boolean {
     return t.isBlockScoped(path.node);
-  }
+  },
 };
 
 export const Var = {
   types: ["VariableDeclaration"],
   checkPath(path: NodePath): boolean {
     return t.isVar(path.node);
-  }
+  },
 };
 
 export const User = {
   checkPath(path: NodePath): boolean {
     return path.node && !!path.node.loc;
-  }
+  },
 };
 
 export const Generated = {
   checkPath(path: NodePath): boolean {
     return !path.isUser();
-  }
+  },
 };
 
 export const Pure = {
   checkPath(path: NodePath, opts?): boolean {
     return path.scope.isPure(path.node, opts);
-  }
+  },
 };
 
 export const Flow = {
@@ -118,7 +118,7 @@ export const Flow = {
     } else {
       return false;
     }
-  }
+  },
 };
 
 // TODO: 7.0 Backwards Compat
@@ -137,16 +137,16 @@ export const SpreadProperty = {
 };
 
 export const ExistentialTypeParam = {
-  types: ["ExistsTypeAnnotation"]
+  types: ["ExistsTypeAnnotation"],
 };
 
 export const NumericLiteralTypeAnnotation = {
-  types: ["NumberLiteralTypeAnnotation"]
+  types: ["NumberLiteralTypeAnnotation"],
 };
 
 export const ForAwaitStatement = {
   types: ["ForOfStatement"],
   checkPath({ node }: NodePath): boolean {
     return node.await === true;
-  }
+  },
 };

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -62,7 +62,7 @@ export function _containerInsert(from, nodes) {
         parent: this.parent,
         container: this.container,
         listKey: this.listKey,
-        key: to
+        key: to,
       }));
     }
   }
@@ -197,7 +197,7 @@ export function unshiftContainer(listKey, nodes) {
     parent: this.node,
     container: this.node[listKey],
     listKey,
-    key: 0
+    key: 0,
   });
 
   return path.insertBefore(nodes);
@@ -217,7 +217,7 @@ export function pushContainer(listKey, nodes) {
     parent: this.node,
     container: container,
     listKey,
-    key: container.length
+    key: container.length,
   });
 
   return path.replaceWithMultiple(nodes);

--- a/packages/babel-traverse/src/path/removal.js
+++ b/packages/babel-traverse/src/path/removal.js
@@ -34,8 +34,8 @@ export function _remove() {
 
 export function _markRemoved() {
   this.shouldSkip = true;
-  this.removed    = true;
-  this.node       = null;
+  this.removed = true;
+  this.node = null;
 }
 
 export function _assertUnremoved() {

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -30,7 +30,7 @@ const hoistVariablesVisitor = {
     }
 
     path.replaceWithMultiple(exprs);
-  }
+  },
 };
 
 /**

--- a/packages/babel-traverse/src/scope/binding.js
+++ b/packages/babel-traverse/src/scope/binding.js
@@ -14,9 +14,9 @@ import type NodePath from "../path";
 export default class Binding {
   constructor({ existing, identifier, scope, path, kind }) {
     this.identifier = identifier;
-    this.scope      = scope;
-    this.path       = path;
-    this.kind       = kind;
+    this.scope = scope;
+    this.path = path;
+    this.kind = kind;
 
     this.constantViolations = [];
     this.constant = true;
@@ -56,13 +56,13 @@ export default class Binding {
   setValue(value: any) {
     if (this.hasDeoptedValue) return;
     this.hasValue = true;
-    this.value    = value;
+    this.value = value;
   }
 
   clearValue() {
     this.hasDeoptedValue = false;
-    this.hasValue        = false;
-    this.value           = null;
+    this.hasValue = false;
+    this.value = null;
   }
 
   /**

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -119,7 +119,7 @@ const collectorVisitor = {
           }
         }
       }
-    }
+    },
   },
 
   LabeledStatement(path) {
@@ -162,7 +162,7 @@ const collectorVisitor = {
         path.scope.getBlockParent().registerDeclaration(bodyPath);
       }
     }
-  }
+  },
 };
 
 let uid = 0;
@@ -184,13 +184,13 @@ export default class Scope {
 
     this.uid = uid++;
     this.parent = parentScope;
-    this.hub    = path.hub;
+    this.hub = path.hub;
 
     this.parentBlock = path.parent;
-    this.block       = path.node;
-    this.path        = path;
+    this.block = path.node;
+    this.path = path;
 
-    this.labels      = new Map();
+    this.labels = new Map();
   }
 
   /**
@@ -207,7 +207,7 @@ export default class Scope {
     "arguments",
     "undefined",
     "Infinity",
-    "NaN"
+    "NaN",
   ];
 
   /**
@@ -271,7 +271,7 @@ export default class Scope {
    * Generate a unique identifier based on a node.
    */
 
-  generateUidIdentifierBasedOnNode(parent: Object, defaultName?: String):  Object {
+  generateUidIdentifierBasedOnNode(parent: Object, defaultName?: String): Object {
     let node = parent;
 
     if (t.isAssignmentExpression(parent)) {
@@ -377,7 +377,7 @@ export default class Scope {
           constant: binding.constant,
           references: binding.references,
           violations: binding.constantViolations.length,
-          kind: binding.kind
+          kind: binding.kind,
         });
       }
     } while (scope = scope.parent);
@@ -513,10 +513,10 @@ export default class Scope {
 
         this.bindings[name] = new Binding({
           identifier: id,
-          existing:   local,
-          scope:      this,
-          path:       bindingPath,
-          kind:       kind
+          existing: local,
+          scope: this,
+          path: bindingPath,
+          kind: kind,
         });
       }
     }
@@ -645,10 +645,10 @@ export default class Scope {
     //
 
     this.references = Object.create(null);
-    this.bindings   = Object.create(null);
-    this.globals    = Object.create(null);
-    this.uids       = Object.create(null);
-    this.data       = Object.create(null);
+    this.bindings = Object.create(null);
+    this.globals = Object.create(null);
+    this.uids = Object.create(null);
+    this.data = Object.create(null);
 
     // ForStatement - left, init
 
@@ -713,7 +713,7 @@ export default class Scope {
       for (const name in ids) {
         if (path.scope.getBinding(name)) continue;
 
-        programParent = programParent ||  path.scope.getProgramParent();
+        programParent = programParent || path.scope.getProgramParent();
         programParent.addGlobal(ids[name]);
       }
 
@@ -760,11 +760,11 @@ export default class Scope {
     }
 
     const unique = opts.unique;
-    const kind   = opts.kind || "var";
+    const kind = opts.kind || "var";
     const blockHoist = opts._blockHoist == null ? 2 : opts._blockHoist;
 
     const dataKey = `declaration:${kind}:${blockHoist}`;
-    let declarPath  = !unique && path.getData(dataKey);
+    let declarPath = !unique && path.getData(dataKey);
 
     if (!declarPath) {
       const declar = t.variableDeclaration(kind, []);

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -20,7 +20,7 @@ const renameVisitor = {
     for (const name in ids) {
       if (name === state.oldName) ids[name].name = state.newName;
     }
-  }
+  },
 };
 
 export default class Renamer {
@@ -82,7 +82,7 @@ export default class Renamer {
     path.node._blockHoist = 3;
 
     path.replaceWith(t.variableDeclaration("let", [
-      t.variableDeclarator(t.identifier(this.newName), t.toExpression(path.node))
+      t.variableDeclarator(t.identifier(this.newName), t.toExpression(path.node)),
     ]));
   }
 
@@ -97,7 +97,7 @@ export default class Renamer {
     path.node.id = t.identifier(this.oldName);
 
     this.binding.scope.parent.push({
-      id: t.identifier(this.newName)
+      id: t.identifier(this.newName),
     });
 
     path.replaceWith(t.assignmentExpression("=", t.identifier(this.newName), path.node));

--- a/packages/babel-traverse/test/ancestry.js
+++ b/packages/babel-traverse/test/ancestry.js
@@ -24,7 +24,7 @@ describe("path/ancestry", function () {
       traverse(ast, {
         "Program|NumericLiteral|StringLiteral"(path) {
           paths.push(path);
-        }
+        },
       });
 
       const [ , numberPath, stringPath ] = paths;
@@ -54,7 +54,7 @@ describe("path/ancestry", function () {
       traverse(ast, {
         "Program|NumericLiteral|StringLiteral"(path) {
           paths.push(path);
-        }
+        },
       });
 
       const [ , numberPath, stringPath ] = paths;

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -9,7 +9,7 @@ function getPath(code) {
     Program: function (_path) {
       path = _path;
       _path.stop();
-    }
+    },
   });
   return path;
 }

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -14,7 +14,7 @@ describe("path/family", function () {
       FunctionDeclaration(path) {
         outerNodes = path.getOuterBindingIdentifiers();
         outerPaths = path.getOuterBindingIdentifierPaths();
-      }
+      },
     });
 
     it("should contain keys of nodes in paths", function () {
@@ -61,7 +61,7 @@ describe("path/family", function () {
       VariableDeclaration(path) {
         sibling = path.getSibling(path.key);
         lastSibling = sibling.getNextSibling().getNextSibling();
-      }
+      },
     });
 
     it("should return traverse sibling nodes", function () {

--- a/packages/babel-traverse/test/inference.js
+++ b/packages/babel-traverse/test/inference.js
@@ -10,7 +10,7 @@ function getPath(code) {
     Program: function (_path) {
       path = _path;
       _path.stop();
-    }
+    },
   });
   return path;
 }

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -10,7 +10,7 @@ function getPath(code) {
     Program: function (_path) {
       path = _path;
       _path.stop();
-    }
+    },
   });
 
   return path;

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -9,7 +9,7 @@ function getPath(code) {
     Program: function (_path) {
       path = _path;
       _path.stop();
-    }
+    },
   });
   return path;
 }
@@ -21,7 +21,7 @@ function getIdentifierPath(code) {
     Identifier: function(path) {
       nodePath = path;
       path.stop();
-    }
+    },
   });
 
   return nodePath;
@@ -85,8 +85,8 @@ describe("scope", function () {
       const path = getIdentifierPath("function square(n) { return n * n}");
       const referencePaths = path.context.scope.bindings.n.referencePaths;
       assert.equal(referencePaths.length, 2);
-      assert.deepEqual(referencePaths[0].node.loc.start, { line: 1, column:28 });
-      assert.deepEqual(referencePaths[1].node.loc.start, { line: 1, column:32 });
+      assert.deepEqual(referencePaths[0].node.loc.start, { line: 1, column: 28 });
+      assert.deepEqual(referencePaths[1].node.loc.start, { line: 1, column: 32 });
     });
   });
 });

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -1,7 +1,7 @@
 const cloneDeep = require("lodash/cloneDeep");
-const traverse  = require("../lib").default;
-const assert    = require("assert");
-const parse     = require("babylon").parse;
+const traverse = require("../lib").default;
+const assert = require("assert");
+const parse = require("babylon").parse;
 
 describe("traverse", function () {
   const code = `
@@ -15,14 +15,14 @@ describe("traverse", function () {
   it("traverse replace", function () {
     const replacement = {
       type: "StringLiteral",
-      value: "foo"
+      value: "foo",
     };
     const ast2 = cloneDeep(program);
 
     traverse(ast2, {
       enter: function (path) {
         if (path.node.type === "ThisExpression") path.replaceWith(replacement);
-      }
+      },
     });
 
     assert.equal(ast2.body[1].expression.left.object, replacement);
@@ -32,7 +32,7 @@ describe("traverse", function () {
     const expect = [
       body[0], body[0].declarations[0], body[0].declarations[0].id, body[0].declarations[0].init,
       body[1], body[1].expression, body[1].expression.left, body[1].expression.left.object,
-      body[1].expression.left.property, body[1].expression.right
+      body[1].expression.left.property, body[1].expression.right,
     ];
 
     const actual = [];
@@ -40,7 +40,7 @@ describe("traverse", function () {
     traverse(program, {
       enter: function (path) {
         actual.push(path.node);
-      }
+      },
     });
 
     assert.deepEqual(actual, expect);
@@ -50,14 +50,14 @@ describe("traverse", function () {
     traverse(null, {
       enter: function () {
         throw new Error("should not be ran");
-      }
+      },
     });
   });
 
   it("traverse blacklistTypes", function () {
     const expect = [
       body[0], body[0].declarations[0], body[0].declarations[0].id, body[0].declarations[0].init,
-      body[1], body[1].expression, body[1].expression.right
+      body[1], body[1].expression, body[1].expression.right,
     ];
 
     const actual = [];
@@ -66,7 +66,7 @@ describe("traverse", function () {
       blacklist: ["MemberExpression"],
       enter: function (path) {
         actual.push(path.node);
-      }
+      },
     });
 
     assert.deepEqual(actual, expect);
@@ -93,7 +93,7 @@ describe("traverse", function () {
         scopes.push(path.scope);
         paths.push(path);
         path.stop();
-      }
+      },
     });
 
     traverse.clearCache();
@@ -105,7 +105,7 @@ describe("traverse", function () {
         scopes2.push(path.scope);
         paths2.push(path);
         path.stop();
-      }
+      },
     });
 
     scopes2.forEach(function (_, i) {
@@ -119,7 +119,7 @@ describe("traverse", function () {
     traverse(ast, {
       enter(path) {
         paths.push(path);
-      }
+      },
     });
 
     traverse.clearCache.clearPath();
@@ -128,7 +128,7 @@ describe("traverse", function () {
     traverse(ast, {
       enter(path) {
         paths2.push(path);
-      }
+      },
     });
 
     paths2.forEach(function (p, i) {
@@ -142,7 +142,7 @@ describe("traverse", function () {
       enter(path) {
         scopes.push(path.scope);
         path.stop();
-      }
+      },
     });
 
     traverse.clearCache.clearScope();
@@ -152,7 +152,7 @@ describe("traverse", function () {
       enter(path) {
         scopes2.push(path.scope);
         path.stop();
-      }
+      },
     });
 
     scopes2.forEach(function (p, i) {

--- a/packages/babel-types/src/constants.js
+++ b/packages/babel-types/src/constants.js
@@ -1,28 +1,28 @@
 /* eslint max-len: "off" */
 
 export const STATEMENT_OR_BLOCK_KEYS = ["consequent", "body", "alternate"];
-export const FLATTENABLE_KEYS        = ["body", "expressions"];
-export const FOR_INIT_KEYS           = ["left", "init"];
-export const COMMENT_KEYS            = ["leadingComments", "trailingComments", "innerComments"];
+export const FLATTENABLE_KEYS = ["body", "expressions"];
+export const FOR_INIT_KEYS = ["left", "init"];
+export const COMMENT_KEYS = ["leadingComments", "trailingComments", "innerComments"];
 
 export const LOGICAL_OPERATORS = ["||", "&&"];
-export const UPDATE_OPERATORS  = ["++", "--"];
+export const UPDATE_OPERATORS = ["++", "--"];
 
 export const BOOLEAN_NUMBER_BINARY_OPERATORS = [">", "<", ">=", "<="];
-export const EQUALITY_BINARY_OPERATORS       = ["==", "===", "!=", "!=="];
-export const COMPARISON_BINARY_OPERATORS     = [...EQUALITY_BINARY_OPERATORS, "in", "instanceof"];
-export const BOOLEAN_BINARY_OPERATORS        = [...COMPARISON_BINARY_OPERATORS, ...BOOLEAN_NUMBER_BINARY_OPERATORS];
-export const NUMBER_BINARY_OPERATORS         = ["-", "/", "%", "*", "**", "&", "|", ">>", ">>>", "<<", "^"];
-export const BINARY_OPERATORS                = ["+", ...NUMBER_BINARY_OPERATORS, ...BOOLEAN_BINARY_OPERATORS];
+export const EQUALITY_BINARY_OPERATORS = ["==", "===", "!=", "!=="];
+export const COMPARISON_BINARY_OPERATORS = [...EQUALITY_BINARY_OPERATORS, "in", "instanceof"];
+export const BOOLEAN_BINARY_OPERATORS = [...COMPARISON_BINARY_OPERATORS, ...BOOLEAN_NUMBER_BINARY_OPERATORS];
+export const NUMBER_BINARY_OPERATORS = ["-", "/", "%", "*", "**", "&", "|", ">>", ">>>", "<<", "^"];
+export const BINARY_OPERATORS = ["+", ...NUMBER_BINARY_OPERATORS, ...BOOLEAN_BINARY_OPERATORS];
 
 export const BOOLEAN_UNARY_OPERATORS = ["delete", "!"];
-export const NUMBER_UNARY_OPERATORS  = ["+", "-", "++", "--", "~"];
-export const STRING_UNARY_OPERATORS  = ["typeof"];
-export const UNARY_OPERATORS         = ["void", ...BOOLEAN_UNARY_OPERATORS, ...NUMBER_UNARY_OPERATORS, ...STRING_UNARY_OPERATORS];
+export const NUMBER_UNARY_OPERATORS = ["+", "-", "++", "--", "~"];
+export const STRING_UNARY_OPERATORS = ["typeof"];
+export const UNARY_OPERATORS = ["void", ...BOOLEAN_UNARY_OPERATORS, ...NUMBER_UNARY_OPERATORS, ...STRING_UNARY_OPERATORS];
 
 export const INHERIT_KEYS = {
   optional: ["typeAnnotation", "typeParameters", "returnType"],
-  force: ["start", "loc", "end"]
+  force: ["start", "loc", "end"],
 };
 
 export const BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");

--- a/packages/babel-types/src/converters.js
+++ b/packages/babel-types/src/converters.js
@@ -23,7 +23,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
   if (!nodes || !nodes.length) return;
 
   const declars = [];
-  let bailed  = false;
+  let bailed = false;
 
   const result = convert(nodes);
   if (bailed) return;
@@ -36,7 +36,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
 
   function convert(nodes) {
     let ensureLastUndefined = false;
-    const exprs   = [];
+    const exprs = [];
 
     for (const node of (nodes: Array)) {
       if (t.isExpression(node)) {
@@ -51,7 +51,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
           for (const key in bindings) {
             declars.push({
               kind: node.kind,
-              id: bindings[key]
+              id: bindings[key],
             });
           }
 

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -26,62 +26,62 @@ defineType("ArrayExpression", {
         assertEach(assertNodeOrValueType("null", "Expression", "SpreadElement"))
       ),
       default: [],
-    }
+    },
   },
   visitor: ["elements"],
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("AssignmentExpression", {
   fields: {
     operator: {
-      validate: assertValueType("string")
+      validate: assertValueType("string"),
     },
     left: {
-      validate: assertNodeType("LVal")
+      validate: assertNodeType("LVal"),
     },
     right: {
-      validate: assertNodeType("Expression")
-    }
+      validate: assertNodeType("Expression"),
+    },
   },
   builder: ["operator", "left", "right"],
   visitor: ["left", "right"],
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("BinaryExpression", {
   builder: ["operator", "left", "right"],
   fields: {
     operator: {
-      validate: assertOneOf(...BINARY_OPERATORS)
+      validate: assertOneOf(...BINARY_OPERATORS),
     },
     left: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     right: {
-      validate: assertNodeType("Expression")
-    }
+      validate: assertNodeType("Expression"),
+    },
   },
   visitor: ["left", "right"],
-  aliases: ["Binary", "Expression"]
+  aliases: ["Binary", "Expression"],
 });
 
 defineType("Directive", {
   visitor: ["value"],
   fields: {
     value: {
-      validate: assertNodeType("DirectiveLiteral")
-    }
-  }
+      validate: assertNodeType("DirectiveLiteral"),
+    },
+  },
 });
 
 defineType("DirectiveLiteral", {
   builder: ["value"],
   fields: {
     value: {
-      validate: assertValueType("string")
-    }
-  }
+      validate: assertValueType("string"),
+    },
+  },
 });
 
 defineType("BlockStatement", {
@@ -90,13 +90,13 @@ defineType("BlockStatement", {
   fields: {
     directives: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Directive"))),
-      default: []
+      default: [],
     },
     body: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Statement")))
-    }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Statement"))),
+    },
   },
-  aliases: ["Scopable", "BlockParent", "Block", "Statement"]
+  aliases: ["Scopable", "BlockParent", "Block", "Statement"],
 });
 
 defineType("BreakStatement", {
@@ -104,52 +104,52 @@ defineType("BreakStatement", {
   fields: {
     label: {
       validate: assertNodeType("Identifier"),
-      optional: true
-    }
+      optional: true,
+    },
   },
-  aliases: ["Statement", "Terminatorless", "CompletionStatement"]
+  aliases: ["Statement", "Terminatorless", "CompletionStatement"],
 });
 
 defineType("CallExpression", {
   visitor: ["callee", "arguments"],
   fields: {
     callee: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     arguments: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement")))
-    }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement"))),
+    },
   },
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("CatchClause", {
   visitor: ["param", "body"],
   fields: {
     param: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     body: {
-      validate: assertNodeType("BlockStatement")
-    }
+      validate: assertNodeType("BlockStatement"),
+    },
   },
-  aliases: ["Scopable"]
+  aliases: ["Scopable"],
 });
 
 defineType("ConditionalExpression", {
   visitor: ["test", "consequent", "alternate"],
   fields: {
     test: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     consequent: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     alternate: {
-      validate: assertNodeType("Expression")
-    }
+      validate: assertNodeType("Expression"),
+    },
   },
-  aliases: ["Expression", "Conditional"]
+  aliases: ["Expression", "Conditional"],
 });
 
 defineType("ContinueStatement", {
@@ -157,41 +157,41 @@ defineType("ContinueStatement", {
   fields: {
     label: {
       validate: assertNodeType("Identifier"),
-      optional: true
-    }
+      optional: true,
+    },
   },
-  aliases: ["Statement", "Terminatorless", "CompletionStatement"]
+  aliases: ["Statement", "Terminatorless", "CompletionStatement"],
 });
 
 defineType("DebuggerStatement", {
-  aliases: ["Statement"]
+  aliases: ["Statement"],
 });
 
 defineType("DoWhileStatement", {
   visitor: ["test", "body"],
   fields: {
     test: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     body: {
-      validate: assertNodeType("Statement")
-    }
+      validate: assertNodeType("Statement"),
+    },
   },
-  aliases: ["Statement", "BlockParent", "Loop", "While", "Scopable"]
+  aliases: ["Statement", "BlockParent", "Loop", "While", "Scopable"],
 });
 
 defineType("EmptyStatement", {
-  aliases: ["Statement"]
+  aliases: ["Statement"],
 });
 
 defineType("ExpressionStatement", {
   visitor: ["expression"],
   fields: {
     expression: {
-      validate: assertNodeType("Expression")
-    }
+      validate: assertNodeType("Expression"),
+    },
   },
-  aliases: ["Statement", "ExpressionWrapper"]
+  aliases: ["Statement", "ExpressionWrapper"],
 });
 
 defineType("File", {
@@ -199,9 +199,9 @@ defineType("File", {
   visitor: ["program"],
   fields: {
     program: {
-      validate: assertNodeType("Program")
-    }
-  }
+      validate: assertNodeType("Program"),
+    },
+  },
 });
 
 defineType("ForInStatement", {
@@ -209,15 +209,15 @@ defineType("ForInStatement", {
   aliases: ["Scopable", "Statement", "For", "BlockParent", "Loop", "ForXStatement"],
   fields: {
     left: {
-      validate: assertNodeType("VariableDeclaration", "LVal")
+      validate: assertNodeType("VariableDeclaration", "LVal"),
     },
     right: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     body: {
-      validate: assertNodeType("Statement")
-    }
-  }
+      validate: assertNodeType("Statement"),
+    },
+  },
 });
 
 defineType("ForStatement", {
@@ -226,20 +226,20 @@ defineType("ForStatement", {
   fields: {
     init: {
       validate: assertNodeType("VariableDeclaration", "Expression"),
-      optional: true
+      optional: true,
     },
     test: {
       validate: assertNodeType("Expression"),
-      optional: true
+      optional: true,
     },
     update: {
       validate: assertNodeType("Expression"),
-      optional: true
+      optional: true,
     },
     body: {
-      validate: assertNodeType("Statement")
-    }
-  }
+      validate: assertNodeType("Statement"),
+    },
+  },
 });
 
 defineType("FunctionDeclaration", {
@@ -247,22 +247,22 @@ defineType("FunctionDeclaration", {
   visitor: ["id", "params", "body", "returnType", "typeParameters"],
   fields: {
     id: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     params: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal"))),
     },
     body: {
-      validate: assertNodeType("BlockStatement")
+      validate: assertNodeType("BlockStatement"),
     },
     generator: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     async: {
       default: false,
-      validate: assertValueType("boolean")
-    }
+      validate: assertValueType("boolean"),
+    },
   },
   aliases: [
     "Scopable",
@@ -271,8 +271,8 @@ defineType("FunctionDeclaration", {
     "FunctionParent",
     "Statement",
     "Pureish",
-    "Declaration"
-  ]
+    "Declaration",
+  ],
 });
 
 defineType("FunctionExpression", {
@@ -281,23 +281,23 @@ defineType("FunctionExpression", {
   fields: {
     id: {
       validate: assertNodeType("Identifier"),
-      optional: true
+      optional: true,
     },
     params: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal"))),
     },
     body: {
-      validate: assertNodeType("BlockStatement")
+      validate: assertNodeType("BlockStatement"),
     },
     generator: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     async: {
       default: false,
-      validate: assertValueType("boolean")
-    }
-  }
+      validate: assertValueType("boolean"),
+    },
+  },
 });
 
 defineType("Identifier", {
@@ -310,12 +310,12 @@ defineType("Identifier", {
         if (!t.isValidIdentifier(val)) {
           // todo
         }
-      }
+      },
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("IfStatement", {
@@ -323,16 +323,16 @@ defineType("IfStatement", {
   aliases: ["Statement", "Conditional"],
   fields: {
     test: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     consequent: {
-      validate: assertNodeType("Statement")
+      validate: assertNodeType("Statement"),
     },
     alternate: {
       optional: true,
-      validate: assertNodeType("Statement")
-    }
-  }
+      validate: assertNodeType("Statement"),
+    },
+  },
 });
 
 defineType("LabeledStatement", {
@@ -340,22 +340,22 @@ defineType("LabeledStatement", {
   aliases: ["Statement"],
   fields: {
     label: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     body: {
-      validate: assertNodeType("Statement")
-    }
-  }
+      validate: assertNodeType("Statement"),
+    },
+  },
 });
 
 defineType("StringLiteral", {
   builder: ["value"],
   fields: {
     value: {
-      validate: assertValueType("string")
-    }
+      validate: assertValueType("string"),
+    },
   },
-  aliases: ["Expression", "Pureish", "Literal", "Immutable"]
+  aliases: ["Expression", "Pureish", "Literal", "Immutable"],
 });
 
 defineType("NumericLiteral", {
@@ -363,24 +363,24 @@ defineType("NumericLiteral", {
   deprecatedAlias: "NumberLiteral",
   fields: {
     value: {
-      validate: assertValueType("number")
-    }
+      validate: assertValueType("number"),
+    },
   },
-  aliases: ["Expression", "Pureish", "Literal", "Immutable"]
+  aliases: ["Expression", "Pureish", "Literal", "Immutable"],
 });
 
 defineType("NullLiteral", {
-  aliases: ["Expression", "Pureish", "Literal", "Immutable"]
+  aliases: ["Expression", "Pureish", "Literal", "Immutable"],
 });
 
 defineType("BooleanLiteral", {
   builder: ["value"],
   fields: {
     value: {
-      validate: assertValueType("boolean")
-    }
+      validate: assertValueType("boolean"),
+    },
   },
-  aliases: ["Expression", "Pureish", "Literal", "Immutable"]
+  aliases: ["Expression", "Pureish", "Literal", "Immutable"],
 });
 
 defineType("RegExpLiteral", {
@@ -389,13 +389,13 @@ defineType("RegExpLiteral", {
   aliases: ["Expression", "Literal"],
   fields: {
     pattern: {
-      validate: assertValueType("string")
+      validate: assertValueType("string"),
     },
     flags: {
       validate: assertValueType("string"),
-      default: ""
-    }
-  }
+      default: "",
+    },
+  },
 });
 
 defineType("LogicalExpression", {
@@ -404,15 +404,15 @@ defineType("LogicalExpression", {
   aliases: ["Binary", "Expression"],
   fields: {
     operator: {
-      validate: assertOneOf(...LOGICAL_OPERATORS)
+      validate: assertOneOf(...LOGICAL_OPERATORS),
     },
     left: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     right: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("MemberExpression", {
@@ -421,18 +421,18 @@ defineType("MemberExpression", {
   aliases: ["Expression", "LVal"],
   fields: {
     object: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     property: {
       validate(node, key, val) {
         const expectedType = node.computed ? "Expression" : "Identifier";
         assertNodeType(expectedType)(node, key, val);
-      }
+      },
     },
     computed: {
-      default: false
-    }
-  }
+      default: false,
+    },
+  },
 });
 
 defineType("NewExpression", {
@@ -440,12 +440,12 @@ defineType("NewExpression", {
   aliases: ["Expression"],
   fields: {
     callee: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     arguments: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression", "SpreadElement"))),
+    },
+  },
 });
 
 defineType("Program", {
@@ -454,13 +454,13 @@ defineType("Program", {
   fields: {
     directives: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Directive"))),
-      default: []
+      default: [],
     },
     body: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Statement")))
-    }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Statement"))),
+    },
   },
-  aliases: ["Scopable", "BlockParent", "Block", "FunctionParent"]
+  aliases: ["Scopable", "BlockParent", "Block", "FunctionParent"],
 });
 
 defineType("ObjectExpression", {
@@ -471,9 +471,9 @@ defineType("ObjectExpression", {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("ObjectMethod", "ObjectProperty", "SpreadElement"))
-      )
-    }
-  }
+      ),
+    },
+  },
 });
 
 defineType("ObjectMethod", {
@@ -481,35 +481,35 @@ defineType("ObjectMethod", {
   fields: {
     kind: {
       validate: chain(assertValueType("string"), assertOneOf("method", "get", "set")),
-      default: "method"
+      default: "method",
     },
     computed: {
       validate: assertValueType("boolean"),
-      default: false
+      default: false,
     },
     key: {
       validate(node, key, val) {
         const expectedTypes = node.computed ? ["Expression"] : ["Identifier", "StringLiteral", "NumericLiteral"];
         assertNodeType(...expectedTypes)(node, key, val);
-      }
+      },
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
     },
     body: {
-      validate: assertNodeType("BlockStatement")
+      validate: assertNodeType("BlockStatement"),
     },
     generator: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     async: {
       default: false,
-      validate: assertValueType("boolean")
-    }
+      validate: assertValueType("boolean"),
+    },
   },
   visitor: ["key", "params", "body", "decorators", "returnType", "typeParameters"],
-  aliases: ["UserWhitespacable", "Function", "Scopable", "BlockParent", "FunctionParent", "Method", "ObjectMember"]
+  aliases: ["UserWhitespacable", "Function", "Scopable", "BlockParent", "FunctionParent", "Method", "ObjectMember"],
 });
 
 defineType("ObjectProperty", {
@@ -517,28 +517,28 @@ defineType("ObjectProperty", {
   fields: {
     computed: {
       validate: assertValueType("boolean"),
-      default: false
+      default: false,
     },
     key: {
       validate(node, key, val) {
         const expectedTypes = node.computed ? ["Expression"] : ["Identifier", "StringLiteral", "NumericLiteral"];
         assertNodeType(...expectedTypes)(node, key, val);
-      }
+      },
     },
     value: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     shorthand: {
       validate: assertValueType("boolean"),
-      default: false
+      default: false,
     },
     decorators: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
-      optional: true
-    }
+      optional: true,
+    },
   },
   visitor: ["key", "value", "decorators"],
-  aliases: ["UserWhitespacable", "Property", "ObjectMember"]
+  aliases: ["UserWhitespacable", "Property", "ObjectMember"],
 });
 
 defineType("RestElement", {
@@ -546,12 +546,12 @@ defineType("RestElement", {
   aliases: ["LVal"],
   fields: {
     argument: {
-      validate: assertNodeType("LVal")
+      validate: assertNodeType("LVal"),
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("ReturnStatement", {
@@ -560,19 +560,19 @@ defineType("ReturnStatement", {
   fields: {
     argument: {
       validate: assertNodeType("Expression"),
-      optional: true
-    }
-  }
+      optional: true,
+    },
+  },
 });
 
 defineType("SequenceExpression", {
   visitor: ["expressions"],
   fields: {
     expressions: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
-    }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression"))),
+    },
   },
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("SwitchCase", {
@@ -580,12 +580,12 @@ defineType("SwitchCase", {
   fields: {
     test: {
       validate: assertNodeType("Expression"),
-      optional: true
+      optional: true,
     },
     consequent: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Statement")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Statement"))),
+    },
+  },
 });
 
 defineType("SwitchStatement", {
@@ -593,16 +593,16 @@ defineType("SwitchStatement", {
   aliases: ["Statement", "BlockParent", "Scopable"],
   fields: {
     discriminant: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     cases: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("SwitchCase")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("SwitchCase"))),
+    },
+  },
 });
 
 defineType("ThisExpression", {
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("ThrowStatement", {
@@ -610,9 +610,9 @@ defineType("ThrowStatement", {
   aliases: ["Statement", "Terminatorless", "CompletionStatement"],
   fields: {
     argument: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 // todo: at least handler or finalizer should be set to be valid
@@ -621,51 +621,51 @@ defineType("TryStatement", {
   aliases: ["Statement"],
   fields: {
     body: {
-      validate: assertNodeType("BlockStatement")
+      validate: assertNodeType("BlockStatement"),
     },
     handler: {
       optional: true,
-      handler: assertNodeType("BlockStatement")
+      handler: assertNodeType("BlockStatement"),
     },
     finalizer: {
       optional: true,
-      validate: assertNodeType("BlockStatement")
-    }
-  }
+      validate: assertNodeType("BlockStatement"),
+    },
+  },
 });
 
 defineType("UnaryExpression", {
   builder: ["operator", "argument", "prefix"],
   fields: {
     prefix: {
-      default: true
+      default: true,
     },
     argument: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     operator: {
-      validate: assertOneOf(...UNARY_OPERATORS)
-    }
+      validate: assertOneOf(...UNARY_OPERATORS),
+    },
   },
   visitor: ["argument"],
-  aliases: ["UnaryLike", "Expression"]
+  aliases: ["UnaryLike", "Expression"],
 });
 
 defineType("UpdateExpression", {
   builder: ["operator", "argument", "prefix"],
   fields: {
     prefix: {
-      default: false
+      default: false,
     },
     argument: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     operator: {
-      validate: assertOneOf(...UPDATE_OPERATORS)
-    }
+      validate: assertOneOf(...UPDATE_OPERATORS),
+    },
   },
   visitor: ["argument"],
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("VariableDeclaration", {
@@ -674,25 +674,25 @@ defineType("VariableDeclaration", {
   aliases: ["Statement", "Declaration"],
   fields: {
     kind: {
-      validate: chain(assertValueType("string"), assertOneOf("var", "let", "const"))
+      validate: chain(assertValueType("string"), assertOneOf("var", "let", "const")),
     },
     declarations: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("VariableDeclarator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("VariableDeclarator"))),
+    },
+  },
 });
 
 defineType("VariableDeclarator", {
   visitor: ["id", "init"],
   fields: {
     id: {
-      validate: assertNodeType("LVal")
+      validate: assertNodeType("LVal"),
     },
     init: {
       optional: true,
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("WhileStatement", {
@@ -700,12 +700,12 @@ defineType("WhileStatement", {
   aliases: ["Statement", "BlockParent", "Loop", "While", "Scopable"],
   fields: {
     test: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     body: {
-      validate: assertNodeType("BlockStatement", "Statement")
-    }
-  }
+      validate: assertNodeType("BlockStatement", "Statement"),
+    },
+  },
 });
 
 defineType("WithStatement", {
@@ -713,10 +713,10 @@ defineType("WithStatement", {
   aliases: ["Statement"],
   fields: {
     object: {
-      object: assertNodeType("Expression")
+      object: assertNodeType("Expression"),
     },
     body: {
-      validate: assertNodeType("BlockStatement", "Statement")
-    }
-  }
+      validate: assertNodeType("BlockStatement", "Statement"),
+    },
+  },
 });

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -13,15 +13,15 @@ defineType("AssignmentPattern", {
   aliases: ["Pattern", "LVal"],
   fields: {
     left: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     right: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("ArrayPattern", {
@@ -29,12 +29,12 @@ defineType("ArrayPattern", {
   aliases: ["Pattern", "LVal"],
   fields: {
     elements: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression"))),
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("ArrowFunctionExpression", {
@@ -43,25 +43,25 @@ defineType("ArrowFunctionExpression", {
   aliases: ["Scopable", "Function", "BlockParent", "FunctionParent", "Expression", "Pureish"],
   fields: {
     params: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal"))),
     },
     body: {
-      validate: assertNodeType("BlockStatement", "Expression")
+      validate: assertNodeType("BlockStatement", "Expression"),
     },
     async: {
       validate: assertValueType("boolean"),
-      default: false
-    }
-  }
+      default: false,
+    },
+  },
 });
 
 defineType("ClassBody", {
   visitor: ["body"],
   fields: {
     body: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("ClassMethod", "ClassProperty")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("ClassMethod", "ClassProperty"))),
+    },
+  },
 });
 
 defineType("ClassDeclaration", {
@@ -74,24 +74,24 @@ defineType("ClassDeclaration", {
     "typeParameters",
     "superTypeParameters",
     "implements",
-    "decorators"
+    "decorators",
   ],
   aliases: ["Scopable", "Class", "Statement", "Declaration", "Pureish"],
   fields: {
     id: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     body: {
-      validate: assertNodeType("ClassBody")
+      validate: assertNodeType("ClassBody"),
     },
     superClass: {
       optional: true,
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("ClassExpression", {
@@ -100,19 +100,19 @@ defineType("ClassExpression", {
   fields: {
     id: {
       optional: true,
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     body: {
-      validate: assertNodeType("ClassBody")
+      validate: assertNodeType("ClassBody"),
     },
     superClass: {
       optional: true,
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("ExportAllDeclaration", {
@@ -120,9 +120,9 @@ defineType("ExportAllDeclaration", {
   aliases: ["Statement", "Declaration", "ModuleDeclaration", "ExportDeclaration"],
   fields: {
     source: {
-      validate: assertNodeType("StringLiteral")
-    }
-  }
+      validate: assertNodeType("StringLiteral"),
+    },
+  },
 });
 
 defineType("ExportDefaultDeclaration", {
@@ -130,9 +130,9 @@ defineType("ExportDefaultDeclaration", {
   aliases: ["Statement", "Declaration", "ModuleDeclaration", "ExportDeclaration"],
   fields: {
     declaration: {
-      validate: assertNodeType("FunctionDeclaration", "ClassDeclaration", "Expression")
-    }
-  }
+      validate: assertNodeType("FunctionDeclaration", "ClassDeclaration", "Expression"),
+    },
+  },
 });
 
 defineType("ExportNamedDeclaration", {
@@ -141,16 +141,16 @@ defineType("ExportNamedDeclaration", {
   fields: {
     declaration: {
       validate: assertNodeType("Declaration"),
-      optional: true
+      optional: true,
     },
     specifiers: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("ExportSpecifier")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("ExportSpecifier"))),
     },
     source: {
       validate: assertNodeType("StringLiteral"),
-      optional: true
-    }
-  }
+      optional: true,
+    },
+  },
 });
 
 defineType("ExportSpecifier", {
@@ -158,12 +158,12 @@ defineType("ExportSpecifier", {
   aliases: ["ModuleSpecifier"],
   fields: {
     local: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     exported: {
-      validate: assertNodeType("Identifier")
-    }
-  }
+      validate: assertNodeType("Identifier"),
+    },
+  },
 });
 
 defineType("ForOfStatement", {
@@ -171,19 +171,19 @@ defineType("ForOfStatement", {
   aliases: ["Scopable", "Statement", "For", "BlockParent", "Loop", "ForXStatement"],
   fields: {
     left: {
-      validate: assertNodeType("VariableDeclaration", "LVal")
+      validate: assertNodeType("VariableDeclaration", "LVal"),
     },
     right: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     body: {
-      validate: assertNodeType("Statement")
+      validate: assertNodeType("Statement"),
     },
     await: {
       default: false,
-      validate: assertValueType("boolean")
-    }
-  }
+      validate: assertValueType("boolean"),
+    },
+  },
 });
 
 defineType("ImportDeclaration", {
@@ -194,12 +194,12 @@ defineType("ImportDeclaration", {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"))
-      )
+      ),
     },
     source: {
-      validate: assertNodeType("StringLiteral")
-    }
-  }
+      validate: assertNodeType("StringLiteral"),
+    },
+  },
 });
 
 defineType("ImportDefaultSpecifier", {
@@ -207,9 +207,9 @@ defineType("ImportDefaultSpecifier", {
   aliases: ["ModuleSpecifier"],
   fields: {
     local: {
-      validate: assertNodeType("Identifier")
-    }
-  }
+      validate: assertNodeType("Identifier"),
+    },
+  },
 });
 
 defineType("ImportNamespaceSpecifier", {
@@ -217,9 +217,9 @@ defineType("ImportNamespaceSpecifier", {
   aliases: ["ModuleSpecifier"],
   fields: {
     local: {
-      validate: assertNodeType("Identifier")
-    }
-  }
+      validate: assertNodeType("Identifier"),
+    },
+  },
 });
 
 defineType("ImportSpecifier", {
@@ -227,16 +227,16 @@ defineType("ImportSpecifier", {
   aliases: ["ModuleSpecifier"],
   fields: {
     local: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     imported: {
-      validate: assertNodeType("Identifier")
+      validate: assertNodeType("Identifier"),
     },
     importKind: {
       // Handle Flowtype's extension "import {typeof foo} from"
-      validate: assertOneOf(null, "type", "typeof")
-    }
-  }
+      validate: assertOneOf(null, "type", "typeof"),
+    },
+  },
 });
 
 defineType("MetaProperty", {
@@ -245,12 +245,12 @@ defineType("MetaProperty", {
   fields: {
     // todo: limit to new.target
     meta: {
-      validate: assertValueType("string")
+      validate: assertValueType("string"),
     },
     property: {
-      validate: assertValueType("string")
-    }
-  }
+      validate: assertValueType("string"),
+    },
+  },
 });
 
 defineType("ClassMethod", {
@@ -260,37 +260,37 @@ defineType("ClassMethod", {
   fields: {
     kind: {
       validate: chain(assertValueType("string"), assertOneOf("get", "set", "method", "constructor")),
-      default: "method"
+      default: "method",
     },
     computed: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     static: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     key: {
       validate(node, key, val) {
         const expectedTypes = node.computed ? ["Expression"] : ["Identifier", "StringLiteral", "NumericLiteral"];
         assertNodeType(...expectedTypes)(node, key, val);
-      }
+      },
     },
     params: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("LVal"))),
     },
     body: {
-      validate: assertNodeType("BlockStatement")
+      validate: assertNodeType("BlockStatement"),
     },
     generator: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     async: {
       default: false,
-      validate: assertValueType("boolean")
-    }
-  }
+      validate: assertValueType("boolean"),
+    },
+  },
 });
 
 defineType("ObjectPattern", {
@@ -298,12 +298,12 @@ defineType("ObjectPattern", {
   aliases: ["Pattern", "LVal"],
   fields: {
     properties: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("RestElement", "Property")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("RestElement", "Property"))),
     },
     decorators: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),
+    },
+  },
 });
 
 defineType("SpreadElement", {
@@ -311,13 +311,13 @@ defineType("SpreadElement", {
   aliases: ["UnaryLike"],
   fields: {
     argument: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("Super", {
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("TaggedTemplateExpression", {
@@ -325,12 +325,12 @@ defineType("TaggedTemplateExpression", {
   aliases: ["Expression"],
   fields: {
     tag: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression"),
     },
     quasi: {
-      validate: assertNodeType("TemplateLiteral")
-    }
-  }
+      validate: assertNodeType("TemplateLiteral"),
+    },
+  },
 });
 
 defineType("TemplateElement", {
@@ -341,9 +341,9 @@ defineType("TemplateElement", {
     },
     tail: {
       validate: assertValueType("boolean"),
-      default: false
-    }
-  }
+      default: false,
+    },
+  },
 });
 
 defineType("TemplateLiteral", {
@@ -351,12 +351,12 @@ defineType("TemplateLiteral", {
   aliases: ["Expression", "Literal"],
   fields: {
     quasis: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("TemplateElement")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("TemplateElement"))),
     },
     expressions: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
-    }
-  }
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression"))),
+    },
+  },
 });
 
 defineType("YieldExpression", {
@@ -366,11 +366,11 @@ defineType("YieldExpression", {
   fields: {
     delegate: {
       validate: assertValueType("boolean"),
-      default: false
+      default: false,
     },
     argument: {
       optional: true,
       validate: assertNodeType("Expression"),
-    }
-  }
+    },
+  },
 });

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -7,8 +7,8 @@ defineType("AwaitExpression", {
   fields: {
     argument: {
       validate: assertNodeType("Expression"),
-    }
-  }
+    },
+  },
 });
 
 defineType("BindExpression", {
@@ -16,20 +16,20 @@ defineType("BindExpression", {
   aliases: ["Expression"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("Import", {
-  aliases: ["Expression"]
+  aliases: ["Expression"],
 });
 
 defineType("Decorator", {
   visitor: ["expression"],
   fields: {
     expression: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("DoExpression", {
@@ -37,9 +37,9 @@ defineType("DoExpression", {
   aliases: ["Expression"],
   fields: {
     body: {
-      validate: assertNodeType("BlockStatement")
-    }
-  }
+      validate: assertNodeType("BlockStatement"),
+    },
+  },
 });
 
 defineType("ExportDefaultSpecifier", {
@@ -47,9 +47,9 @@ defineType("ExportDefaultSpecifier", {
   aliases: ["ModuleSpecifier"],
   fields: {
     exported: {
-      validate: assertNodeType("Identifier")
-    }
-  }
+      validate: assertNodeType("Identifier"),
+    },
+  },
 });
 
 defineType("ExportNamespaceSpecifier", {
@@ -57,7 +57,7 @@ defineType("ExportNamespaceSpecifier", {
   aliases: ["ModuleSpecifier"],
   fields: {
     exported: {
-      validate: assertNodeType("Identifier")
-    }
-  }
+      validate: assertNodeType("Identifier"),
+    },
+  },
 });

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -1,12 +1,12 @@
 import defineType, {
-  assertValueType
+  assertValueType,
 } from "./index";
 
 defineType("AnyTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ArrayTypeAnnotation", {
@@ -14,24 +14,24 @@ defineType("ArrayTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("BooleanTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("BooleanLiteralTypeAnnotation", {
   aliases: ["Flow"],
-  fields: {}
+  fields: {},
 });
 
 defineType("NullLiteralTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {}
+  fields: {},
 });
 
 defineType("ClassImplements", {
@@ -39,7 +39,7 @@ defineType("ClassImplements", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ClassProperty", {
@@ -49,10 +49,10 @@ defineType("ClassProperty", {
   fields: {
     computed: {
       validate: assertValueType("boolean"),
-      default: false
-    }
+      default: false,
+    },
     // todo
-  }
+  },
 });
 
 defineType("DeclareClass", {
@@ -60,7 +60,7 @@ defineType("DeclareClass", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("DeclareFunction", {
@@ -68,7 +68,7 @@ defineType("DeclareFunction", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("DeclareInterface", {
@@ -76,7 +76,7 @@ defineType("DeclareInterface", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("DeclareModule", {
@@ -84,7 +84,7 @@ defineType("DeclareModule", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("DeclareModuleExports", {
@@ -92,7 +92,7 @@ defineType("DeclareModuleExports", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("DeclareTypeAlias", {
@@ -100,7 +100,7 @@ defineType("DeclareTypeAlias", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("DeclareVariable", {
@@ -108,11 +108,11 @@ defineType("DeclareVariable", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ExistsTypeAnnotation", {
-  aliases: ["Flow"]
+  aliases: ["Flow"],
 });
 
 defineType("FunctionTypeAnnotation", {
@@ -120,7 +120,7 @@ defineType("FunctionTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("FunctionTypeParam", {
@@ -128,7 +128,7 @@ defineType("FunctionTypeParam", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("GenericTypeAnnotation", {
@@ -136,7 +136,7 @@ defineType("GenericTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("InterfaceExtends", {
@@ -144,7 +144,7 @@ defineType("InterfaceExtends", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("InterfaceDeclaration", {
@@ -152,7 +152,7 @@ defineType("InterfaceDeclaration", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("IntersectionTypeAnnotation", {
@@ -160,15 +160,15 @@ defineType("IntersectionTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("MixedTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"]
+  aliases: ["Flow", "FlowBaseAnnotation"],
 });
 
 defineType("EmptyTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"]
+  aliases: ["Flow", "FlowBaseAnnotation"],
 });
 
 defineType("NullableTypeAnnotation", {
@@ -176,40 +176,40 @@ defineType("NullableTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("NumberLiteralTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("NumberTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("StringLiteralTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("StringTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ThisTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {}
+  fields: {},
 });
 
 defineType("TupleTypeAnnotation", {
@@ -217,7 +217,7 @@ defineType("TupleTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeofTypeAnnotation", {
@@ -225,7 +225,7 @@ defineType("TypeofTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeAlias", {
@@ -233,7 +233,7 @@ defineType("TypeAlias", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeAnnotation", {
@@ -241,7 +241,7 @@ defineType("TypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeCastExpression", {
@@ -249,7 +249,7 @@ defineType("TypeCastExpression", {
   aliases: ["Flow", "ExpressionWrapper", "Expression"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeParameter", {
@@ -257,7 +257,7 @@ defineType("TypeParameter", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeParameterDeclaration", {
@@ -265,7 +265,7 @@ defineType("TypeParameterDeclaration", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("TypeParameterInstantiation", {
@@ -273,7 +273,7 @@ defineType("TypeParameterInstantiation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ObjectTypeAnnotation", {
@@ -281,7 +281,7 @@ defineType("ObjectTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ObjectTypeCallProperty", {
@@ -289,7 +289,7 @@ defineType("ObjectTypeCallProperty", {
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ObjectTypeIndexer", {
@@ -297,7 +297,7 @@ defineType("ObjectTypeIndexer", {
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("ObjectTypeProperty", {
@@ -305,7 +305,7 @@ defineType("ObjectTypeProperty", {
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("QualifiedTypeIdentifier", {
@@ -313,7 +313,7 @@ defineType("QualifiedTypeIdentifier", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("UnionTypeAnnotation", {
@@ -321,12 +321,12 @@ defineType("UnionTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
     // todo
-  }
+  },
 });
 
 defineType("VoidTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
   fields: {
     // todo
-  }
+  },
 });

--- a/packages/babel-types/src/definitions/index.js
+++ b/packages/babel-types/src/definitions/index.js
@@ -129,7 +129,7 @@ export default function defineType(
 ) {
   const inherits = (opts.inherits && store[opts.inherits]) || {};
 
-  opts.fields  = opts.fields || inherits.fields || {};
+  opts.fields = opts.fields || inherits.fields || {};
   opts.visitor = opts.visitor || inherits.visitor || [];
   opts.aliases = opts.aliases || inherits.aliases || [];
   opts.builder = opts.builder || inherits.builder || opts.visitor || [];
@@ -158,8 +158,8 @@ export default function defineType(
 
   VISITOR_KEYS[type] = opts.visitor;
   BUILDER_KEYS[type] = opts.builder;
-  NODE_FIELDS[type]  = opts.fields;
-  ALIAS_KEYS[type]   = opts.aliases;
+  NODE_FIELDS[type] = opts.fields;
+  ALIAS_KEYS[type] = opts.aliases;
 
   store[type] = opts;
 }

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -5,13 +5,13 @@ defineType("JSXAttribute", {
   aliases: ["JSX", "Immutable"],
   fields: {
     name: {
-      validate: assertNodeType("JSXIdentifier", "JSXNamespacedName")
+      validate: assertNodeType("JSXIdentifier", "JSXNamespacedName"),
     },
     value: {
       optional: true,
-      validate: assertNodeType("JSXElement", "StringLiteral", "JSXExpressionContainer")
-    }
-  }
+      validate: assertNodeType("JSXElement", "StringLiteral", "JSXExpressionContainer"),
+    },
+  },
 });
 
 defineType("JSXClosingElement", {
@@ -19,9 +19,9 @@ defineType("JSXClosingElement", {
   aliases: ["JSX", "Immutable"],
   fields: {
     name: {
-      validate: assertNodeType("JSXIdentifier", "JSXMemberExpression")
-    }
-  }
+      validate: assertNodeType("JSXIdentifier", "JSXMemberExpression"),
+    },
+  },
 });
 
 defineType("JSXElement", {
@@ -30,23 +30,23 @@ defineType("JSXElement", {
   aliases: ["JSX", "Immutable", "Expression"],
   fields: {
     openingElement: {
-      validate: assertNodeType("JSXOpeningElement")
+      validate: assertNodeType("JSXOpeningElement"),
     },
     closingElement: {
       optional: true,
-      validate: assertNodeType("JSXClosingElement")
+      validate: assertNodeType("JSXClosingElement"),
     },
     children: {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("JSXText", "JSXExpressionContainer", "JSXSpreadChild", "JSXElement"))
-      )
-    }
-  }
+      ),
+    },
+  },
 });
 
 defineType("JSXEmptyExpression", {
-  aliases: ["JSX", "Expression"]
+  aliases: ["JSX", "Expression"],
 });
 
 defineType("JSXExpressionContainer", {
@@ -54,9 +54,9 @@ defineType("JSXExpressionContainer", {
   aliases: ["JSX", "Immutable"],
   fields: {
     expression: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("JSXSpreadChild", {
@@ -64,9 +64,9 @@ defineType("JSXSpreadChild", {
   aliases: ["JSX", "Immutable"],
   fields: {
     expression: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("JSXIdentifier", {
@@ -74,9 +74,9 @@ defineType("JSXIdentifier", {
   aliases: ["JSX", "Expression"],
   fields: {
     name: {
-      validate: assertValueType("string")
-    }
-  }
+      validate: assertValueType("string"),
+    },
+  },
 });
 
 defineType("JSXMemberExpression", {
@@ -84,12 +84,12 @@ defineType("JSXMemberExpression", {
   aliases: ["JSX", "Expression"],
   fields: {
     object: {
-      validate: assertNodeType("JSXMemberExpression", "JSXIdentifier")
+      validate: assertNodeType("JSXMemberExpression", "JSXIdentifier"),
     },
     property: {
-      validate: assertNodeType("JSXIdentifier")
-    }
-  }
+      validate: assertNodeType("JSXIdentifier"),
+    },
+  },
 });
 
 defineType("JSXNamespacedName", {
@@ -97,12 +97,12 @@ defineType("JSXNamespacedName", {
   aliases: ["JSX"],
   fields: {
     namespace: {
-      validate: assertNodeType("JSXIdentifier")
+      validate: assertNodeType("JSXIdentifier"),
     },
     name: {
-      validate: assertNodeType("JSXIdentifier")
-    }
-  }
+      validate: assertNodeType("JSXIdentifier"),
+    },
+  },
 });
 
 defineType("JSXOpeningElement", {
@@ -111,19 +111,19 @@ defineType("JSXOpeningElement", {
   aliases: ["JSX", "Immutable"],
   fields: {
     name: {
-      validate: assertNodeType("JSXIdentifier", "JSXMemberExpression")
+      validate: assertNodeType("JSXIdentifier", "JSXMemberExpression"),
     },
     selfClosing: {
       default: false,
-      validate: assertValueType("boolean")
+      validate: assertValueType("boolean"),
     },
     attributes: {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("JSXAttribute", "JSXSpreadAttribute"))
-      )
-    }
-  }
+      ),
+    },
+  },
 });
 
 defineType("JSXSpreadAttribute", {
@@ -131,9 +131,9 @@ defineType("JSXSpreadAttribute", {
   aliases: ["JSX"],
   fields: {
     argument: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });
 
 defineType("JSXText", {
@@ -141,7 +141,7 @@ defineType("JSXText", {
   builder: ["value"],
   fields: {
     value: {
-      validate: assertValueType("string")
-    }
-  }
+      validate: assertValueType("string"),
+    },
+  },
 });

--- a/packages/babel-types/src/definitions/misc.js
+++ b/packages/babel-types/src/definitions/misc.js
@@ -1,7 +1,7 @@
 import defineType, { assertNodeType } from "./index";
 
 defineType("Noop", {
-  visitor: []
+  visitor: [],
 });
 
 defineType("ParenthesizedExpression", {
@@ -9,7 +9,7 @@ defineType("ParenthesizedExpression", {
   aliases: ["Expression", "ExpressionWrapper"],
   fields: {
     expression: {
-      validate: assertNodeType("Expression")
-    }
-  }
+      validate: assertNodeType("Expression"),
+    },
+  },
 });

--- a/packages/babel-types/src/flow.js
+++ b/packages/babel-types/src/flow.js
@@ -6,7 +6,7 @@ import * as t from "./index";
  */
 
 export function createUnionTypeAnnotation(types: Array<Object>) {
-  const flattened  = removeTypeDuplicates(types);
+  const flattened = removeTypeDuplicates(types);
 
   if (flattened.length === 1) {
     return flattened[0];

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -46,7 +46,7 @@ export {
   UNARY_OPERATORS,
   INHERIT_KEYS,
   BLOCK_SCOPED_SYMBOL,
-  NOT_LOCAL_BINDING
+  NOT_LOCAL_BINDING,
 } from "./constants";
 
 import "./definitions/init";
@@ -230,7 +230,7 @@ export function shallowEqual(actual: Object, expected: Object): boolean {
  */
 
 export function appendToMemberExpression(member: Object, append: Object, computed?: boolean): Object {
-  member.object   = t.memberExpression(member.object, member.property, member.computed);
+  member.object = t.memberExpression(member.object, member.property, member.computed);
   member.property = append;
   member.computed = !!computed;
   return member;
@@ -485,11 +485,11 @@ export function traverseFast(node: Node, enter: (node: Node) => void, opts?: Obj
 const CLEAR_KEYS: Array = [
   "tokens",
   "start", "end", "loc",
-  "raw", "rawValue"
+  "raw", "rawValue",
 ];
 
 const CLEAR_KEYS_PLUS_COMMENTS: Array = t.COMMENT_KEYS.concat([
-  "comments"
+  "comments",
 ]).concat(CLEAR_KEYS);
 
 /**
@@ -522,7 +522,7 @@ export function removePropertiesDeep(tree: Node, opts?: Object): Node {
 //
 export {
   getBindingIdentifiers,
-  getOuterBindingIdentifiers
+  getOuterBindingIdentifiers,
 } from "./retrievers";
 
 export {
@@ -535,7 +535,7 @@ export {
   isSpecifierDefault,
   isScope,
   isImmutable,
-  isNodesEquivalent
+  isNodesEquivalent,
 } from "./validators";
 
 export {
@@ -547,11 +547,11 @@ export {
   toStatement,
   toExpression,
   toBlock,
-  valueToNode
+  valueToNode,
 } from "./converters";
 
 export {
   createUnionTypeAnnotation,
   removeTypeDuplicates,
-  createTypeAnnotationBasedOnTypeof
+  createTypeAnnotationBasedOnTypeof,
 } from "./flow";

--- a/packages/babel-types/src/retrievers.js
+++ b/packages/babel-types/src/retrievers.js
@@ -10,7 +10,7 @@ export function getBindingIdentifiers(
   outerOnly?: boolean
 ): Object {
   let search = [].concat(node);
-  const ids    = Object.create(null);
+  const ids = Object.create(null);
 
   while (search.length) {
     const id = search.shift();
@@ -101,7 +101,7 @@ getBindingIdentifiers.keys = {
   ObjectPattern: ["properties"],
 
   VariableDeclaration: ["declarations"],
-  VariableDeclarator: ["id"]
+  VariableDeclarator: ["id"],
 };
 
 export function getOuterBindingIdentifiers(

--- a/packages/babel-types/test/converters.js
+++ b/packages/babel-types/test/converters.js
@@ -31,10 +31,10 @@ describe("converters", function () {
     it("object", function () {
       assert.deepEqual(t.valueToNode({
         a: 1,
-        "b c": 2
+        "b c": 2,
       }), t.objectExpression([
         t.objectProperty(t.identifier("a"), t.numericLiteral(1)),
-        t.objectProperty(t.stringLiteral("b c"), t.numericLiteral(2))
+        t.objectProperty(t.stringLiteral("b c"), t.numericLiteral(2)),
       ]));
     });
     it("throws if cannot convert", function () {


### PR DESCRIPTION
Here's a preview of latest batch of rule changes in `eslint-config-babel`, we can tweak here without needing to bump versions.

This should also minimize a number of changes in https://github.com/babel/babel/pull/5412.