### PR TITLE
Fix babel-runtime helpers gererator

### DIFF
--- a/packages/babel-runtime/scripts/build-dist.js
+++ b/packages/babel-runtime/scripts/build-dist.js
@@ -32,7 +32,7 @@ function relative(filename) {
 }
 
 function defaultify(name) {
-  return `module.exports = { "default": '${name}", __esModule: true };`;
+  return `module.exports = { "default": ${name}, __esModule: true };`;
 }
 
 function writeRootFile(filename, content) {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Fixed a bug in babel-runtime helper generator where invalid helpers were created and as a result there were the `Unterminated string constant` errors.