### PR TITLE
Avoid creating a new line comment when a block comment is preceded by a forward slash

### DIFF
--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -557,6 +557,9 @@ export default class Printer {
       val = val.replace(/\n(?!$)/g, `\n${repeat(" ", indentSize)}`);
     }
 
+    // Avoid creating //* comments
+    if (this.endsWith("/")) this._space();
+
     this.withSource("start", comment.loc, () => {
       this._append(val);
     });

--- a/packages/babel-generator/test/fixtures/comments/slash-before-leading-comment-compact/actual.js
+++ b/packages/babel-generator/test/fixtures/comments/slash-before-leading-comment-compact/actual.js
@@ -1,0 +1,1 @@
+var foo = 1 / /* leading */ 1;

--- a/packages/babel-generator/test/fixtures/comments/slash-before-leading-comment-compact/expected.js
+++ b/packages/babel-generator/test/fixtures/comments/slash-before-leading-comment-compact/expected.js
@@ -1,0 +1,1 @@
+var foo=1/ /* leading */1;

--- a/packages/babel-generator/test/fixtures/comments/slash-before-leading-comment-compact/options.json
+++ b/packages/babel-generator/test/fixtures/comments/slash-before-leading-comment-compact/options.json
@@ -1,0 +1,3 @@
+{
+  "compact": true
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5557
| License                  | MIT
| Doc PR                   | no
| Dependency Changes	| no

Adds a space before block comments if the preceding character is a forward slash. This prevents an expression such as `1 / /* comment */ 1` from getting mangled into `1//* comment */1` in compact mode.