### PR TITLE
Added another test case for path.insertBefore

### DIFF
--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -1,0 +1,33 @@
+import traverse from "../lib";
+import assert from "assert";
+import { parse } from "babylon";
+import * as t from "babel-types";
+import generate from "babel-generator";
+
+describe("path/modification", function () {
+  describe("insertBefore", function () {
+    const ast = parse(`function abc() {
+      var x = 3;
+    }`);
+
+    it("does things", function () {
+      traverse(ast, {
+        BlockStatement(path) {
+          path.insertBefore(t.expressionStatement(
+            t.callExpression(
+              t.identifier("s"),
+              [],
+            )
+          ));
+        },
+      });
+
+      assert.equal(generate(ast).code, `function abc() {
+  s();
+  {
+    var x = 3;
+  }
+}`);
+    });
+  });
+});


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes and yes
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
I added a new test file for `NodePath` methods defined in `babel-traverse/src/path/modification.js`. It checks one possible case of `insertBefore()` that was not tested yet. I inserted a node using this method and then generated code from the modified ast checking against a source string written by hand. I am note sure if that is the best way to test things like this, maybe it would make more sense to run another test visitor checking for the inserted node? 