### PR TITLE
Remove incorrect docs.

### DIFF
--- a/packages/babel-plugin-transform-es2015-spread/README.md
+++ b/packages/babel-plugin-transform-es2015-spread/README.md
@@ -9,31 +9,13 @@
 ```js
 var a = ['a', 'b', 'c'];
 var b = [...a, 'foo'];
-
-var c = { foo: 'bar', baz: 42 };
-var d = {...c, a: 2};
 ```
 
 **Out**
 
 ```js
-var _extends = Object.assign || function (target) {
-  for (var i = 1; i < arguments.length; i++) {
-    var source = arguments[i];
-    for (var key in source) {
-      if (Object.prototype.hasOwnProperty.call(source, key)) {
-        target[key] = source[key];
-      }
-    }
-  }
-  return target;
-}
-
 var a = [ 'a', 'b', 'c' ];
 var b = [].concat(a, [ 'foo' ]);
-
-var c = { foo: 'bar', baz: 42 };
-var d = _extends({}, c, { a: 2 });
 ```
 
 ## Installation


### PR DESCRIPTION
These examples are valid for object-rest-spread but not ES2015 spread.