### PR TITLE
Fix PathHoister attaching to default parameters.

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/actual.js
@@ -1,0 +1,5 @@
+function render(title= '') {
+  return () => (
+    <Component title={title} />
+  );
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/expected.js
@@ -1,0 +1,7 @@
+function render() {
+  var title = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+
+  var _ref = <Component title={title} />;
+
+  return () => _ref;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params-2/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "transform-es2015-parameters",
+    "transform-react-constant-elements",
+    "transform-es2015-block-scoping",
+    "syntax-jsx"
+  ]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/actual.js
@@ -1,0 +1,5 @@
+function render(Component, text = '') {
+  return function() {
+    return <Component text={text} />;
+  }
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/expected.js
@@ -1,0 +1,9 @@
+function render(Component) {
+  var text = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+
+  var _ref = <Component text={text} />;
+
+  return function () {
+    return _ref;
+  };
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-default-params/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "transform-es2015-parameters",
+    "transform-react-constant-elements",
+    "transform-es2015-block-scoping",
+    "syntax-jsx"
+  ]
+}

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -140,7 +140,7 @@ export default class PathHoister {
           if (bodies[i].node._blockHoist) continue;
           return bodies[i];
         }
-        // deopt: If here, no attachmen path found
+        // deopt: If here, no attachment path found
       } else {
         // doesn't need to be be attached to this scope
         return this.getNextScopeAttachmentParent();

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -133,7 +133,14 @@ export default class PathHoister {
         if (this.scope === scope) return;
 
         // needs to be attached to the body
-        return scope.path.get("body").get("body")[0];
+        const bodies = scope.path.get("body").get("body");
+        for (let i = 0; i < bodies.length; i++) {
+          // Don't attach to something that's going to get hoisted,
+          // like a default parameter
+          if (bodies[i].node._blockHoist) continue;
+          return bodies[i];
+        }
+        // deopt: If here, no attachmen path found
       } else {
         // doesn't need to be be attached to this scope
         return this.getNextScopeAttachmentParent();


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5315
| License                  | MIT

As described in #5315, there are cases in combination with `transform-default-parameters` that can cause the node to be completely lost due to [block-hoist](https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/internal-plugins/block-hoist.js).

We now look for the internal property `_blockHoist` and skip attaching to that node if found.

Added two tests (only slightly different) to confirm this behavior.
