### PR TITLE
Fix babel runtime helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,13 @@ dist
 /.package.json
 /packages/babel-runtime/core-js
 /packages/babel-runtime/helpers/*.js
+!/packages/babel-runtime/helpers/toArray.js
 /packages/babel-runtime/helpers/builtin/*.js
+!/packages/babel-runtime/helpers/builtin/toArray.js
 /packages/babel-runtime/helpers/builtin/es6/*.js
+!/packages/babel-runtime/helpers/builtin/es6/toArray.js
 /packages/babel-runtime/helpers/es6/*.js
+!/packages/babel-runtime/helpers/es6/toArray.js
 /packages/babel-register/test/.babel
 /packages/*/lib
 _babel.github.io

--- a/packages/babel-core/src/transformation/pipeline.js
+++ b/packages/babel-core/src/transformation/pipeline.js
@@ -31,7 +31,7 @@ export function transformFromAst(ast: Object, code: string, opts: Object): Babel
   if (config === null) return null;
 
   if (ast && ast.type === "Program") {
-    return t.file(ast, [], []);
+    ast = t.file(ast, [], []);
   } else if (!ast || ast.type !== "File") {
     throw new Error("Not a valid ast?");
   }

--- a/packages/babel-runtime/helpers/builtin/es6/toArray.js
+++ b/packages/babel-runtime/helpers/builtin/es6/toArray.js
@@ -1,0 +1,3 @@
+export default function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+}

--- a/packages/babel-runtime/helpers/builtin/toArray.js
+++ b/packages/babel-runtime/helpers/builtin/toArray.js
@@ -1,0 +1,5 @@
+exports.__esModule = true;
+
+exports.default = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};

--- a/packages/babel-runtime/helpers/es6/toArray.js
+++ b/packages/babel-runtime/helpers/es6/toArray.js
@@ -1,0 +1,4 @@
+import _Array$from from "../../core-js/array/from";
+export default function (arr) {
+  return Array.isArray(arr) ? arr : _Array$from(arr);
+}

--- a/packages/babel-runtime/helpers/toArray.js
+++ b/packages/babel-runtime/helpers/toArray.js
@@ -1,0 +1,11 @@
+exports.__esModule = true;
+
+var _from = require("../core-js/array/from");
+
+var _from2 = _interopRequireDefault(_from);
+
+exports.default = function (arr) {
+  return Array.isArray(arr) ? arr : (0, _from2.default)(arr);
+};
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -1,5 +1,10 @@
 const outputFile = require("output-file-sync");
+const kebabCase = require("lodash/kebabCase");
 const coreDefinitions = require("babel-plugin-transform-runtime").definitions;
+const helpers = require("babel-helpers");
+const babel = require("../../babel-core");
+const t = require("../../babel-types");
+
 const paths = ["is-iterable", "get-iterator"];
 
 Object.keys(coreDefinitions.builtins).forEach((key) => {
@@ -21,11 +26,6 @@ paths.forEach(function(path) {
     defaultify(`require("core-js/library/fn/${path}")`)
   );
 });
-
-const helpers = require("babel-helpers");
-const babel = require("../../babel-core");
-const t = require("../../babel-types");
-
 
 function relative(filename) {
   return `${__dirname}/../${filename}`;
@@ -135,13 +135,13 @@ for (const modules of ["commonjs", false]) {
         buildHelper(helperName, modules, builtin)
       );
 
-      // // compat
-      // var helperAlias = kebabCase(helperName);
-      // var content = !modules
-      //   ? `export { default } from \"./${helperName}.js\";`
-      //   : "module.exports = require(\"./" + helperName + ".js\");";
-      // writeFile(`${dirname}_${helperAlias}.js`, content);
-      // if (helperAlias !== helperName) writeFile(`${dirname}${helperAlias}.js`, content);
+      // compat
+      var helperAlias = kebabCase(helperName);
+      var content = !modules
+        ? `export { default } from \"./${helperName}.js\";`
+        : "module.exports = require(\"./" + helperName + ".js\");";
+      writeFile(`${dirname}_${helperAlias}.js`, content);
+      if (helperAlias !== helperName) writeFile(`${dirname}${helperAlias}.js`, content);
     }
   }
 }

