### PR TITLE
Removes unused lodash dep from babel-helper-builder-react-jsx

### DIFF
--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -7,7 +7,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-types": "7.0.0-alpha.1",
-    "esutils": "^2.0.0",
-    "lodash": "^4.2.0"
+    "esutils": "^2.0.0"
   }
 }


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      |  no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        |  no
| Fixed Tickets            | Fixes #5482
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       |  Removes unused lodash dependency

<!-- Describe your changes below in as much detail as possible -->

Removed an unused dependency on lodash from the package.json file for babel-helper-builder-react-jsx.