### PR TITLE
Handle cycles of plugins compiling themselves and .babelrc.js files loading themselves

### DIFF
--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -3,6 +3,9 @@
 import { getEnv } from "./helpers/environment";
 import path from "path";
 import micromatch from "micromatch";
+import buildDebug from "debug";
+
+const debug = buildDebug("babel:config:config-chain");
 
 import { findConfigs, loadConfig } from "./loading/files";
 
@@ -67,7 +70,15 @@ class ConfigChainBuilder {
         );
       }
 
-      if (this.matchesPatterns(ignore, dirname)) return true;
+      if (this.matchesPatterns(ignore, dirname)) {
+        debug(
+          "Ignored %o because it matched one of %O from %o",
+          this.filename,
+          ignore,
+          dirname,
+        );
+        return true;
+      }
     }
 
     if (only) {
@@ -77,7 +88,15 @@ class ConfigChainBuilder {
         );
       }
 
-      if (!this.matchesPatterns(only, dirname)) return true;
+      if (!this.matchesPatterns(only, dirname)) {
+        debug(
+          "Ignored %o because it failed to match one of %O from %o",
+          this.filename,
+          only,
+          dirname,
+        );
+        return true;
+      }
     }
 
     return false;

--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -1,11 +1,14 @@
 // @flow
 
+import buildDebug from "debug";
 import path from "path";
 import fs from "fs";
 import json5 from "json5";
 import resolve from "resolve";
 import { getEnv } from "../../helpers/environment";
 import { makeStrongCache } from "../../caching";
+
+const debug = buildDebug("babel:config:loading:files:configuration");
 
 type ConfigFile = {
   filepath: string,
@@ -31,6 +34,7 @@ export function findConfigs(dirname: string): Array<ConfigFile> {
       const ignore = readIgnoreConfig(ignoreLoc);
 
       if (ignore) {
+        debug("Found ignore %o from %o.", ignore.filepath, dirname);
         confs.push(ignore);
         foundIgnore = true;
       }
@@ -57,6 +61,7 @@ export function findConfigs(dirname: string): Array<ConfigFile> {
       }, null);
 
       if (conf) {
+        debug("Found configuration %o from %o.", conf.filepath, dirname);
         confs.push(conf);
         foundConfig = true;
       }
@@ -80,6 +85,7 @@ export function loadConfig(name: string, dirname: string): ConfigFile {
     throw new Error(`Config file ${filepath} contains no configuration data`);
   }
 
+  debug("Loaded config %o from $o.", name, dirname);
   return conf;
 }
 

--- a/packages/babel-core/src/config/loading/files/plugins.js
+++ b/packages/babel-core/src/config/loading/files/plugins.js
@@ -4,8 +4,11 @@
  * This file handles all logic for converting string-based configuration references into loaded objects.
  */
 
+import buildDebug from "debug";
 import resolve from "resolve";
 import path from "path";
+
+const debug = buildDebug("babel:config:loading:files:plugins");
 
 const EXACT_RE = /^module:/;
 const BABEL_PLUGIN_PREFIX_RE = /^(?!@|module:|[^/\/]+[/\/]|babel-plugin-)/;
@@ -32,10 +35,10 @@ export function loadPlugin(
     throw new Error(`Plugin ${name} not found relative to ${dirname}`);
   }
 
-  return {
-    filepath,
-    value: requireModule(filepath),
-  };
+  const value = requireModule(filepath);
+  debug("Loaded plugin %o from %o.", name, dirname);
+
+  return { filepath, value };
 }
 
 export function loadPreset(
@@ -47,10 +50,11 @@ export function loadPreset(
     throw new Error(`Preset ${name} not found relative to ${dirname}`);
   }
 
-  return {
-    filepath,
-    value: requireModule(filepath),
-  };
+  const value = requireModule(filepath);
+
+  debug("Loaded preset %o from %o.", name, dirname);
+
+  return { filepath, value };
 }
 
 export function loadParser(
@@ -71,10 +75,13 @@ export function loadParser(
       `Parser ${name} relative to ${dirname} does not export a .parse function`,
     );
   }
+  const value = mod.parse;
+
+  debug("Loaded parser %o from %o.", name, dirname);
 
   return {
     filepath,
-    value: mod.parse,
+    value,
   };
 }
 
@@ -96,10 +103,13 @@ export function loadGenerator(
       `Generator ${name} relative to ${dirname} does not export a .print function`,
     );
   }
+  const value = mod.print;
+
+  debug("Loaded generator %o from %o.", name, dirname);
 
   return {
     filepath,
-    value: mod.print,
+    value,
   };
 }
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

* Silently skips require-hook cycles of compiling files used inside a `.babelrc.js`.
* Throw a helpful error when a plugin tries to compile itself from a require hook.
* Add a bunch of `debug()` calls to help debug things.