### PR TITLE
Hardcode to double quotes, indent to 2 spaces

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "babel-messages": "7.0.0-alpha.12",
     "babel-types": "7.0.0-alpha.12",
-    "detect-indent": "^4.0.0",
     "jsesc": "^1.3.0",
     "lodash": "^4.2.0",
     "source-map": "^0.5.0",

--- a/packages/babel-generator/test/fixtures/auto-indentation/hard-tab/expected.js
+++ b/packages/babel-generator/test/fixtures/auto-indentation/hard-tab/expected.js
@@ -1,6 +1,6 @@
 function foo() {
-	bar();
-	if (foo) {
-		bar();
-	}
+  bar();
+  if (foo) {
+    bar();
+  }
 }

--- a/packages/babel-generator/test/fixtures/auto-indentation/soft-tab-4/expected.js
+++ b/packages/babel-generator/test/fixtures/auto-indentation/soft-tab-4/expected.js
@@ -1,6 +1,6 @@
 function foo() {
+  bar();
+  if (foo) {
     bar();
-    if (foo) {
-        bar();
-    }
+  }
 }

--- a/packages/babel-generator/test/fixtures/parentheses/await-arrow-function/expected.js
+++ b/packages/babel-generator/test/fixtures/parentheses/await-arrow-function/expected.js
@@ -1,3 +1,3 @@
 async function fn() {
-    await (() => {});
+  await (() => {});
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -13,6 +13,6 @@ let foo = exports.foo = (() => {
   };
 })();
 
-var _bar = require('bar');
+var _bar = require("bar");
 
 var _bar2 = babelHelpers.interopRequireDefault(_bar);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
@@ -1,19 +1,19 @@
 "use strict";
 
 var Child = function (_Parent) {
-    babelHelpers.inherits(Child, _Parent);
+  babelHelpers.inherits(Child, _Parent);
 
-    function Child() {
-        babelHelpers.classCallCheck(this, Child);
+  function Child() {
+    babelHelpers.classCallCheck(this, Child);
 
-        var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
 
-        _this.scopedFunctionWithThis = function () {
-            _this.name = {};
-        };
+    _this.scopedFunctionWithThis = function () {
+      _this.name = {};
+    };
 
-        return _this;
-    }
+    return _this;
+  }
 
-    return Child;
+  return Child;
 }(Parent);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
