### PR TITLE
Catch error when fs does not exist

### DIFF
--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -4,6 +4,7 @@ import json5 from "json5";
 import path from "path";
 import fs from "fs";
 
+const isFsAvailable = typeof fs.existsSync === "function";
 const existsCache = {};
 const jsonCache = {};
 
@@ -14,7 +15,7 @@ const BABELIGNORE_FILENAME = ".babelignore";
 
 function exists(filename) {
   if (existsCache[filename] == null) {
-    if (typeof fs.existsSync !== "function") {
+    if (!isFsAvailable) {
       throw new Error(
         "You are using babel in an environment that does not include filesystem access. " +
         "You can disable .babelrc lookup by setting `babelrc: false` in your config."

--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -13,12 +13,18 @@ const PACKAGE_FILENAME = "package.json";
 const BABELIGNORE_FILENAME = ".babelignore";
 
 function exists(filename) {
-  const cached = existsCache[filename];
-  if (cached == null) {
-    return existsCache[filename] = fs.existsSync(filename);
-  } else {
-    return cached;
+  if (existsCache[filename] == null) {
+    if (typeof fs.existsSync !== "function") {
+      throw new Error(
+        "You are using babel in an environment that does not include filesystem access. " +
+        "You can disable .babelrc lookup by setting `babelrc: false` in your config."
+      );
+    }
+
+    existsCache[filename] = fs.existsSync(filename);
   }
+
+  return existsCache[filename];
 }
 
 export default function buildConfigChain(opts: Object = {}) {


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | y?
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         n| 
| Tests Added/Pass?        | y
| Fixed Tickets            | Fixes #4778, Fixes #4781, Fixes babel/babel-standalone#64
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

This just changes the error message from
```
_fs2.default.existsSync is not a function
```

to 

```
You are using babel in an environment that does not include filesystem access. Ensure to disable .babelrc lookup by setting `babelrc: false` in your config.
```