### PR TITLE
Changes the throw error for test in super-illegal-non-constructor-call

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-illegal-non-constructor-call/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-illegal-non-constructor-call/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "super() outside of class constructor"
+  "throws": "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor' and has no typos"
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-illegal-non-constructor-call/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-illegal-non-constructor-call/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor' and has no typos"
+  "throws": "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor'."
 }


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            |  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | yes

<!-- Describe your changes below in as much detail as possible -->

I have raised a PR in babylon [here](https://github.com/babel/babylon/pull/408) which improves error message when `super()` is used outside of class constructor. This PR makes sure that the tests pass in babel too when that PR is merged