### PR TITLE
Add noInterop option to babel-plugin-transform-es2015-modules-commonjs.

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/README.md
+++ b/packages/babel-plugin-transform-es2015-modules-amd/README.md
@@ -55,3 +55,7 @@ require("babel-core").transform("code", {
   plugins: ["transform-es2015-modules-amd"]
 });
 ```
+
+### Options
+
+See options for `babel-plugin-transform-es2015-commonjs`.

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/actual.js
@@ -1,0 +1,1 @@
+export { default } from 'foo';

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/expected.js
@@ -1,0 +1,13 @@
+define(['exports', 'foo'], function (exports, _foo) {
+  'use strict';
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  Object.defineProperty(exports, 'default', {
+    enumerable: true,
+    get: function () {
+      return _foo.default;
+    }
+  });
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", ["transform-es2015-modules-amd", { "noInterop": true }]]
+}

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-import-default-only/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-import-default-only/actual.js
@@ -1,0 +1,3 @@
+import foo from "foo";
+
+foo;

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-import-default-only/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-import-default-only/expected.js
@@ -1,0 +1,5 @@
+define(["foo"], function (_foo) {
+  "use strict";
+
+  _foo.default;
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-import-default-only/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-import-default-only/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", ["transform-es2015-modules-amd", { "noInterop": true }]]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/README.md
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/README.md
@@ -82,10 +82,53 @@ Object.defineProperty(exports, "__esModule", {
 });
 ```
 
-In environments that don't support this you can enable loose mode on `es6.modules`
+In environments that don't support this you can enable loose mode on `babel-plugin-transform-es20150-modules-commonjs`
 and instead of using `Object.defineProperty` an assignment will be used instead.
 
 ```javascript
 var foo = exports.foo = 5;
 exports.__esModule = true;
 ```
+
+### `strict`
+
+`boolean`, defaults to `false`
+
+By default, when using exports with babel a non-enumerable `__esModule` property
+is exported. In some cases this property is used to determine if the import _is_ the
+default export or if it _contains_ the default export.
+
+```javascript
+var foo = exports.foo = 5;
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+```
+
+In order to prevent the `__esModule` property from being exported, you can set
+the `strict` option to `true`.
+
+### `noInterop`
+
+`boolean`, defaults to `false`
+
+By default, when using exports with babel a non-enumerable `__esModule` property
+is exported. This property is then used to determine if the import _is_ the default
+export or if it _contains_ the default export.
+
+```javascript
+"use strict";
+
+var _foo = require("foo");
+
+var _foo2 = _interopRequireDefault(_foo);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
+```
+
+In cases where the auto-unwrapping of `default` is not needed, you can set the
+`noInterop` option to `true` to avoid the usage of the `interopRequireDefault`
+helper (shown in inline form above).

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -151,6 +151,7 @@ export default function () {
           this.ranCommonJS = true;
 
           const strict = !!this.opts.strict;
+          const noInterop = !!this.opts.noInterop;
 
           const { scope } = path;
 
@@ -327,7 +328,7 @@ export default function () {
                   } else if (specifier.isExportDefaultSpecifier()) {
                     // todo
                   } else if (specifier.isExportSpecifier()) {
-                    if (specifier.node.local.name === "default") {
+                    if (!noInterop && specifier.node.local.name === "default") {
                       topNodes.push(buildExportsFrom(t.stringLiteral(specifier.node.exported.name),
                         t.memberExpression(
                           t.callExpression(this.addHelper("interopRequireDefault"), [ref]),
@@ -371,7 +372,7 @@ export default function () {
               for (let i = 0; i < specifiers.length; i++) {
                 const specifier = specifiers[i];
                 if (t.isImportNamespaceSpecifier(specifier)) {
-                  if (strict) {
+                  if (strict || noInterop) {
                     remaps[specifier.local.name] = uid;
                   } else {
                     const varDecl = t.variableDeclaration("var", [
@@ -402,7 +403,7 @@ export default function () {
                   if (specifier.imported.name === "default") {
                     if (wildcard) {
                       target = wildcard;
-                    } else {
+                    } else if (!noInterop) {
                       target = wildcard = path.scope.generateUidIdentifier(uid.name);
                       const varDecl = t.variableDeclaration("var", [
                         t.variableDeclarator(

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/actual.js
@@ -1,0 +1,1 @@
+export { default } from 'foo';

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/expected.js
@@ -1,0 +1,14 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _foo = require('foo');
+
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function () {
+    return _foo.default;
+  }
+});

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-default-only/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-default-only/actual.js
@@ -1,0 +1,3 @@
+import foo from "foo";
+
+foo();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-default-only/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-default-only/expected.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var _foo = require("foo");
+
+(0, _foo.default)();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-wildcard/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-wildcard/actual.js
@@ -1,0 +1,4 @@
+import * as foo from 'foo';
+
+foo.bar();
+foo.baz();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-wildcard/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-wildcard/expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var _foo = require('foo');
+
+_foo.bar();
+_foo.baz();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", ["transform-es2015-modules-commonjs", { "noInterop": true }]]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/actual.js
@@ -1,0 +1,4 @@
+import * as foo from 'foo';
+
+foo.bar();
+foo.baz();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var _foo = require('foo');
+
+_foo.bar();
+_foo.baz();


### PR DESCRIPTION
The intent of this option is to toggle module interop behavior. When `true`
the `interopRequireXXX` helper invocations will not be emitted in the transpiled output.


<details>
  <summary>Original PR Description</summary>
The intent of the `strict` option for `babel-plugin-transform-es2015-modules-commonjs` was to toggle module interop behavior, 
however a few scenarios were not being handled properly.

Specifically, when only a default import is used from a given module, such as:

```js
import Foo from 'foo';
```

The transpiled output with and without `strict` flag still included `_interopRequireDefault`.

After this change, the output is now properly disabling the inclusion of `_interopRequireDefault`.
</details>
Fixes https://github.com/babel/babel/issues/4073.