### PR TITLE
Use 'resolve' from npm instead of private 'module' methods.

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -41,6 +41,7 @@
     "lodash": "^4.2.0",
     "minimatch": "^3.0.2",
     "private": "^0.1.6",
+    "resolve": "^1.3.2",
     "slash": "^1.0.0",
     "source-map": "^0.5.0"
   },

--- a/packages/babel-core/src/helpers/resolve.js
+++ b/packages/babel-core/src/helpers/resolve.js
@@ -1,33 +1,8 @@
-import Module from "module";
-import path from "path";
-
-const relativeModules = {};
+import resolve from "resolve";
 
 export default function (loc: string, relative: string = process.cwd()): ?string {
-  // we're in the browser, probably
-  if (typeof Module === "object") return null;
-
-  let relativeMod = relativeModules[relative];
-
-  if (!relativeMod) {
-    relativeMod = new Module;
-
-    // We need to define an id and filename on our "fake" relative` module so that
-    // Node knows what "." means in the case of us trying to resolve a plugin
-    // such as "./myPlugins/somePlugin.js". If we don't specify id and filename here,
-    // Node presumes "." is process.cwd(), not our relative path.
-    // Since this fake module is never "loaded", we don't have to worry about mutating
-    // any global Node module cache state here.
-    const filename = path.join(relative, ".babelrc");
-    relativeMod.id = filename;
-    relativeMod.filename = filename;
-
-    relativeMod.paths = Module._nodeModulePaths(relative);
-    relativeModules[relative] = relativeMod;
-  }
-
   try {
-    return Module._resolveFilename(loc, relativeMod);
+    return resolve.sync(loc, { basedir: relative });
   } catch (err) {
     return null;
   }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -8,12 +8,13 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
   "main": "lib/index.js",
   "dependencies": {
+    "babel-code-frame": "7.0.0-alpha.1",
     "babel-core": "7.0.0-alpha.1",
     "babel-polyfill": "7.0.0-alpha.1",
     "babel-helper-fixtures": "7.0.0-alpha.1",
-    "source-map": "^0.5.0",
-    "babel-code-frame": "7.0.0-alpha.1",
     "chai": "^3.0.0",
-    "lodash": "^4.2.0"
+    "lodash": "^4.2.0",
+    "resolve": "^1.3.2",
+    "source-map": "^0.5.0"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -8,12 +8,12 @@ import includes from "lodash/includes";
 import * as helpers from "./helpers";
 import extend from "lodash/extend";
 import merge from "lodash/merge";
+import resolve from "resolve";
 import assert from "assert";
 import chai from "chai";
 import fs from "fs";
 import path from "path";
 import vm from "vm";
-import Module from "module";
 
 const moduleCache = {};
 const testContext = vm.createContext({
@@ -35,13 +35,7 @@ runCodeInTestContext(buildExternalHelpers());
  * This allows us to run our unittests
  */
 function runModuleInTestContext(id: string, relativeFilename: string) {
-  // This code is a gross hack using internal APIs, but we also have the same logic in babel-core
-  // to resolve presets and plugins, so if this breaks, we'll have even worse issues to deal with.
-  const relativeMod = new Module();
-  relativeMod.id = relativeFilename;
-  relativeMod.filename = relativeFilename;
-  relativeMod.paths = Module._nodeModulePaths(path.dirname(relativeFilename));
-  const filename = Module._resolveFilename(id, relativeMod);
+  const filename = resolve.sync(id, { basedir: path.dirname(relativeFilename) });
 
   // Expose Node-internal modules if the tests want them. Note, this will not execute inside
   // the context's global scope.


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

The old code was using a private API and is real gross.