### PR TITLE
Keep parentheses for logical expression when in await expression (fix…

### DIFF
--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -50,7 +50,8 @@ export function Binary(node: Object, parent: Object): boolean {
   if (
     ((t.isCallExpression(parent) || t.isNewExpression(parent)) && parent.callee === node) ||
     t.isUnaryLike(parent) ||
-    (t.isMemberExpression(parent) && parent.object === node)
+    (t.isMemberExpression(parent) && parent.object === node) ||
+    t.isAwaitExpression(parent)
   ) {
     return true;
   }

--- a/packages/babel-generator/test/fixtures/parentheses/await-expression/actual.js
+++ b/packages/babel-generator/test/fixtures/parentheses/await-expression/actual.js
@@ -5,6 +5,7 @@ async function asdf() {
   true ? (await 1) : (await 2);
   await (1 ? 2 : 3);
   await (await 1);
+  await (a || b);
 }
 
 async function a(b) {

--- a/packages/babel-generator/test/fixtures/parentheses/await-expression/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/await-expression/expected.js
@@ -5,6 +5,7 @@ async function asdf() {
   true ? await 1 : await 2;
   await (1 ? 2 : 3);
   await await 1;
+  await (a || b);
 }
 
 async function a(b) {


### PR DESCRIPTION
… #5428) (#5433)

cherry pick https://github.com/babel/babel/pull/5433 to 6.x