### PR TITLE
Add additional tests for ignore/only

### DIFF
--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -32,9 +32,7 @@ describe("buildConfigChain", function() {
     process.env.NODE_ENV = oldNodeEnv;
   });
 
-  describe("ignore/only", () => {
-    // TODO: More tests for ignore and only
-
+  describe("ignore", () => {
     it("should ignore files that match", () => {
       const chain = buildConfigChain({
         filename: fixture("nonexistant-fake", "src.js"),
@@ -47,6 +45,94 @@ describe("buildConfigChain", function() {
           fixture("nonexistant-fake", "other.js"),
           fixture("nonexistant-fake", "misc.js"),
         ],
+      });
+
+      assert.equal(chain, null);
+    });
+
+    it("should not ignore files that don't match", () => {
+      const chain = buildConfigChain({
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        ignore: [
+          fixture("nonexistant-fake", "other.js"),
+          fixture("nonexistant-fake", "misc.js"),
+        ],
+      });
+
+      const expected = [
+        {
+          type: "arguments",
+          options: {
+            filename: fixture("nonexistant-fake", "src.js"),
+            babelrc: false,
+            ignore: [
+              fixture("nonexistant-fake", "other.js"),
+              fixture("nonexistant-fake", "misc.js"),
+            ],
+          },
+          alias: "base",
+          loc: "base",
+          dirname: base(),
+        },
+      ];
+
+      assert.deepEqual(chain, expected);
+    });
+  });
+
+  describe("only", () => {
+    it("should ignore files that don't match", () => {
+      const chain = buildConfigChain({
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        only: [
+          fixture("nonexistant-fake", "other.js"),
+          fixture("nonexistant-fake", "misc.js"),
+        ],
+      });
+
+      assert.equal(chain, null);
+    });
+
+    it("should not ignore files that match", () => {
+      const chain = buildConfigChain({
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        only: [
+          fixture("nonexistant-fake", "src.js"),
+          fixture("nonexistant-fake", "misc.js"),
+        ],
+      });
+
+      const expected = [
+        {
+          type: "arguments",
+          options: {
+            filename: fixture("nonexistant-fake", "src.js"),
+            babelrc: false,
+            only: [
+              fixture("nonexistant-fake", "src.js"),
+              fixture("nonexistant-fake", "misc.js"),
+            ],
+          },
+          alias: "base",
+          loc: "base",
+          dirname: base(),
+        },
+      ];
+
+      assert.deepEqual(chain, expected);
+    });
+  });
+
+  describe("ignore/only", () => {
+    it("should ignore files that match ignore and don't match only", () => {
+      const chain = buildConfigChain({
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        ignore: [fixture("nonexistant-fake", "src.js")],
+        only: [fixture("nonexistant-fake", "src.js")],
       });
 
       assert.equal(chain, null);


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | Y
| Fixed Tickets            | Fixes #5645
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

Adds additional tests for ignore/only behavior. Tests that both ignore and only are used when both are present per https://github.com/babel/babel/commit/b6194a8533ae0070fb1744d5a69575416ca0a598
