### PR TITLE
Change babel-register default ignore to cwd content.

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -126,8 +126,14 @@ export default function register(opts?: Object = {}) {
   extend(transformOpts, opts);
 
   if (!transformOpts.ignore && !transformOpts.only) {
-    // By default, ignore files inside the node_modules relative to the current working directory.
     transformOpts.ignore = [
+      // Ignore any node_modules content outside the current working directory.
+      new RegExp(
+        "^(?!" + escapeRegExp(process.cwd()) + ").*" +
+        escapeRegExp(path.sep + "node_modules" + path.sep)
+      , "i"),
+
+      // Ignore any node_modules inside the current working directory.
       new RegExp(
         "^" +
         escapeRegExp(process.cwd()) +


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y, from https://github.com/babel/babel/pull/5487
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

I realized that I regressed this behavior from https://github.com/babel/babel/pull/5487/files#diff-75a0292ed78043766c2d5564edd84ad2L92

The behavior of `babel-register` in 6.x is equivalent to:

```
function shouldIgnore(filename){
  return (isInAnyNodeModules(filename) && !isInCwd(filename)) ||
    isInCwdNodeModules(filename);
}
```
assuming I'm covering all the edge cases here finally. The relative directory logic that was there before was pretty confusing and I misunderstood it the first time.

Currently I broke it by making it

```
function shouldIgnore(filename){
  return isInCwdNodeModules(filename);
}
```

which will try to compile `node_modules` that are not nested in the working directory, like things that are symlinked.