### PR TITLE
Add displayName to more types of React components.

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
@@ -34,4 +34,5 @@ var RandomComponent = function (_Component) {
   return RandomComponent;
 }(_react.Component);
 
+RandomComponent.displayName = 'RandomComponent';
 exports.default = RandomComponent;

--- a/packages/babel-plugin-transform-react-display-name/README.md
+++ b/packages/babel-plugin-transform-react-display-name/README.md
@@ -1,9 +1,11 @@
 # babel-plugin-transform-react-display-name
 
-> Add displayName to React.createClass calls
+> Add displayName to React.createClass calls, ES6-classes style components and stateless components that return JSX.
+
 
 ## Example
 
+### React.createClass calls
 **In**
 
 ```js
@@ -16,6 +18,41 @@ var foo = React.createClass({});
 var foo = React.createClass({
   displayName: "foo"
 });
+```
+### Stateless components
+**In**
+
+```js
+var foo = () => <div></div>;
+```
+
+**Out**
+
+```js
+var foo = () => <div></div>;
+foo.displayName = 'foo';
+```
+
+### ES6-classes style components
+**In**
+
+```js
+class Foo extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+```
+
+**Out**
+
+```js
+class Foo extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+Foo.displayName = 'Foo';
 ```
 
 ## Installation

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -1,28 +1,55 @@
-import path from "path";
+import { default as pathMod } from "path";
 
