### PR TITLE
Fix the stack frame of async-to-generator class methods

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/expected.js
@@ -16,7 +16,7 @@ class Class {
   m() {
     var _this2 = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* m() {
       var c = function () {
         var _ref2 = babelHelpers.asyncToGenerator(function* (b) {
           _this2;
@@ -26,6 +26,6 @@ class Class {
           return _ref2.apply(this, arguments);
         };
       }();
-    })();
+    }).call(this);
   }
 }

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -83,12 +83,15 @@ function classOrObjectMethod(path: NodePath, callId: Object) {
 
   node.async = false;
 
-  const container = t.functionExpression(null, [], t.blockStatement(body.body), true);
+  const container = t.functionExpression(node.key, [], t.blockStatement(body.body), true);
   container.shadow = true;
   body.body = [
     t.returnStatement(t.callExpression(
-      t.callExpression(callId, [container]),
-      []
+      t.memberExpression(
+        t.callExpression(callId, [container]),
+        t.identifier("call")
+      ),
+      [t.identifier("this")]
     )),
   ];
 

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/class-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/class-method/expected.js
@@ -2,11 +2,11 @@ class C {
   g() {
     var _this = this;
 
-    return babelHelpers.asyncGenerator.wrap(function* () {
+    return babelHelpers.asyncGenerator.wrap(function* g() {
       _this;
       yield babelHelpers.asyncGenerator.await(1);
       yield 2;
       return 3;
-    })();
+    }).call(this);
   }
 }

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/object-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/object-method/expected.js
@@ -2,11 +2,11 @@
   g() {
     var _this = this;
 
-    return babelHelpers.asyncGenerator.wrap(function* () {
+    return babelHelpers.asyncGenerator.wrap(function* g() {
       _this;
       yield babelHelpers.asyncGenerator.await(1);
       yield 2;
       return 3;
-    })();
+    }).call(this);
   }
 });

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/static-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/static-method/expected.js
@@ -2,11 +2,11 @@ class C {
   static g() {
     var _this = this;
 
-    return babelHelpers.asyncGenerator.wrap(function* () {
+    return babelHelpers.asyncGenerator.wrap(function* g() {
       _this;
       yield babelHelpers.asyncGenerator.await(1);
       yield 2;
       return 3;
-    })();
+    }).call(this);
   }
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async/expected.js
@@ -1,7 +1,7 @@
 class Foo {
   foo() {
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* foo() {
       var wat = yield bar();
-    })();
+    }).call(this);
   }
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-arrows/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-arrows/expected.js
@@ -2,7 +2,7 @@ class Class {
   method() {
     var _this = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* method() {
       _this;
       (function () {
         return _this;
@@ -35,6 +35,6 @@ class Class {
           _this3;
         });
       }
-    })();
+    }).call(this);
   }
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/expected.js
@@ -1,8 +1,8 @@
 let obj = {
   a: 123,
   foo(bar) {
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* foo() {
       return yield baz(bar);
-    })();
+    }).call(this);
   }
 };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
@@ -2,19 +2,19 @@ class Test {
   static method1() {
     var _this = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* method1() {
       console.log(_this);
 
       setTimeout(babelHelpers.asyncToGenerator(function* () {
         console.log(_this);
       }));
-    })();
+    }).call(this);
   }
 
   static method2() {
     var _this2 = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* method2() {
       console.log(_this2);
 
       setTimeout((() => {
@@ -26,25 +26,25 @@ class Test {
           return _ref2.apply(this, arguments);
         };
       })());
-    })();
+    }).call(this);
   }
 
   method1() {
     var _this3 = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* method1() {
       console.log(_this3);
 
       setTimeout(babelHelpers.asyncToGenerator(function* () {
         console.log(_this3);
       }));
-    })();
+    }).call(this);
   }
 
   method2() {
     var _this4 = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
+    return babelHelpers.asyncToGenerator(function* method2() {
       console.log(_this4);
 
       setTimeout((() => {
@@ -56,6 +56,6 @@ class Test {
           return _ref4.apply(this, arguments);
         };
       })());
-    })();
+    }).call(this);
   }
 }

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/class/expected.js
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/class/expected.js
@@ -1,8 +1,8 @@
 import { coroutine as _coroutine } from "bluebird";
 class Foo {
   foo() {
-    return _coroutine(function* () {
+    return _coroutine(function* foo() {
       var wat = yield bar();
-    })();
+    }).call(this);
   }
 }


### PR DESCRIPTION
Ensure that the stack frame picks up the class name and method of the
original source code.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

Sample test case:

``` js
async function func() {
  return 10
}

class TestClass {
  async method() {
    await func()

    throw new Error('Test error')
  }
}

const obj = new TestClass()

obj.method()
  .then(() => console.log('Done!'))
  .catch(error => console.error(error))
```

Without this fix:

```
Error: Test error
    at /path/to/test.js:20:13
    at Generator.next (<anonymous>)
    at step (/path/to/test.js:13:191)
    at /path/to/test.js:13:361
    at process._tickCallback (internal/process/next_tick.js:109:7)
    at Module.runMain (module.js:607:11)
    at run (bootstrap_node.js:427:7)
    at startup (bootstrap_node.js:148:9)
    at bootstrap_node.js:542:3
```

With this fix:

```
Error: Test error
    at TestClass.method (/path/to/test.js:20:13)
    at method.next (<anonymous>)
    at step (/path/to/test.js:13:191)
    at /path/to/test.js:13:361
    at process._tickCallback (internal/process/next_tick.js:109:7)
    at Module.runMain (module.js:607:11)
    at run (bootstrap_node.js:427:7)
    at startup (bootstrap_node.js:148:9)
    at bootstrap_node.js:542:3
```

This is useful for error reporting services such as Sentry that display the class name and method for exceptions. I can't use Node's native async/await because domains don't work with async/await.