### PR TITLE
Fix #4840: Alias class prototype for methods in loose mode

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/src/loose.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/loose.js
@@ -5,25 +5,23 @@ import * as t from "babel-types";
 export default class LooseClassTransformer extends VanillaTransformer {
   constructor() {
     super(...arguments);
+    this._protoAlias = null;
     this.isLoose = true;
   }
 
   _insertProtoAliasOnce() {
-    if (!this.methodAlias) {
-      this.methodAlias = this.path.scope.generateUidIdentifier("proto");
+    if (!this._protoAlias) {
+      this._protoAlias = this.scope.generateUidIdentifier("proto");
       const classProto = t.memberExpression(
         this.classRef,
         t.identifier("prototype"),
       );
       const protoDeclaration = t.variableDeclaration("var", [
-        t.variableDeclarator(this.methodAlias, classProto),
+        t.variableDeclarator(this._protoAlias, classProto),
       ]);
 
       this.body.push(protoDeclaration);
-      this.aliasInserted = true;
-      return true;
     }
-    return false;
   }
 
   _processMethod(node, scope) {
@@ -33,7 +31,7 @@ export default class LooseClassTransformer extends VanillaTransformer {
       let classRef = this.classRef;
       if (!node.static) {
         this._insertProtoAliasOnce();
-        classRef = this.methodAlias;
+        classRef = this._protoAlias;
       }
       const methodName = t.memberExpression(
         classRef,

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-constructor/expected.js
@@ -5,7 +5,9 @@ let A = function A() {
 let B = function () {
   function B() {}
 
-  B.prototype.b = function b() {
+  var _proto = B.prototype;
+
+  _proto.b = function b() {
     console.log('b');
   };
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/constructor-order/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/constructor-order/expected.js
@@ -1,5 +1,7 @@
 var x = function () {
-  x.prototype.f = function f() {
+  var _proto = x.prototype;
+
+  _proto.f = function f() {
     1;
     2;
     3;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/literal-key/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/literal-key/expected.js
@@ -1,7 +1,9 @@
 var Foo = function () {
   function Foo() {}
 
-  Foo.prototype["bar"] = function bar() {};
+  var _proto = Foo.prototype;
+
+  _proto["bar"] = function bar() {};
 
   return Foo;
 }();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
@@ -2,7 +2,9 @@
 var C = function () {
   function C() {}
 
-  C.prototype.m = function m(x: number): string {
+  var _proto = C.prototype;
+
+  _proto.m = function m(x: number): string {
     return 'a';
   };
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/actual.js
@@ -1,0 +1,5 @@
+class Test {
+  a() {}
+  static b() {}
+  c() {}
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/expected.js
@@ -1,0 +1,13 @@
+var Test = function () {
+  function Test() {}
+
+  var _proto = Test.prototype;
+
+  _proto.a = function a() {};
+
+  Test.b = function b() {};
+
+  _proto.c = function c() {};
+
+  return Test;
+}();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6755/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6755/expected.js
@@ -3,11 +3,13 @@
 var Example = function () {
   function Example() {}
 
-  Example.prototype.test1 = async function test1() {
+  var _proto = Example.prototype;
+
+  _proto.test1 = async function test1() {
     await Promise.resolve(2);
   };
 
-  Example.prototype.test2 =
+  _proto.test2 =
   /*#__PURE__*/
   regeneratorRuntime.mark(function test2() {
     return regeneratorRuntime.wrap(function test2$(_context) {

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
@@ -4,7 +4,9 @@
 var C = function () {
   function C() {}
 
-  C.prototype.m = function m(x
+  var _proto = C.prototype;
+
+  _proto.m = function m(x
   /*: number*/
   )
   /*: string*/

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
@@ -3,7 +3,9 @@
 var C = function () {
   function C() {}
 
-  C.prototype.m = function m(x) {
+  var _proto = C.prototype;
+
+  _proto.m = function m(x) {
     return 'a';
   };
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes?
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #4840 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Alias class prototype for methods in loose mode.