### PR TITLE
Fix bug `super` ref check doesn’t honor spec evaluation order

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -23,13 +23,15 @@ const noMethodVisitor = {
 };
 
 const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
-  Super(path) {
-    if (
-      this.isDerived && !this.hasBareSuper &&
-      !path.parentPath.isCallExpression({ callee: path.node })
-    ) {
-      throw path.buildCodeFrameError("'super.*' is not allowed before super()");
-    }
+  MemberExpression: {
+    exit(path) {
+      if (this.isDerived && !this.hasBareSuper) {
+        const objectPath = path.get("object");
+        if (objectPath.isSuper()) {
+          throw objectPath.buildCodeFrameError("'super.*' is not allowed before super()");
+        }
+      }
+    },
   },
 
   CallExpression: {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super-inline/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super-inline/actual.js
@@ -1,0 +1,5 @@
+class Foo extends Bar {
+  constructor() {
+    super.foo(super());
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super-inline/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super-inline/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "'super.*' is not allowed before super()"
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/actual.js
@@ -1,0 +1,5 @@
+class Foo extends Bar {
+  constructor() {
+    super[super().method]();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/exec.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/exec.js
@@ -1,0 +1,20 @@
+let called = false;
+
+class A {
+  method() {
+    called = true;
+  }
+
+  get methodName() {
+    return "method";
+  }
+}
+
+class B extends A {
+  constructor() {
+    super[super().methodName]()
+  }
+}
+
+new B();
+assert.equal(called, true);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/expected.js
@@ -1,0 +1,14 @@
+var Foo = function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
+  function Foo() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Foo);
+
+    babelHelpers.get(Foo.prototype.__proto__ || Object.getPrototypeOf(Foo.prototype), (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), _this).method, _this).call(_this);
+    return _this;
+  }
+
+  return Foo;
+}(Bar);


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes #5800
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

Per [spec](https://www.ecma-international.org/ecma-262/7.0/index.html#sec-super-keyword-runtime-semantics-evaluation), the following is valid code but Babel throws `'super.*' is not allowed before super()` error.

```js
class Foo extends Bar {
  constructor() {
    super[super().method]();
  }
}
```
Fixed by performing validation in `exit` handler of `MemberExpression` whose object is `super`. Also added a related test for the case of `super.foo(super());` (should throw).