-export default function ({ types: t }) {
-  function addDisplayName(id, call) {
+export default function ({ types }) {
+  function setDisplayNameAfter(path, nameNodeId, displayName) {
+    if (!displayName) {
+      displayName = nameNodeId.name;
+    }
+
+    let blockLevelStmnt;
+    path.find(function (path) {
+      if (path.parentPath.isBlock()) {
+        blockLevelStmnt = path;
+        return true;
+      }
+    });
+
+    if (blockLevelStmnt) {
+      // Put our `displayName` on the right side of trailing comments
+      delete blockLevelStmnt.node.trailingComments;
+
+      const setDisplayNameStmn = types.expressionStatement(types.assignmentExpression(
+        "=",
+        types.memberExpression(nameNodeId, types.identifier("displayName")),
+        types.stringLiteral(displayName)
+      ));
+
+      blockLevelStmnt.insertAfter(setDisplayNameStmn);
+    }
+  }
+
+  function addDisplayNameProperty(id, call) {
     const props = call.arguments[0].properties;
     let safe = true;
 
     for (let i = 0; i < props.length; i++) {
       const prop = props[i];
-      const key = t.toComputedKey(prop);
-      if (t.isLiteral(key, { value: "displayName" })) {
+      const key = types.toComputedKey(prop);
+      if (types.isLiteral(key, { value: "displayName" })) {
         safe = false;
         break;
       }
     }
 
     if (safe) {
-      props.unshift(t.objectProperty(t.identifier("displayName"), t.stringLiteral(id)));
+      props.unshift(types.objectProperty(types.identifier("displayName"), types.stringLiteral(id)));
     }
   }
 
-  const isCreateClassCallExpression = t.buildMatchMemberExpression("React.createClass");
+  const isCreateClassCallExpression = types.buildMatchMemberExpression("React.createClass");
 
   function isCreateClass(node) {
-    if (!node || !t.isCallExpression(node)) return false;
+    if (!node || !types.isCallExpression(node)) return false;
 
     // not React.createClass call member object
     if (!isCreateClassCallExpression(node.callee)) return false;
@@ -33,7 +60,7 @@ export default function ({ types: t }) {
 
     // first node arg is not an object
     const first = args[0];
-    if (!t.isObjectExpression(first)) return false;
+    if (!types.isObjectExpression(first)) return false;
 
     return true;
   }
@@ -42,53 +69,161 @@ export default function ({ types: t }) {
     visitor: {
       ExportDefaultDeclaration({ node }, state) {
         if (isCreateClass(node.declaration)) {
-          let displayName = path.basename(state.file.opts.filename, path.extname(state.file.opts.filename));
+          const extname = pathMod.extname(state.file.opts.filename);
+          let displayName = pathMod.basename(state.file.opts.filename, extname);
 
           // ./{module name}/index.js
           if (displayName === "index") {
-            displayName = path.basename(path.dirname(state.file.opts.filename));
+            displayName = pathMod.basename(pathMod.dirname(state.file.opts.filename));
           }
 
-          addDisplayName(displayName, node.declaration);
+          addDisplayNameProperty(displayName, node.declaration);
         }
       },
-
       CallExpression(path) {
         const { node } = path;
         if (!isCreateClass(node)) return;
 
-        let id;
-
-        // crawl up the ancestry looking for possible candidates for displayName inference
-        path.find(function (path) {
-          if (path.isAssignmentExpression()) {
-            id = path.node.left;
-          } else if (path.isObjectProperty()) {
-            id = path.node.key;
-          } else if (path.isVariableDeclarator()) {
-            id = path.node.id;
-          } else if (path.isStatement()) {
-            // we've hit a statement, we should stop crawling up
-            return true;
-          }
-
-          // we've got an id! no need to continue
-          if (id) return true;
-        });
+        let id = findCandidateNameForExpression(path, true);
 
         // ensure that we have an identifier we can inherit from
         if (!id) return;
 
         // foo.bar -> bar
-        if (t.isMemberExpression(id)) {
+        if (types.isMemberExpression(id)) {
           id = id.property;
         }
 
         // identifiers are the only thing we can reliably get a name from
-        if (t.isIdentifier(id)) {
-          addDisplayName(id.name, node);
+        if (types.isIdentifier(id)) {
+          addDisplayNameProperty(id.name, node);
+        }
+      },
+      ClassDeclaration: function (path) {
+        if (classHasRenderMethod(path)) {
+          setDisplayNameAfter(path, path.node.id);
+        }
+      },
+      FunctionDeclaration: function (path, state) {
+        if (doesReturnJSX(path.node.body)) {
+          let displayName;
+          if (path.parentPath.node.type === "ExportDefaultDeclaration") {
+            if (path.node.id == null) {
+              // An anonymous function declaration in export default declaration.
+              // Transform `export default function () { ... }`
+              // to `var _uid1 = function () { .. }; export default __uid;`
+              // then add displayName to _uid1
+              const extension = pathMod.extname(state.file.opts.filename);
+              const name = pathMod.basename(state.file.opts.filename, extension);
+
+              const id = path.scope.generateUidIdentifier("uid");
+              path.node.id = id;
+              displayName = name;
+            }
+            setDisplayNameAfter(path, path.node.id, displayName);
+          } else if (path.parentPath.node.type === "Program"
+                     || path.parentPath.node.type == "ExportNamedDeclaration") {
+            setDisplayNameAfter(path, path.node.id, displayName);
+          }
+        }
+      },
+      FunctionExpression: function (path) {
+        if (shouldSetDisplayNameForFuncExpr(path)) {
+          const id = findCandidateNameForExpression(path);
+          if (id) {
+            setDisplayNameAfter(path, id);
+          }
+        }
+      },
+      ArrowFunctionExpression: function (path) {
+        if (shouldSetDisplayNameForFuncExpr(path)) {
+          const id = findCandidateNameForExpression(path);
+          if (id) {
+            setDisplayNameAfter(path, id);
+          }
         }
       },
     },
   };
 }
+
+function shouldSetDisplayNameForFuncExpr(path) {
+  // Parent must be either 'AssignmentExpression' or
+  // 'VariableDeclarator' or 'CallExpression' with a parent of 'VariableDeclarator'
+  if (path.parentPath.node.type === "AssignmentExpression" &&
+      path.parentPath.node.left.type !== "MemberExpression" && // skip static members
+      path.parentPath.parentPath.node.type == "ExpressionStatement" &&
+      path.parentPath.parentPath.parentPath.node.type == "Program") {
+    return doesReturnJSX(path.node.body);
+  } else {
+    // if parent is a call expression, we have something like (function () { .. })()
+    // move up, past the call expression and run the rest of the checks as usual
+    if (path.parentPath.node.type === "CallExpression") {
+      path = path.parentPath;
+    }
+
+    if (path.parentPath.node.type === "VariableDeclarator") {
+      if (path.parentPath.parentPath.parentPath.node.type === "ExportNamedDeclaration" ||
+          path.parentPath.parentPath.parentPath.node.type === "Program") {
+        return doesReturnJSX(path.node.body);
+      }
+    }
+  }
+
+  return false;
+}
+
+function classHasRenderMethod(node) {
+  if (!node.node.body) {
+    return false;
+  }
+  const members = node.node.body.body;
+  for (let i = 0; i < members.length; i++) {
+    if (members[i].type == "ClassMethod" && members[i].key.name == "render") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// crawl up the ancestry looking for possible candidates for displayName inference
+// optionally look for object properties
+function findCandidateNameForExpression(path, inclObjProp) {
+  let id;
+  path.find(function (path) {
+    if (path.isAssignmentExpression()) {
+      id = path.node.left;
+    } else if (inclObjProp && path.isObjectProperty()) {
+      id = path.node.key;
+    } else if (path.isVariableDeclarator()) {
+      id = path.node.id;
+    } else if (path.isStatement()) {
+      // we've hit a statement, we should stop crawling up
+      return true;
+    }
+
+    // we've got an id! no need to continue
+    if (id) return true;
+  });
+  return id;
+}
+
+function doesReturnJSX (body) {
+  if (!body) return false;
+  if (body.type === "JSXElement") {
+    return true;
+  }
+
+  const block = body.body;
+  if (block && block.length) {
+    const lastBlock = block.slice(0).pop();
+
+    if (lastBlock.type === "ReturnStatement") {
+      return lastBlock.argument.type === "JSXElement";
+    }
+  }
+
+  return false;
+}
+

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/arrowFun/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/arrowFun/actual.js
@@ -1,0 +1,6 @@
+// Stateless componenet with an arrow function
+var Component2 = ({value}) => {
+  return (
+    <div>{value}</div>
+  )
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/arrowFun/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/arrowFun/expected.js
@@ -1,0 +1,5 @@
+// Stateless componenet with an arrow function
+var Component2 = ({ value }) => {
+  return <div>{value}</div>;
+};
+Component2.displayName = "Component2";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/classComponents/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/classComponents/actual.js
@@ -1,0 +1,26 @@
+export class Component3a extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+
+export default class Component3b extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+
+export class Component3c extends Component {
+  render() {
+    return <div></div>;
+  }
+}
+
+class Component3d extends Component {
+  static get = () => {
+    return <div />;
+  }
+  render() {
+    return <div />;
+  }
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/classComponents/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/classComponents/expected.js
@@ -1,0 +1,30 @@
+export class Component3a extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+
+Component3a.displayName = "Component3a";
+export default class Component3b extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+
+Component3b.displayName = "Component3b";
+export class Component3c extends Component {
+  render() {
+    return <div></div>;
+  }
+}
+
+Component3c.displayName = "Component3c";
+class Component3d extends Component {
+  static get = () => {
+    return <div />;
+  };
+  render() {
+    return <div />;
+  }
+}
+Component3d.displayName = "Component3d";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/createClass/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/createClass/actual.js
@@ -1,0 +1,6 @@
+// Babel already sets displayName for this one
+export var Component0 = React.createClass({
+  render: function() {
+    <div></div>
+  }
+})

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/createClass/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/createClass/expected.js
@@ -1,0 +1,8 @@
+// Babel already sets displayName for this one
+export var Component0 = React.createClass({
+  displayName: "Component0",
+
+  render: function () {
+    <div></div>;
+  }
+});

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/decorators/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/decorators/actual.js
@@ -1,0 +1,6 @@
+@connect(Component)
+export default class DecoratedComponent extends React.Component {
+  render() {
+    return <div></div>
+  }
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/decorators/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/decorators/expected.js
@@ -1,0 +1,7 @@
+export default @connect(Component)
+class DecoratedComponent extends React.Component {
+  render() {
+    return <div></div>;
+  }
+}
+DecoratedComponent.displayName = "DecoratedComponent";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/exportDefaultAnon/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/exportDefaultAnon/actual.js
@@ -1,0 +1,4 @@
+// Exported default stateless component used in variable declaration
+export default function ({value}) {
+  return <div>{value}</div>
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/exportDefaultAnon/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/exportDefaultAnon/expected.js
@@ -1,0 +1,5 @@
+// Exported default stateless component used in variable declaration
+export default function _uid({ value }) {
+  return <div>{value}</div>;
+}
+_uid.displayName = "actual";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/functionExpr/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/functionExpr/actual.js
@@ -1,0 +1,30 @@
+// Exported stateless componenet
+export function Component1a(value) {
+  return <div>{value}</div>
+}
+
+// Stateless componenet
+function Component1b(value) {
+  return <div>{value}</div>
+}
+
+// Stateless componenet used in a variable declaration
+var Component1c = function (value) {
+  return <div>{value}</div>
+}
+
+// Exported named stateless component used in variable declaration
+export var Component1d = function (value) {
+  return <div>{value}</div>
+}
+
+// Stateless componenet used in an assignment
+var Component1e;
+Component1e = function (value) {
+  return <div>{value}</div>
+}
+
+// Exported default stateless *named* component used in variable declaration
+export default function Component1f (value) {
+  return <div>{value}</div>
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/functionExpr/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/functionExpr/expected.js
@@ -1,0 +1,36 @@
+// Exported stateless componenet
+export function Component1a(value) {
+  return <div>{value}</div>;
+}
+
+Component1a.displayName = "Component1a";
+// Stateless componenet
+function Component1b(value) {
+  return <div>{value}</div>;
+}
+
+Component1b.displayName = "Component1b";
+// Stateless componenet used in a variable declaration
+var Component1c = function (value) {
+  return <div>{value}</div>;
+};
+
+Component1c.displayName = "Component1c";
+// Exported named stateless component used in variable declaration
+export var Component1d = function (value) {
+  return <div>{value}</div>;
+};
+
+Component1d.displayName = "Component1d";
+// Stateless componenet used in an assignment
+var Component1e;
+Component1e = function (value) {
+  return <div>{value}</div>;
+};
+
+Component1e.displayName = "Component1e";
+// Exported default stateless *named* component used in variable declaration
+export default function Component1f(value) {
+  return <div>{value}</div>;
+}
+Component1f.displayName = "Component1f";

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/options.json
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["transform-react-display-name"]
+  "plugins": ["syntax-class-properties", "syntax-decorators", "syntax-jsx", "syntax-export-extensions", "transform-react-display-name"]
 }

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/passThrough/actual.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/passThrough/actual.js
@@ -1,0 +1,57 @@
+// ---------------------
+// Should pass through unaltered
+// ---------------------
+var f1 = function({value}) {
+  return "somestring"
+}
+
+function f2({value}) {
+  return "somestring"
+}
+
+class f3 {
+  method1() {
+    return "whatever"
+  }
+}
+
+var f4 = (
+  <div>
+    {(() => <span></span>)()}
+  </div>
+)
+
+// Component which don't sit directly on the `Program` node get left alone
+{
+  var Component5c = function () {
+    function Component5c () {}
+    return Component5c
+  }()
+}
+
+// ---------------------
+// Not supported
+// ---------------------
+
+// High-order things will be hard to catch
+var jsxChunk = <div>{value}</div>
+function UnsupportedComponent1({value}) {
+  return function() {
+    return jsxChunk
+  }
+}
+
+var a = {
+  smoke: function() {},
+  Component1d: function ({value}) {
+    return <div>{value}</div>
+  }
+}
+
+var external = function() {
+  var internal = function() {
+    return <div />
+  }
+  return internal
+}
+

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/passThrough/expected.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/passThrough/expected.js
@@ -1,0 +1,54 @@
+// ---------------------
+// Should pass through unaltered
+// ---------------------
+var f1 = function ({ value }) {
+  return "somestring";
+};
+
+function f2({ value }) {
+  return "somestring";
+}
+
+class f3 {
+  method1() {
+    return "whatever";
+  }
+}
+
+var f4 = <div>
+    {(() => <span></span>)()}
+  </div>;
+
+// Component which don't sit directly on the `Program` node get left alone
+{
+  var Component5c = function () {
+    function Component5c() {}
+    return Component5c;
+  }();
+}
+
+// ---------------------
+// Not supported
+// ---------------------
+
+// High-order things will be hard to catch
+var jsxChunk = <div>{value}</div>;
+function UnsupportedComponent1({ value }) {
+  return function () {
+    return jsxChunk;
+  };
+}
+
+var a = {
+  smoke: function () {},
+  Component1d: function ({ value }) {
+    return <div>{value}</div>;
+  }
+};
+
+var external = function () {
+  var internal = function () {
+    return <div />;
+  };
+  return internal;
+};


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
This adds support for the two other kinds of React component definitions not previously covered by the existing displayName plugin:

- ES6-classes style components
- Stateless components that return JSX

See https://github.com/babel/babel/issues/4663 for a brief discussion.

### Heuristics
ES6 classes are considered to be React components if they have a `render` method. Functions are considered components if they return JSX on the last line. 

In our testing, these are quite accurate heuristics. Besides, the cost of erroneously determining a function/class to be a component and then proceeding to set `displayName` on a non-component should not be a big problem.

There are some nuances involved to make it work. Please see the tests for details.