### PR TITLE
Allow --inspect-brk option to be used with babel-node [6.x backport]

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -46,6 +46,7 @@ getV8Flags(function (err, v8Flags) {
       case "--debug":
       case "--debug-brk":
       case "--inspect":
+      case "--inspect-brk":
         args.unshift(arg);
         break;
 


### PR DESCRIPTION
Backport of #5785

(first attempt was at #5795, sorry)