### PR TITLE
Fix typo a => b

### DIFF
--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -245,7 +245,7 @@ export function isImmutable(node: Object): boolean {
  */
 
 export function isNodesEquivalent(a, b) {
-  if (typeof a !== "object" || typeof a !== "object" || a == null || b == null) {
+  if (typeof a !== "object" || typeof b !== "object" || a == null || b == null) {
     return a === b;
   }
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | None
| Fixed Tickets            | None
| License                  | MIT
| Doc PR                   | No
| Dependency Changes       | None

This PR fixes what looks like a very simple typo. Interestingly as far as I can tell it doesn't actually affect the behaviour of the function as it just skips the shortcut case and uses the generic comparison below which is pretty solidly written. Nevertheless this still looks wrong and should probably be fixed.
I would have liked to have added a test to cover this but as I say as far as I can tell the function behaviour isn't changed. Please correct me if wrong.

This was actually found by [lgtm.com](https://lgtm.com/projects/g/babel/babel/), which analyses many open source projects including Babel, where it detected that the two comparisons were the same.