### PR TITLE
Remove `strict` toggling `interopRequireWildcard` behavior.

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -372,7 +372,7 @@ export default function () {
               for (let i = 0; i < specifiers.length; i++) {
                 const specifier = specifiers[i];
                 if (t.isImportNamespaceSpecifier(specifier)) {
-                  if (strict || noInterop) {
+                  if (noInterop) {
                     remaps[specifier.local.name] = uid;
                   } else {
                     const varDecl = t.variableDeclaration("var", [

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/expected.js
@@ -2,5 +2,8 @@
 
 var _foo = require('foo');
 
-_foo.bar();
-_foo.baz();
+var foo = babelHelpers.interopRequireWildcard(_foo);
+
+
+foo.bar();
+foo.baz();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import/expected.js
@@ -2,7 +2,10 @@
 
 var _foo = require("foo");
 
-_foo.default;
-_foo.default;
+var foo4 = babelHelpers.interopRequireWildcard(_foo);
+
+
+foo4.default;
+foo4.default;
 _foo.foo3;
 (0, _foo.foo3)();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import/source-mappings.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import/source-mappings.json
@@ -3,7 +3,7 @@
     "line": 6, "column": 0
   },
   "generated": {
-    "line": 5, "column": 0
+    "line": 8, "column": 0
   }
 },{
   "original": {


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | yes
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | ?
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

I first noticed this while working on https://github.com/babel/babel/pull/5422. Prior to this change, using the `strict` flag affected two different and unrelated things. 

* Prevent usage of `interopRequireWildcard` [here](https://github.com/babel/babel/blob/8a82cc060ae0ab46bf52e05e592de770bd246f6f/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js#L374)
* Prevent definition of `exports.__esModule` [here](https://github.com/babel/babel/blob/8a82cc060ae0ab46bf52e05e592de770bd246f6f/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js#L466)

It seems that only the toggling of `__esModule` was intended though, so this commit removes the relationship between `strict` and `interopRequireWildcard`.

This is potentially breaking change, if folks are relying on `strict: true` disabling the insertion of `interopRequireWildcard`. Therefore I believe that this change should only target 7.0.
