### PR TITLE
Correct the validator for ArrayPattern

### DIFF
--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -29,7 +29,7 @@ defineType("ArrayPattern", {
   aliases: ["Pattern", "LVal"],
   fields: {
     elements: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression"))),
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Identifier", "Pattern", "RestElement"))),
     },
     decorators: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),


### PR DESCRIPTION
The elements of the `elements` array should be either `Identifier`, `Pattern` or `RestElement`, but the validator was requiring `Expression`. It happened to work for `Identifier` since an `Identifier` is an `Expression`, but not for the other possible pattern elements.
