### PR TITLE
Refactor OptionManager to be a short class with a bunch of pure helper functions.

### DIFF
--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -10,21 +10,5 @@ export type ResolvedConfig = {
  * Standard API for loading Babel configuration data. Not for public consumption.
  */
 export default function loadConfig(opts: Object): ResolvedConfig|null {
-  const mergedOpts = manageOptions(opts);
-  if (!mergedOpts) return null;
-
-  let passes = [];
-  if (mergedOpts.plugins) {
-    passes.push(mergedOpts.plugins);
-  }
-
-  // With "passPerPreset" enabled there may still be presets in the options.
-  if (mergedOpts.presets) {
-    passes = passes.concat(mergedOpts.presets.map((preset) => preset.plugins).filter(Boolean));
-  }
-
-  return {
-    options: mergedOpts,
-    passes,
-  };
+  return manageOptions(opts);
 }

--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -1,5 +1,5 @@
 import type Plugin from "./plugin";
-import OptionManager from "./option-manager";
+import manageOptions from "./option-manager";
 
 export type ResolvedConfig = {
   options: Object,
@@ -10,7 +10,7 @@ export type ResolvedConfig = {
  * Standard API for loading Babel configuration data. Not for public consumption.
  */
 export default function loadConfig(opts: Object): ResolvedConfig|null {
-  const mergedOpts = new OptionManager().init(opts);
+  const mergedOpts = manageOptions(opts);
   if (!mergedOpts) return null;
 
   let passes = [];

--- a/packages/babel-core/src/config/loading/files/index-browser.js
+++ b/packages/babel-core/src/config/loading/files/index-browser.js
@@ -25,18 +25,18 @@ export function resolvePreset(name: string, dirname: string): string|null {
   return null;
 }
 
-export function loadPlugin(name: string, dirname: string): { filepath: string, plugin: mixed } {
+export function loadPlugin(name: string, dirname: string): { filepath: string, value: mixed } {
   throw new Error(`Cannot load plugin ${name} relative to ${dirname} in a browser`);
 }
 
-export function loadPreset(name: string, dirname: string): { filepath: string, preset: mixed } {
+export function loadPreset(name: string, dirname: string): { filepath: string, value: mixed } {
   throw new Error(`Cannot load preset ${name} relative to ${dirname} in a browser`);
 }
 
-export function loadParser(name: string, dirname: string): { filepath: string, parser: Function } {
+export function loadParser(name: string, dirname: string): { filepath: string, value: Function } {
   throw new Error(`Cannot load parser ${name} relative to ${dirname} in a browser`);
 }
 
-export function loadGenerator(name: string, dirname: string): { filepath: string, generator: Function } {
+export function loadGenerator(name: string, dirname: string): { filepath: string, value: Function } {
   throw new Error(`Cannot load generator ${name} relative to ${dirname} in a browser`);
 }

--- a/packages/babel-core/src/config/loading/files/plugins.js
+++ b/packages/babel-core/src/config/loading/files/plugins.js
@@ -26,27 +26,27 @@ export function resolvePreset(presetName: string, dirname: string): string|null 
   return resolveFromPossibleNames(possibleNames, dirname);
 }
 
-export function loadPlugin(name: string, dirname: string): { filepath: string, plugin: mixed } {
+export function loadPlugin(name: string, dirname: string): { filepath: string, value: mixed } {
   const filepath = resolvePlugin(name, dirname);
   if (!filepath) throw new Error(`Plugin ${name} not found relative to ${dirname}`);
 
   return {
     filepath,
-    plugin: requireModule(filepath),
+    value: requireModule(filepath),
   };
 }
 
-export function loadPreset(name: string, dirname: string): { filepath: string, preset: mixed } {
+export function loadPreset(name: string, dirname: string): { filepath: string, value: mixed } {
   const filepath = resolvePreset(name, dirname);
   if (!filepath) throw new Error(`Preset ${name} not found relative to ${dirname}`);
 
   return {
     filepath,
-    preset: requireModule(filepath),
+    value: requireModule(filepath),
   };
 }
 
-export function loadParser(name: string, dirname: string): { filepath: string, parser: Function } {
+export function loadParser(name: string, dirname: string): { filepath: string, value: Function } {
   const filepath = resolveQuiet(name, dirname);
   if (!filepath) throw new Error(`Parser ${name} not found relative to ${dirname}`);
 
@@ -61,11 +61,11 @@ export function loadParser(name: string, dirname: string): { filepath: string, p
 
   return {
     filepath,
-    parser: mod.parse,
+    value: mod.parse,
   };
 }
 
-export function loadGenerator(name: string, dirname: string): { filepath: string, generator: Function } {
+export function loadGenerator(name: string, dirname: string): { filepath: string, value: Function } {
   const filepath = resolveQuiet(name, dirname);
   if (!filepath) throw new Error(`Generator ${name} not found relative to ${dirname}`);
 
@@ -80,7 +80,7 @@ export function loadGenerator(name: string, dirname: string): { filepath: string
 
   return {
     filepath,
-    generator: mod.print,
+    value: mod.print,
   };
 }
 

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -85,7 +85,11 @@ const ALLOWED_PLUGIN_KEYS = new Set([
   "inherits",
 ]);
 
-export default class OptionManager {
+export default function manageOptions(opts?: Object) {
+  return new OptionManager().init(opts);
+}
+
+class OptionManager {
   constructor() {
     this.options = OptionManager.createBareOptions();
   }

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -171,12 +171,14 @@ class OptionManager {
     }
 
     if (opts.parserOpts && typeof opts.parserOpts.parser === "string") {
-      opts.parserOpts.parser = loadParser(opts.parserOpts.parser, dirname).parser;
+      opts.parserOpts.parser = loadParser(opts.parserOpts.parser, dirname).value;
     }
 
     if (opts.generatorOpts && typeof opts.generatorOpts.generator === "string") {
-      opts.generatorOpts.generator = loadGenerator(opts.generatorOpts.generator, dirname).generator;
+      opts.generatorOpts.generator = loadGenerator(opts.generatorOpts.generator, dirname).value;
     }
+
+    // const plugins =
 
     // resolve presets
     if (opts.presets) {
@@ -298,7 +300,7 @@ function resolvePresets(presets: Array<string | Object>, dirname: string) {
       if (typeof preset === "string") {
         ({
           filepath: presetLoc,
-          preset,
+          value: preset,
         } = loadPreset(preset, dirname));
       }
       const resolvedPreset = loadPresetObject(preset, options, { dirname });
@@ -455,7 +457,7 @@ function normalisePlugins(loc, dirname, plugins) {
 
     // allow plugins to be specified as strings
     if (typeof plugin === "string") {
-      plugin = loadPlugin(plugin, dirname).plugin;
+      plugin = loadPlugin(plugin, dirname).value;
     }
 
     plugin = normalisePlugin(plugin, loc, i, alias);

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -76,7 +76,7 @@ export default function manageOptions(opts?: Object) {
 
 class OptionManager {
   constructor() {
-    this.options = createBareOptions();
+    this.options = createInitialOptions();
     this.passes = [[]];
   }
 
@@ -442,7 +442,7 @@ function chain(a, b) {
   };
 }
 
-function createBareOptions() {
+function createInitialOptions() {
   return {
     sourceType: "module",
     babelrc: true,

--- a/packages/babel-core/src/config/plugin.js
+++ b/packages/babel-core/src/config/plugin.js
@@ -1,90 +1,16 @@
-import OptionManager from "./option-manager";
-import * as messages from "babel-messages";
-import traverse from "babel-traverse";
-import clone from "lodash/clone";
-
-const GLOBAL_VISITOR_PROPS = ["enter", "exit"];
-
 export default class Plugin {
   constructor(plugin: Object, key?: string) {
-    this.initialized = false;
-    this.raw = Object.assign({}, plugin);
-    this.key = this.take("name") || key;
+    this.key = plugin.name || key;
 
-    this.manipulateOptions = this.take("manipulateOptions");
-    this.post = this.take("post");
-    this.pre = this.take("pre");
-    this.visitor = this.normaliseVisitor(clone(this.take("visitor")) || {});
+    this.manipulateOptions = plugin.manipulateOptions;
+    this.post = plugin.post;
+    this.pre = plugin.pre;
+    this.visitor = plugin.visitor;
   }
 
-  initialized: boolean;
-  raw: Object;
+  key: ?string;
   manipulateOptions: ?Function;
   post: ?Function;
   pre: ?Function;
   visitor: Object;
-
-  take(key) {
-    const val = this.raw[key];
-    delete this.raw[key];
-    return val;
-  }
-
-  chain(target, key) {
-    if (!target[key]) return this[key];
-    if (!this[key]) return target[key];
-
-    const fns: Array<?Function> = [target[key], this[key]];
-
-    return function (...args) {
-      let val;
-      for (const fn of fns) {
-        if (fn) {
-          const ret = fn.apply(this, args);
-          if (ret != null) val = ret;
-        }
-      }
-      return val;
-    };
-  }
-
-  maybeInherit(loc: string) {
-    let inherits = this.take("inherits");
-    if (!inherits) return;
-
-    inherits = OptionManager.normalisePlugin(inherits, loc, "inherits");
-
-    this.manipulateOptions = this.chain(inherits, "manipulateOptions");
-    this.post = this.chain(inherits, "post");
-    this.pre = this.chain(inherits, "pre");
-    this.visitor = traverse.visitors.merge([inherits.visitor, this.visitor]);
-  }
-
-  /**
-   * We lazy initialise parts of a plugin that rely on contextual information such as
-   * position on disk and how it was specified.
-   */
-
-  init(loc: string, i: number) {
-    if (this.initialized) return;
-    this.initialized = true;
-
-    this.maybeInherit(loc);
-
-    for (const key in this.raw) {
-      throw new Error(messages.get("pluginInvalidProperty", loc, i, key));
-    }
-  }
-
-  normaliseVisitor(visitor: Object): Object {
-    for (const key of GLOBAL_VISITOR_PROPS) {
-      if (visitor[key]) {
-        throw new Error("Plugins aren't allowed to specify catch-all enter/exit handlers. " +
-          "Please target individual nodes.");
-      }
-    }
-
-    traverse.explode(visitor);
-    return visitor;
-  }
 }

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -146,7 +146,7 @@ describe("api", function () {
           plugins: [__dirname + "/../../babel-plugin-syntax-jsx", false],
         });
       },
-      /TypeError: \[BABEL\] unknown: Falsy value found in plugins/
+      /Error: \[BABEL\] unknown: Unexpected falsy value: false/
     );
   });
 

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -45,7 +45,7 @@ describe("option-manager", () => {
             "presets": [path.join(__dirname, "fixtures/option-manager/not-a-preset")],
           });
         },
-        /While processing preset: .*option-manager(?:\/|\\\\)not-a-preset\.js/
+        /While processing: .*option-manager(?:\/|\\\\)not-a-preset\.js/
       );
     });
   });
@@ -77,8 +77,8 @@ describe("option-manager", () => {
     presetTest("es2015_default_function");
     presetTest("es2015_default_object");
 
-    presetThrowsTest("es2015_named", /Preset must export a default export when using ES6 modules/);
-    presetThrowsTest("es2015_invalid", /Unsupported preset format: string/);
-    presetThrowsTest("es5_invalid", /Unsupported preset format: string/);
+    presetThrowsTest("es2015_named", /Must export a default export when using ES6 modules/);
+    presetThrowsTest("es2015_invalid", /Unsupported format: string/);
+    presetThrowsTest("es5_invalid", /Unsupported format: string/);
   });
 });

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -3,13 +3,15 @@ import OptionManager from "../lib/config/option-manager";
 import path from "path";
 
 describe("option-manager", () => {
-  describe("memoisePluginContainer", () => {
-    it("throws for babel 5 plugin", () => {
-      return assert.throws(
-        () => OptionManager.memoisePluginContainer(({ Plugin }) => new Plugin("object-assign", {})),
-        /Babel 5 plugin is being run with Babel 6/
-      );
-    });
+  it("throws for babel 5 plugin", () => {
+    return assert.throws(() => {
+      const opt = new OptionManager();
+      opt.init({
+        plugins: [
+          ({ Plugin }) => new Plugin("object-assign", {}),
+        ],
+      });
+    }, /Babel 5 plugin is being run with Babel 6/);
   });
 
   describe("mergeOptions", () => {

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -53,12 +53,14 @@ describe("option-manager", () => {
   describe("presets", function () {
     function presetTest(name) {
       it(name, function () {
-        const options = manageOptions({
+        const { options, passes } = manageOptions({
           "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)],
         });
 
         assert.equal(true, Array.isArray(options.plugins));
         assert.equal(1, options.plugins.length);
+        assert.equal(1, passes.length);
+        assert.equal(1, passes[0].length);
       });
     }
 

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,12 +1,11 @@
 import assert from "assert";
-import OptionManager from "../lib/config/option-manager";
+import manageOptions from "../lib/config/option-manager";
 import path from "path";
 
 describe("option-manager", () => {
   it("throws for babel 5 plugin", () => {
     return assert.throws(() => {
-      const opt = new OptionManager();
-      opt.init({
+      manageOptions({
         plugins: [
           ({ Plugin }) => new Plugin("object-assign", {}),
         ],
@@ -18,8 +17,7 @@ describe("option-manager", () => {
     it("throws for removed babel 5 options", () => {
       return assert.throws(
         () => {
-          const opt = new OptionManager();
-          opt.init({
+          manageOptions({
             "randomOption": true,
           });
         },
@@ -30,8 +28,7 @@ describe("option-manager", () => {
     it("throws for removed babel 5 options", () => {
       return assert.throws(
         () => {
-          const opt = new OptionManager();
-          opt.init({
+          manageOptions({
             "auxiliaryComment": true,
             "blacklist": true,
           });
@@ -44,8 +41,7 @@ describe("option-manager", () => {
     it("throws for resolved but erroring preset", () => {
       return assert.throws(
         () => {
-          const opt = new OptionManager();
-          opt.init({
+          manageOptions({
             "presets": [path.join(__dirname, "fixtures/option-manager/not-a-preset")],
           });
         },
@@ -57,8 +53,7 @@ describe("option-manager", () => {
   describe("presets", function () {
     function presetTest(name) {
       it(name, function () {
-        const opt = new OptionManager();
-        const options = opt.init({
+        const options = manageOptions({
           "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)],
         });
 
@@ -69,8 +64,7 @@ describe("option-manager", () => {
 
     function presetThrowsTest(name, msg) {
       it(name, function () {
-        const opt = new OptionManager();
-        assert.throws(() => opt.init({
+        assert.throws(() => manageOptions({
           "presets": [path.join(__dirname, "fixtures/option-manager/presets", name)],
         }), msg);
       });

--- a/packages/babel-messages/src/index.js
+++ b/packages/babel-messages/src/index.js
@@ -40,7 +40,7 @@ export const MESSAGES = {
   pluginNotObject: "Plugin $2 specified in $1 was expected to return an object when invoked but returned $3",
   pluginNotFunction: "Plugin $2 specified in $1 was expected to return a function but returned $3",
   pluginUnknown: "Unknown plugin $1 specified in $2 at $3, attempted to resolve relative to $4",
-  pluginInvalidProperty: "Plugin $2 specified in $1 provided an invalid property of $3",
+  pluginInvalidProperty: "Plugin $1 provided an invalid property of $3",
 };
 
 /**


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

Last PR before I post the changes to OptionManager for caching. This PR is basically slowly moving things around and simplifying OptionManager, so it no longer has all kinds of hard to follow statics. It's a simple class 100 lines long, with a bunch of pure functions that it uses to slowly build up the config info.

Review-wise it might be easier to just look at the final option-manager.js file to say what you think?