### PR TITLE
Fix numeric separator Number transform

### DIFF
--- a/packages/babel-plugin-transform-numeric-separator/src/index.js
+++ b/packages/babel-plugin-transform-numeric-separator/src/index.js
@@ -1,15 +1,20 @@
 import syntaxNumericSeparator from "babel-plugin-syntax-numeric-separator";
 
-export default function () {
+export default function ({ types: t }) {
 
   function replacer(value) {
     return value.replace(/_/g, "");
   }
 
   function replaceNumberArg({ node }) {
-    if (node.callee.name === "Number") {
-      node.arguments[0].value = replacer(node.arguments[0].value);
+    if (node.callee.name !== "Number") {
+      return;
     }
+    const arg = node.arguments[0];
+    if (!t.isStringLiteral(arg)) {
+      return;
+    }
+    arg.value = replacer(arg.value);
   }
 
   const CallExpression = replaceNumberArg;

--- a/packages/babel-plugin-transform-numeric-separator/test/fixtures/number/exec.js
+++ b/packages/babel-plugin-transform-numeric-separator/test/fixtures/number/exec.js
@@ -7,3 +7,13 @@ assert.equal(new Number("1_000").valueOf(), new Number("1000").valueOf());
 assert.equal(new Number("0xAE_BE_CE").valueOf(), new Number("0xAEBECE").valueOf());
 assert.equal(new Number("0b1010_0001_1000_0101").valueOf(), new Number("0b1010000110000101").valueOf());
 assert.equal(new Number("0o0_6_6_6").valueOf(), new Number("0o0666").valueOf());
+
+assert.equal(Number(1_000), Number("1000"));
+assert.equal(Number(0xAE_BE_CE), Number("0xAEBECE"));
+assert.equal(Number(0b1010_0001_1000_0101), Number("0b1010000110000101"));
+assert.equal(Number(0o0_6_6_6), Number("0o0666"));
+
+assert.equal(new Number(1_000).valueOf(), new Number("1000").valueOf());
+assert.equal(new Number(0xAE_BE_CE).valueOf(), new Number("0xAEBECE").valueOf());
+assert.equal(new Number(0b1010_0001_1000_0101).valueOf(), new Number("0b1010000110000101").valueOf());
+assert.equal(new Number(0o0_6_6_6).valueOf(), new Number("0o0666").valueOf());


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes?
| Tests Added/Pass?        | Yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

The transform assumed the argument to `Number` was always a string, which isn't correct. Now, we only remove the separators if it is in fact a string.