### PR TITLE
Disallow .extends in .env and disallow misc options in presets

### DIFF
--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -270,7 +270,7 @@ class ConfigChainBuilder {
       delete options.env;
 
       this.mergeConfig({
-        type,
+        type: "env",
         options: envOpts,
         alias: `${alias}.env.${envKey}`,
         dirname: dirname,
@@ -287,6 +287,10 @@ class ConfigChainBuilder {
 
     // add extends clause
     if (options.extends) {
+      if (type === "env") {
+        throw new Error(`.extends blocks are not allowed in .env subconfigs in ${alias}.`);
+      }
+
       const extendsLoc = resolve(options.extends, dirname);
       if (extendsLoc) {
         this.addConfig(extendsLoc);

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -25,7 +25,7 @@ type PluginObject = {
 };
 
 type MergeOptions = {
-  type: "arguments"|"options"|"preset",
+  type: "arguments"|"options"|"env"|"preset",
   options?: Object,
   extending?: Object,
   alias: string,

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -226,10 +226,12 @@ export default class OptionManager {
     }
 
     if (type === "preset") {
-      if (opts.only !== undefined) throw new Error(`${alias}.only is not supported in a preset`);
-      if (opts.ignore !== undefined) throw new Error(`${alias}.ignore is not supported in a preset`);
-      if (opts.extends !== undefined) throw new Error(`${alias}.extends is not supported in a preset`);
-      if (opts.env !== undefined) throw new Error(`${alias}.env is not supported in a preset`);
+      const disallowedProps = Object.keys(opts).filter((name) => name !== "plugins" && name !== "presets");
+
+      if (disallowedProps.length > 0) {
+        const names = disallowedProps.map((prop) => `"${prop}"`).join(",");
+        throw new Error(`Babel 7 has disallowed options inside presets. ${alias} uses ${names}`);
+      }
     }
 
     if (opts.sourceMap !== undefined) {

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -128,6 +128,19 @@ describe("buildConfigChain", function () {
     assert.deepEqual(chain, expected);
   });
 
+  it("env - extends throw", function () {
+    assert.throws(() => {
+      buildConfigChain({
+        filename: fixture("env", "src.js"),
+        env: {
+          development: {
+            extends: "./foo.js",
+          },
+        },
+      });
+    }, /\.extends blocks are not allowed in \.env subconfigs/);
+  });
+
   it("env - base", function () {
     const chain = buildConfigChain({
       filename: fixture("env", "src.js"),
@@ -201,7 +214,7 @@ describe("buildConfigChain", function () {
         dirname: fixture("env"),
       },
       {
-        type: "options",
+        type: "env",
         options: {
           plugins: [
             "env-foo",
@@ -257,7 +270,7 @@ describe("buildConfigChain", function () {
         dirname: fixture("env"),
       },
       {
-        type: "options",
+        type: "env",
         options: {
           plugins: [
             "env-bar",

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -39,6 +39,22 @@ describe("option-manager", () => {
       );
     });
 
+    it("throws for options in presets", () => {
+      return assert.throws(
+        () => {
+          const opt = new OptionManager();
+          opt.init({
+            presets: [
+              {
+                compact: true,
+              },
+            ],
+          });
+        },
+        /Babel 7 has disallowed options inside presets/
+      );
+    });
+
     it("throws for resolved but erroring preset", () => {
       return assert.throws(
         () => {


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | Y
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

My goal here is to simplify the config loading process so it is more understandable. The ordering of pieces right now complex and this could help simplify. I want to allow each config file to be validated and normalized ahead of time. This is difficult because of cases like

```
{
  compact: true,
  retainLines: false,
  presets: [
    function() {
      return {
        retainLines: true,
      };
    },
  ],
  env: {
    development: {
      extends: './foo.json',
      minified: true,
    }, 
  },
}
```
with `foo.json` as
```
{
  minified: false,
  compact: false,
}
```

The result in
```
{
  compact: false,
  minified: true,
  retainLines: true,
}
```

Note that the extends block overrides the root content, and the env content overrides the extends. This means that midway through processing one file, we need to bail out to process a different file, which makes things much more nested.

Note also that the preset gets executed and processed each time too.

These two changes should allow us to fully understand Babel's options before we have to execute any presets or plugins, and it should allow us to do it one file at a time in a clear way, which will make things easier to follow and easier to cache.