### PR TITLE
[WIP] path: rename getBindingIdentifierPaths to getBindingIdentifiers

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/tdz.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/tdz.js
@@ -76,7 +76,7 @@ export const visitor = {
       const ids = path.getBindingIdentifiers();
 
       for (const name in ids) {
-        const id = ids[name];
+        const id = ids[name].node;
 
         if (isReference(id, path.scope, state)) {
           nodes.push(buildTDZAssert(id, state.file));

--- a/packages/babel-traverse/src/path/family.js
+++ b/packages/babel-traverse/src/path/family.js
@@ -2,6 +2,7 @@
 
 import type TraversalContext from "../index";
 import NodePath from "./index";
+import util from "util";
 import * as t from "babel-types";
 
 export function getStatementParent(): ?NodePath {
@@ -148,18 +149,24 @@ export function _getPattern(parts, context) {
   return path;
 }
 
-export function getBindingIdentifiers(duplicates?) {
-  return t.getBindingIdentifiers(this.node, duplicates);
-}
+export const getBindingIdentifierPaths = util.deprecate(
+  function getBindingIdentifierPaths(duplicates = false, outerOnly = false) {
+    return this.getBindingIdentifiers(duplicates, outerOnly);
+  },
+  "path.getBindingIdentifierPaths is replaced with path.getBindingIdentifiers"
+);
 
-export function getOuterBindingIdentifiers(duplicates?) {
-  return t.getOuterBindingIdentifiers(this.node, duplicates);
-}
+export const getOuterBindingIdentifierPaths = util.deprecate(
+  function getOuterBindingIdentifierPaths(duplicates?) {
+    return this.getOuterBindingIdentifiers(duplicates);
+  },
+  "path.getOuterBindingIdentifierPaths is replaced with path.getOuterBindingIdentifiers"
+);
 
 // original source - https://github.com/babel/babel/blob/master/packages/babel-types/src/retrievers.js
 // path.getBindingIdentifiers returns nodes where the following re-implementation
 // returns paths
-export function getBindingIdentifierPaths(duplicates = false, outerOnly = false) {
+export function getBindingIdentifiers(duplicates = false, outerOnly = false) {
   const path = this;
   let search = [].concat(path);
   const ids = Object.create(null);
@@ -213,6 +220,6 @@ export function getBindingIdentifierPaths(duplicates = false, outerOnly = false)
   return ids;
 }
 
-export function getOuterBindingIdentifierPaths(duplicates?) {
-  return this.getBindingIdentifierPaths(duplicates, true);
+export function getOuterBindingIdentifiers(duplicates?) {
+  return this.getBindingIdentifiers(duplicates, true);
 }

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -16,7 +16,7 @@ const hoistVariablesVisitor = {
 
     const bindings = path.getBindingIdentifiers();
     for (const key in bindings) {
-      path.scope.push({ id: bindings[key] });
+      path.scope.push({ id: bindings[key].node });
     }
 
     const exprs = [];

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -499,9 +499,9 @@ export default class Scope {
         if (local) {
           // same identifier so continue safely as we're likely trying to register it
           // multiple times
-          if (local.identifier === id) continue;
+          if (local.identifier === id.node) continue;
 
-          this.checkBlockScopedCollisions(local, kind, name, id);
+          this.checkBlockScopedCollisions(local, kind, name, id.node);
         }
 
         // It's erroneous that we currently consider flow a binding, however, we can't
@@ -512,7 +512,7 @@ export default class Scope {
         parent.references[name] = true;
 
         this.bindings[name] = new Binding({
-          identifier: id,
+          identifier: id.node,
           existing: local,
           scope: this,
           path: bindingPath,
@@ -714,7 +714,7 @@ export default class Scope {
         if (path.scope.getBinding(name)) continue;
 
         programParent = programParent || path.scope.getProgramParent();
-        programParent.addGlobal(ids[name]);
+        programParent.addGlobal(ids[name].node);
       }
 
       // register as constant violation

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -18,7 +18,7 @@ const renameVisitor = {
     const ids = path.getOuterBindingIdentifiers();
 
     for (const name in ids) {
-      if (name === state.oldName) ids[name].name = state.newName;
+      if (name === state.oldName) ids[name].node.name = state.newName;
     }
   },
 };

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -5,54 +5,31 @@ const parse = require("babylon").parse;
 describe("path/family", function () {
   describe("getBindingIdentifiers", function () {
     const ast = parse("var a = 1, {b} = c, [d] = e; function f() {}");
-    let nodes = {}, paths = {}, outerNodes = {}, outerPaths = {};
+    let paths = {}, outerPaths = {};
     traverse(ast, {
       VariableDeclaration(path) {
-        nodes = path.getBindingIdentifiers();
-        paths = path.getBindingIdentifierPaths();
+        paths = path.getBindingIdentifiers();
       },
       FunctionDeclaration(path) {
-        outerNodes = path.getOuterBindingIdentifiers();
-        outerPaths = path.getOuterBindingIdentifierPaths();
+        outerPaths = path.getOuterBindingIdentifiers();
       },
-    });
-
-    it("should contain keys of nodes in paths", function () {
-      Object.keys(nodes).forEach((id) => {
-        assert.strictEqual(hop(paths, id), true, "Node's keys exists in paths");
-      });
-    });
-
-    it("should contain outer bindings", function () {
-      Object.keys(outerNodes).forEach((id) => {
-        assert.strictEqual(hop(outerPaths, id), true, "Has same outer keys");
-      });
     });
 
     it("should return paths", function () {
-      Object.keys(paths).forEach((id) => {
-        assert.strictEqual(!!paths[id].node, true, "Has a property node that's not falsy");
-        assert.strictEqual(paths[id].type, paths[id].node.type, "type matches");
-      });
-
-      Object.keys(outerPaths).forEach((id) => {
-        assert.strictEqual(!!outerPaths[id].node, true, "has property node");
-        assert.strictEqual(outerPaths[id].type, outerPaths[id].node.type, "type matches");
+      [
+        ...Object.keys(paths).map((id) => paths[id]),
+        ...Object.keys(outerPaths).map((id) => outerPaths[id]),
+      ].forEach((id) => {
+        assert.strictEqual(id.isIdentifier(), true);
       });
     });
 
-    it("should match paths and nodes returned for the same ast", function () {
-      Object.keys(nodes).forEach((id) => {
-        assert.strictEqual(nodes[id], paths[id].node, "Nodes match");
-      });
+    it("should return binding identifiers", function () {
+      assert.deepEqual(Object.keys(paths).sort(), ["a", "b", "d"]);
     });
-
-    it("should match paths and nodes returned for outer Bindings", function () {
-      Object.keys(outerNodes).forEach((id) => {
-        assert.strictEqual(outerNodes[id], outerPaths[id].node, "nodes match");
-      });
+    it("should return outer binding identifiers", function () {
+      assert.deepEqual(Object.keys(outerPaths).sort(), ["f"]);
     });
-
   });
   describe("getSibling", function () {
     const ast = parse("var a = 1, {b} = c, [d] = e; function f() {} function g() {}");
@@ -79,7 +56,3 @@ describe("path/family", function () {
     });
   });
 });
-
-function hop(o, key) {
-  return Object.hasOwnProperty.call(o, key);
-}

--- a/packages/babel-types/src/converters.js
+++ b/packages/babel-types/src/converters.js
@@ -51,7 +51,7 @@ export function toSequenceExpression(nodes: Array<Object>, scope: Scope): ?Objec
           for (const key in bindings) {
             declars.push({
               kind: node.kind,
-              id: bindings[key],
+              id: bindings[key].node,
             });
           }
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | yes
| Minor: New Feature?      | no
| Deprecations?            | path.getBindingIdentifierPaths, path.getOuterBindingIdentifierPaths
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
`getBindingIdentifiers` is an API in `path` that returns `Node`s and others return `NodePath`s. In Babel 6.2x.x getBindingIdentifierPaths was introduced to maintain backward compatibility. This PR Deprecates it for 7 - and `getBindingIdentifiers` returns `NodePath`s