### PR TITLE
Fix optimisation of shadowed rest parameters

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -7,18 +7,14 @@ var x = function (foo) {
 };
 
 var y = function (foo) {
-  for (var _len2 = arguments.length, bar = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
-    bar[_key2 - 1] = arguments[_key2];
-  }
-
   var x = function z(bar) {
     bar[1] = 5;
   };
 };
 
 var b = function (x, y) {
-  for (var _len3 = arguments.length, args = Array(_len3 > 2 ? _len3 - 2 : 0), _key3 = 2; _key3 < _len3; _key3++) {
-    args[_key3 - 2] = arguments[_key3];
+  for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+    args[_key2 - 2] = arguments[_key2];
   }
 
   console.log(args[0]);
@@ -27,8 +23,8 @@ var b = function (x, y) {
 };
 
 var z = function (foo) {
-  for (var _len4 = arguments.length, bar = Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
-    bar[_key4 - 1] = arguments[_key4];
+  for (var _len3 = arguments.length, bar = Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+    bar[_key3 - 1] = arguments[_key3];
   }
 
   var x = function () {
@@ -37,8 +33,8 @@ var z = function (foo) {
 };
 
 var a = function (foo) {
-  for (var _len5 = arguments.length, bar = Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
-    bar[_key5 - 1] = arguments[_key5];
+  for (var _len4 = arguments.length, bar = Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
+    bar[_key4 - 1] = arguments[_key4];
   }
 
   return bar.join(",");
@@ -47,16 +43,16 @@ var a = function (foo) {
 var b = function (foo) {
   var join = "join";
 
-  for (var _len6 = arguments.length, bar = Array(_len6 > 1 ? _len6 - 1 : 0), _key6 = 1; _key6 < _len6; _key6++) {
-    bar[_key6 - 1] = arguments[_key6];
+  for (var _len5 = arguments.length, bar = Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
+    bar[_key5 - 1] = arguments[_key5];
   }
 
   return bar[join];
 };
 
 var b = function () {
-  for (var _len7 = arguments.length, bar = Array(_len7), _key7 = 0; _key7 < _len7; _key7++) {
-    bar[_key7] = arguments[_key7];
+  for (var _len6 = arguments.length, bar = Array(_len6), _key6 = 0; _key6 < _len6; _key6++) {
+    bar[_key6] = arguments[_key6];
   }
 
   return bar.len;
@@ -71,16 +67,16 @@ var b = function (foo, baz) {
 };
 
 function x() {
-  for (var _len8 = arguments.length, rest = Array(_len8), _key8 = 0; _key8 < _len8; _key8++) {
-    rest[_key8] = arguments[_key8];
+  for (var _len7 = arguments.length, rest = Array(_len7), _key7 = 0; _key7 < _len7; _key7++) {
+    rest[_key7] = arguments[_key7];
   }
 
   rest[0] = 0;
 }
 
 function swap() {
-  for (var _len9 = arguments.length, rest = Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
-    rest[_key9] = arguments[_key9];
+  for (var _len8 = arguments.length, rest = Array(_len8), _key8 = 0; _key8 < _len8; _key8++) {
+    rest[_key8] = arguments[_key8];
   }
 
   var _ref = [rest[1], rest[0]];
@@ -89,8 +85,8 @@ function swap() {
 }
 
 function forIn() {
-  for (var _len10 = arguments.length, rest = Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
-    rest[_key10] = arguments[_key10];
+  for (var _len9 = arguments.length, rest = Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
+    rest[_key9] = arguments[_key9];
   }
 
   for (rest[0] in this) {
@@ -99,40 +95,40 @@ function forIn() {
 }
 
 function inc() {
-  for (var _len11 = arguments.length, rest = Array(_len11), _key11 = 0; _key11 < _len11; _key11++) {
-    rest[_key11] = arguments[_key11];
+  for (var _len10 = arguments.length, rest = Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
+    rest[_key10] = arguments[_key10];
   }
 
   ++rest[0];
 }
 
 function dec() {
-  for (var _len12 = arguments.length, rest = Array(_len12), _key12 = 0; _key12 < _len12; _key12++) {
-    rest[_key12] = arguments[_key12];
+  for (var _len11 = arguments.length, rest = Array(_len11), _key11 = 0; _key11 < _len11; _key11++) {
+    rest[_key11] = arguments[_key11];
   }
 
   --rest[0];
 }
 
 function del() {
-  for (var _len13 = arguments.length, rest = Array(_len13), _key13 = 0; _key13 < _len13; _key13++) {
-    rest[_key13] = arguments[_key13];
+  for (var _len12 = arguments.length, rest = Array(_len12), _key12 = 0; _key12 < _len12; _key12++) {
+    rest[_key12] = arguments[_key12];
   }
 
   delete rest[0];
 }
 
 function method() {
-  for (var _len14 = arguments.length, rest = Array(_len14), _key14 = 0; _key14 < _len14; _key14++) {
-    rest[_key14] = arguments[_key14];
+  for (var _len13 = arguments.length, rest = Array(_len13), _key13 = 0; _key13 < _len13; _key13++) {
+    rest[_key13] = arguments[_key13];
   }
 
   rest[0]();
 }
 
 function newExp() {
-  for (var _len15 = arguments.length, rest = Array(_len15), _key15 = 0; _key15 < _len15; _key15++) {
-    rest[_key15] = arguments[_key15];
+  for (var _len14 = arguments.length, rest = Array(_len14), _key14 = 0; _key14 < _len14; _key14++) {
+    rest[_key14] = arguments[_key14];
   }
 
   new rest[0]();
@@ -141,8 +137,8 @@ function newExp() {
 // In addition to swap() above because at some point someone tried checking
 // grandparent path for isArrayExpression() to deopt.
 function arrayDestructure() {
-  for (var _len16 = arguments.length, rest = Array(_len16), _key16 = 0; _key16 < _len16; _key16++) {
-    rest[_key16] = arguments[_key16];
+  for (var _len15 = arguments.length, rest = Array(_len15), _key15 = 0; _key15 < _len15; _key15++) {
+    rest[_key15] = arguments[_key15];
   }
 
   var _x = babelHelpers.slicedToArray(x, 1);
@@ -151,8 +147,8 @@ function arrayDestructure() {
 }
 
 function forOf() {
-  for (var _len17 = arguments.length, rest = Array(_len17), _key17 = 0; _key17 < _len17; _key17++) {
-    rest[_key17] = arguments[_key17];
+  for (var _len16 = arguments.length, rest = Array(_len16), _key16 = 0; _key16 < _len16; _key16++) {
+    rest[_key16] = arguments[_key16];
   }
 
   var _iteratorNormalCompletion = true;
@@ -180,16 +176,16 @@ function forOf() {
 }
 
 function postfixIncrement() {
-  for (var _len18 = arguments.length, rest = Array(_len18), _key18 = 0; _key18 < _len18; _key18++) {
-    rest[_key18] = arguments[_key18];
+  for (var _len17 = arguments.length, rest = Array(_len17), _key17 = 0; _key17 < _len17; _key17++) {
+    rest[_key17] = arguments[_key17];
   }
 
   rest[0]++;
 }
 
 function postfixDecrement() {
-  for (var _len19 = arguments.length, rest = Array(_len19), _key19 = 0; _key19 < _len19; _key19++) {
-    rest[_key19] = arguments[_key19];
+  for (var _len18 = arguments.length, rest = Array(_len18), _key18 = 0; _key18 < _len18; _key18++) {
+    rest[_key18] = arguments[_key18];
   }
 
   rest[0]--;

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-5656/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-5656/actual.js
@@ -1,0 +1,22 @@
+function a(...args) {
+  const foo = (...list) => bar(...list);
+  foo(...args);
+}
+
+function b(...args) {
+  const foo = (...args) => bar(...args);
+  foo(...args);
+}
+
+function c(...args) {
+  const foo = (...args) => bar(...args);
+  foo([]);
+}
+
+function d(thing, ...args) {
+  const foo = (...args) => bar(...args);
+  {
+    let args = thing;
+    foo(thing);
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-5656/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-5656/expected.js
@@ -1,0 +1,30 @@
+function a() {
+  var foo = function () {
+    return bar.apply(undefined, arguments);
+  };
+  foo.apply(undefined, arguments);
+}
+
+function b() {
+  var foo = function () {
+    return bar.apply(undefined, arguments);
+  };
+  foo.apply(undefined, arguments);
+}
+
+function c() {
+  var foo = function () {
+    return bar.apply(undefined, arguments);
+  };
+  foo([]);
+}
+
+function d(thing) {
+  var foo = function () {
+    return bar.apply(undefined, arguments);
+  };
+  {
+    var _args = thing;
+    foo(thing);
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?    |   no
| Deprecations?            |  no
| Spec Compliancy?         | no
| Tests Added/Pass?      |   yes
| Fixed Tickets            | #5656 
| License                  | MIT
| Doc PR                   |no
| Dependency Changes       | no

The arguments of a function would be unnecessarily copied if there was
a nested function that had a parameter with the same identifier as the
rest parameter for the outer function. This checks the scope of the
parameter is correct before deoptimising.

Possibly has something to do with #2091 but not sure.