### PR TITLE
Added test for getStatementParent method of NodePath

### DIFF
--- a/packages/babel-traverse/test/ancestry.js
+++ b/packages/babel-traverse/test/ancestry.js
@@ -62,4 +62,22 @@ describe("path/ancestry", function () {
       assert(!numberPath.isDescendant(stringPath));
     });
   });
+
+  describe("getStatementParent", function () {
+    const ast = parse("function a(){ var x = 3; }");
+
+    it("returns closest parent Statement", function() {
+      const paths = [];
+      traverse(ast, {
+        "VariableDeclaration|NumericLiteral"(path) {
+          paths.push(path);
+        },
+      });
+
+      const [ varDeclarationPath, numberPath ] = paths;
+
+      assert.strictEqual(numberPath.getStatementParent(), varDeclarationPath);
+    });
+
+  });
 });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | Added one test case
| Fixed Tickets            | <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

If I understand codecov correctly, the `getStatementParent` of `NodePath` is currently untested ( Iooked at coverage for branch 7.0). I added a test case by following the same steps as the other tests relevant to this file.