### PR TITLE
Hoist block-scoped wrapping functions

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2364/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2364/expected.js
@@ -1,18 +1,19 @@
+var _ref = function (fn, _arguments) {
+  var val = fn(..._arguments);
+  return {
+    v: val.test(function () {
+      console.log(val);
+    })
+  };
+};
+
 function wrapper(fn) {
   return function () {
     var _arguments = arguments;
-
-    var _loop = function () {
-      var val = fn(..._arguments);
-      return {
-        v: val.test(function () {
-          console.log(val);
-        })
-      };
-    };
+    var _loop = _ref;
 
     while (someCondition) {
-      var _ret = _loop();
+      var _ret = _loop(fn, _arguments);
 
       if (typeof _ret === "object") return _ret.v;
     }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-break-continue-return/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-break-continue-return/expected.js
@@ -1,18 +1,20 @@
+var _ref = function (i) {
+  fns.push(function () {
+    return i;
+  });
+  if (i === 1) {
+    return "continue";
+  } else if (i === 2) {
+    return "break";
+  } else if (i === 3) {
+    return {
+      v: i
+    };
+  }
+};
+
 (function () {
-  var _loop2 = function (i) {
-    fns.push(function () {
-      return i;
-    });
-    if (i === 1) {
-      return "continue";
-    } else if (i === 2) {
-      return "break";
-    } else if (i === 3) {
-      return {
-        v: i
-      };
-    }
-  };
+  var _loop2 = _ref;
 
   _loop: for (var i in nums) {
     var _ret = _loop2(i);

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-return-undefined/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-return-undefined/expected.js
@@ -1,12 +1,14 @@
-(function () {
-  var _loop = function (i) {
-    fns.push(function () {
-      return i;
-    });
-    return {
-      v: void 0
-    };
+var _ref = function (i) {
+  fns.push(function () {
+    return i;
+  });
+  return {
+    v: void 0
   };
+};
+
+(function () {
+  var _loop = _ref;
 
   for (var i in nums) {
     var _ret = _loop(i);

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-return/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/for-return/expected.js
@@ -1,12 +1,14 @@
-(function () {
-  var _loop = function (i) {
-    fns.push(function () {
-      return i;
-    });
-    return {
-      v: i
-    };
+var _ref = function (i) {
+  fns.push(function () {
+    return i;
+  });
+  return {
+    v: i
   };
+};
+
+(function () {
+  var _loop = _ref;
 
   for (var i in nums) {
     var _ret = _loop(i);

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/hoisting-2/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/hoisting-2/actual.js
@@ -1,0 +1,49 @@
+function test() {
+  let result = [];
+  for (let i = 1; i < 3; i ++) {
+    for (let j = 9; j > 7; j --) {
+      result.push(i, j, function() { return i + ':' + j; });
+    }
+  }
+}
+
+function test() {
+  for (let i = 0; i < 10; i++) {
+    setTimeout(() => {
+      console.log(i);
+    }, 10);
+  }
+}
+
+function test() {
+  let a = 0;
+
+  function other() {
+    console.log(a);
+  }
+
+  for (let i = 0; i < 10; i++) {
+    justDoShit(() => {
+      console.log(a++, i);
+      other();
+    }, 10);
+  }
+}
+
+function test() {
+  for (let i = 0; i < 10; i++) {
+    setTimeout(() => {
+      console.log(this, i);
+      other();
+    }, 10);
+  }
+}
+
+function test() {
+  for (let i = 0; i < 10; i++) {
+    setTimeout(() => {
+      console.log(arguments, i);
+      other();
+    }, 10);
+  }
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/hoisting-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/hoisting-2/expected.js
@@ -1,0 +1,87 @@
+var _ref5 = function (j, result, i) {
+  result.push(i, j, function () {
+    return i + ':' + j;
+  });
+};
+
+var _ref = function (i, result) {
+  var _loop6 = _ref5;
+
+  for (var j = 9; j > 7; j--) {
+    _loop6(j, result, i);
+  }
+};
+
+function test() {
+  var result = [];
+  var _loop = _ref;
+  for (var i = 1; i < 3; i++) {
+    _loop(i, result);
+  }
+}
+
+var _ref2 = function (i) {
+  setTimeout(function () {
+    console.log(i);
+  }, 10);
+};
+
+function test() {
+  var _loop2 = _ref2;
+
+  for (var i = 0; i < 10; i++) {
+    _loop2(i);
+  }
+}
+
+function test() {
+  var a = 0;
+
+  function other() {
+    console.log(a);
+  }
+
+  var _loop3 = function (i, other) {
+    justDoShit(function () {
+      console.log(a++, i);
+      other();
+    }, 10);
+  };
+
+  for (var i = 0; i < 10; i++) {
+    _loop3(i, other);
+  }
+}
+
+var _ref3 = function (i, _this) {
+  setTimeout(function () {
+    console.log(_this, i);
+    other();
+  }, 10);
+};
+
+function test() {
+  var _this = this;
+
+  var _loop4 = _ref3;
+
+  for (var i = 0; i < 10; i++) {
+    _loop4(i, _this);
+  }
+}
+
+var _ref4 = function (i, _arguments) {
+  setTimeout(function () {
+    console.log(_arguments, i);
+    other();
+  }, 10);
+};
+
+function test() {
+  var _arguments = arguments;
+  var _loop5 = _ref4;
+
+  for (var i = 0; i < 10; i++) {
+    _loop5(i, _arguments);
+  }
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-1051/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-1051/expected.js
@@ -1,15 +1,17 @@
+var _ref = function () {
+  function func2() {}
+  function func3() {}
+  func4(function () {
+    func2();
+  });
+  return "break";
+};
+
 foo.func1 = function () {
   if (cond1) {
     for (;;) {
       if (cond2) {
-        var _ret = function () {
-          function func2() {}
-          function func3() {}
-          func4(function () {
-            func2();
-          });
-          return "break";
-        }();
+        var _ret = _ref();
 
         if (_ret === "break") break;
       }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-973/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-973/expected.js
@@ -1,12 +1,15 @@
 var arr = [];
+
+var _ref = function (_i, arr) {
+  arr.push(function () {
+    return _i;
+  });
+};
+
 for (var i = 0; i < 10; i++) {
-  var _loop = function (_i) {
-    arr.push(function () {
-      return _i;
-    });
-  };
+  var _loop = _ref;
 
   for (var _i = 0; _i < 10; _i++) {
-    _loop(_i);
+    _loop(_i, arr);
   }
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/superswitch/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/superswitch/expected.js
@@ -1,22 +1,24 @@
+var _ref = function () {
+  if (true) {
+    return {
+      v: void 0
+    };
+  }
+
+  var stuff = new Map();
+  var data = 0;
+  stuff.forEach(function () {
+    var d = data;
+  });
+  return "break";
+};
+
 function foo() {
   while (true) {
     switch (2) {
       case 0:
         {
-          var _ret = function () {
-            if (true) {
-              return {
-                v: void 0
-              };
-            }
-
-            var stuff = new Map();
-            var data = 0;
-            stuff.forEach(function () {
-              var d = data;
-            });
-            return "break";
-          }();
+          var _ret = _ref();
 
           switch (_ret) {
             case "break":

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-callbacks/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-callbacks/expected.js
@@ -1,16 +1,18 @@
+var _ref = function () {
+  switch (true) {
+    default:
+      var foo = 4;
+      if (true) {
+        var bar = function () {
+          return foo;
+        };
+        console.log(bar());
+      }
+  }
+};
+
 function fn() {
   while (true) {
-    (function () {
-      switch (true) {
-        default:
-          var foo = 4;
-          if (true) {
-            var bar = function () {
-              return foo;
-            };
-            console.log(bar());
-          }
-      }
-    })();
+    _ref();
   }
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/expected.js
@@ -46,17 +46,19 @@ assert.equal(j, 9);
 // it should work with loops nested within switch
 j = 0;
 
+var _ref = function () {
+  var z = 3;
+  (function () {
+    return z;
+  });
+  j++;
+  return "break";
+};
+
 var _loop3 = function () {
   switch (i) {
     case 0:
-      var _loop4 = function () {
-        var z = 3;
-        (function () {
-          return z;
-        });
-        j++;
-        return "break";
-      };
+      var _loop4 = _ref;
 
       for (k = 0; k < 10; k++) {
         var _ret2 = _loop4();

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/expected.js
@@ -2,20 +2,24 @@ import React from 'react';
 
 // Regression test for https://github.com/babel/babel/issues/5552
 
-var _ref = <div />;
+var _ref2 = <div />;
 
 class BugReport extends React.Component {
   constructor(...args) {
     var _temp;
 
-    return _temp = super(...args), this.thisWontWork = ({ color }) => data => {
-      return <div color={color}>does not reference data</div>;
+    return _temp = super(...args), this.thisWontWork = ({ color }) => {
+      var _ref = <div color={color}>does not reference data</div>;
+
+      return data => {
+        return _ref;
+      };
     }, this.thisWorks = ({ color }) => data => {
       return <div color={color}>{data}</div>;
     }, _temp;
   }
 
   render() {
-    return _ref;
+    return _ref2;
   }
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/param-and-var/expected.js
@@ -1,7 +1,8 @@
 function fn(Component, obj) {
 
-  var data = obj.data,
-      _ref = <Component prop={data} />;
+  var data = obj.data;
+
+  var _ref = <Component prop={data} />;
 
   return () => _ref;
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/var/expected.js
@@ -1,7 +1,8 @@
 function fn(Component) {
 
-  var data = "prop",
-      _ref = <Component prop={data} />;
+  var data = "prop";
+
+  var _ref = <Component prop={data} />;
 
   return () => _ref;
 }

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -231,7 +231,7 @@ export function pushContainer(listKey, nodes) {
  * referencing it.
  */
 
-export function hoist(scope = this.scope) {
-  const hoister = new PathHoister(this, scope);
+export function hoist() {
+  const hoister = new PathHoister(this);
   return hoister.run();
 }


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

This might be one of the biggest performance boosts we can make. Block scoping is used _everywhere_, and it's the easiest thing to screw up.

We can definitely clean up this code, but it's a start. Basically, if we pass in any constant variables, we can likely hoist these wrapped functions wayyy up, avoid recreating the function instances constantly (😉). This is one of the few times we can do it, since we control both the (only) call-site _and_ the function definition.