### PR TITLE
Fix relative execution location introspection

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-optimisation/expected.js
@@ -20,11 +20,7 @@ function t() {
 
 
 function t() {
-  for (var _len = arguments.length, items = Array(_len), _key = 0; _key < _len; _key++) {
-    items[_key] = arguments[_key];
-  }
-
-  for (var i = 0; i < items.length; i++) {
-    return items[i];
+  for (var i = 0; i < arguments.length; i++) {
+    return arguments.length <= i ? undefined : arguments[i];
   }
 }

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -268,12 +268,9 @@ export function _guessExecutionStatusRelativeTo(target) {
   }
 
   // otherwise we're associated by a parent node, check which key comes before the other
-  const targetKeyPosition = t.VISITOR_KEYS[targetRelationship.type].indexOf(
-    targetRelationship.key,
-  );
-  const selfKeyPosition = t.VISITOR_KEYS[selfRelationship.type].indexOf(
-    selfRelationship.key,
-  );
+  const keys = t.VISITOR_KEYS[commonPath.type];
+  const targetKeyPosition = keys.indexOf(targetRelationship.key);
+  const selfKeyPosition = keys.indexOf(selfRelationship.key);
   return targetKeyPosition > selfKeyPosition ? "before" : "after";
 }
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Maybe?
| Major: Breaking Change?  | Probably not
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | No
| Fixed Tickets            | Fixes #6097
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

So, I was reading the new Flow type strictness and noticed
https://flow.org/blog/2017/05/07/Strict-Function-Call-Arity/
Specifically, I wondered whether the `sum_all` example would copy the
arguments into an array, then loop over. Sadly, it does.

```js
function sum_all(...rest) {
  let ret = 0;
  for (let i = 0; i < rest.length; i++) { ret += rest[i]; }
  return ret;
}

// output
function sum_all() {
  var ret = 0;
  for (var _len = arguments.length, rest = Array(_len), _key = 0; _key < _len; _key++) {
    rest[_key] = arguments[_key];
  }
  for (var i = 0; i < rest.length; i++) { ret += rest[i]; }
  return ret;
}
```

But then I noticed if I moved `let i = 0` (the whole thing) above of the `ForStatement`, it
worked directly on `arguments`. That lead me down a rabbit hole to
`Path#_guessExecutionStatusRelativeTo`. When tracing through, the last
comparison made no sense to me. It was trying to find the index of
`"init"` in a list of `["declarations"]` and `"body"` in `["directives",
"body"]`. Red flags and such.

But it makes sense when you're trying to compare the visitor order of
the common ancestor path. Then we're trying to find `"init"` in a list
of `["init", "test", "update", "body"]`. Oh, and there's `"body"` in
there too! And now we know the `ForStatement`'s `init` is executed
before the `body`.