### PR TITLE
separate enabled cache from the disabled cache code.

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -2,9 +2,23 @@ import path from "path";
 import fs from "fs";
 import { sync as mkdirpSync } from "mkdirp";
 import homeOrTmp from "home-or-tmp";
+import * as babel from "babel-core";
 
 const FILENAME: string = process.env.BABEL_CACHE_PATH || path.join(homeOrTmp, ".babel.json");
 let data: Object = {};
+
+/**
+ * Create a key from transform options.
+ */
+
+export function key(opts) {
+  let cacheKey = `${JSON.stringify(opts)}:${babel.version}`;
+
+  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  if (env) cacheKey += `:${env}`;
+
+  return cacheKey;
+}
 
 /**
  * Write stringified cache to disk.
@@ -34,8 +48,6 @@ export function save() {
  */
 
 export function load() {
-  if (process.env.BABEL_DISABLE_CACHE) return;
-
   process.on("exit", save);
   process.nextTick(save);
 
@@ -52,6 +64,10 @@ export function load() {
  * Retrieve data from cache.
  */
 
-export function get(): Object {
-  return data;
+export function get(opts): Object {
+  return data[key(opts)];
+}
+
+export function set(opts, value) {
+  data[key(opts)] = value;
 }

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -34,51 +34,55 @@ function resetCache() {
 describe("babel register", () => {
 
   describe("cache", () => {
-    let load, get, save;
+    let key, load, get, save, set;
 
     beforeEach(() => {
       // Since lib/cache is a singleton we need to fully reload it
       decache("../lib/cache");
       const cache = require("../lib/cache");
 
+      key = cache.key;
       load = cache.load;
       get = cache.get;
       save = cache.save;
+      set = cache.set;
     });
 
     afterEach(cleanCache);
     after(resetCache);
 
     it("should load and get cached data", () => {
-      writeCache({ foo: "bar" });
+      writeCache({ [key("foo")]: "bar" });
 
       load();
 
-      expect(get()).to.be.an("object");
-      expect(get()).to.deep.equal({ foo: "bar" });
+      expect(get("foo")).to.be.a("string");
+      expect(get("foo")).to.equal("bar");
     });
 
-    it("should load and get an object with no cached data", () => {
+    it("should set and get data", () => {
+      set("foo", "bar");
+      expect(get("foo")).to.be.equal("bar");
+    });
+
+    it("should load and get with no cached data", () => {
       load();
 
-      expect(get()).to.be.an("object");
-      expect(get()).to.deep.equal({});
+      expect(get("foo")).to.be.undefined;
     });
 
-    it("should load and get an object with invalid cached data", () => {
+    it("should load and get with invalid cached data", () => {
       writeCache("foobar");
 
       load();
 
-      expect(get()).to.be.an("object");
-      expect(get()).to.deep.equal({});
+      expect(get("foo")).to.be.undefined;
     });
 
     it("should create the cache on save", () => {
       save();
 
       expect(fs.existsSync(testCacheFilename)).to.be.true;
-      expect(get()).to.deep.equal({});
     });
   });
 });


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  N
| Major: Breaking Change?  |  N
| Minor: New Feature?      |  N
| Deprecations?            |  N
| Spec Compliancy?         |  Y
| Tests Added/Pass?        |  N/Y
| License                  | MIT

This PR splits the existing cache functionality into a noop cache (in the case of cache: false or BABEL_DISABLE_CACHE) and the default caching functionality. Turning the cache on and off is now just a matter of toggling between cache implementations (one of which just has noop get/set functions). In addition, the cache is now responsible for generating keys based on the transform options, so if the cache is disabled, the transform options won't be needlessly stringified for each file.

Most of this was ripped out of https://github.com/babel/babel/pull/5402. This should be nice little perf win when caching is disabled, and I wanted it evaluated seperately from the custom cache feature (though this PR will make that feature a one liner).
