### PR TITLE
Switch continue

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/regenerator/destructuring/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/regenerator/destructuring/exec.js
@@ -22,21 +22,22 @@ function* foo3() {
         case "one":
           // Removing these 5 lines makes the tests pass.
           if(value === 1) {
-            break;
+            break loop;
           } else if(value === 2) {
-            break;
+            break loop;
           }
-
+          break;
         case "two":
           // Removing these 3 lines makes the tests pass.
           ["a", "b"].map(function(v) {
             return value + v;
           });
 
+          break loop;
           break;
-
         case "three":
           break loop;
+          break;
       }
     }
 }
@@ -45,7 +46,12 @@ var gen3 = foo3();
 
 assert.equal(gen3.next().value, "iteration");
 assert.equal(gen3.next({what: "one", value: 3}).done, false);
-assert.equal(gen3.next({what: "one", value: 2}).done, false);
-assert.equal(gen3.next({what: "one", value: 1}).done, false);
-assert.equal(gen3.next({what: "two", value: "sometext"}).done, false);
-assert.equal(gen3.next({what: "three"}).done, true);
+assert.equal(gen3.next({what: "one", value: 2}).done, true);
+
+var gen4 = foo3();
+assert.equal(gen4.next().value, "iteration");
+assert.equal(gen4.next({what: "two", value: "sometext"}).done, true);
+
+var gen5 = foo3();
+assert.equal(gen5.next().value, "iteration");
+assert.equal(gen5.next({what: "three"}).done, true);

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -240,9 +240,6 @@ const loopVisitor = {
         // they don't refer to the actual loop we're scopifying
         if (state.ignoreLabeless) return;
 
-        //
-        if (state.inSwitchCase) return;
-
         // break statements mean something different in this context
         if (t.isBreakStatement(node) && t.isSwitchCase(parent)) return;
       }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/actual.js
@@ -7,3 +7,16 @@ let x, y;
 switch (0) {
   case 0: a: let x=0;
 }
+
+// it should break from inside of switch statements using labels
+
+loop:
+for (var i = 0; i < 10; i++) {
+  const z = 3; // force loop function
+  () => z;
+  switch(true) {
+    case true:
+      break loop;
+  }
+}
+

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/label/expected.js
@@ -9,3 +9,22 @@ switch (0) {
   case 0:
     a: var _x2 = 0;
 }
+
+// it should break from inside of switch statements using labels
+
+var _loop = function () {
+  var z = 3; // force loop function
+  (function () {
+    return z;
+  });
+  switch (true) {
+    case true:
+      return "break|loop";
+  }
+};
+
+loop: for (var i = 0; i < 10; i++) {
+  var _ret = _loop();
+
+  if (_ret === "break|loop") break loop;
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/actual.js
@@ -1,0 +1,48 @@
+// it shouldn't break on a case-break statement
+var i;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 1:
+      break;
+  }
+
+  const z = 3; // to force the plugin to convert to loop function call 
+  () => z;
+}
+
+assert.equal(i, 10);
+
+// it should continue on continue statements within switch
+var j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      continue;
+  }
+  j++;
+
+  const z = 3;
+  () => z;
+}
+
+assert.equal(j, 9);
+
+// it should work with loops nested within switch
+j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      for (var k = 0; k < 10; k++) {
+        const z = 3;
+        () => z;
+        j++;
+        break;
+      }
+      break;
+  }
+
+  const z = 3;
+  () => z;
+}
+
+assert.equal(j, 1);

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/exec.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/exec.js
@@ -1,0 +1,48 @@
+// it shouldn't break on a case-break statement
+var i;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 1:
+      break;
+  }
+
+  const z = 3; // to force the plugin to convert to loop function call 
+  () => z;
+}
+
+assert.equal(i, 10);
+
+// it should continue on continue statements within switch
+var j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      continue;
+  }
+  j++;
+
+  const z = 3;
+  () => z;
+}
+
+assert.equal(j, 9);
+
+// it should work with loops nested within switch
+j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      for (var k = 0; k < 10; k++) {
+        const z = 3;
+        () => z;
+        j++;
+        break;
+      }
+      break;
+  }
+
+  const z = 3;
+  () => z;
+}
+
+assert.equal(j, 1);

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-inside-loop/expected.js
@@ -1,0 +1,81 @@
+// it shouldn't break on a case-break statement
+var i;
+
+var _loop = function () {
+  switch (i) {
+    case 1:
+      break;
+  }
+
+  var z = 3; // to force the plugin to convert to loop function call 
+  (function () {
+    return z;
+  });
+};
+
+for (i = 0; i < 10; i++) {
+  _loop();
+}
+
+assert.equal(i, 10);
+
+// it should continue on continue statements within switch
+var j = 0;
+
+var _loop2 = function () {
+  switch (i) {
+    case 0:
+      return "continue";
+  }
+  j++;
+
+  var z = 3;
+  (function () {
+    return z;
+  });
+};
+
+for (i = 0; i < 10; i++) {
+  var _ret = _loop2();
+
+  if (_ret === "continue") continue;
+}
+
+assert.equal(j, 9);
+
+// it should work with loops nested within switch
+j = 0;
+
+var _loop3 = function () {
+  switch (i) {
+    case 0:
+      var _loop4 = function () {
+        var z = 3;
+        (function () {
+          return z;
+        });
+        j++;
+        return "break";
+      };
+
+      for (k = 0; k < 10; k++) {
+        var _ret2 = _loop4();
+
+        if (_ret2 === "break") break;
+      }
+      break;
+  }
+
+  var z = 3;
+  (function () {
+    return z;
+  });
+};
+
+for (i = 0; i < 10; i++) {
+  var k;
+
+  _loop3();
+}
+
+assert.equal(j, 1);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5725 
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

The only significant change is removing 

```diff
-        if (state.inSwitchCase) return;
```
from block scoping transform. It was pretty ad-hoc, there wasn't any sense to it, and the correct functionality was already present in a later line

```js
         // break statements mean something different in this context
         if (t.isBreakStatement(node) && t.isSwitchCase(parent)) return;
```

Rest of the changes are just tests