### PR TITLE
[Documentation change] regeneratorRuntime -> _regenerator2.default

### DIFF
--- a/packages/babel-plugin-transform-runtime/README.md
+++ b/packages/babel-plugin-transform-runtime/README.md
@@ -253,7 +253,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var _marked = [foo].map(_regenerator2.default.mark);
 
 function foo() {
-  return regeneratorRuntime.wrap(function foo$(_context) {
+  return _regenerator2.default.wrap(function foo$(_context) {
     while (1) switch (_context.prev = _context.next) {
       case 0:
       case "end":


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no 
| Major: Breaking Change?  | no
| Minor: New Feature?      | no 
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | yes
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

Changed `regeneratorRuntime` to `_regenerator2.default`. `regeneratorRuntime` is the global the runtime transform is supposed to do away with?