### PR TITLE
Fix PathHoister hoisting before a same-scope variable declaration.

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/actual.js
@@ -1,0 +1,9 @@
+export default {
+    async function(name) {
+        const uppercasedName = name.upperCase();
+
+        // awaits depending on uppercasedName go here
+
+        return (<Foo name={uppercasedName} />);
+    }
+};

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
@@ -1,0 +1,13 @@
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+
+export default {
+    function(name) {
+        return _asyncToGenerator(function* () {
+            const uppercasedName = name.upperCase();
+
+            // awaits depending on uppercasedName go here
+
+            return <Foo name={uppercasedName} />;
+        })();
+    }
+};

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-async-to-generator", "transform-react-constant-elements", "syntax-jsx"]
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/actual.js
@@ -1,0 +1,6 @@
+function fn(Component, obj) {
+
+  var data = obj.data;
+
+  return () => <Component prop={data} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/expected.js
@@ -1,0 +1,7 @@
+function fn(Component, obj) {
+
+  var data = obj.data,
+      _ref = <Component prop={data} />;
+
+  return () => _ref;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/actual.js
@@ -1,0 +1,6 @@
+function fn(Component) {
+
+  var data = "prop";
+
+  return () => <Component prop={data} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/expected.js
@@ -1,0 +1,7 @@
+function fn(Component) {
+
+  var data = "prop",
+      _ref = <Component prop={data} />;
+
+  return () => _ref;
+}

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -99,11 +99,15 @@ export default class PathHoister {
 
         const binding = this.bindings[name];
 
-        // allow parameter references
-        if (binding.kind === "param") continue;
+        // allow parameter references and expressions in params (like destructuring rest)
+        if (binding.kind === "param" || binding.path.parentKey === "params") continue;
 
-        // if this binding appears after our attachment point, then we move after it.
-        if (this.getAttachmentParentForPath(binding.path).key > path.key) {
+        // For each binding, get its attachment parent. This gives us an idea of where we might
+        // introduce conflicts.
+        const bindingParentPath = this.getAttachmentParentForPath(binding.path);
+
+        // If the binding's attachment appears at or after our attachment point, then we move after it.
+        if (bindingParentPath.key >= path.key) {
           this.attachAfter = true;
           path = binding.path;
 


### PR DESCRIPTION
Seems we didn't have tests running for this very simple case.

When a binding conflict exists in the same scope, the parent path's key may be the same. We then have to be sure that we're at least after that item, thus the change from `>` to `>=`.

The above change alone causes a very strange issue with rest expressions in destructuring parameters, so I added an additional check to deopt there.

Fixes #5520, perhaps others.

Ping @loganfsmyth ([failing test](https://github.com/babel/babel/commit/bf57c6917e1f54f93c4f4f7e0637a74c6c5cbc02))


| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | n/a
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5520 
| License                  | MIT
| Dependency Changes       | no

