### PR TITLE
Fix multi-character operator processing in object super.

### DIFF
--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -227,7 +227,7 @@ export default class ReplaceSupers {
           t.variableDeclarator(ref, node.left),
         ]),
         t.expressionStatement(t.assignmentExpression("=", node.left,
-          t.binaryExpression(node.operator[0], ref, node.right))),
+          t.binaryExpression(node.operator.slice(0, -1), ref, node.right))),
       ];
     }
   }
@@ -263,7 +263,7 @@ export default class ReplaceSupers {
       property = node.property;
       computed = node.computed;
     } else if (t.isUpdateExpression(node) && isMemberExpressionSuper(node.argument)) {
-      const binary = t.binaryExpression(node.operator[0], node.argument, t.numericLiteral(1));
+      const binary = t.assignmentExpression(node.operator[0] + "=", node.argument, t.numericLiteral(1));
       if (node.prefix) {
         // ++super.foo;
         // to

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/actual.js
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/actual.js
@@ -1,0 +1,5 @@
+foo = {
+  bar() {
+    return super.baz **= 12;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/expected.js
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/expected.js
@@ -1,0 +1,13 @@
+var _obj;
+
+var _set = function set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; };
+
+var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+foo = _obj = {
+  bar: function () {
+    var _ref;
+
+    return _ref = _get(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", this), _set(_obj.__proto__ || Object.getPrototypeOf(_obj), "baz", _ref ** 12, this);
+  }
+};

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/options.json
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-object-super"]
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            |  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

This fix was originally included in https://github.com/babel/babel/pull/5635 but I don't think that will land, so I'm pulling it out into this PR.

Thanks for the fix @aickin, I preserved your commit info so it still shows as authored by you.