### PR TITLE
Fix incorrect destructuring in for loop `let` initialization

### DIFF
--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
@@ -2,9 +2,9 @@
 
 let foo = (() => {
   var _ref = _asyncToGenerator(function* (_ref2) {
-    let a = _ref2.a;
-    var _ref2$b = _ref2.b;
-    let b = _ref2$b === undefined ? mandatory("b") : _ref2$b;
+    let a = _ref2.a,
+        _ref2$b = _ref2.b,
+        b = _ref2$b === undefined ? mandatory("b") : _ref2$b;
 
     return Promise.resolve(b);
   });

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/export-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/export-variable/expected.js
@@ -1,8 +1,8 @@
-var _ref = {};
-var a = _ref.a,
-    b = _ref.b;
-var _ref$c = _ref.c;
-var d = _ref$c.d;
-var _ref$c$e$f = _ref$c.e.f;
-var f = _ref$c$e$f === undefined ? 4 : _ref$c$e$f;
+var _ref = {},
+    a = _ref.a,
+    b = _ref.b,
+    _ref$c = _ref.c,
+    d = _ref$c.d,
+    _ref$c$e$f = _ref$c.e.f,
+    f = _ref$c$e$f === undefined ? 4 : _ref$c$e$f;
 export { a, b, d, f };

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/for-let/actual.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/for-let/actual.js
@@ -1,0 +1,2 @@
+for (let [ i, n ] = range; ; ) {
+}

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/for-let/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/for-let/expected.js
@@ -1,0 +1,1 @@
+for (var _range = range, _range2 = babelHelpers.slicedToArray(_range, 2), i = _range2[0], n = _range2[1];;) {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
@@ -8,7 +8,6 @@ var _foo2 = _interopRequireDefault(_foo);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _bar = bar,
-    _bar2 = _slicedToArray(_bar, 1);
-
-const x = _bar2[0];
+const _bar = bar,
+      _bar2 = _slicedToArray(_bar, 1),
+      x = _bar2[0];

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/destructure/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/destructure/expected.js
@@ -1,7 +1,7 @@
 class AnchorLink extends Component {
   render() {
-    var _props = this.props;
-    const isExternal = _props.isExternal,
+    const _props = this.props,
+          isExternal = _props.isExternal,
           children = _props.children;
 
     if (isExternal) {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no 
| Deprecations?            | no 
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #4893
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

__Input__

```js
for (let [ i, n ] = range; ; ) {}
```

__Current (wrong) output__

```js
for (function () {
  var _range = range,
      _range2 = _slicedToArray(_range, 2);

  var i = _range2[0],
      n = _range2[1];
}();;) {}
```

This PR adds special handling in the case of for-init so that all declarations are merged into a single statement, preventing `replaceWithMultiple` from being called and causing the above incorrect transformation.