--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -1,38 +1,38 @@
-var outputFile = require("output-file-sync");
-var kebabCase  = require("lodash/kebabCase");
-var fs         = require("fs");
+const outputFile = require("output-file-sync");
+const coreDefinitions = require("babel-plugin-transform-runtime").definitions;
+const paths = ["is-iterable", "get-iterator"];
 
-var coreDefinitions = require("babel-plugin-transform-runtime").definitions;
-
-var paths = ["is-iterable", "get-iterator"];
-
-Object.keys(coreDefinitions.builtins).forEach(function (key) {
+Object.keys(coreDefinitions.builtins).forEach((key) => {
   const path = coreDefinitions.builtins[key];
   paths.push(path);
 });
 
-Object.keys(coreDefinitions.methods).forEach(function (key) {
+Object.keys(coreDefinitions.methods).forEach((key) => {
   const props = coreDefinitions.methods[key];
-  Object.keys(props).forEach(function (key2) {
+  Object.keys(props).forEach((key2) => {
     const path = props[key2];
     paths.push(path);
   });
 });
 
-paths.forEach(function (path) {
-  writeFile("core-js/" + path + ".js", defaultify('require("core-js/library/fn/' + path + '")'));
+paths.forEach(function(path) {
+  writeFile(
+    "core-js/" + path + ".js",
+    defaultify(`require("core-js/library/fn/${path}")`)
+  );
 });
 
-var helpers    = require("babel-helpers");
-var babel      = require("../../babel-core");
-var t          = require("../../babel-types");
+const helpers = require("babel-helpers");
+const babel = require("../../babel-core");
+const t = require("../../babel-types");
+
 
 function relative(filename) {
-  return __dirname + "/../" + filename;
+  return `${__dirname}/../${filename}`;
 }
 
 function defaultify(name) {
-  return 'module.exports = { "default": ' + name + ', __esModule: true };';
+  return `module.exports = { "default": '${name}", __esModule: true };`;
 }
 
 function writeRootFile(filename, content) {
@@ -47,27 +47,31 @@ function writeFile(filename, content) {
 
 function makeTransformOpts(modules, useBuiltIns) {
   const opts = {
-    presets: [
-      [require("../../babel-preset-es2015"), { modules: false }]
-    ],
+    presets: [[require("../../babel-preset-es2015"), { modules: false }]],
 
     plugins: [
-      [require("../../babel-plugin-transform-runtime"), { useBuiltIns: useBuiltIns, useESModules: modules === false }]
-    ]
-  }
-  if (modules === 'commonjs') {
-    opts.plugins.push([require("../../babel-plugin-transform-es2015-modules-commonjs"), { loose: true, strict: false }])
+      [
+        require("../../babel-plugin-transform-runtime"),
+        { useBuiltIns, useESModules: modules === false },
+      ],
+    ],
+  };
+  if (modules === "commonjs") {
+    opts.plugins.push([
+      require("../../babel-plugin-transform-es2015-modules-commonjs"),
+      { loose: true, strict: false },
+    ]);
   } else if (modules !== false) {
-    throw new Error('Unsupported module type')
+    throw new Error("Unsupported module type");
   }
-  return opts
+  return opts;
 }
 
 function buildRuntimeRewritePlugin(relativePath, helperName) {
   return {
-    pre: function (file) {
-      var original = file.get("helperGenerator");
-      file.set("helperGenerator", function(name) {
+    pre(file) {
+      const original = file.get("helperGenerator");
+      file.set("helperGenerator", (name) => {
         // make sure that helpers won't insert circular references to themselves
         if (name === helperName) return false;
 
@@ -75,57 +79,69 @@ function buildRuntimeRewritePlugin(relativePath, helperName) {
       });
     },
     visitor: {
-      ImportDeclaration: function(path){
-        path.get("source").node.value = path.get("source").node.value
-          .replace(/^babel-runtime/, relativePath);
+      ImportDeclaration(path) {
+        path.get("source").node.value = path
+          .get("source")
+          .node.value.replace(/^babel-runtime/, relativePath);
       },
-      CallExpression: function(path){
-        if (!path.get("callee").isIdentifier({name: "require"}) ||
+      CallExpression(path) {
+        if (
+          !path.get("callee").isIdentifier({ name: "require" }) ||
           path.get("arguments").length !== 1 ||
-          !path.get("arguments")[0].isStringLiteral()) return;
+          !path.get("arguments")[0].isStringLiteral()
+        ) {
+          return;
+        }
 
         // replace any reference to babel-runtime with a relative path
-        path.get("arguments")[0].node.value = path.get("arguments")[0].node.value
-          .replace(/^babel-runtime/, relativePath);
-      }
-    }
+        path.get("arguments")[0].node.value = path
+          .get("arguments")[0]
+          .node.value.replace(/^babel-runtime/, relativePath);
+      },
+    },
   };
 }
 
 function buildHelper(helperName, modules, useBuiltIns) {
-  const helper = helpers.get(helperName)
+  const helper = helpers.get(helperName);
   // avoid an unneccessary TDZ in the easy case
   if (helper.type === "FunctionExpression") {
-    helper.type = "FunctionDeclaration"
+    helper.type = "FunctionDeclaration";
   }
-  var tree = t.program([
-    t.exportDefaultDeclaration(helper)
-  ]);
+  const tree = t.program([t.exportDefaultDeclaration(helper)]);
 
-  const transformOpts = makeTransformOpts(modules, useBuiltIns)
+  const transformOpts = makeTransformOpts(modules, useBuiltIns);
 
-  const relative = useBuiltIns ? "../.." : ".."
+  const relative = useBuiltIns ? "../.." : "..";
 
   return babel.transformFromAst(tree, null, {
     presets: transformOpts.presets,
-    plugins: transformOpts.plugins.concat([buildRuntimeRewritePlugin(modules === false ? `../${relative}` : relative, helperName)])
+    plugins: transformOpts.plugins.concat([
+      buildRuntimeRewritePlugin(
+        modules === false ? `../${relative}` : relative,
+        helperName
+      ),
+    ]),
   }).code;
 }
 
 for (const modules of ["commonjs", false]) {
   for (const builtin of [false, true]) {
-    const dirname = `helpers/${builtin ? 'builtin/' : ''}${!modules ? 'es6/' : ''}`
+    const dirname = `helpers/${builtin ? "builtin/" : ""}${!modules ? "es6/" : ""}`;
 
     for (const helperName of helpers.list) {
-      writeFile(`${dirname}${helperName}.js`, buildHelper(helperName, modules, builtin));
+      writeFile(
+        `${dirname}${helperName}.js`,
+        buildHelper(helperName, modules, builtin)
+      );
 
-      // compat
-      var helperAlias = kebabCase(helperName);
-      var content = !modules
-        ? `export { default } from \"./${helperName}.js\";`
-        : "module.exports = require(\"./" + helperName + ".js\");";
-      writeFile(`${dirname}_${helperAlias}.js`, content);
-      if (helperAlias !== helperName) writeFile(`${dirname}${helperAlias}.js`, content);
+      // // compat
+      // var helperAlias = kebabCase(helperName);
+      // var content = !modules
+      //   ? `export { default } from \"./${helperName}.js\";`
+      //   : "module.exports = require(\"./" + helperName + ".js\");";
+      // writeFile(`${dirname}_${helperAlias}.js`, content);
+      // if (helperAlias !== helperName) writeFile(`${dirname}${helperAlias}.js`, content);
     }
   }
 }


### PR DESCRIPTION
helpers were generating `undefined` before due to https://github.com/babel/babel/commit/f3f907bdb39f1eb559c38eddbef738edfd2d2677#diff-339968af11c78f10673c78c6c7568d2fR34

Also figured it would be a good idea to commit one of the helpers to catch this kind of regression.