### PR TITLE
Cleanup traverse cache APIs

### DIFF
--- a/packages/babel-traverse/src/cache.js
+++ b/packages/babel-traverse/src/cache.js
@@ -13,9 +13,3 @@ export function clearPath() {
 export function clearScope() {
   scope = new WeakMap;
 }
-
-export function copyPath(source, destination) {
-  if (path.has(source)) {
-    path.set(destination, path.get(source));
-  }
-}

--- a/packages/babel-traverse/src/cache.js
+++ b/packages/babel-traverse/src/cache.js
@@ -13,3 +13,9 @@ export function clearPath() {
 export function clearScope() {
   scope = new WeakMap;
 }
+
+export function copyPath(source, destination) {
+  if (path.has(source)) {
+    path.set(destination, path.get(source));
+  }
+}

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -104,15 +104,4 @@ traverse.hasType = function (
   return state.has;
 };
 
-traverse.clearCache = function() {
-  cache.clear();
-};
-
-traverse.clearCache.clearPath = cache.clearPath;
-traverse.clearCache.clearScope = cache.clearScope;
-
-traverse.copyCache = function(source, destination) {
-  if (cache.path.has(source)) {
-    cache.path.set(destination, cache.path.get(source));
-  }
-};
+traverse.cache = cache;

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -96,7 +96,7 @@ describe("traverse", function () {
       },
     });
 
-    traverse.clearCache();
+    traverse.cache.clear();
 
     const paths2 = [];
     const scopes2 = [];
@@ -122,7 +122,7 @@ describe("traverse", function () {
       },
     });
 
-    traverse.clearCache.clearPath();
+    traverse.cache.clearPath();
 
     const paths2 = [];
     traverse(ast, {
@@ -145,7 +145,7 @@ describe("traverse", function () {
       },
     });
 
-    traverse.clearCache.clearScope();
+    traverse.cache.clearScope();
 
     const scopes2 = [];
     traverse(ast, {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | yes
| Minor: New Feature?      | no
| Deprecations?            | traverse.clearCache
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

Old traverse cache API:

```js
traverse.clearCache(); // clears path and scope cache
traverse.clearCache.clearPath(); // included in babel ~= 6.18 to not break clearCache API
traverse.clearCache.clearScope();

traverse.copyCache(sourceKey, destinationKey); // copies path cache and is removed in the new API
```

New traverse cache APIs:

```js
traverse.cache.clear() // clears path and scope
traverse.cache.clearPath();
traverse.cache.clearScope();
traverse.cache.path // the path cache
traverse.cache.scope // the scope cache
```
