### PR TITLE
Update coffescript/register reference link address

### DIFF
--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -5,7 +5,7 @@
 One of the ways you can use Babel is through the require hook. The require hook
 will bind itself to node's `require` and automatically compile files on the
 fly. This is equivalent to CoffeeScript's
-[coffee-script/register](http://coffeescript.org/documentation/docs/register.html).
+[coffee-script/register](http://coffeescript.org/v2/annotated-source/register.html).
 
 ## Install
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            |
| Spec Compliancy?         |
| Tests Added/Pass?        |
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | 

Current reference to `coffescript/register` refers to 404. This PR updates link with up-to-date version.
