### PR TITLE
Updated transform-react-display-name for createReactClass addon

### DIFF
--- a/packages/babel-plugin-transform-react-display-name/README.md
+++ b/packages/babel-plugin-transform-react-display-name/README.md
@@ -1,6 +1,6 @@
 # babel-plugin-transform-react-display-name
 
-> Add displayName to React.createClass calls
+> Add displayName to `ReactCreateClass` (and `React.createClass`) calls
 
 ## Example
 

--- a/packages/babel-plugin-transform-react-display-name/README.md
+++ b/packages/babel-plugin-transform-react-display-name/README.md
@@ -7,7 +7,8 @@
 **In**
 
 ```js
-var foo = React.createClass({});
+var foo = React.createClass({}); // React <= 15
+var bar = ReactCreateClass({});  // React 16+
 ```
 
 **Out**
@@ -15,7 +16,10 @@ var foo = React.createClass({});
 ```js
 var foo = React.createClass({
   displayName: "foo"
-});
+}); // React <= 15
+var bar = ReactCreateClass({
+  displayName: "bar"
+}); // React 16+
 ```
 
 ## Installation

--- a/packages/babel-plugin-transform-react-display-name/README.md
+++ b/packages/babel-plugin-transform-react-display-name/README.md
@@ -1,6 +1,6 @@
 # babel-plugin-transform-react-display-name
 
-> Add displayName to `ReactCreateClass` (and `React.createClass`) calls
+> Add displayName to `createReactClass` (and `React.createClass`) calls
 
 ## Example
 
@@ -8,7 +8,7 @@
 
 ```js
 var foo = React.createClass({}); // React <= 15
-var bar = ReactCreateClass({});  // React 16+
+var bar = createReactClass({});  // React 16+
 ```
 
 **Out**
@@ -17,7 +17,7 @@ var bar = ReactCreateClass({});  // React 16+
 var foo = React.createClass({
   displayName: "foo"
 }); // React <= 15
-var bar = ReactCreateClass({
+var bar = createReactClass({
   displayName: "bar"
 }); // React 16+
 ```

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -20,12 +20,12 @@ export default function ({ types: t }) {
   }
 
   const isCreateClassCallExpression = t.buildMatchMemberExpression("React.createClass");
-  const isCreateClassAddon = (callee) => callee.name === "ReactCreateClass";
+  const isCreateClassAddon = (callee) => callee.name === "createReactClass";
 
   function isCreateClass(node) {
     if (!node || !t.isCallExpression(node)) return false;
 
-    // not ReactCreateClass nor React.createClass call member object
+    // not createReactClass nor React.createClass call member object
     if (
       !isCreateClassCallExpression(node.callee) &&
       !isCreateClassAddon(node.callee)

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -20,12 +20,16 @@ export default function ({ types: t }) {
   }
 
   const isCreateClassCallExpression = t.buildMatchMemberExpression("React.createClass");
+  const isCreateClassAddon = (callee) => callee.name === "ReactCreateClass";
 
   function isCreateClass(node) {
     if (!node || !t.isCallExpression(node)) return false;
 
-    // not React.createClass call member object
-    if (!isCreateClassCallExpression(node.callee)) return false;
+    // not ReactCreateClass nor React.createClass call member object
+    if (
+      !isCreateClassCallExpression(node.callee) &&
+      !isCreateClassAddon(node.callee)
+    ) return false;
 
     // no call arguments
     const args = node.arguments;

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/actual.js
@@ -1,2 +1,2 @@
-foo = ReactCreateClass({});
+foo = createReactClass({});
 bar = React.createClass({});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/actual.js
@@ -1,1 +1,2 @@
-foo = React.createClass({});
+foo = ReactCreateClass({});
+bar = React.createClass({});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/expected.js
@@ -1,3 +1,6 @@
-foo = React.createClass({
+foo = ReactCreateClass({
   displayName: "foo"
+});
+bar = React.createClass({
+  displayName: "bar"
 });

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/assignment-expression/expected.js
@@ -1,4 +1,4 @@
-foo = ReactCreateClass({
+foo = createReactClass({
   displayName: "foo"
 });
 bar = React.createClass({

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/actual.js
@@ -1,1 +1,2 @@
-var foo = bar(React.createClass({}));
+var foo = qux(ReactCreateClass({}));
+var bar = qux(React.createClass({}));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/actual.js
@@ -1,2 +1,2 @@
-var foo = qux(ReactCreateClass({}));
+var foo = qux(createReactClass({}));
 var bar = qux(React.createClass({}));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/expected.js
@@ -1,4 +1,4 @@
-var foo = qux(ReactCreateClass({
+var foo = qux(createReactClass({
   displayName: "foo"
 }));
 var bar = qux(React.createClass({

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/nested/expected.js
@@ -1,3 +1,6 @@
-var foo = bar(React.createClass({
+var foo = qux(ReactCreateClass({
   displayName: "foo"
+}));
+var bar = qux(React.createClass({
+  displayName: "bar"
 }));

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/actual.js
@@ -1,3 +1,6 @@
 ({
-  foo: React.createClass({})
+  foo: ReactCreateClass({})
+});
+({
+  bar: React.createClass({})
 });

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/actual.js
@@ -1,5 +1,5 @@
 ({
-  foo: ReactCreateClass({})
+  foo: createReactClass({})
 });
 ({
   bar: React.createClass({})

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/expected.js
@@ -1,5 +1,5 @@
 ({
-  foo: ReactCreateClass({
+  foo: createReactClass({
     displayName: "foo"
   })
 });

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/object-property/expected.js
@@ -1,5 +1,10 @@
 ({
-  foo: React.createClass({
+  foo: ReactCreateClass({
     displayName: "foo"
+  })
+});
+({
+  bar: React.createClass({
+    displayName: "bar"
   })
 });

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/actual.js
@@ -1,1 +1,2 @@
-var foo = React.createClass({});
+var foo = ReactCreateClass({});
+var bar = React.createClass({});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/actual.js
@@ -1,2 +1,2 @@
-var foo = ReactCreateClass({});
+var foo = createReactClass({});
 var bar = React.createClass({});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/expected.js
@@ -1,4 +1,4 @@
-var foo = ReactCreateClass({
+var foo = createReactClass({
   displayName: "foo"
 });
 var bar = React.createClass({

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/variable-declarator/expected.js
@@ -1,3 +1,6 @@
-var foo = React.createClass({
+var foo = ReactCreateClass({
   displayName: "foo"
+});
+var bar = React.createClass({
+  displayName: "bar"
 });


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | Yes
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | Yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

The React team will be deprecating `React.createClass` soon (see facebook/react/pull/9232). This method will be moving to a new add-on package `create-react-class` (~~not yet released~~ **edit** Released on Friday, April 7). We are in the process of creating a codemod now that will replace:
```js
import React from 'react';

React.createClass({...})
```
with:
```js
import createReactClass from 'create-react-class';

createReactClass({...})
```

This diff updates the `transform-react-display-name` plugin to handle the new naming convention (`createReactClass`) as well as the pre-existing use case (`React.createClass`) in order to remain backwards compatible with existing versions of React. The new check is a naive string comparison and so it's pretty weak- but hopefully this is sufficient given that `createClass` is deprecated going forward.

**Caveat**: It is possible that someone will manually write code using the new add-on that does not conform to the naming convention used by the codemod. This use case is not supported.

cc @acdlite