### PR TITLE
Adds the entry point to package.json for the babel-runtime package

### DIFF
--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
+  "main": "core-js.js",
   "dependencies": {
     "core-js": "^2.4.0",
     "regenerator-runtime": "^0.10.0"


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          yes
| Major: Breaking Change?  no
| Minor: New Feature?      no
| Deprecations?            no
| Spec Compliancy?         no
| Tests Added/Pass?        no
| Fixed Tickets            no
| License                  | MIT
| Doc PR                   no
| Dependency Changes       no

the [babel/packages/babel-runtime](https://github.com/babel/babel/tree/7.0/packages/babel-runtime) `package.json` didn't specify an entry point. Because it's entry point is the `core-js.js` file it wasn't being detected by default. This PR makes its `package.json` specify its entry point by adding the line `"main": "core-js.js"` to it. 