### PR TITLE
Add support for evaluating `String.raw` expressions

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -92,28 +92,6 @@ function _evaluate(path, state) {
     return evaluateQuasis(path, node.quasis, state);
   }
 
-  function evaluateQuasis (path, quasis: Array<Object>, state, raw = false) {
-    let str = "";
-
-    let i = 0;
-    const exprs = path.get("expressions");
-
-    for (const elem of quasis) {
-      // not confident, evaluated an expression we don't like
-      if (!state.confident) break;
-
-      // add on element
-      str += raw ? elem.value.raw : elem.value.cooked;
-
-      // add on interpolated expression if it's present
-      const expr = exprs[i++];
-      if (expr) str += String(evaluateCached(expr, state));
-    }
-
-    if (!state.confident) return;
-    return str;
-  }
-
   if (path.isTaggedTemplateExpression() && path.get("tag").isMemberExpression()) {
     const object = path.get("tag.object");
     const { node: { name } } = object;
@@ -364,6 +342,28 @@ function _evaluate(path, state) {
   }
 
   deopt(path, state);
+}
+
+function evaluateQuasis (path, quasis: Array<Object>, state, raw = false) {
+  let str = "";
+
+  let i = 0;
+  const exprs = path.get("expressions");
+
+  for (const elem of quasis) {
+    // not confident, evaluated an expression we don't like
+    if (!state.confident) break;
+
+    // add on element
+    str += raw ? elem.value.raw : elem.value.cooked;
+
+    // add on interpolated expression if it's present
+    const expr = exprs[i++];
+    if (expr) str += String(evaluateCached(expr, state));
+  }
+
+  if (!state.confident) return;
+  return str;
 }
 
 /**

--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -89,17 +89,21 @@ function _evaluate(path, state) {
   }
 
   if (path.isTemplateLiteral()) {
+    return evaluateQuasis(path, node.quasis, state);
+  }
+
+  function evaluateQuasis (path, quasis: Array<Object>, state, raw = false) {
     let str = "";
 
     let i = 0;
     const exprs = path.get("expressions");
 
-    for (const elem of (node.quasis: Array<Object>)) {
+    for (const elem of quasis) {
       // not confident, evaluated an expression we don't like
       if (!state.confident) break;
 
-      // add on cooked element
-      str += elem.value.cooked;
+      // add on element
+      str += raw ? elem.value.raw : elem.value.cooked;
 
       // add on interpolated expression if it's present
       const expr = exprs[i++];
@@ -108,6 +112,19 @@ function _evaluate(path, state) {
 
     if (!state.confident) return;
     return str;
+  }
+
+  if (path.isTaggedTemplateExpression() && path.get("tag").isMemberExpression()) {
+    const object = path.get("tag.object");
+    const { node: { name } } = object;
+    const property = path.get("tag.property");
+
+    if (
+      object.isIdentifier() && name === "String" && !path.scope.getBinding(name, true) &&
+      property.isIdentifier && property.node.name === "raw"
+    ) {
+      return evaluateQuasis(path, node.quasi.quasis, state, true);
+    }
   }
 
   if (path.isConditionalExpression()) {

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -119,4 +119,16 @@ describe("evaluation", function () {
     assert.strictEqual(eval_undef.deopt.type, "VariableDeclarator");
     assert.strictEqual(eval_undef.deopt.parentPath.node.kind, "let");
   });
+
+  it("should work with String.raw", function () {
+    assert.strictEqual(
+      getPath("String.raw`\\d`").get("body")[0].evaluate().value,
+      "\\d"
+    );
+
+    assert.strictEqual(
+      getPath("`${String.raw`\\d`}`").get("body")[0].evaluate().value,
+      "\\d"
+    );
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

This makes it possible for Babel to statically evaluate `String.raw`
expressions like this:

```js
String.raw`\d`
```

to values like this:

```js
"\\d"
```

I made the changes in two commits:

1. Implement the new functionality
2. Deduplicate copy/pasted code into a helper function