### PR TITLE
Correctly requeue CallExpression in AMD transform

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -135,6 +135,9 @@ export default function({ types: t }) {
               FACTORY: factory,
             }),
           ];
+
+          // requeue the CallExpression
+          path.requeue(path.get("body.0.expression"));
         },
       },
     },

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -128,16 +128,15 @@ export default function({ types: t }) {
           factory.expression.body.directives = node.directives;
           node.directives = [];
 
-          node.body = [
+          node.body = [];
+
+          path.pushContainer("body", [
             buildDefine({
               MODULE_NAME: moduleName,
               SOURCES: sources,
               FACTORY: factory,
             }),
-          ];
-
-          // requeue the CallExpression
-          path.requeue(path.get("body.0.expression"));
+          ]);
         },
       },
     },

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/4192/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/4192/actual.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/4192/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/4192/expected.js
@@ -1,0 +1,9 @@
+define(["exports"], function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  exports["default"] = function () {};
+});

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/4192/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/regression/4192/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-es2015-modules-amd",
+    "transform-es3-member-expression-literals"
+  ]
+}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/regression/4192/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/regression/4192/actual.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/regression/4192/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/regression/4192/expected.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["exports"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(exports);
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports);
+    global.actual = mod.exports;
+  }
+})(this, function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  exports["default"] = function () {};
+});

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/regression/4192/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/regression/4192/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-es2015-modules-umd",
+    "transform-es3-member-expression-literals"
+  ]
+}


### PR DESCRIPTION

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | y
| Fixed Tickets            | Fixes #4192
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

This requeues the CallExpression so that the es3 transforms can do their job afterwards.
I tried requeueing just the path which is the `Program` in this case, but then the strict transforms adds an additional directive.