### PR TITLE
Fix 5768

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -73,23 +73,61 @@ export default function () {
       if (node[REASSIGN_REMAP_SKIP]) return;
 
       const left = path.get("left");
-      if (!left.isIdentifier()) return;
+      if (left.isIdentifier()) {
+        const name = left.node.name;
+        const exports = this.exports[name];
+        if (!exports) return;
 
-      const name = left.node.name;
-      const exports = this.exports[name];
-      if (!exports) return;
+        // redeclared in this scope
+        if (this.scope.getBinding(name) !== path.scope.getBinding(name)) return;
 
-      // redeclared in this scope
-      if (this.scope.getBinding(name) !== path.scope.getBinding(name)) return;
+        node[REASSIGN_REMAP_SKIP] = true;
 
-      node[REASSIGN_REMAP_SKIP] = true;
+        for (const reid of exports) {
+          node = buildExportsAssignment(reid, node).expression;
+        }
 
-      for (const reid of exports) {
-        node = buildExportsAssignment(reid, node).expression;
+        path.replaceWith(node);
+        this.requeueInParent(path);
       }
+      else if (left.isObjectPattern()) {
+        for (const property of left.node.properties) {
+          const name = property.value.name;
 
-      path.replaceWith(node);
-      this.requeueInParent(path);
+          const exports = this.exports[name];
+          if (!exports) continue;
+
+          // redeclared in this scope
+          if (this.scope.getBinding(name) !== path.scope.getBinding(name)) return;
+
+          node[REASSIGN_REMAP_SKIP] = true;
+
+          path.insertAfter(t.expressionStatement(t.assignmentExpression(
+            "=",
+            t.memberExpression(t.identifier("exports"), t.identifier(name)),
+            t.identifier(name)
+          )));
+        }
+      }
+      else if (left.isArrayPattern()) {
+        for (const element of left.node.elements) {
+          const name = element.name;
+
+          const exports = this.exports[name];
+          if (!exports) continue;
+
+          // redeclared in this scope
+          if (this.scope.getBinding(name) !== path.scope.getBinding(name)) return;
+
+          node[REASSIGN_REMAP_SKIP] = true;
+
+          path.insertAfter(t.expressionStatement(t.assignmentExpression(
+            "=",
+            t.memberExpression(t.identifier("exports"), t.identifier(name)),
+            t.identifier(name)
+          )));
+        }
+      }
     },
 
     UpdateExpression(path) {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -102,11 +102,7 @@ export default function () {
 
           node[REASSIGN_REMAP_SKIP] = true;
 
-          path.insertAfter(t.expressionStatement(t.assignmentExpression(
-            "=",
-            t.memberExpression(t.identifier("exports"), t.identifier(name)),
-            t.identifier(name)
-          )));
+          path.insertAfter(buildExportsAssignment(t.identifier(name), t.identifier(name)));
         }
       }
       else if (left.isArrayPattern()) {
@@ -121,11 +117,7 @@ export default function () {
 
           node[REASSIGN_REMAP_SKIP] = true;
 
-          path.insertAfter(t.expressionStatement(t.assignmentExpression(
-            "=",
-            t.memberExpression(t.identifier("exports"), t.identifier(name)),
-            t.identifier(name)
-          )));
+          path.insertAfter(buildExportsAssignment(t.identifier(name), t.identifier(name)));
         }
       }
     },

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-destructured/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-destructured/actual.js
@@ -1,0 +1,14 @@
+export let x = 0;
+export let y = 0;
+
+export function f1 () {
+  ({x} = { x: 1 });
+}
+
+export function f2 () {
+  ({x, y} = { x: 2, y: 3 });
+}
+
+export function f3 () {
+  [x, y, z] = [3, 4, 5]
+}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-destructured/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-destructured/expected.js
@@ -1,0 +1,27 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.f1 = f1;
+exports.f2 = f2;
+exports.f3 = f3;
+let x = exports.x = 0;
+let y = exports.y = 0;
+
+function f1() {
+  ({ x } = { x: 1 });
+  exports.x = x;
+}
+
+function f2() {
+  ({ x, y } = { x: 2, y: 3 });
+  exports.y = y;
+  exports.x = x;
+}
+
+function f3() {
+  [x, y, z] = [3, 4, 5];
+  exports.y = y;
+  exports.x = x;
+}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         |  yes
| Tests Added/Pass?        |  yes
| Fixed Tickets            | Fixes #5768  <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

As described in #5768, the current behaviour treats exports correctly if they are assigned a value normally, but incorrectly if they are assigned a value via destructuring.

This PR adds a failing test based on description in #5768, and updates to make the test pass.

The `isIdentifier` case is unchanged, I've just added new cases for `ObjectPattern` and `ArrayPattern`.  There might be a more elegant way to frame this, so please suggest if you see one :)

PS. first PR so please let me know if I missed any steps