### PR TITLE
Fix 'Unhandled promise rejection (rejection id: 1): ReferenceError: setTimeout is not defined' warning.

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -20,6 +20,8 @@ const testContext = vm.createContext({
   ...helpers,
   assert: chai.assert,
   transform: babel.transform,
+  setTimeout: setTimeout,
+  setImmediate: setImmediate,
 });
 testContext.global = testContext;
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/exec.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/exec.js
@@ -8,12 +8,6 @@ async function foo({ a, b = mandatory("b") } = {}) {
   return Promise.resolve(b);
 }
 
-return (async () => {
-  assert.doesNotThrow(() => {
-    foo()
-      .then(() => {
-        throw new Error('should not occcur');
-      })
-      .catch(() => true);
-  });
-})();
+return foo().then(() => {
+  throw new Error('should not occcur');
+}, () => true);


### PR DESCRIPTION
This wasn't breaking anything, but it was annoying. I think our new `exec` test happens to be the first one that uses Promises, and `core-js` relies on `setTimeout` or some other timing function for the promises to be fully-functional.

Also fixed a small issue with the test itself, but wasn't actually causing the warning,