### PR TITLE
Set an 80% coverage goal instead of 'auto'?

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,9 @@ coverage:
   parsers:
     javascript:
       enable_partials: yes
+  status:
+    project:
+      default:
+        target: "80%"
+    patch:
+      enabled: false


### PR DESCRIPTION
It seems like we get a lot of PRs marked as failures for coverage dropping tiny percentages. Would people be open to setting a static target for now, since coverage isn't really something we totally focus on anyway?

Also disabling `patch` since it doesn't seem to give us anything if we have a fixed goal anyway?