### PR TITLE
Improve example of babel-plugin-transform-es2015-arrow-functions

### DIFF
--- a/packages/babel-plugin-transform-es2015-arrow-functions/README.md
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/README.md
@@ -40,7 +40,7 @@ console.log(double); // [2,4,6]
 var bob = {
   _name: "Bob",
   _friends: ["Sally", "Tom"],
-  printFriends: function printFriends() {
+  printFriends() {
     var _this = this;
 
     this._friends.forEach(function (f) {

--- a/packages/babel-plugin-transform-es2015-arrow-functions/README.md
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/README.md
@@ -32,7 +32,7 @@ var a = function (b) {
   return b;
 };
 
-var double = [1, 2, 3].map(function (num) {
+const double = [1, 2, 3].map(function (num) {
   return num * 2;
 });
 console.log(double); // [2,4,6]

--- a/packages/babel-plugin-transform-es2015-arrow-functions/README.md
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/README.md
@@ -27,8 +27,8 @@ console.log(bob.printFriends());
 **Out**
 
 ```javascript
-var a = function a() {};
-var a = function a(b) {
+var a = function () {};
+var a = function (b) {
   return b;
 };
 


### PR DESCRIPTION
[skip ci]

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | No
| Fixed Tickets            | No
| License                  | MIT
| Doc PR                   | Yes
| Dependency Changes       | No

<!-- Describe your changes below in as much detail as possible -->

The example in the README file suggested that the plugin transforms shorthand properties to ES5 object syntax but that operation is performed by another plugin (babel-plugin-transform-es2015-shorthand-properties).

