### PR TITLE
Add useBuiltIns and useESModules options to transform-runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist
 /.package.json
 /packages/babel-runtime/core-js
 /packages/babel-runtime/helpers/*.js
+/packages/babel-runtime/helpers/builtin/*.js
+/packages/babel-runtime/helpers/builtin/es6/*.js
+/packages/babel-runtime/helpers/es6/*.js
 /packages/babel-register/test/.babel
 /packages/*/lib
 _babel.github.io

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/actual.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/actual.js
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/expected.js
@@ -1,0 +1,15 @@
+import _classCallCheck from "babel-runtime/helpers/builtin/es6/classCallCheck";
+import _possibleConstructorReturn from "babel-runtime/helpers/builtin/es6/possibleConstructorReturn";
+import _inherits from "babel-runtime/helpers/builtin/es6/inherits";
+
+let Foo = function (_Bar) {
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-runtime", { "useBuiltIns": true, "useESModules": true }], "transform-es2015-classes"]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/actual.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/actual.js
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/expected.js
@@ -1,0 +1,15 @@
+import _classCallCheck from "babel-runtime/helpers/builtin/classCallCheck";
+import _possibleConstructorReturn from "babel-runtime/helpers/builtin/possibleConstructorReturn";
+import _inherits from "babel-runtime/helpers/builtin/inherits";
+
+let Foo = function (_Bar) {
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-runtime", { "useBuiltIns": true }], "transform-es2015-classes"]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/actual.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/actual.js
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/expected.js
@@ -1,0 +1,16 @@
+import _Object$getPrototypeOf from "babel-runtime/core-js/object/get-prototype-of";
+import _classCallCheck from "babel-runtime/helpers/es6/classCallCheck";
+import _possibleConstructorReturn from "babel-runtime/helpers/es6/possibleConstructorReturn";
+import _inherits from "babel-runtime/helpers/es6/inherits";
+
+let Foo = function (_Bar) {
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, (Foo.__proto__ || _Object$getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-runtime", { "useESModules": true }], "transform-es2015-classes"]
+}

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -46,7 +46,7 @@ function writeFile(filename, content) {
   return writeRootFile(filename, content);
 }
 
-function makeTransformOpts(modules = "commonjs", useBuiltIns = false) {
+function makeTransformOpts(modules, useBuiltIns) {
   const opts = {
     presets: [
       [require("../../babel-preset-es2015"), { modules: false }]
@@ -93,7 +93,7 @@ function buildRuntimeRewritePlugin(relativePath, helperName) {
   };
 }
 
-function buildHelper(helperName, modules = "commonjs", useBuiltIns = false) {
+function buildHelper(helperName, modules, useBuiltIns) {
   const helper = helpers.get(helperName)
   // avoid an unneccessary TDZ in the easy case
   if (helper.type === "FunctionExpression") {

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -46,16 +46,23 @@ function writeFile(filename, content) {
   return writeRootFile(filename, content);
 }
 
-var transformOpts = {
-  presets: [
-    require("../../babel-preset-es2015")
-  ],
+function makeTransformOpts(modules = "commonjs", useBuiltIns = false) {
+  const opts = {
+    presets: [
+      [require("../../babel-preset-es2015"), { modules: false }]
+    ],
 
-  plugins: [
-    require("../../babel-plugin-transform-runtime"),
-    [require("../../babel-plugin-transform-es2015-modules-commonjs"), { loose: true, strict: false }]
-  ]
-};
+    plugins: [
+      [require("../../babel-plugin-transform-runtime"), { useBuiltIns: useBuiltIns, useESModules: modules === false }]
+    ]
+  }
+  if (modules === 'commonjs') {
+    opts.plugins.push([require("../../babel-plugin-transform-es2015-modules-commonjs"), { loose: true, strict: false }])
+  } else if (modules !== false) {
+    throw new Error('Unsupported module type')
+  }
+  return opts
+}
 
 function buildRuntimeRewritePlugin(relativePath, helperName) {
   return {
@@ -63,12 +70,16 @@ function buildRuntimeRewritePlugin(relativePath, helperName) {
       var original = file.get("helperGenerator");
       file.set("helperGenerator", function(name) {
         // make sure that helpers won't insert circular references to themselves
-        if (name === helperName) return;
+        if (name === helperName) return false;
 
         return original(name);
       });
     },
     visitor: {
+      ImportDeclaration: function(path){
+        path.get("source").node.value = path.get("source").node.value
+          .replace(/^babel-runtime/, relativePath);
+      },
       CallExpression: function(path){
         if (!path.get("callee").isIdentifier({name: "require"}) ||
           path.get("arguments").length !== 1 ||
@@ -82,23 +93,40 @@ function buildRuntimeRewritePlugin(relativePath, helperName) {
   };
 }
 
-function buildHelper(helperName) {
+function buildHelper(helperName, modules = "commonjs", useBuiltIns = false) {
+  const helper = helpers.get(helperName)
+  // avoid an unneccessary TDZ in the easy case
+  if (helper.type === "FunctionExpression") {
+    helper.type = "FunctionDeclaration"
+  }
   var tree = t.program([
-    t.exportDefaultDeclaration(helpers.get(helperName))
+    t.exportDefaultDeclaration(helper)
   ]);
+
+  const transformOpts = makeTransformOpts(modules, useBuiltIns)
+
+  const relative = useBuiltIns ? "../.." : ".."
 
   return babel.transformFromAst(tree, null, {
     presets: transformOpts.presets,
-    plugins: transformOpts.plugins.concat([buildRuntimeRewritePlugin("..", helperName)])
+    plugins: transformOpts.plugins.concat([buildRuntimeRewritePlugin(modules === false ? `../${relative}` : relative, helperName)])
   }).code;
 }
 
-helpers.list.forEach(function (helperName) {
-  writeFile("helpers/" + helperName + ".js", buildHelper(helperName));
+for (const modules of ["commonjs", false]) {
+  for (const builtin of [false, true]) {
+    const dirname = `helpers/${builtin ? 'builtin/' : ''}${!modules ? 'es6/' : ''}`
 
-  // compat
-  var helperAlias = kebabCase(helperName);
-  var content = "module.exports = require(\"./" + helperName + ".js\");";
-  writeFile("helpers/_" + helperAlias + ".js", content);
-  if (helperAlias !== helperName) writeFile("helpers/" + helperAlias + ".js", content);
-});
+    for (const helperName of helpers.list) {
+      writeFile(`${dirname}${helperName}.js`, buildHelper(helperName, modules, builtin));
+
+      // compat
+      var helperAlias = kebabCase(helperName);
+      var content = !modules
+        ? `export { default } from \"./${helperName}.js\";`
+        : "module.exports = require(\"./" + helperName + ".js\");";
+      writeFile(`${dirname}_${helperAlias}.js`, content);
+      if (helperAlias !== helperName) writeFile(`${dirname}${helperAlias}.js`, content);
+    }
+  }
+}


### PR DESCRIPTION
useBuiltIns uses versions of the helpers that do not import even
internal polyfills from core-js.

useESModules uses versions of the helpers that do not go through
transform-es2015-modules-commonjs. This allows for smaller builds in
module systems like webpack, as it doesn't need to preserve commonjs
semantics.

This includes changes to the babel-runtime build-dist script, which
will build the versions of the runtime helpers to be used by
combinations of useBuiltIns and useESModules.

This is untested other than by looking at the output and seeing if it makes sense >_<

`{ polyfill: false, useBuiltIns: true, useESModules: true }` will be perfect for webpack/rollup
users that want to deduplicate helpers without accidentally bundling an extra
core-js when babel-polyfill is already in use, or when, say, targeting electron.