### PR TITLE
Allow --inspect-brk option to be used with babel-node

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -46,6 +46,7 @@ getV8Flags(function (err, v8Flags) {
       case "--debug":
       case "--debug-brk":
       case "--inspect":
+      case "--inspect-brk":
         args.unshift(arg);
         break;
 


### PR DESCRIPTION
`--inspect-brk` was added in Node 7.6 and [mentioned in the docs](https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js) since Node 7.7

Going forward it is preferred over the `--inspect --debug-brk` combination, which will be deprecated in Node 8 (see nodejs/node#12949)

babel-node should respect this option, currently it just outputs:
<samp>error: unknown option `--inspect-brk'</samp>

Note: I wasn't quite sure which branch to make the pull request for, so I just used the default (7.0), but it would be nice to get it into 6.x as well.