@@ -7,7 +7,7 @@ export default (param => {
     }
 
     babelHelpers.createClass(App, [{
-      key: 'getParam',
+      key: "getParam",
       value: function getParam() {
         return param;
       }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
@@ -1,20 +1,20 @@
 function withContext(ComposedComponent) {
-    var _class, _temp;
+  var _class, _temp;
 
-    return _temp = _class = function (_Component) {
-        babelHelpers.inherits(WithContext, _Component);
+  return _temp = _class = function (_Component) {
+    babelHelpers.inherits(WithContext, _Component);
 
-        function WithContext() {
-            babelHelpers.classCallCheck(this, WithContext);
-            return babelHelpers.possibleConstructorReturn(this, (WithContext.__proto__ || Object.getPrototypeOf(WithContext)).apply(this, arguments));
-        }
+    function WithContext() {
+      babelHelpers.classCallCheck(this, WithContext);
+      return babelHelpers.possibleConstructorReturn(this, (WithContext.__proto__ || Object.getPrototypeOf(WithContext)).apply(this, arguments));
+    }
 
-        return WithContext;
-    }(Component), _class.propTypes = {
-        context: PropTypes.shape({
-            addCss: PropTypes.func,
-            setTitle: PropTypes.func,
-            setMeta: PropTypes.func
-        })
-    }, _temp;
+    return WithContext;
+  }(Component), _class.propTypes = {
+    context: PropTypes.shape({
+      addCss: PropTypes.func,
+      setTitle: PropTypes.func,
+      setMeta: PropTypes.func
+    })
+  }, _temp;
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/foobar/expected.js
@@ -1,22 +1,22 @@
 "use strict";
 
 var Child = function (_Parent) {
-    babelHelpers.inherits(Child, _Parent);
+  babelHelpers.inherits(Child, _Parent);
 
-    function Child() {
-        babelHelpers.classCallCheck(this, Child);
+  function Child() {
+    babelHelpers.classCallCheck(this, Child);
 
-        var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
 
-        Object.defineProperty(_this, "scopedFunctionWithThis", {
-            enumerable: true,
-            writable: true,
-            value: function value() {
-                _this.name = {};
-            }
-        });
-        return _this;
-    }
+    Object.defineProperty(_this, "scopedFunctionWithThis", {
+      enumerable: true,
+      writable: true,
+      value: function value() {
+        _this.name = {};
+      }
+    });
+    return _this;
+  }
 
-    return Child;
+  return Child;
 }(Parent);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/non-block-arrow-func/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/non-block-arrow-func/expected.js
@@ -7,13 +7,13 @@ export default (param => {
     }
 
     babelHelpers.createClass(App, [{
-      key: 'getParam',
+      key: "getParam",
       value: function getParam() {
         return param;
       }
     }]);
     return App;
-  }(), Object.defineProperty(_class, 'props', {
+  }(), Object.defineProperty(_class, "props", {
     enumerable: true,
     writable: true,
     value: {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/regression-T6719/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/regression-T6719/expected.js
@@ -1,24 +1,24 @@
 function withContext(ComposedComponent) {
-    var _class, _temp;
+  var _class, _temp;
 
-    return _temp = _class = function (_Component) {
-        babelHelpers.inherits(WithContext, _Component);
+  return _temp = _class = function (_Component) {
+    babelHelpers.inherits(WithContext, _Component);
 
-        function WithContext() {
-            babelHelpers.classCallCheck(this, WithContext);
-            return babelHelpers.possibleConstructorReturn(this, (WithContext.__proto__ || Object.getPrototypeOf(WithContext)).apply(this, arguments));
-        }
+    function WithContext() {
+      babelHelpers.classCallCheck(this, WithContext);
+      return babelHelpers.possibleConstructorReturn(this, (WithContext.__proto__ || Object.getPrototypeOf(WithContext)).apply(this, arguments));
+    }
 
-        return WithContext;
-    }(Component), Object.defineProperty(_class, "propTypes", {
-        enumerable: true,
-        writable: true,
-        value: {
-            context: PropTypes.shape({
-                addCss: PropTypes.func,
-                setTitle: PropTypes.func,
-                setMeta: PropTypes.func
-            })
-        }
-    }), _temp;
+    return WithContext;
+  }(Component), Object.defineProperty(_class, "propTypes", {
+    enumerable: true,
+    writable: true,
+    value: {
+      context: PropTypes.shape({
+        addCss: PropTypes.func,
+        setTitle: PropTypes.func,
+        setMeta: PropTypes.func
+      })
+    }
+  }), _temp;
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-callbacks/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/switch-callbacks/expected.js
@@ -1,16 +1,16 @@
 function fn() {
-    while (true) {
-        (function () {
-            switch (true) {
-                default:
-                    var foo = 4;
-                    if (true) {
-                        var bar = function () {
-                            return foo;
-                        };
-                        console.log(bar());
-                    }
-            }
-        })();
-    }
+  while (true) {
+    (function () {
+      switch (true) {
+        default:
+          var foo = 4;
+          if (true) {
+            var bar = function () {
+              return foo;
+            };
+            console.log(bar());
+          }
+      }
+    })();
+  }
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
@@ -1,49 +1,49 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 exports.default = undefined;
 
-var _net = require('net');
+var _net = require("net");
 
 var _net2 = babelHelpers.interopRequireDefault(_net);
 
-var _events = require('events');
+var _events = require("events");
 
-var _binarySerializer = require('./helpers/binary-serializer');
+var _binarySerializer = require("./helpers/binary-serializer");
 
 var _binarySerializer2 = babelHelpers.interopRequireDefault(_binarySerializer);
 
 // import ...
 
 var Connection = function (_EventEmitter) {
-    babelHelpers.inherits(Connection, _EventEmitter);
+  babelHelpers.inherits(Connection, _EventEmitter);
 
-    function Connection(endpoint, joinKey, joinData, roomId) {
-        babelHelpers.classCallCheck(this, Connection);
+  function Connection(endpoint, joinKey, joinData, roomId) {
+    babelHelpers.classCallCheck(this, Connection);
 
-        var _this = babelHelpers.possibleConstructorReturn(this, (Connection.__proto__ || Object.getPrototypeOf(Connection)).call(this));
+    var _this = babelHelpers.possibleConstructorReturn(this, (Connection.__proto__ || Object.getPrototypeOf(Connection)).call(this));
 
-        _this.isConnected = false;
-        _this.roomId = roomId;
+    _this.isConnected = false;
+    _this.roomId = roomId;
 
-        // ...
-        return _this;
+    // ...
+    return _this;
+  }
+
+  babelHelpers.createClass(Connection, [{
+    key: "send",
+    value: function send(message) {
+      this.sock.write(_binarySerializer2.default.serializeMessage(message));
     }
-
-    babelHelpers.createClass(Connection, [{
-        key: 'send',
-        value: function send(message) {
-            this.sock.write(_binarySerializer2.default.serializeMessage(message));
-        }
-    }, {
-        key: 'disconnect',
-        value: function disconnect() {
-            this.sock.close();
-        }
-    }]);
-    return Connection;
+  }, {
+    key: "disconnect",
+    value: function disconnect() {
+      this.sock.close();
+    }
+  }]);
+  return Connection;
 }(_events.EventEmitter);
 
 exports.default = Connection;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
@@ -1,11 +1,11 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = undefined;
 
-var _BaseFoo2 = require('./BaseFoo');
+var _BaseFoo2 = require("./BaseFoo");
 
 var _BaseFoo3 = babelHelpers.interopRequireDefault(_BaseFoo2);
 
@@ -18,9 +18,9 @@ var SubFoo = function (_BaseFoo) {
   }
 
   babelHelpers.createClass(SubFoo, null, [{
-    key: 'talk',
+    key: "talk",
     value: function talk() {
-      babelHelpers.get(SubFoo.__proto__ || Object.getPrototypeOf(SubFoo), 'talk', this).call(this);
+      babelHelpers.get(SubFoo.__proto__ || Object.getPrototypeOf(SubFoo), "talk", this).call(this);
       console.log('SubFoo.talk');
     }
   }]);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
@@ -1,11 +1,11 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = undefined;
 
-var _react = require('react');
+var _react = require("react");
 
 var _react2 = babelHelpers.interopRequireDefault(_react);
 
@@ -18,15 +18,15 @@ var RandomComponent = function (_Component) {
   }
 
   babelHelpers.createClass(RandomComponent, [{
-    key: 'render',
+    key: "render",
     value: function render() {
       return _react2.default.createElement(
-        'div',
-        { className: 'sui-RandomComponent' },
+        "div",
+        { className: "sui-RandomComponent" },
         _react2.default.createElement(
-          'h2',
+          "h2",
           null,
-          'Hi there!'
+          "Hi there!"
         )
       );
     }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/expected.js
@@ -5,7 +5,7 @@ var C = function () {
   }
 
   babelHelpers.createClass(C, [{
-    key: 'm',
+    key: "m",
     value: function m(x: number): string {
       return 'a';
     }

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/import-order/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/import-order/expected.js
@@ -1,5 +1,5 @@
-define(['./foo', './bar', './derp', './qux'], function (_foo, _bar, _derp, _qux) {
-  'use strict';
+define(["./foo", "./bar", "./derp", "./qux"], function (_foo, _bar, _derp, _qux) {
+  "use strict";
 
   var _bar2 = babelHelpers.interopRequireDefault(_bar);
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/noInterop-export-from/expected.js
@@ -1,10 +1,10 @@
-define(['exports', 'foo'], function (exports, _foo) {
-  'use strict';
+define(["exports", "foo"], function (exports, _foo) {
+  "use strict";
 
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-  Object.defineProperty(exports, 'default', {
+  Object.defineProperty(exports, "default", {
     enumerable: true,
     get: function () {
       return _foo.default;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-ordering/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-ordering/expected.js
@@ -1,11 +1,11 @@
-'use strict';
+"use strict";
 
-require('./foo');
+require("./foo");
 
-var _bar = require('./bar');
+var _bar = require("./bar");
 
 var _bar2 = babelHelpers.interopRequireDefault(_bar);
 
-require('./derp');
+require("./derp");
 
-var _qux = require('./qux');
+var _qux = require("./qux");

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/expected.js
@@ -1,12 +1,12 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _foo = require('foo');
+var _foo = require("foo");
 
-Object.defineProperty(exports, 'default', {
+Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
     return _foo.default;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-wildcard/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/import-wildcard/expected.js
@@ -1,6 +1,6 @@
-'use strict';
+"use strict";
 
-var _foo = require('foo');
+var _foo = require("foo");
 
 _foo.bar();
 _foo.baz();

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _bar = require('bar');
+var _bar = require("bar");
 
 Object.keys(_bar).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
@@ -16,7 +16,7 @@ Object.keys(_bar).forEach(function (key) {
   });
 });
 
-var _foo = require('foo');
+var _foo = require("foo");
 
 var _foo2 = _interopRequireDefault(_foo);
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
@@ -1,12 +1,12 @@
-'use strict';
+"use strict";
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-var _foo = require('foo');
+var _foo = require("foo");
 
 var _foo2 = _interopRequireDefault(_foo);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 const _bar = bar,
       _bar2 = _slicedToArray(_bar, 1),

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility/expected.js
@@ -1,15 +1,15 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _foo = require('foo');
+var _foo = require("foo");
 
 var _foo2 = _interopRequireDefault(_foo);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-console.log(_foo2['default']);
+console.log(_foo2["default"]);
 
-exports['default'] = 5;
+exports["default"] = 5;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-3/expected.js
@@ -1,3 +1,3 @@
-'use strict';
+"use strict";
 
-var _foo = require('foo');
+var _foo = require("foo");

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _mod = require('mod');
+var _mod = require("mod");
 
 Object.keys(_mod).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/import-wildcard/expected.js
@@ -1,6 +1,6 @@
-'use strict';
+"use strict";
 
-var _foo = require('foo');
+var _foo = require("foo");
 
 _foo.bar();
 _foo.baz();

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/dynamic-import/dynamic-import/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/dynamic-import/dynamic-import/expected.js
@@ -7,7 +7,7 @@ System.register([], function (_export, _context) {
     });
   }
 
-  _export('lazyLoadOperation', lazyLoadOperation);
+  _export("lazyLoadOperation", lazyLoadOperation);
 
   return {
     setters: [],

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-multiple/expected.js
@@ -1,19 +1,19 @@
 var t = function (f) {
-    var x = f;
-    x = arguments.length <= 1 ? undefined : arguments[1];
-    x = arguments.length <= 2 ? undefined : arguments[2];
+  var x = f;
+  x = arguments.length <= 1 ? undefined : arguments[1];
+  x = arguments.length <= 2 ? undefined : arguments[2];
 };
 
 function t(f) {
-    var x = f;
-    x = arguments.length <= 1 ? undefined : arguments[1];
-    x = arguments.length <= 2 ? undefined : arguments[2];
+  var x = f;
+  x = arguments.length <= 1 ? undefined : arguments[1];
+  x = arguments.length <= 2 ? undefined : arguments[2];
 }
 
 function u(f, g) {
-    var x = f;
-    var y = g;
-    x[12] = arguments.length <= 2 ? undefined : arguments[2];
-    y.prop = arguments.length <= 3 ? undefined : arguments[3];
-    var z = (arguments.length <= 4 ? undefined : arguments[4]) | 0 || 12;
+  var x = f;
+  var y = g;
+  x[12] = arguments.length <= 2 ? undefined : arguments[2];
+  y.prop = arguments.length <= 3 ? undefined : arguments[3];
+  var z = (arguments.length <= 4 ? undefined : arguments[4]) | 0 || 12;
 }

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/regression/T6761/expected.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/regression/T6761/expected.js
@@ -6,7 +6,7 @@ var args = [1, 2, 3];
 var obj = { obj: { fn } };
 
 switch (true) {
-    case true:
-        (_obj$obj = obj.obj).fn.apply(_obj$obj, args);
-        break;
+  case true:
+    (_obj$obj = obj.obj).fn.apply(_obj$obj, args);
+    break;
 }

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/expected.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-multiple-args/expected.js
@@ -1,5 +1,5 @@
 class Foo {
-	bar() {
-		super.bar.apply(this, [arg1, arg2].concat(babelHelpers.toConsumableArray(args)));
-	}
+  bar() {
+    super.bar.apply(this, [arg1, arg2].concat(babelHelpers.toConsumableArray(args)));
+  }
 }

--- a/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-single-arg/expected.js
+++ b/packages/babel-plugin-transform-es2015-spread/test/fixtures/spread/contexted-method-call-super-single-arg/expected.js
@@ -1,5 +1,5 @@
 class Foo {
-	bar() {
-		super.bar.apply(this, babelHelpers.toConsumableArray(args));
-	}
+  bar() {
+    super.bar.apply(this, babelHelpers.toConsumableArray(args));
+  }
 }

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/non-typeof/expected.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/non-typeof/expected.js
@@ -1,5 +1,5 @@
 export default function (number) {
-    if (!isNaN(number)) {
-        return 1;
-    }
+  if (!isNaN(number)) {
+    return 1;
+  }
 }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 // @flow
 var C = function () {

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 // @flow
 var C = function () {
@@ -7,7 +7,7 @@ var C = function () {
   }
 
   babelHelpers.createClass(C, [{
-    key: 'm',
+    key: "m",
     value: function m(x /*: number*/) /*: string*/ {
       return 'a';
     }

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var C = function () {
   function C() {

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var C = function () {
   function C() {
@@ -6,7 +6,7 @@ var C = function () {
   }
 
   babelHelpers.createClass(C, [{
-    key: 'm',
+    key: "m",
     value: function m(x) {
       return 'a';
     }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/expected.js
@@ -8,4 +8,4 @@ const defunct = {
 };
 
 const { outer: { inner: { three } } } = defunct,
-      other = babelHelpers.objectWithoutProperties(defunct.outer.inner, ['three']);
+      other = babelHelpers.objectWithoutProperties(defunct.outer.inner, ["three"]);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
@@ -1,13 +1,13 @@
 function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 export default {
-    function(name) {
-        return _asyncToGenerator(function* () {
-            const uppercasedName = name.upperCase();
+  function(name) {
+    return _asyncToGenerator(function* () {
+      const uppercasedName = name.upperCase();
 
-            // awaits depending on uppercasedName go here
+      // awaits depending on uppercasedName go here
 
-            return <Foo name={uppercasedName} />;
-        })();
-    }
+      return <Foo name={uppercasedName} />;
+    })();
+  }
 };

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/expected.js
@@ -5,17 +5,17 @@ import React from 'react';
 var _ref = <div />;
 
 class BugReport extends React.Component {
-    constructor(...args) {
-        var _temp;
+  constructor(...args) {
+    var _temp;
 
-        return _temp = super(...args), this.thisWontWork = ({ color }) => data => {
-            return <div color={color}>does not reference data</div>;
-        }, this.thisWorks = ({ color }) => data => {
-            return <div color={color}>{data}</div>;
-        }, _temp;
-    }
+    return _temp = super(...args), this.thisWontWork = ({ color }) => data => {
+      return <div color={color}>does not reference data</div>;
+    }, this.thisWorks = ({ color }) => data => {
+      return <div color={color}>{data}</div>;
+    }, _temp;
+  }
 
-    render() {
-        return _ref;
-    }
+  render() {
+    return _ref;
+  }
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export-default/expected.js
@@ -1,7 +1,7 @@
 class A {
-    render() {
-        return _ref;
-    }
+  render() {
+    return _ref;
+  }
 }
 
 export default class B {}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/regression-node-type-export/expected.js
@@ -1,7 +1,7 @@
 class A {
-    render() {
-        return _ref;
-    }
+  render() {
+    return _ref;
+  }
 }
 
 export class B {}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-escape-xhtml-jsxtext/expected.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-escape-xhtml-jsxtext/expected.js
@@ -1,50 +1,49 @@
 React.createElement(
-  'div',
+  "div",
   null,
-  'wow'
+  "wow"
 );
 React.createElement(
-  'div',
+  "div",
   null,
-  'w\xF4w'
-);
-
-React.createElement(
-  'div',
-  null,
-  'w & w'
-);
-React.createElement(
-  'div',
-  null,
-  'w & w'
+  "w\xF4w"
 );
 
 React.createElement(
-  'div',
+  "div",
   null,
-  'w \xA0 w'
+  "w & w"
 );
 React.createElement(
-  'div',
+  "div",
   null,
-  'this should not parse as unicode: \\u00a0'
+  "w & w"
+);
+
+React.createElement(
+  "div",
+  null,
+  "w \xA0 w"
 );
 React.createElement(
-  'div',
+  "div",
   null,
-  'this should parse as nbsp: \xA0 '
+  "this should not parse as unicode: \\u00a0"
 );
 React.createElement(
-  'div',
+  "div",
   null,
-  'this should parse as unicode: ',
+  "this should parse as nbsp: \xA0 "
+);
+React.createElement(
+  "div",
+  null,
+  "this should parse as unicode: ",
   '\u00a0 '
 );
 
 React.createElement(
-  'div',
+  "div",
   null,
-  'w < w'
+  "w < w"
 );
-

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-quote-jsx-attributes/expected.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-quote-jsx-attributes/expected.js
@@ -1,5 +1,5 @@
 React.createElement(
-  'button',
-  { 'data-value': 'a value' },
-  'Button'
+  "button",
+  { "data-value": "a value" },
+  "Button"
 );

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/expected.js
@@ -1,6 +1,6 @@
 var func = regeneratorRuntime.mark(function _callee() {var actual;return regeneratorRuntime.wrap(function _callee$(_context) {while (1) switch (_context.prev = _context.next) {case 0:_context.next = 2;return (
-                    obj.
-                    method().
-                    method2());case 2:
+          obj.
+          method().
+          method2());case 2:
 
-                actual = true;case 3:case "end":return _context.stop();}}, _callee, this);});
+        actual = true;case 3:case "end":return _context.stop();}}, _callee, this);});


### PR DESCRIPTION
If we want to actually remove the tokens, we'd need to refactor https://github.com/babel/babel/blob/7.0/packages/babel-generator/src/printer.js and https://github.com/babel/babel/blob/7.0/packages/babel-generator/src/whitespace.js to not use tokens and instead the loc in the AST?