### PR TITLE
Return new object from spread

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -261,6 +261,7 @@ export default function ({ types: t }) {
           ])
         );
       },
+
       // var a = { ...b, ...c }
       ObjectExpression(path, file) {
         if (!hasSpread(path.node)) return;
@@ -274,9 +275,15 @@ export default function ({ types: t }) {
         const args = [];
         let props = [];
 
+        // proposal-object-rest-spread 3.1 - CopyDataProperties
+        // > The target passed is in here is always a newly created object
+        args.push(t.ObjectExpression([]));
+
         function push() {
-          if (!props.length) return;
-          args.push(t.objectExpression(props));
+          if (props.length > 0) {
+            args.push(t.objectExpression(props));
+          }
+
           props = [];
         }
 
@@ -290,10 +297,6 @@ export default function ({ types: t }) {
         }
 
         push();
-
-        if (!t.isObjectExpression(args[0])) {
-          args.unshift(t.objectExpression([]));
-        }
 
         const helper = useBuiltIns ?
           t.memberExpression(t.identifier("Object"), t.identifier("assign")) :

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/assignment/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/assignment/expected.js
@@ -1,5 +1,5 @@
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-z = _extends({ x }, y);
+z = _extends({}, { x }, y);
 
 z = { x, w: _extends({}, y) };

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/expression/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/expression/expected.js
@@ -1,3 +1,3 @@
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-_extends({ x }, y, { a }, b, { c });
+_extends({}, { x }, y, { a }, b, { c });

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/useBuiltIns/assignment-true/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/useBuiltIns/assignment-true/expected.js
@@ -1,1 +1,1 @@
-z = Object.assign({ x }, y);
+z = Object.assign({}, { x }, y);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

> The target passed is in here is always a newly created object

See spec https://tc39.github.io/proposal-object-rest-spread/#AbstractOperations-CopyDataProperties

Initially found by @tomesch