### PR TITLE
Fix multiple var declarations in transform-react-constant-elements 

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/append-to-end-when-declared-in-scope/expected.js
@@ -4,8 +4,9 @@ export default class App extends React.Component {
   }
 }
 
-const _ref2 = <div>child</div>,
-      AppItem = () => {
+var _ref2 = <div>child</div>;
+
+const AppItem = () => {
   return _ref2;
 },
       _ref = <div>

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/actual.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import Loader from 'loader';
+
+const errorComesHere = () => <Loader className="full-height"/>,
+  thisWorksFine = () => <Loader className="p-y-5"/>;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/compound-assignment/expected.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Loader from 'loader';
+
+var _ref = <Loader className="full-height" />;
+
+var _ref2 = <Loader className="p-y-5" />;
+
+const errorComesHere = () => _ref,
+      thisWorksFine = () => _ref2;

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-class/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/dont-hoist-before-class/expected.js
@@ -4,10 +4,11 @@ const Parent = ({}) => _ref;
 
 export default Parent;
 
-let _ref2 = <div className="child">
+var _ref2 = <div className="child">
     ChildTextContent
-  </div>,
-    Child = () => _ref2,
+  </div>;
+
+let Child = () => _ref2,
     _ref = <div className="parent">
     <Child />
   </div>;

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -172,12 +172,10 @@ export default class PathHoister {
         // Beginning of the scope
         !path.parentPath ||
         // Has siblings and is a statement
-        (Array.isArray(path.container) && path.isStatement()) ||
-        // Is part of multiple var declarations
-        (path.isVariableDeclarator() &&
-          path.parentPath.node !== null &&
-          path.parentPath.node.declarations.length > 1))
-        {return path;}
+        (Array.isArray(path.container) && path.isStatement())
+      ) {
+        return path;
+      }
     } while ((path = path.parentPath));
   }
 


### PR DESCRIPTION


| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5732
| License                  | MIT

This was broken by a legacy attachment path conditional that
is no longer needed.
