### PR TITLE
Support specifying minimum Node version a test requires

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,15 @@ If you need to check for an error that is thrown you can add to the `options.jso
 }
 ```
 
+If the test requires a minimum Node version, you can add `minNodeVersion` (must be in semver format).
+
+```js
+// options.json example
+{
+  "minNodeVersion": "5.0.0"
+}
+```
+
 #### Bootstrapping expected output
 
 For both `babel-plugin-x` and `babylon`, you can easily generate an `expected.js`/`expected.json` automatically by just providing `actual.js` and running the tests as you usually would.

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -8,6 +8,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "lodash": "^4.2.0",
-    "try-resolve": "^1.0.0"
+    "try-resolve": "^1.0.0",
+    "semver": "^5.3.0"
   }
 }

--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -3,8 +3,11 @@ import trimEnd from "lodash/trimEnd";
 import resolve from "try-resolve";
 import clone from "lodash/clone";
 import merge from "lodash/merge";
+import semver from "semver";
 import path from "path";
 import fs from "fs";
+
+const nodeVersion = semver.clean(process.version.slice(1));
 
 function humanize(val, noext) {
   if (noext) val = path.basename(val, path.extname(val));
@@ -124,6 +127,22 @@ export default function get(entryLoc): Array<Suite> {
           filename: expectLocAlias,
         },
       };
+
+      // If there's node requirement, check it before pushing task
+      if (taskOpts.minNodeVersion) {
+        const minimumVersion = semver.clean(taskOpts.minNodeVersion);
+
+        if (minimumVersion == null) {
+          throw new Error(`'minNodeVersion' has invalid semver format: ${taskOpts.minNodeVersion}`);
+        }
+
+        if (semver.lt(nodeVersion, minimumVersion)) {
+          return;
+        }
+
+        // Delete to avoid option validation error
+        delete taskOpts.minNodeVersion;
+      }
 
       // traceur checks
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no 
| Major: Breaking Change?  | no 
| Minor: New Feature?      | yes
| Deprecations?            | no 
| Spec Compliancy?         | n/a
| Tests Added/Pass?        | n/a
| Fixed Tickets            | Implement #5752
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no 

Add an option `minNodeVersion` so that test case can bail out if the current Node version isn't >= the expected version. This is to avoid having to check version in each test and do the eval hack (see #5752).

I can't figure out a good way to write automated test for this. I tested by adding `options.json` manually, changing `minNodeVersion` and observing behavior. I don't think an automated test is very important for this, but if you disagree, please let me know (and any idea to write this test is very welcome).

Also, there's a choice of making this change here or in transform-fixture-test-runner. I decided to bail out as early as possible, so here makes more sense. 
