### PR TITLE
Spec compatibility for template literals.

### DIFF
--- a/packages/babel-plugin-transform-es2015-template-literals/README.md
+++ b/packages/babel-plugin-transform-es2015-template-literals/README.md
@@ -75,16 +75,16 @@ In loose mode, tagged template literal objects aren't frozen.
 
 `boolean`, defaults to `false`.
 
-This option combines all template literal expressions and quasis with `String.prototype.concat`.
+This option combines all template literal expressions and quasis with `String.prototype.concat`. It allows to pass the correct hint to `ToPrimitive` operation and to throw if template literal expression is a `Symbol()`. See [babel/babel#5791](https://github.com/babel/babel/pull/5791).
 
 **In**
 
 ```javascript
-`foo${bar}`;
+`foo${bar}baz${quux}${1}`;
 ```
 
 **Out**
 
 ```javascript
-"foo".concat(bar);
+"foo".concat(bar, "baz").concat(quux, 1);
 ```

--- a/packages/babel-plugin-transform-es2015-template-literals/README.md
+++ b/packages/babel-plugin-transform-es2015-template-literals/README.md
@@ -75,7 +75,7 @@ In loose mode, tagged template literal objects aren't frozen.
 
 `boolean`, defaults to `false`.
 
-This option combines all template literal expressions and quasis with `String.prototype.concat`. It allows to pass the correct hint to `ToPrimitive` operation and to throw if template literal expression is a `Symbol()`. See [babel/babel#5791](https://github.com/babel/babel/pull/5791).
+This option combines all template literal expressions and quasis with `String.prototype.concat`. It will handle cases with `Symbol.toPrimitive` correctly and throw correctly if template literal expression is a `Symbol()`. See [babel/babel#5791](https://github.com/babel/babel/pull/5791).
 
 **In**
 

--- a/packages/babel-plugin-transform-es2015-template-literals/README.md
+++ b/packages/babel-plugin-transform-es2015-template-literals/README.md
@@ -75,7 +75,7 @@ In loose mode, tagged template literal objects aren't frozen.
 
 `boolean`, defaults to `false`.
 
-This option wraps all template literal expressions with `String`. See [babel/babel#1065](https://github.com/babel/babel/issues/1065) for more info.
+This option combines all template literal expressions and quasis with `String.prototype.concat`.
 
 **In**
 
@@ -86,5 +86,5 @@ This option wraps all template literal expressions with `String`. See [babel/bab
 **Out**
 
 ```javascript
-"foo" + String(bar);
+"foo".concat(bar);
 ```

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -1,8 +1,15 @@
 export default function ({ types: t }) {
 
   function buildConcatCallExressions(items) {
+    let avail = true;
     return items.reduce(function(left, right) {
-      if (t.isCallExpression(left) && t.isLiteral(right)) {
+      let canBeInserted = t.isLiteral(right);
+
+      if (!canBeInserted && avail) {
+        canBeInserted = true;
+        avail = false;
+      }
+      if (t.isCallExpression(left) && canBeInserted) {
         left.arguments.push(right);
         return left;
       }

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -65,7 +65,7 @@ export default function ({ types: t }) {
         let root = nodes[0];
 
         if (state.opts.spec) {
-          if (nodes.length) {
+          if (nodes.length > 1) {
             root = buildConcatCallExression(root, nodes.slice(1));
           }
         } else {

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -62,14 +62,14 @@ export default function ({ types: t }) {
         if (!t.isStringLiteral(nodes[0]) && (state.opts.spec || !t.isStringLiteral(nodes[1]))) {
           nodes.unshift(t.stringLiteral(""));
         }
-        let root = nodes.shift();
+        let root = nodes[0];
 
         if (state.opts.spec) {
           if (nodes.length) {
-            root = buildConcatCallExression(root, nodes);
+            root = buildConcatCallExression(root, nodes.slice(1));
           }
         } else {
-          for (let i = 0; i < nodes.length; i++) {
+          for (let i = 1; i < nodes.length; i++) {
             root = t.binaryExpression("+", root, nodes[i]);
           }
         }

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -2,20 +2,14 @@ export default function ({ types: t }) {
 
   function buildConcatCallExressions(items) {
     return items.reduce(function(left, right) {
-      const isString = t.isStringLiteral(right);
-      const canBeInserted = !left._withIdentifier || isString;
-
-      if (t.isCallExpression(left) && canBeInserted) {
-        left._withIdentifier = left._withIdentifier || !isString;
+      if (t.isCallExpression(left) && t.isLiteral(right)) {
         left.arguments.push(right);
         return left;
       }
-      const nextCall = t.callExpression(
+      return t.callExpression(
         t.memberExpression(left, t.identifier("concat")),
         [right]
       );
-      nextCall._withIdentifier = !isString;
-      return nextCall;
     });
   }
 

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -9,7 +9,7 @@ export default function ({ types: t }) {
         canBeInserted = true;
         avail = false;
       }
-      if (t.isCallExpression(left) && canBeInserted) {
+      if (canBeInserted && t.isCallExpression(left)) {
         left.arguments.push(right);
         return left;
       }

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/escape-quotes/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/escape-quotes/expected.js
@@ -1,1 +1,1 @@
-var t = "'" + String(foo) + "' \"" + String(bar) + "\"";
+var t = "'".concat(foo, "' \"", bar, "\"");

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/escape-quotes/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/escape-quotes/expected.js
@@ -1,1 +1,1 @@
-var t = "'".concat(foo, "' \"", bar, "\"");
+var t = "'".concat(foo, "' \"").concat(bar, "\"");

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/functions/expected.js
@@ -1,1 +1,1 @@
-var foo = "test " + String(_.test(foo)) + " " + String(bar);
+var foo = "test ".concat(_.test(foo), " ", bar);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/functions/expected.js
@@ -1,1 +1,1 @@
-var foo = "test ".concat(_.test(foo), " ", bar);
+var foo = "test ".concat(_.test(foo), " ").concat(bar)

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/functions/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/functions/expected.js
@@ -1,1 +1,1 @@
-var foo = "test ".concat(_.test(foo), " ").concat(bar)
+var foo = "test ".concat(_.test(foo), " ").concat(bar);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/literals/actual.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/literals/actual.js
@@ -1,0 +1,1 @@
+var foo = `${1}${f}oo${true}${b}ar${0}${baz}`;

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/literals/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/literals/expected.js
@@ -1,0 +1,1 @@
+var foo = "".concat(1, f, "oo", true).concat(b, "ar", 0).concat(baz);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/multiple/expected.js
@@ -1,1 +1,1 @@
-var foo = "test ".concat(foo, " ", bar);
+var foo = "test ".concat(foo, " ").concat(bar);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/multiple/expected.js
@@ -1,1 +1,1 @@
-var foo = "test " + String(foo) + " " + String(bar);
+var foo = "test ".concat(foo, " ", bar);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/only/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/only/expected.js
@@ -1,1 +1,1 @@
-var foo = "" + String(test);
+var foo = "".concat(test);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/order/exec.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/order/exec.js
@@ -1,0 +1,24 @@
+const calls = [];
+
+`
+  ${
+    calls.push(1),
+    {
+      [Symbol.toPrimitive](){
+        calls.push(2);
+        return 'foo';
+      }
+    }
+  }
+  ${
+    calls.push(3),
+    {
+      [Symbol.toPrimitive](){
+        calls.push(4);
+        return 'bar';
+      }
+    }
+  }
+`;
+
+assert.deepEqual(calls, [1, 2, 3, 4]);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/order/options.json
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/order/options.json
@@ -1,0 +1,3 @@
+{
+  "minNodeVersion": "6.0.0"
+}

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/single/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/single/expected.js
@@ -1,1 +1,1 @@
-var foo = "test " + String(foo);
+var foo = "test ".concat(foo);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/statement/expected.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/statement/expected.js
@@ -1,1 +1,1 @@
-var foo = "test " + String(foo + bar);
+var foo = "test ".concat(foo + bar);

--- a/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/symbol/exec.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/test/fixtures/spec/symbol/exec.js
@@ -1,0 +1,3 @@
+const fn = () => `${Symbol()}`;
+
+assert.throws(fn, TypeError);

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/spec/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/spec/expected.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _this = undefined;
-"1" + String(a);
+"1".concat(a);
 
 (function () {
   babelHelpers.newArrowCheck(this, _this);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | y
| Tests Added/Pass?        | y
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

Without `spec` option there is spec compatibility problem:
`+` always passes **"default"** hint, but **not "string"**.

For ex:
```js
const obj = {
  [Symbol.toPrimitive](hint) {
    if (hint == 'number') {
      return 1;
    }
    if (hint == 'string') {
      return 'hello';
    }
    return true;
  }
};

`${obj}` // returns 'hello' as expected.
// After babel transform w/o spec option:
"" + obj; // returns true;
```

It was resolved and described under [babel/babel#1065](https://github.com/babel/babel/issues/1065), but the solution isn't the best and could be optimized.

For now, with `spec` option we just wrap expressions with `String`:
`"a" + String(1) + "b" + String("c")`

But for ex, if one of the template literal expressions is a `Symbol()` it won't throw.

```js
`${Symbol()}` // Will throw TypeError: Cannot convert a Symbol value to a string
"" + String(Symbol()) // Won't throw.
```
`String` constructor special-cases symbols and return description string instead of throwing.
So, proposed solution is to use `String.prototype.concat` which handle this cases according to the spec:

**in**
```js
`a${1}${"b"}${"c"}`
```
**out**
```js
`"a".concat(1, "b", "c")`
```

thanks @shvaikalesh for pointing me to this issue and help!