### PR TITLE
Fix replacing function declaration in export default (fixes #4468)

### DIFF
--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -125,7 +125,8 @@ export function replaceWith(replacement) {
   if (this.isNodeType("Statement") && t.isExpression(replacement)) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
-      !this.canSwapBetweenExpressionAndStatement(replacement)
+      !this.canSwapBetweenExpressionAndStatement(replacement) &&
+      !this.parentPath.isExportDefaultDeclaration()
     ) {
       // replacing a statement with an expression so wrap it in an expression statement
       replacement = t.expressionStatement(replacement);

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -1,0 +1,28 @@
+import traverse from "../lib";
+import assert from "assert";
+import { parse } from "babylon";
+import * as t from "babel-types";
+
+describe("path/replacement", function () {
+  describe("replaceWith", function () {
+    const ast = parse("export default function() {};", { sourceType: "module" });
+
+    it("replaces declaration in ExportDefaultDeclaration node", function() {
+      traverse(ast, {
+        FunctionDeclaration(path) {
+          path.replaceWith(t.arrayExpression([
+            t.functionExpression(
+              path.node.id,
+              path.node.params,
+              path.node.body,
+              path.node.generator,
+              path.node.async
+            ),
+          ]));
+        },
+      });
+
+      assert(ast.program.body[0].declaration.type == "ArrayExpression");
+    });
+  });
+});


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #4468 <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

I fixed #4468, because I need that functionality to fix a bug in [babel-plugin-angularjs-annotate](https://github.com/schmod/babel-plugin-angularjs-annotate/issues/17).

If anyone got a better idea how to fix this, I am all ears ;)