### PR TITLE
Resolve programmatic/CLI arguments from cwd, not file being compiled.

### DIFF
--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -33,7 +33,7 @@ export default function buildConfigChain(opts: Object = {}) {
   builder.mergeConfig({
     options: opts,
     alias: "base",
-    dirname: filename && path.dirname(filename),
+    dirname: process.cwd(),
   });
 
   return builder.configs;
@@ -173,7 +173,6 @@ class ConfigChainBuilder {
 
     options = Object.assign({}, options);
 
-    dirname = dirname || process.cwd();
     loc = loc || alias;
 
     // add extends clause

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -10,6 +10,10 @@ function fixture() {
   return path.join.apply(path, args);
 }
 
+function base() {
+  return process.cwd();
+}
+
 describe("buildConfigChain", function () {
   let oldBabelEnv;
   let oldNodeEnv;
@@ -69,7 +73,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("dir1"),
+        dirname: base(),
       },
     ];
 
@@ -108,7 +112,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("dir2"),
+        dirname: base(),
       },
     ];
 
@@ -147,7 +151,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("env"),
+        dirname: base(),
       },
     ];
 
@@ -198,7 +202,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("env"),
+        dirname: base(),
       },
     ];
 
@@ -250,7 +254,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("env"),
+        dirname: base(),
       },
     ];
 
@@ -288,7 +292,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("pkg"),
+        dirname: base(),
       },
     ];
 
@@ -328,7 +332,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("js-config"),
+        dirname: base(),
       },
     ];
 
@@ -368,7 +372,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("js-config-default"),
+        dirname: base(),
       },
     ];
 
@@ -417,7 +421,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("js-config-extended"),
+        dirname: base(),
       },
     ];
 
@@ -457,7 +461,7 @@ describe("buildConfigChain", function () {
         },
         alias: "base",
         loc: "base",
-        dirname: fixture("json-pkg-config-no-babel"),
+        dirname: base(),
       },
     ];
 

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -33,13 +33,21 @@ describe("addon resolution", function () {
     function fixturesReady (err) {
       if (err) return done(err);
 
-      const actual = babel.transform(fixtures.actual, {
-        filename: paths.actual,
-        plugins: ["addons/plugin"],
-        presets: ["addons/preset"],
-      }).code;
+      const orignalCwd = process.cwd();
+      try {
+        process.chdir(paths.fixtures);
 
-      assert.equal(actual, fixtures.expected);
+        const actual = babel.transform(fixtures.actual, {
+          filename: paths.actual,
+          plugins: ["addons/plugin"],
+          presets: ["addons/preset"],
+        }).code;
+
+        assert.equal(actual, fixtures.expected);
+      } finally {
+        process.chdir(orignalCwd);
+      }
+
       done();
     }
     // fixturesReady


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |  <!-- rm the quotes to link the issues --> Fixes #5434 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

This is a change that is breaking, but is _probably_ what people thought was already happening?

In Babel 6, you could have
```
  node_modules/
    babel-preset-example/package.json

  dir/
    node_modules/
      babel-preset-example/package.json
    file.js
```

and do

```
babel --presets example dir/file.js
```
and it would use `example` from the inner directory instead of the current working directory in the base.

While not that weird in this case, it got really confusing for people in cases like this:

```
  file.js
  dir/
    node_modules/
      babel-preset-example/package.json
```

with
```
cd dir
babel --presets example ../file.js
```

which would throw an error because there was no `babel-preset-example` relative to `file.js`.

Similarly, it complicates things like `ignore` and `only`, so we've decided to standardize on the working directory instead.
