### PR TITLE
Typecheck much more of the config loading process

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,7 @@ packages/*/src
 lib/file.js
 lib/parser.js
 lib/types.js
+lib/third-party-libs.js.flow
 
 [options]
 strip_root=true

--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -1,0 +1,9 @@
+/**
+ * Basic declarations for the npm modules we use.
+ */
+
+declare module "micromatch" {
+  declare function exports(Array<string>, Array<string>, ?{
+    nocase: boolean,
+  }): Array<string>;
+}

--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -166,7 +166,6 @@ class ConfigChainBuilder {
     delete options.env;
     delete options.extends;
 
-    // env
     const envKey = getEnv();
 
     if (rawOpts.env != null && (typeof rawOpts.env !== "object" || Array.isArray(rawOpts.env))) {
@@ -196,7 +195,6 @@ class ConfigChainBuilder {
       dirname,
     });
 
-    // add extends clause
     if (rawOpts.extends) {
       if (typeof rawOpts.extends !== "string") throw new Error(".extends must be a string");
 

--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -1,10 +1,24 @@
-import * as babel from "../index";
+// @flow
+
+import { getEnv } from "./helpers/environment";
 import path from "path";
 import micromatch from "micromatch";
 
 import { findConfigs, loadConfig } from "./loading/files";
 
-export default function buildConfigChain(opts: Object = {}) {
+type ConfigItem = {
+  type: "options"|"arguments",
+  options: {},
+  dirname: string,
+  alias: string,
+  loc: string,
+};
+
+export default function buildConfigChain(opts: {}): Array<ConfigItem>|null {
+  if (typeof opts.filename !== "string" && opts.filename != null) {
+    throw new Error(".filename must be a string, null, or undefined");
+  }
+
   const filename = opts.filename ? path.resolve(opts.filename) : null;
   const builder = new ConfigChainBuilder(filename);
 
@@ -17,7 +31,7 @@ export default function buildConfigChain(opts: Object = {}) {
     });
 
     // resolve all .babelrc files
-    if (opts.babelrc !== false) {
+    if (opts.babelrc !== false && filename) {
       builder.findConfigs(filename);
     }
   } catch (e) {
@@ -30,6 +44,10 @@ export default function buildConfigChain(opts: Object = {}) {
 }
 
 class ConfigChainBuilder {
+  filename: string|null;
+  configs: Array<ConfigItem>;
+  possibleDirs: null|Array<string>;
+
   constructor(filename) {
     this.configs = [];
     this.filename = filename;
@@ -40,59 +58,68 @@ class ConfigChainBuilder {
    * Tests if a filename should be ignored based on "ignore" and "only" options.
    */
   shouldIgnore(
-    ignore: Array<string | RegExp | Function>,
-    only?: Array<string | RegExp | Function>,
+    ignore: mixed,
+    only: mixed,
     dirname: string,
   ): boolean {
     if (!this.filename) return false;
 
-    if (ignore && !Array.isArray(ignore)) {
-      throw new Error(`.ignore should be an array, ${JSON.stringify(ignore)} given`);
+    if (ignore) {
+      if (!Array.isArray(ignore)) {
+        throw new Error(`.ignore should be an array, ${JSON.stringify(ignore)} given`);
+      }
+
+      if (this.matchesPatterns(ignore, dirname)) return true;
     }
 
-    if (only && !Array.isArray(only)) {
-      throw new Error(`.only should be an array, ${JSON.stringify(only)} given`);
+    if (only) {
+      if (!Array.isArray(only)) {
+        throw new Error(`.only should be an array, ${JSON.stringify(only)} given`);
+      }
+
+      if (!this.matchesPatterns(only, dirname)) return true;
     }
 
-    return (ignore && this.matchesPatterns(ignore, dirname)) ||
-      (only && !this.matchesPatterns(only, dirname));
+    return false;
   }
 
   /**
    * Returns result of calling function with filename if pattern is a function.
    * Otherwise returns result of matching pattern Regex with filename.
    */
-  matchesPatterns(patterns: Array<string | Function | RegExp>, dirname: string) {
+  matchesPatterns(patterns: Array<mixed>, dirname: string) {
+    const filename = this.filename;
+    if (!filename) throw new Error("Assertion failure: .filename should always exist here");
+
     const res = [];
     const strings = [];
     const fns = [];
 
     patterns.forEach((pattern) => {
-      const type = typeof pattern;
-      if (type === "string") strings.push(pattern);
-      else if (type === "function") fns.push(pattern);
-      else res.push(pattern);
+      if (typeof pattern === "string") strings.push(pattern);
+      else if (typeof pattern === "function") fns.push(pattern);
+      else if (pattern instanceof RegExp) res.push(pattern);
+      else throw new Error("Patterns must be a string, function, or regular expression");
     });
 
-    if (res.some((re) => re.test(this.filename))) return true;
-    if (fns.some((fn) => fn(this.filename))) return true;
+    if (res.some((re) => re.test(filename))) return true;
+    if (fns.some((fn) => fn(filename))) return true;
 
     if (strings.length > 0) {
+      let possibleDirs = this.possibleDirs;
       // Lazy-init so we don't initialize this for files that have no glob patterns.
-      if (!this.possibleDirs) {
-        this.possibleDirs = [];
+      if (!possibleDirs) {
+        possibleDirs = this.possibleDirs = [];
 
-        if (this.filename) {
-          this.possibleDirs.push(this.filename);
+        possibleDirs.push(filename);
 
-          let current = this.filename;
-          while (true) {
-            const previous = current;
-            current = path.dirname(current);
-            if (previous === current) break;
+        let current = filename;
+        while (true) {
+          const previous = current;
+          current = path.dirname(current);
+          if (previous === current) break;
 
-            this.possibleDirs.push(current);
-          }
+          possibleDirs.push(current);
         }
       }
 
@@ -104,7 +131,7 @@ class ConfigChainBuilder {
         return (negate ? "!" : "") + path.resolve(dirname, pattern);
       });
 
-      if (micromatch(this.possibleDirs, absolutePatterns, { nocase: true }).length > 0) {
+      if (micromatch(possibleDirs, absolutePatterns, { nocase: true }).length > 0) {
         return true;
       }
     }
@@ -113,12 +140,6 @@ class ConfigChainBuilder {
   }
 
   findConfigs(loc: string) {
-    if (!loc) return;
-
-    if (!path.isAbsolute(loc)) {
-      loc = path.join(process.cwd(), loc);
-    }
-
     findConfigs(path.dirname(loc)).forEach(({ filepath, dirname, options }) => {
       this.mergeConfig({
         type: "options",
@@ -131,31 +152,34 @@ class ConfigChainBuilder {
 
   mergeConfig({
     type,
-    options,
+    options: rawOpts,
     alias,
-    loc,
     dirname,
   }) {
-    if (!options) {
-      return false;
-    }
-
     // Bail out ASAP if this file is ignored so that we run as little logic as possible on ignored files.
-    if (this.filename && this.shouldIgnore(options.ignore, options.only, dirname)) {
+    if (this.filename && this.shouldIgnore(rawOpts.ignore || null, rawOpts.only || null, dirname)) {
       // TODO(logan): This is a really cross way to bail out. Avoid this in rewrite.
-      throw Object.assign(new Error("This file has been ignored."), { code: "BABEL_IGNORED_FILE" });
+      throw Object.assign((new Error("This file has been ignored."): any), { code: "BABEL_IGNORED_FILE" });
     }
 
-    options = Object.assign({}, options);
-
-    loc = loc || alias;
+    const options = Object.assign({}, rawOpts);
+    delete options.env;
+    delete options.extends;
 
     // env
-    const envKey = babel.getEnv();
-    if (options.env) {
-      const envOpts = options.env[envKey];
-      delete options.env;
+    const envKey = getEnv();
 
+    if (rawOpts.env != null && (typeof rawOpts.env !== "object" || Array.isArray(rawOpts.env))) {
+      throw new Error(".env block must be an object, null, or undefined");
+    }
+
+    const envOpts = rawOpts.env && rawOpts.env[envKey];
+
+    if (envOpts != null && (typeof envOpts !== "object" || Array.isArray(envOpts))) {
+      throw new Error(".env[...] block must be an object, null, or undefined");
+    }
+
+    if (envOpts) {
       this.mergeConfig({
         type,
         options: envOpts,
@@ -168,13 +192,15 @@ class ConfigChainBuilder {
       type,
       options,
       alias,
-      loc,
+      loc: alias,
       dirname,
     });
 
     // add extends clause
-    if (options.extends) {
-      const extendsConfig = loadConfig(options.extends, dirname);
+    if (rawOpts.extends) {
+      if (typeof rawOpts.extends !== "string") throw new Error(".extends must be a string");
+
+      const extendsConfig = loadConfig(rawOpts.extends, dirname);
 
       const existingConfig = this.configs.some((config) => {
         return config.alias === extendsConfig.filepath;
@@ -187,7 +213,6 @@ class ConfigChainBuilder {
           dirname: extendsConfig.dirname,
         });
       }
-      delete options.extends;
     }
   }
 }

--- a/packages/babel-core/src/config/caching.js
+++ b/packages/babel-core/src/config/caching.js
@@ -31,7 +31,7 @@ export function makeStrongCache<ArgT, ResultT>(
  * configures its caching behavior. Cached values are stored weakly and the function argument must be
  * an object type.
  */
-export function makeWeakCache<ArgT: Object, ResultT>(
+export function makeWeakCache<ArgT: {}, ResultT>(
   handler: (ArgT, CacheConfigurator) => ResultT,
   autoPermacache?: boolean,
 ): (ArgT) => ResultT {

--- a/packages/babel-core/src/config/helpers/environment.js
+++ b/packages/babel-core/src/config/helpers/environment.js
@@ -1,5 +1,6 @@
-export function getEnv(defaultValue = "development") {
+// @flow
 
+export function getEnv(defaultValue: string = "development"): string {
   return process.env.BABEL_ENV
     || process.env.NODE_ENV
     || defaultValue;

--- a/packages/babel-core/src/config/helpers/merge.js
+++ b/packages/babel-core/src/config/helpers/merge.js
@@ -1,9 +1,11 @@
+// @flow
+
 import mergeWith from "lodash/mergeWith";
 
-export default function (dest?: Object, src?: Object): ?Object {
+export default function<T: {}>(dest?: T, src?: T) {
   if (!dest || !src) return;
 
-  return mergeWith(dest, src, function (a, b) {
+  mergeWith(dest, src, function (a, b) {
     if (b && Array.isArray(a)) {
       const newArray = b.slice(0);
 

--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -1,14 +1,20 @@
+// @flow
+
 import type Plugin from "./plugin";
 import manageOptions from "./option-manager";
 
 export type ResolvedConfig = {
   options: Object,
-  passes: Array<Array<Plugin>>,
+  passes: Array<Array<[ Plugin, ?{} ]>>,
 };
 
 /**
  * Standard API for loading Babel configuration data. Not for public consumption.
  */
-export default function loadConfig(opts: Object): ResolvedConfig|null {
-  return manageOptions(opts);
+export default function loadConfig(opts: mixed): ResolvedConfig|null {
+  if (opts != null && typeof opts !== "object") {
+    throw new Error("Babel options must be an object, null, or undefined");
+  }
+
+  return manageOptions(opts || {});
 }

--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -10,7 +10,7 @@ import { makeStrongCache } from "../../caching";
 type ConfigFile = {
   filepath: string,
   dirname: string,
-  options: Object,
+  options: {},
 };
 
 const BABELRC_FILENAME = ".babelrc";

--- a/packages/babel-core/src/config/loading/files/index-browser.js
+++ b/packages/babel-core/src/config/loading/files/index-browser.js
@@ -3,7 +3,7 @@
 type ConfigFile = {
   filepath: string,
   dirname: string,
-  options: Object,
+  options: {},
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/packages/babel-core/src/config/plugin.js
+++ b/packages/babel-core/src/config/plugin.js
@@ -1,5 +1,23 @@
+// @flow
+
 export default class Plugin {
-  constructor(plugin: Object, key?: string) {
+  constructor(plugin: {}, key?: string) {
+    if (plugin.name != null && typeof plugin.name !== "string") {
+      throw new Error("Plugin .name must be a string, null, or undefined");
+    }
+    if (plugin.manipulateOptions != null && typeof plugin.manipulateOptions !== "function") {
+      throw new Error("Plugin .manipulateOptions must be a function, null, or undefined");
+    }
+    if (plugin.post != null && typeof plugin.post !== "function") {
+      throw new Error("Plugin .post must be a function, null, or undefined");
+    }
+    if (plugin.pre != null && typeof plugin.pre !== "function") {
+      throw new Error("Plugin .pre must be a function, null, or undefined");
+    }
+    if (plugin.visitor != null && typeof plugin.visitor !== "object") {
+      throw new Error("Plugin .visitor must be an object, null, or undefined");
+    }
+
     this.key = plugin.name || key;
 
     this.manipulateOptions = plugin.manipulateOptions;
@@ -12,5 +30,5 @@ export default class Plugin {
   manipulateOptions: ?Function;
   post: ?Function;
   pre: ?Function;
-  visitor: Object;
+  visitor: ?{};
 }

--- a/packages/babel-core/src/config/removed.js
+++ b/packages/babel-core/src/config/removed.js
@@ -1,3 +1,4 @@
+// @flow
 /* eslint max-len: "off" */
 
 export default {

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/honor-custom-jsx-comment-if-jsx-pragma-option-set/options.json
@@ -1,3 +1,5 @@
 {
-  "plugins": [["transform-react-jsx", "foo.bar"]]
+  "plugins": [
+    ["transform-react-jsx", {"pragma": "foo.bar"}]
+  ]
 }


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

Just adding a bunch of Flowtype annotations to the config folder files. With this, everything in `babel-core/src/config` has an `@flow` declaration.

There are still a few places typed generic `Object`, but this gets rid of most of them except for the actual result `options` object, which has not changed and is only partially validated.