### PR TITLE
document cache option for babel-register

### DIFF
--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -69,7 +69,7 @@ require("babel-register")({
   extensions: [".es6", ".es", ".jsx", ".js"],
 
   // Setting this to false will disable the cache.
-  cache: false
+  cache: true
 });
 ```
 

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -66,7 +66,10 @@ require("babel-register")({
 
   // Setting this will remove the currently hooked extensions of .es6, `.es`, `.jsx`
   // and .js so you'll have to add them back if you want them to be used again.
-  extensions: [".es6", ".es", ".jsx", ".js"]
+  extensions: [".es6", ".es", ".jsx", ".js"],
+
+  // Setting this to false will disable the cache.
+  cache: false
 });
 ```
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| License                  | MIT
| Doc PR                   | yes

Documenting the ability to programmatically disable the babel-register cache as an alternative to `BABEL_DISABLE_CACHE`.
https://github.com/babel/babel/blob/7.0/packages/babel-register/src/node.js#L139
