### PR TITLE
Only compile files inside the cwd in babel-register.

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -107,16 +107,11 @@ export default function register(opts?: Object = {}) {
   Object.assign(transformOpts, opts);
 
   if (!transformOpts.ignore && !transformOpts.only) {
+    transformOpts.only = [
+      // Only compile things inside the current working directory.
+      new RegExp("^" + escapeRegExp(process.cwd()), "i"),
+    ];
     transformOpts.ignore = [
-      // Ignore any node_modules content outside the current working directory.
-      new RegExp(
-        "^(?!" +
-          escapeRegExp(process.cwd()) +
-          ").*" +
-          escapeRegExp(path.sep + "node_modules" + path.sep),
-        "i",
-      ),
-
       // Ignore any node_modules inside the current working directory.
       new RegExp(
         "^" +


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Kinda?
| Major: Breaking Change?  | Y
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

This fixes the error in https://github.com/babel/babylon/issues/447 which we introduced in https://github.com/babel/babel/pull/5555 by removing the `only`, which makes `babel-register` try to compile `babylon`.

The breaking change here is that this consistently focuses on the cwd. Take a structure like this:

```
projects/
  node_modules/ancestor/index.js
  one/
    index.js
    node_modules/child/index.js
  two/     => working directory
    index.js
```

If `project/two/index.js` did `require('./one/index.js')` or mode likely, has `one` symlinked to `two/node_modules/one` and does `require('one')`, it will try to compile `projects/one/index.js`, even though it isn't in the working directory.

This PR fixes this to exclude _everything_ outside the working directory. So in the terminology of https://github.com/babel/babel/pull/5583, 

```
function shouldIgnore(filename){
  return (isInAnyNodeModules(filename) && !isInCwd(filename)) ||
    isInCwdNodeModules(filename);
}
```

becomes

```
function shouldIgnore(filename){
  return !isInCwd(filename)) ||  isInCwdNodeModules(filename);
}
```