### PR TITLE
Update regenerator-transform to new version

### DIFF
--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
   "main": "lib/index.js",
   "dependencies": {
-    "regenerator-transform": "0.9.8"
+    "regenerator-transform": "0.9.11"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/actual.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/actual.js
@@ -1,0 +1,5 @@
+var o = {
+  *foo() {
+    return "foo";
+  }
+};

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/expected.js
@@ -1,0 +1,14 @@
+var o = {
+  foo: regeneratorRuntime.mark(function _callee() {
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) switch (_context.prev = _context.next) {
+        case 0:
+          return _context.abrupt("return", "foo");
+
+        case 1:
+        case "end":
+          return _context.stop();
+      }
+    }, _callee, this);
+  })
+};

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/computed-properties/example/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-regenerator"]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/actual.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/actual.js
@@ -1,0 +1,5 @@
+function test(fn) {
+    return async (...args) => {
+    return fn(...args);
+    };
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/expected.js
@@ -1,0 +1,21 @@
+"use strict";
+
+function test(fn) {
+    var _this = this;
+
+    return function _callee() {
+        var _args = arguments;
+        return regeneratorRuntime.async(function _callee$(_context) {
+            while (1) {
+                switch (_context.prev = _context.next) {
+                    case 0:
+                        return _context.abrupt("return", fn.apply(undefined, _args));
+
+                    case 1:
+                    case "end":
+                        return _context.stop();
+                }
+            }
+        }, null, _this);
+    };
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/options.json
@@ -1,0 +1,7 @@
+{
+    "plugins": [
+        "transform-es2015-parameters", 
+        "transform-es2015-spread",
+        "transform-regenerator"
+    ]
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | don't know of any filed
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | updated regenerator-transform version

<!-- Describe your changes below in as much detail as possible -->
There was a bug with the code produced by `regenerator-transform` when it runs on an object with a shorthand property generator; the code produced by the transform created an undefined variable. In normal usage in Babel, this was usually masked by the fact that almost everyone uses `babel-plugin-transform-regenerator` after `babel-plugin-transform-es2015-shorthand-properties`, so the regenerator transformation was never seeing untransformed shorthand properties. (Also, shorthand property generators are not super common.)

I reported this problem in facebook/regenerator#267, and it was merged and released to npm in February. This PR updates `babel-plugin-transform-regenerator` to depend on that new version or `regenerator-transform`, and adds a unit test that fails with the old version of `regenerator-transform`.

Thanks for all the great work you do for the web and the world!