### PR TITLE
Multiple inheritances for plugins

### DIFF
--- a/packages/babel-core/test/fixtures/plugins/multiple-inherits-targets/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/multiple-inherits-targets/exec.js
@@ -1,0 +1,50 @@
+var doubleIfFour = function (b) {
+  var t = b.types;
+  return {
+    visitor: {
+      NumericLiteral(path) {
+        var value = path.node.value;
+        if (value === 4) {
+          path.replaceWith(t.numericLiteral(value * 2));
+        }
+      }
+    }
+  };
+};
+
+var doubleIfTen = function (b) {
+  var t = b.types;
+  return {
+    visitor: {
+      NumericLiteral(path) {
+        var value = path.node.value;
+        if (value === 10) {
+          path.replaceWith(t.numericLiteral(value * 2));
+        }
+      }
+    }
+  };
+};
+
+// transforms to `2 + 8 + 20`
+var res = transform('1 + 4 + 10', {
+  plugins: function doubleIfOne (b) {
+    var t = b.types;
+    return {
+      inherits: [
+        doubleIfFour,
+        doubleIfTen
+      ],
+      visitor: {
+        NumericLiteral(path) {
+          var value = path.node.value;
+          if (value === 1) {
+            path.replaceWith(t.numericLiteral(value * 2));
+          }
+        }
+      }
+    };
+  }
+});
+
+assert.equal(eval(res.code), 30);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  n
| Major: Breaking Change?  |  n
| Minor: New Feature?      |  y
| Deprecations?            |  n
| Spec Compliancy?         | n
| Tests Added/Pass?        |  y
| Fixed Tickets            | n
| License                  | MIT
| Doc PR                   | n
| Dependency Changes       | n

<!-- Describe your changes below in as much detail as possible -->
This PR allows use array for `inherits` field. 
I've faced some problems when we need to specify multiple plugins, but could only one. For example, for `babel-plugin-transform-es2015-modules-commonjs` to support rest-spread syntax we need to inherit from `syntax-object-rest-spread` and seems like it's impossible unless if we already inherit from `transform-strict-mode`. (https://github.com/babel/babel/pull/5469).

For now, we can check `inherits` field and in the case of array just merge all the plugins with the current plugin like we do for the single item.
