### PR TITLE
addMapping method call missing name parameter

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -396,7 +396,9 @@ export default class File extends Store {
               column: mapping.originalColumn
             },
 
-            generated: generatedPosition
+            generated: generatedPosition,
+            
+            name: mapping.name
           });
         }
       });

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -397,7 +397,7 @@ export default class File extends Store {
             },
 
             generated: generatedPosition,
-            
+
             name: mapping.name
           });
         }


### PR DESCRIPTION
in mergeSourceMap, addMapping method call missing name parameter
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | maybe
| Tests Added/Pass?        | no
| Fixed Tickets            | no <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
