### PR TITLE
Fixing bug with transforming references to super in arrow functions.

### DIFF
--- a/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
+++ b/packages/babel-core/src/transformation/internal-plugins/shadow-functions.js
@@ -22,6 +22,10 @@ export default {
       remap(path, "this");
     },
 
+    Super(path) {
+      remap(path, "super");
+    },
+
     ReferencedIdentifier(path) {
       if (path.node.name === "arguments") {
         remap(path, "arguments");

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -227,7 +227,7 @@ export default class ReplaceSupers {
           t.variableDeclarator(ref, node.left),
         ]),
         t.expressionStatement(t.assignmentExpression("=", node.left,
-          t.binaryExpression(node.operator[0], ref, node.right))),
+          t.binaryExpression(node.operator.substring(0, node.operator.length - 1), ref, node.right))),
       ];
     }
   }
@@ -263,7 +263,7 @@ export default class ReplaceSupers {
       property = node.property;
       computed = node.computed;
     } else if (t.isUpdateExpression(node) && isMemberExpressionSuper(node.argument)) {
-      const binary = t.binaryExpression(node.operator[0], node.argument, t.numericLiteral(1));
+      const binary = t.assignmentExpression(node.operator[0] + "=", node.argument, t.numericLiteral(1));
       if (node.prefix) {
         // ++super.foo;
         // to

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-class-method/actual.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-class-method/actual.js
@@ -1,0 +1,22 @@
+class SuperClass {
+  doStuff() {
+    return "superclass";
+  }
+}
+
+class MyClass extends SuperClass {
+  superDotAccess() {
+    const arrow = () => {
+      return super.doStuff();
+    };
+    return arrow() + ", but in MyClass";
+  }
+
+  superBracketAccess() {
+    const arrow = () => {
+      const fnName = "doStuff";
+      return super[fnName]();
+    };
+    return arrow() + ", but in MyClass";
+  }
+}

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-class-method/expected.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-class-method/expected.js
@@ -1,0 +1,26 @@
+class SuperClass {
+  doStuff() {
+    return "superclass";
+  }
+}
+
+class MyClass extends SuperClass {
+  superDotAccess() {
+    var _super = super;
+
+    const arrow = function () {
+      return _super.doStuff();
+    };
+    return arrow() + ", but in MyClass";
+  }
+
+  superBracketAccess() {
+    var _super2 = super;
+
+    const arrow = function () {
+      const fnName = "doStuff";
+      return _super2[fnName]();
+    };
+    return arrow() + ", but in MyClass";
+  }
+}

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-constructor/actual.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-constructor/actual.js
@@ -1,0 +1,10 @@
+class SuperClass {}
+
+class MyClass extends SuperClass {
+  constructor() {
+    const arrow = () => {
+      super();
+    }
+    arrow();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-constructor/expected.js
@@ -1,0 +1,12 @@
+class SuperClass {}
+
+class MyClass extends SuperClass {
+  constructor() {
+    var _super = super;
+
+    const arrow = function () {
+      _super();
+    };
+    arrow();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-object-method/actual.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-object-method/actual.js
@@ -1,0 +1,16 @@
+const o = {
+  superDotAccess() {
+    const arrow = () => {
+      return super.doStuff();
+    };
+    arrow();
+  },
+
+  superBracketAccess() {
+    const arrow = () => {
+      const fnName = "doStuff";
+      return super[fnName]();
+    };
+    arrow();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-object-method/expected.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/test/fixtures/arrow-functions/super-in-object-method/expected.js
@@ -1,0 +1,20 @@
+const o = {
+  superDotAccess() {
+    var _super = super;
+
+    const arrow = function () {
+      return _super.doStuff();
+    };
+    arrow();
+  },
+
+  superBracketAccess() {
+    var _super2 = super;
+
+    const arrow = function () {
+      const fnName = "doStuff";
+      return _super2[fnName]();
+    };
+    arrow();
+  }
+};

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/actual.js
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/actual.js
@@ -1,0 +1,5 @@
+foo = {
+  bar() {
+    return super.baz **= 12;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/expected.js
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/expected.js
@@ -5,9 +5,9 @@ var _set = function set(object, property, value, receiver) { var desc = Object.g
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
 foo = _obj = {
-  bar() {
+  bar: function () {
     var _ref;
 
-    return _ref = _get(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", this), _set(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", Math.pow(_ref, 12), this);
+    return _ref = _get(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", this), _set(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", _ref ** 12, this);
   }
 };

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/options.json
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-object-super"]
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no?
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | None that I know of <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
I found out that running `babel-plugin-transform-es2015-arrow-functions` on its own did not play well with the `super` keyword. Arrow functions keep the `super` of their context, just like they keep `this`, but when you run just the arrow function plugin on this code:

```
class A extends B {
  myFunction() {
    const arrow = () => {
      super.otherFunction();
    };
    arrow();
  }
}
```
you end up with this code:
```
class A extends B {
  myFunction() {
    const arrow = function () {
      super.otherFunction();
    };
    arrow();
  }
}
```
This transpiled code throws a `SyntaxError: super is not valid in this context.` because super is in a normal function that doesn't get `this` or `super` from context, as opposed to an arrow function that does.

In this PR, I tried to fix this problem. I made 3 unit tests for different scenarios of `super` in an arrow function: class constructor, class method, and object method.

The implementation was pretty easy in the arrow function transform, because it is essentially just doing the same thing that we are doing with `this`. Unfortunately, though, this broke a traceur unit test for the es2015 preset. I believe this unit test was broken because of ordering effects between the `object-super`, `shorthand-properties`, `arrow-function`, and `internal.shadow-functions` transforms. I tinkered a bunch to fix that and ended up just moving `object-super`'s logic all into `enter` instead of `exit`. If there's a better way, I'd love to hear it; this part was complicated.

The change to `object-super` in turn revealed another bug, which was that the `object-super` plugin didn't understand the exponentiation assignment operator. (It treated it like the multiplication assignment operator.)

So if you ran just the `object-super` plugin on code like this:
```
var o = {
  someFn() {
    super.x **= 10;
  }
};
```
the resulting code would **multiply** `super.x` by 10 rather than taking it to the 10th power. I fixed that and added a unit test.

All tests are passing on my machine except for the browserify one, which seems unrelated and fails for me on the 7.0 branch.

Thanks for you time and have a great day!