### PR TITLE
Fix issues with ES3 and injected helper code

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -302,7 +302,9 @@ export default class File extends Store {
       ref._generated = true;
       ref.id = uid;
       ref.type = "FunctionDeclaration";
-      this.path.unshiftContainer("body", ref);
+      this.path
+        .unshiftContainer("body", ref)
+        .forEach(path => this.path.requeue(path));
     } else {
       ref._compact = true;
       this.scope.push({

--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -304,7 +304,7 @@ export default class File extends Store {
       ref.type = "FunctionDeclaration";
       this.path
         .unshiftContainer("body", ref)
-        .forEach(path => this.path.requeue(path));
+        .forEach((path) => this.path.requeue(path));
     } else {
       ref._compact = true;
       this.scope.push({

--- a/packages/babel-plugin-transform-es3-property-literals/test/fixtures/property-literals/issue-4367/actual.js
+++ b/packages/babel-plugin-transform-es3-property-literals/test/fixtures/property-literals/issue-4367/actual.js
@@ -1,0 +1,3 @@
+import something from 'module'
+class C {}
+(class { f() {} })

--- a/packages/babel-plugin-transform-es3-property-literals/test/fixtures/property-literals/issue-4367/expected.js
+++ b/packages/babel-plugin-transform-es3-property-literals/test/fixtures/property-literals/issue-4367/expected.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _module = require('module');
+
+var _module2 = _interopRequireDefault(_module);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+let C = function C() {
+  _classCallCheck(this, C);
+};
+
+(function () {
+  function _class() {
+    _classCallCheck(this, _class);
+  }
+
+  _createClass(_class, [{
+    key: 'f',
+    value: function f() {}
+  }]);
+
+  return _class;
+})();

--- a/packages/babel-plugin-transform-es3-property-literals/test/fixtures/property-literals/issue-4367/options.json
+++ b/packages/babel-plugin-transform-es3-property-literals/test/fixtures/property-literals/issue-4367/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-es3-property-literals",
+    "transform-es2015-modules-commonjs",
+    "transform-es2015-classes"
+  ]
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #4367
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

See context in https://github.com/babel/babel/issues/4367#issuecomment-287621278.

This is **a** fix, not necessarily the best possible one:

1. I imagine there's quite some overhead associated with my approach of blindly requeueing nodes in `addHelper`, and it probably doesn't address the core problem which is somewhere deeper in `babel-traverse`.
2. Given that this is more of a workaround than a solution - it might make more sense to just tweak the helper code to be ES3 compatible in the first place (essentially add quotes around a couple of `default`s) and be done with it for now. This wouldn't be any more elegant than the current PR is, but would likely be more performant.

Thoughts?