### PR TITLE
Add regression test for transform-react-constant-elements (#5552)

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/actual.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/actual.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+// Regression test for https://github.com/babel/babel/issues/5552
+class BugReport extends React.Component {
+    thisWontWork = ({ color }) => (data) => {
+        return <div color={ color }>does not reference data</div>;
+    };
+
+    thisWorks = ({ color }) => (data) => {
+        return <div color={ color }>{ data }</div>;
+    };
+
+    render() {
+        return <div />
+    }
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/expected.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// Regression test for https://github.com/babel/babel/issues/5552
+
+var _ref = <div />;
+
+class BugReport extends React.Component {
+    constructor(...args) {
+        var _temp;
+
+        return _temp = super(...args), this.thisWontWork = ({ color }) => data => {
+            return <div color={color}>does not reference data</div>;
+        }, this.thisWorks = ({ color }) => data => {
+            return <div color={color}>{data}</div>;
+        }, _temp;
+    }
+
+    render() {
+        return _ref;
+    }
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/options.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-class-properties", "transform-react-constant-elements", "syntax-jsx"]
+}


### PR DESCRIPTION

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | #5552
| License                  | MIT

At some point in the development of `7.0`, between `7.0.0-alpha.9` and the current `master`, we fixed #5552. This PR simply adds another test to ensure we don't regress.
