### PR TITLE
Remove unnecessary returns in asyncToGenerator helper

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -46,7 +46,7 @@ var foo = function () {
   };
 }();
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } step("next"); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -46,7 +46,7 @@ var foo = function () {
   };
 }();
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } step("next"); }); }; }
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -230,15 +230,13 @@ helpers.asyncToGenerator = template(`
           if (info.done) {
             resolve(value);
           } else {
-            Promise.resolve(value).then(function (value) {
-              step("next", value);
-            }, function (err) {
-              step("throw", err);
-            });
+            Promise.resolve(value).then(_next, _throw);
           }
         }
+        function _next(value) { step("next", value); }
+        function _throw(err) { step("throw", err); }
 
-        step("next");
+        _next();
       });
     };
   })

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -230,7 +230,7 @@ helpers.asyncToGenerator = template(`
           if (info.done) {
             resolve(value);
           } else {
-            return Promise.resolve(value).then(function (value) {
+            Promise.resolve(value).then(function (value) {
               step("next", value);
             }, function (err) {
               step("throw", err);
@@ -238,7 +238,7 @@ helpers.asyncToGenerator = template(`
           }
         }
 
-        return step("next");
+        step("next");
       });
     };
   })


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | N
| Spec Compliancy?         | N
| Tests Added/Pass?        | N
| Fixed Tickets            | n/a <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | n/a <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | n/a

---

These `return`s aren't necessary, so remove them and save a few bytes.

You can also reuse the callbacks passed to `then` - but I don't know if it's worth it:

```diff
diff --git a/packages/babel-helpers/src/helpers.js b/packages/babel-helpers/src/helpers.js
index d7e1c0a..f081957 100644
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -230,13 +230,11 @@ helpers.asyncToGenerator = template(`
           if (info.done) {
             resolve(value);
           } else {
-            Promise.resolve(value).then(function (value) {
-              step("next", value);
-            }, function (err) {
-              step("throw", err);
-            });
+            Promise.resolve(value).then(_next, _throw);
           }
         }
+        function _next(value) { step("next", value); }
+        function _throw(err) { step("throw", err); }

         step("next");
       });
```
