### PR TITLE
Fixed broken links in README.md [skip-ci]

### DIFF
--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -109,7 +109,7 @@ Following is a table of the options you can use:
 | `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
 | `parserOpts`             | `{}`                 | An object containing the options to be passed down to the babel parser, babylon |
 | `plugins`                | `[]`                 | List of [plugins](https://babeljs.io/docs/plugins/) to load and use. |
-| `presets`                | `[]`                 | List of [presets](https://babeljs.io/docs/plugins/preset-latest/) (a set of plugins) to load and use. |
+| `presets`                | `[]`                 | List of [presets](https://babeljs.io/docs/plugins/#presets) (a set of plugins) to load and use. |
 | `retainLines`            | `false`              | Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. (**NOTE:** This will not retain the columns) |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
 | `shouldPrintComment`     | `null`               | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -108,8 +108,8 @@ Following is a table of the options you can use:
 | `moduleRoot`             | `(sourceRoot)`       | Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. |
 | `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
 | `parserOpts`             | `{}`                 | An object containing the options to be passed down to the babel parser, babylon |
-| `plugins`                | `[]`                 | List of [plugins](/docs/plugins/) to load and use. |
-| `presets`                | `[]`                 | List of [presets](/docs/plugins/#presets) (a set of plugins) to load and use. |
+| `plugins`                | `[]`                 | List of [plugins](https://babeljs.io/docs/plugins/) to load and use. |
+| `presets`                | `[]`                 | List of [presets](https://babeljs.io/docs/plugins/preset-latest/) (a set of plugins) to load and use. |
 | `retainLines`            | `false`              | Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. (**NOTE:** This will not retain the columns) |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
 | `shouldPrintComment`     | `null`               | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |


### PR DESCRIPTION
- [plugins](https://github.com/babel/babel/blob/master/docs/plugins) changed to [plugins](https://babeljs.io/docs/plugins/)
- [presets](https://github.com/babel/babel/blob/master/docs/plugins/#presets) changed to [presets](https://babeljs.io/docs/plugins/preset-latest/)

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | no <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | yes <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

```
[plugins](https://github.com/babel/babel/blob/master/docs/plugins) changed to [plugins](https://babeljs.io/docs/plugins/)
```
```
[presets](https://github.com/babel/babel/blob/master/docs/plugins/#presets) changed to [presets](https://babeljs.io/docs/plugins/preset-latest/)
```