### PR TITLE
Fix PathHoister error attaching after export declarations.

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/actual.js
@@ -1,0 +1,7 @@
+class A {
+    render() {
+        return <B />
+    }
+}
+
+export default class B {}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/expected.js
@@ -1,0 +1,9 @@
+class A {
+    render() {
+        return _ref;
+    }
+}
+
+export default class B {}
+
+var _ref = React.createElement(B, null);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/options.json
@@ -1,0 +1,6 @@
+{
+    "plugins": [
+        "transform-react-jsx",
+        "transform-react-constant-elements"
+    ]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/actual.js
@@ -1,0 +1,7 @@
+class A {
+    render() {
+        return <B />
+    }
+}
+
+export class B {}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/expected.js
@@ -1,0 +1,9 @@
+class A {
+    render() {
+        return _ref;
+    }
+}
+
+export class B {}
+
+var _ref = React.createElement(B, null);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/options.json
@@ -1,0 +1,6 @@
+{
+    "plugins": [
+        "transform-react-jsx",
+        "transform-react-constant-elements"
+    ]
+}

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -117,6 +117,12 @@ export default class PathHoister {
       }
     }
 
+    // We can't insert before/after a child of an export declaration, so move up
+    // to the declaration itself.
+    if (path.parentPath.isExportDeclaration()) {
+      path = path.parentPath;
+    }
+
     return path;
   }
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5369 
| License                  | MIT

In #5369, the user notes that PathHoister fails hard when attempting to `insertAfter` or `insertBefore` on the child of an `ExportDeclaration`. Much like in [transform-class-properties](https://github.com/babel/babel/blob/4ee385e96cac4b2c0e851932f1b48550b7523dfc/packages/babel-plugin-transform-class-properties/src/index.js#L167), we now look for this and move to the parent `ExportDeclaration`.