### PR TITLE
Create index.js

### DIFF
--- a/packages/babel-runtime/index.js
+++ b/packages/babel-runtime/index.js
@@ -1,0 +1,1 @@
+throw new Error('The "babel-runtime" module is not designed to be imported directly');


### PR DESCRIPTION
Add this file so that babel-runtime module does not unnecessarily fail require.resolve() checks.


