### PR TITLE
[Doc PR] naming fix in example

### DIFF
--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -66,7 +66,7 @@ Given, an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const string = "if (true) return;";
-const parsedAst = babel.parse(string, { allowReturnOutsideFunction: true });
+const parsedAst = babylon.parse(string, { allowReturnOutsideFunction: true });
 const { code, map, ast } = babel.transformFromAst(parsedAst, string, options);
 ```
 

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -65,9 +65,9 @@ babel.transformFileSync("filename.js", options).code;
 Given, an [AST](https://astexplorer.net/), transform it.
 
 ```js
-const code = "if (true) return;";
-const ast = babylon.parse(code, { allowReturnOutsideFunction: true });
-const { code, map, ast } = babel.transformFromAst(ast, code, options);
+const string = "if (true) return;";
+const ast = babylon.parse(string, { allowReturnOutsideFunction: true });
+const { code, map, ast } = babel.transformFromAst(ast, string, options);
 ```
 
 ## Options

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -66,8 +66,8 @@ Given, an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const string = "if (true) return;";
-const ast = babylon.parse(string, { allowReturnOutsideFunction: true });
-const { code, map, ast } = babel.transformFromAst(ast, string, options);
+const parsedAst = babel.parse(string, { allowReturnOutsideFunction: true });
+const { code, map, ast } = babel.transformFromAst(parsedAst, string, options);
 ```
 
 ## Options

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -65,9 +65,9 @@ babel.transformFileSync("filename.js", options).code;
 Given, an [AST](https://astexplorer.net/), transform it.
 
 ```js
-const string = "if (true) return;";
-const parsedAst = babylon.parse(string, { allowReturnOutsideFunction: true });
-const { code, map, ast } = babel.transformFromAst(parsedAst, string, options);
+const sourceCode = "if (true) return;";
+const generatedCode = babylon.parse(sourceCode, { allowReturnOutsideFunction: true });
+const { code, map, ast } = babel.transformFromAst(generatedCode, sourceCode, options);
 ```
 
 ## Options

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -66,8 +66,8 @@ Given, an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const generatedCode = babylon.parse(sourceCode, { allowReturnOutsideFunction: true });
-const { code, map, ast } = babel.transformFromAst(generatedCode, sourceCode, options);
+const parsedAst = babylon.parse(sourceCode, { allowReturnOutsideFunction: true });
+const { code, map, ast } = babel.transformFromAst(parsedAst, sourceCode, options);
 ```
 
 ## Options


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Doc PR                   | x <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->

because code is declared as const twice 
