### PR TITLE
Don't call deprecated code frame export

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -7,7 +7,7 @@ import PluginPass from "../plugin-pass";
 import { NodePath, Hub, Scope } from "babel-traverse";
 import sourceMap from "source-map";
 import generate from "babel-generator";
-import codeFrame from "babel-code-frame";
+import { codeFrameColumns } from "babel-code-frame";
 import traverse from "babel-traverse";
 import Store from "../store";
 import { parse } from "babylon";
@@ -438,7 +438,7 @@ export default class File extends Store {
             column: loc.column + 1,
           },
         };
-        err.codeFrame = codeFrame(code, location, this.opts);
+        err.codeFrame = codeFrameColumns(code, location, this.opts);
         message += "\n" + err.codeFrame;
       }
 

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -2,7 +2,7 @@ import * as babel from "babel-core";
 import { buildExternalHelpers } from "babel-core";
 import getFixtures from "babel-helper-fixtures";
 import sourceMap from "source-map";
-import codeFrame from "babel-code-frame";
+import { codeFrameColumns } from "babel-code-frame";
 import defaults from "lodash/defaults";
 import includes from "lodash/includes";
 import * as helpers from "./helpers";
@@ -150,7 +150,7 @@ function run(task) {
       resultExec = runCodeInTestContext(execCode, execOpts);
     } catch (err) {
       err.message = exec.loc + ": " + err.message;
-      err.message += codeFrame(execCode);
+      err.message += codeFrameColumns(execCode, exec.loc);
       throw err;
     }
   }

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -1,6 +1,6 @@
 // This file contains methods responsible for replacing a node with another.
 
-import codeFrame from "babel-code-frame";
+import { codeFrameColumns } from "babel-code-frame";
 import traverse from "../index";
 import NodePath from "./index";
 import { parse } from "babylon";
@@ -81,7 +81,7 @@ export function replaceWithSourceString(replacement) {
         },
       };
       err.message += " - make sure this is an expression.";
-      err.message += "\n" + codeFrame(replacement, location);
+      err.message += "\n" + codeFrameColumns(replacement, location);
     }
     throw err;
   }


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Ref #5808
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

Use new export from #5646.
