### PR TITLE
Added export declaration to getBindingIdentifierPaths testcase

### DIFF
--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -15,8 +15,8 @@ describe("path/family", function () {
         Object.assign(paths, path.getBindingIdentifierPaths());
       },
       FunctionDeclaration(path) {
-        Object.assign(outerNodes, path.getBindingIdentifiers());
-        Object.assign(outerPaths, path.getBindingIdentifierPaths());
+        Object.assign(outerNodes, path.getOuterBindingIdentifiers());
+        Object.assign(outerPaths, path.getOuterBindingIdentifierPaths());
       },
     });
 

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -4,12 +4,15 @@ const parse = require("babylon").parse;
 
 describe("path/family", function () {
   describe("getBindingIdentifiers", function () {
-    const ast = parse("var a = 1, {b} = c, [d] = e; function f() {}");
+    const ast = parse(
+      "var a = 1, {b} = c, [d] = e; function f() {}; export class Y {}",
+      { sourceType: "module" }
+    );
     let nodes = {}, paths = {}, outerNodes = {}, outerPaths = {};
     traverse(ast, {
-      VariableDeclaration(path) {
-        nodes = path.getBindingIdentifiers();
-        paths = path.getBindingIdentifierPaths();
+      "VariableDeclaration|ExportDeclaration"(path) {
+        nodes = Object.assign(nodes, path.getBindingIdentifiers());
+        paths = Object.assign(paths, path.getBindingIdentifierPaths());
       },
       FunctionDeclaration(path) {
         outerNodes = path.getOuterBindingIdentifiers();

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -8,15 +8,15 @@ describe("path/family", function () {
       "var a = 1, {b} = c, [d] = e; function f() {}; export class Y {}",
       { sourceType: "module" }
     );
-    let nodes = {}, paths = {}, outerNodes = {}, outerPaths = {};
+    const nodes = {}, paths = {}, outerNodes = {}, outerPaths = {};
     traverse(ast, {
       "VariableDeclaration|ExportDeclaration"(path) {
-        nodes = Object.assign(nodes, path.getBindingIdentifiers());
-        paths = Object.assign(paths, path.getBindingIdentifierPaths());
+        Object.assign(nodes, path.getBindingIdentifiers());
+        Object.assign(paths, path.getBindingIdentifierPaths());
       },
       FunctionDeclaration(path) {
-        outerNodes = path.getOuterBindingIdentifiers();
-        outerPaths = path.getOuterBindingIdentifierPaths();
+        Object.assign(outerNodes, path.getBindingIdentifiers());
+        Object.assign(outerPaths, path.getBindingIdentifierPaths());
       },
     });
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes and yes
| Fixed Tickets            | <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

I extend the current test case for `NodePath.getBindingIdentifierPaths`. I added an exported class declaration because this case is currently uncovered by tests.