### PR TITLE
Fix incorrect property ordering with obj rest spread on nested

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -107,14 +107,21 @@ export default function ({ types: t }) {
             }
 
             let ref = this.originalPath.node.init;
+            const refPropertyPath = [];
 
             path.findParent((path) => {
               if (path.isObjectProperty()) {
-                ref = t.memberExpression(ref, t.identifier(path.node.key.name));
+                refPropertyPath.unshift(path.node.key.name);
               } else if (path.isVariableDeclarator()) {
                 return true;
               }
             });
+
+            if (refPropertyPath.length) {
+              refPropertyPath.forEach((prop) => {
+                ref = t.memberExpression(ref, t.identifier(prop));
+              });
+            }
 
             const [ argument, callExpression ] = createObjectSpread(
               file,

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/actual.js
@@ -1,0 +1,15 @@
+const test = {
+  foo: {
+    bar: {
+      baz: {
+        a: {
+          x: 1,
+          y: 2,
+          z: 3,
+        },
+      },
+    },
+  },
+};
+
+const { foo: { bar: { baz: { a: { x, ...other } } } } } = test;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/expected.js
@@ -1,0 +1,16 @@
+const test = {
+  foo: {
+    bar: {
+      baz: {
+        a: {
+          x: 1,
+          y: 2,
+          z: 3
+        }
+      }
+    }
+  }
+};
+
+const { foo: { bar: { baz: { a: { x } } } } } = test,
+      other = babelHelpers.objectWithoutProperties(test.foo.bar.baz.a, ["x"]);

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/actual.js
@@ -1,0 +1,10 @@
+const defunct = {
+  outer: {
+    inner: {
+      three: 'three',
+      four: 'four'
+    }
+  }
+}
+
+const { outer: { inner: { three, ...other } } } = defunct

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/expected.js
@@ -1,0 +1,11 @@
+const defunct = {
+  outer: {
+    inner: {
+      three: 'three',
+      four: 'four'
+    }
+  }
+};
+
+const { outer: { inner: { three } } } = defunct,
+      other = babelHelpers.objectWithoutProperties(defunct.outer.inner, ['three']);


### PR DESCRIPTION
Backports #5685, fixes #5747.