### PR TITLE
Update deprecation warning on flow bindings

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -869,7 +869,7 @@ export default class Scope {
     if (_crawlCallsCount === 0 && binding && binding.path.isFlow()) {
       console.warn(`
         You or one of the Babel plugins you are using are using Flow declarations as bindings.
-        Support for this will be removed in version 6.8. To find out the caller, grep for this
+        Support for this will be removed in version 7. To find out the caller, grep for this
         message and change it to a \`console.trace()\`.
       `);
     }


### PR DESCRIPTION
Babel 6 is at 6.24, doesn't seem like this is getting removed in version 6 anymore.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  |  no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no
