### PR TITLE
Allow block scoped variable to shadow the name of its containing function expr

### DIFF
--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-declaration/actual.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-declaration/actual.js
@@ -1,0 +1,3 @@
+function B() {
+  const B = 1;
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-declaration/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-declaration/expected.js
@@ -1,0 +1,3 @@
+function B() {
+  var B = 1;
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression-2/actual.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression-2/actual.js
@@ -1,0 +1,4 @@
+(function B() {
+  const B = 1;
+  B = 2;
+});

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression-2/options.json
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression-2/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "\"B\" is read-only"
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression/actual.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression/actual.js
@@ -1,0 +1,3 @@
+(function B() {
+  const B = 1;
+});

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/shadowing-function-expression/expected.js
@@ -1,0 +1,3 @@
+(function B() {
+  var B = 1;
+});

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4946/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4946/actual.js
@@ -1,0 +1,3 @@
+(function foo() {
+  let foo = true;
+});

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4946/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4946/expected.js
@@ -1,0 +1,3 @@
+(function foo() {
+  var foo = true;
+});

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -496,6 +496,11 @@ export default class Scope {
     for (const name in ids) {
       for (const id of (ids[name]: Array<Object>)) {
         let local = this.getOwnBinding(name);
+
+        // Ignore existing binding if it's the name of the current function or class
+        // expression
+        if (local && local.kind === "local") local = null;
+
         if (local) {
           // same identifier so continue safely as we're likely trying to register it
           // multiple times
@@ -508,8 +513,6 @@ export default class Scope {
         // remove it because people might be depending on it. See warning section
         // in `warnOnFlowBinding`.
         if (local && local.path.isFlow()) local = null;
-
-        if (local && local.kind === "local") local = null;
 
         parent.references[name] = true;
 

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -509,6 +509,8 @@ export default class Scope {
         // in `warnOnFlowBinding`.
         if (local && local.path.isFlow()) local = null;
 
+        if (local && local.kind === "local") local = null;
+
         parent.references[name] = true;
 
         this.bindings[name] = new Binding({


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5491, fixes #4946 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

## For #5491:
This prevents an incorrect entry from being added to `Binding.constantViolations` when the existing binding of the same name, found in the current scope using `getOwnBinding`, is of type `"local"` - i.e. when it is the name of a function expression (or class expression, in theory) immediately containing the new binding.

To achieve this, I opted to make a minimal change to `Scope.prototype.registerBinding` and pass `existing: null` in this case, rather than e.g. switch on `existing.kind` in `Binding` itself. This can of course be changed, as a matter of architecture or simply taste.

As for testing: #5491 only affects function expressions, but just to future-proof things, I've added a test for the equivalent function _declaration_ case as well.

## For #4946 (added later):

Whereas a standalone fix for #4946 would involve adding something like this to `checkBlockScopedCollisions`:

```js
if (local.kind === "local") return;
```

The two-for-one fix here is to simply check this slightly earlier in `registerBinding`.
```js
let local = this.getOwnBinding(name);

// Ignore existing binding if it's the name of the current function or class
// expression
if (local && local.kind === "local") local = null;
```