### PR TITLE
Fix object destructuring in param arrays

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -50,6 +50,14 @@ export default function ({ types: t }) {
       return;
     }
 
+    if (paramPath.isArrayPattern() && hasRestElement(paramPath)) {
+      const elements = paramPath.get("elements");
+
+      for (let i = 0; i < elements.length; i++) {
+        replaceRestElement(parentPath, elements[i], i, elements.length);
+      }
+    }
+
     if (paramPath.isObjectPattern() && hasRestElement(paramPath)) {
       const uid = parentPath.scope.generateUidIdentifier("ref");
 

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/actual.js
@@ -5,6 +5,9 @@ function a4({a3, ...c3}, {a5, ...c5}) {}
 function a5({a3, b2: { ba1, ...ba2 }, ...c3}) {}
 function a6({a3, b2: { ba1, ...ba2 } }) {}
 function a7({a1 = 1, ...b1} = {}) {}
+function a8([{...a1}]) {}
+function a9([{a1, ...a2}]) {}
+function a10([a1, {...a2}]) {}
 // Unchanged
 function b(a) {}
 function b2(a, ...b) {}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters/expected.js
@@ -28,6 +28,16 @@ function a7(_ref8 = {}) {
   let { a1 = 1 } = _ref8,
       b1 = babelHelpers.objectWithoutProperties(_ref8, ["a1"]);
 }
+function a8([_ref9]) {
+  let a1 = babelHelpers.objectWithoutProperties(_ref9, []);
+}
+function a9([_ref10]) {
+  let { a1 } = _ref10,
+      a2 = babelHelpers.objectWithoutProperties(_ref10, ["a1"]);
+}
+function a10([a1, _ref11]) {
+  let a2 = babelHelpers.objectWithoutProperties(_ref11, []);
+}
 // Unchanged
 function b(a) {}
 function b2(a, ...b) {}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5648 <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Added handling to the `object-rest-spread` for Array params.