### PR TITLE
Add test cases for bad options in babel-preset-es2015

### DIFF
--- a/packages/babel-preset-es2015/test/index.js
+++ b/packages/babel-preset-es2015/test/index.js
@@ -18,6 +18,14 @@ describe("es2015 preset", function () {
       });
     });
 
+    describe("spec", function () {
+      it("throws on non-boolean value", function () {
+        expect(function () {
+          es2015(null, { spec: 1 });
+        }).to.throw(/must be a boolean/);
+      });
+    });
+
     describe("modules", function () {
       it("doesn't throw when passing one false", function () {
         expect(function () {
@@ -41,6 +49,12 @@ describe("es2015 preset", function () {
         expect(function () {
           es2015(null, { modules: "systemjs" });
         }).not.to.throw();
+      });
+
+      it("throws when passing neither true nor one of: 'commonjs', 'amd', 'umd', 'systemjs'", function () {
+        expect(function () {
+          es2015(null, { modules: 1 });
+        }).to.throw();
       });
     });
   });

--- a/packages/babel-preset-es2015/test/index.js
+++ b/packages/babel-preset-es2015/test/index.js
@@ -51,7 +51,7 @@ describe("es2015 preset", function () {
         }).not.to.throw();
       });
 
-      it("throws when passing neither true nor one of: 'commonjs', 'amd', 'umd', 'systemjs'", function () {
+      it("throws when passing neither false nor one of: 'commonjs', 'amd', 'umd', 'systemjs'", function () {
         expect(function () {
           es2015(null, { modules: 1 });
         }).to.throw();


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no 
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

In the code coverage report I saw that `babel-preset-es2015` has two error scenarios caused by bad option values that are not covered by the tests yet. I added two cases to the tests of `babel-preset-es2015` that ensure errors are thrown when an invalid value is passed as option to `spec` (non-boolean) or `module` (neither false nor one of the module system strings).