### PR TITLE
Backport array & object pattern fixes to 6.x

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -526,7 +526,7 @@ defineType("ObjectProperty", {
       }
     },
     value: {
-      validate: assertNodeType("Expression")
+      validate: assertNodeType("Expression", "Pattern", "RestElement")
     },
     shorthand: {
       validate: assertValueType("boolean"),

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -29,7 +29,7 @@ defineType("ArrayPattern", {
   aliases: ["Pattern", "LVal"],
   fields: {
     elements: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression")))
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Identifier", "Pattern", "RestElement")))
     },
     decorators: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator")))

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -51,7 +51,7 @@ suite("validators", function () {
           ])
         ),
       ]);
-  
+
       assert(t.isNodesEquivalent(pattern, pattern) === true);
     });
   });

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -31,4 +31,28 @@ suite("validators", function () {
       assert(t.isValidIdentifier("await") === false);
     });
   });
+
+  suite("patterns", function () {
+    it("allows nested pattern structures", function () {
+      const pattern = t.objectPattern([
+        t.objectProperty(
+          t.identifier("a"),
+          t.objectPattern([
+            t.objectProperty(
+              t.identifier("b"),
+              t.stringLiteral("foo")
+            ),
+            t.objectProperty(
+              t.identifier("c"),
+              t.arrayPattern([
+                t.identifier("value"),
+              ])
+            ),
+          ])
+        ),
+      ]);
+  
+      assert(t.isNodesEquivalent(pattern, pattern) === true);
+    });
+  });
 });


### PR DESCRIPTION
Original PRs merged to 7.0 as #5722 ( which fixes `ArrayPattern` types ) and #5762 ( which fixes `ObjectProperty` value types ). 