### PR TITLE
Flow comments import export

### DIFF
--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -54,7 +54,7 @@ export default function ({ types: t }) {
       // support `export type a = {}` - #8 Error: You passed path.replaceWith() a falsy node
       "ExportNamedDeclaration|Flow"(path) {
         const { node, parent } = path;
-        if (t.isExportNamedDeclaration(node) && !t.isFlow(node.declaration)) {
+        if (t.isExportNamedDeclaration(node) && node.exportKind !== "type" && !t.isFlow(node.declaration)) {
           return;
         }
         wrapInFlowComment(path, parent);

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/actual.js
@@ -1,0 +1,4 @@
+import lib from 'library';
+export { foo } from 'foo';
+export type { B, C } from './types';
+

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/expected.js
@@ -1,0 +1,4 @@
+import lib from 'library';
+export { foo } from 'foo';
+/*:: export type { B, C } from './types';*/
+


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      |  no
| Deprecations?            | no
| Spec Compliancy?         | yes?
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5538
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

While trying to get flow types working in `relay-runtime` I ran into this issue where `babel-plugin-transform-flow-comments` is not re-exporting types (export ... from ...).

Includes separate commit /w failing test if this fix is somehow not appropriate.
