### PR TITLE
Find cache dir

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "babel-core": "7.0.0-alpha.9",
     "core-js": "^2.4.0",
+    "find-cache-dir": "^0.1.1",
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -3,8 +3,10 @@ import fs from "fs";
 import { sync as mkdirpSync } from "mkdirp";
 import homeOrTmp from "home-or-tmp";
 import * as babel from "babel-core";
+import findCacheDir from "find-cache-dir";
 
-const DEFAULT_FILENAME = path.join(homeOrTmp, `.babel.${babel.version}.${babel.getEnv()}.json`);
+const DEFAULT_CACHE_DIR = findCacheDir({ name: "babel-register" }) || homeOrTmp;
+const DEFAULT_FILENAME = path.join(DEFAULT_CACHE_DIR, `.babel.${babel.version}.${babel.getEnv()}.json`);
 const FILENAME: string = process.env.BABEL_CACHE_PATH || DEFAULT_FILENAME;
 let data: Object = {};
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Fixed Tickets            | Fixes #5198 
| License                  | MIT
| Dependency Changes       |  [find-cache-dir](https://www.npmjs.com/package/find-cache-dir)

Make the preferred cache location for babel-register `./node_modules/.cache/babel-register` to match the convention used by babel-loader, ava, etc