### PR TITLE
Fix ObjectProperty patterns

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -526,7 +526,7 @@ defineType("ObjectProperty", {
       },
     },
     value: {
-      validate: assertNodeType("Expression", "Pattern"),
+      validate: assertNodeType("Expression", "Pattern", "RestElement"),
     },
     shorthand: {
       validate: assertValueType("boolean"),

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -526,7 +526,7 @@ defineType("ObjectProperty", {
       },
     },
     value: {
-      validate: assertNodeType("Expression"),
+      validate: assertNodeType("Expression", "Pattern"),
     },
     shorthand: {
       validate: assertValueType("boolean"),

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -31,4 +31,28 @@ suite("validators", function () {
       assert(t.isValidIdentifier("await") === false);
     });
   });
+
+  suite("patterns", function () {
+    it("allows nested pattern structures", function () {
+      const pattern = t.objectPattern([
+        t.objectProperty(
+          t.identifier("a"),
+          t.objectPattern([
+            t.objectProperty(
+              t.identifier("b"),
+              t.stringLiteral("foo")
+            ),
+            t.objectProperty(
+              t.identifier("c"),
+              t.arrayPattern([
+                t.identifier("value"),
+              ])
+            ),
+          ])
+        ),
+      ]);
+
+      assert(t.isNodesEquivalent(pattern, pattern) === true);
+    });
+  });
 });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Deprecations?            | 
| Spec Compliancy?         | yes
| Tests Added/Pass?        | 
| Fixed Tickets            | Fixes #4741 <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

Add `Pattern`s to the `ObjectProperty` validator to fix nested patterns. #5722 has already been merged to fix `ArrayPattern`s.

Also add `RestElement` to allow object rest to appear.

Target case:

```js
t.objectPattern([
  t.objectProperty(
    t.identifier('a'),
    t.objectPattern([
      t.objectProperty(
        t.identifier('b'),
        t.stringLiteral('foo')
      )
    ])
  )
])
```
