### PR TITLE
Remove check for super calls in arrow function

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -23,18 +23,17 @@ const noMethodVisitor = {
 };
 
 const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
-  Super(path, state) {
+  Super(path) {
     if (
       this.isDerived && !this.hasBareSuper &&
-      !path.parentPath.isCallExpression({ callee: path.node }) &&
-      !state.inArrowFunctionExpression
+      !path.parentPath.isCallExpression({ callee: path.node })
     ) {
-      throw path.buildCodeFrameError("'super.*' is not allowed before super()");
-    }
-  },
+      const hasArrowFunctionParent = path.findParent((p) => p.isArrowFunctionExpression());
 
-  ArrowFunctionExpression(path, state) {
-    state.inArrowFunctionExpression = true;
+      if (!hasArrowFunctionParent) {
+        throw path.buildCodeFrameError("'super.*' is not allowed before super()");
+      }
+    }
   },
 
   CallExpression: {

--- a/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/vanilla.js
@@ -23,13 +23,18 @@ const noMethodVisitor = {
 };
 
 const verifyConstructorVisitor = visitors.merge([noMethodVisitor, {
-  Super(path) {
+  Super(path, state) {
     if (
       this.isDerived && !this.hasBareSuper &&
-      !path.parentPath.isCallExpression({ callee: path.node })
+      !path.parentPath.isCallExpression({ callee: path.node }) &&
+      !state.inArrowFunctionExpression
     ) {
       throw path.buildCodeFrameError("'super.*' is not allowed before super()");
     }
+  },
+
+  ArrowFunctionExpression(path, state) {
+    state.inArrowFunctionExpression = true;
   },
 
   CallExpression: {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/actual.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  constructor() {
+    const t = () => super.test()
+    super.foo();
+    super();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "'super.*' is not allowed before super()"
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/actual.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  constructor() {
+    const t = () => super.test()
+    super();
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/expected.js
@@ -1,0 +1,14 @@
+var Foo = function (_Bar) {
+  babelHelpers.inherits(Foo, _Bar);
+
+  function Foo() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Foo);
+
+    var t = () => babelHelpers.get(Foo.prototype.__proto__ || Object.getPrototypeOf(Foo.prototype), "test", _this).call(_this);
+    return _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
+  }
+
+  return Foo;
+}(Bar);


### PR DESCRIPTION
Ref: https://github.com/babel/babel/pull/5425 

Fixes #5371.

While looking at https://github.com/babel/babel/pull/5801, I could have sworn there was something related recently and discovered https://github.com/babel/babel/pull/5425 was inadvertently closed when the `maser` (typo) branch was deleted.

/cc: @xtuc 