### PR TITLE
Remove check for super calls in arrow function

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -25,13 +25,18 @@ const noMethodVisitor = {
 };
 
 const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
-  Super(path) {
+  Super(path, state) {
     if (
       this.isDerived && !this.hasBareSuper &&
-      !path.parentPath.isCallExpression({ callee: path.node })
+      !path.parentPath.isCallExpression({ callee: path.node }) &&
+      !state.inArrowFunctionExpression
     ) {
       throw path.buildCodeFrameError("'super.*' is not allowed before super()");
     }
+  },
+
+  ArrowFunctionExpression(path, state) {
+    state.inArrowFunctionExpression = true;
   },
 
   CallExpression: {

--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -25,18 +25,17 @@ const noMethodVisitor = {
 };
 
 const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
-  Super(path, state) {
+  Super(path) {
     if (
       this.isDerived && !this.hasBareSuper &&
-      !path.parentPath.isCallExpression({ callee: path.node }) &&
-      !state.inArrowFunctionExpression
+      !path.parentPath.isCallExpression({ callee: path.node })
     ) {
-      throw path.buildCodeFrameError("'super.*' is not allowed before super()");
-    }
-  },
+      const hasArrowFunctionParent = path.findParent((p) => p.isArrowFunctionExpression());
 
-  ArrowFunctionExpression(path, state) {
-    state.inArrowFunctionExpression = true;
+      if (!hasArrowFunctionParent) {
+        throw path.buildCodeFrameError("'super.*' is not allowed before super()");
+      }
+    }
   },
 
   CallExpression: {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/actual.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  constructor() {
+    const t = () => super.test()
+    super.foo();
+    super();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "'super.*' is not allowed before super()"
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/actual.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  constructor() {
+    const t = () => super.test()
+    super();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/expected.js
@@ -1,0 +1,14 @@
+var Foo = function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
+  function Foo() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Foo);
+
+    var t = () => babelHelpers.get(Foo.prototype.__proto__ || Object.getPrototypeOf(Foo.prototype), "test", _this).call(_this);
+    return _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
+  }
+
+  return Foo;
+}(Bar);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | maybe
| Tests Added/Pass?        | yes/yes
| Fixed Tickets            | #5371
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

If the parent node is an ArrowFunctionExpression remove the compilation check since we can't staticly tell if it's correct or not.