### PR TITLE
keep one core-js helper file in git, remove babel-runtime from deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ test/tmp
 /coverage
 dist
 /.package.json
-/packages/babel-runtime/core-js
+/packages/babel-runtime/core-js/**/*.js
+!/packages/babel-runtime/core-js/map.js
 /packages/babel-runtime/helpers/*.js
 !/packages/babel-runtime/helpers/toArray.js
 /packages/babel-runtime/helpers/builtin/*.js

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ clean: test-clean
 	rm -rf packages/babel-polyfill/browser*
 	rm -rf packages/babel-polyfill/dist
 	# rm -rf packages/babel-runtime/helpers
-	rm -rf packages/babel-runtime/core-js
+	# rm -rf packages/babel-runtime/core-js
 	rm -rf coverage
 	rm -rf packages/*/npm-debug*
 

--- a/packages/babel-plugin-transform-decorators/package.json
+++ b/packages/babel-plugin-transform-decorators/package.json
@@ -13,7 +13,6 @@
   ],
   "dependencies": {
     "babel-plugin-syntax-decorators": "7.0.0-alpha.3",
-    "babel-runtime": "7.0.0-alpha.3",
     "babel-template": "7.0.0-alpha.3"
   },
   "devDependencies": {

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "babel-runtime": "7.0.0-alpha.3"
-  },
   "devDependencies": {
     "babel-helper-plugin-test-runner": "7.0.0-alpha.3"
   }

--- a/packages/babel-runtime/core-js/map.js
+++ b/packages/babel-runtime/core-js/map.js
@@ -1,0 +1,1 @@
+module.exports = { "default": require("core-js/library/fn/map"), __esModule: true };


### PR DESCRIPTION
Ref https://github.com/babel/babel/pull/5539

same as with the helpers. Keeping one file (packages/babel-runtime/core-js/map.js) in git so that when we change the build-dist.js script it will update so see changes..

actually know I realize it's the same as the build script in preset-env for plugins.json and yarn - would be nice for the bot to run it when you change it.

---

and because of this I found that 2 packages still have babel-runtime in them
