### PR TITLE
[WIP] deprecates unnamed plugins and adds error message

### DIFF
--- a/packages/babel-core/src/transformation/file/logger.js
+++ b/packages/babel-core/src/transformation/file/logger.js
@@ -29,7 +29,8 @@ export default class Logger {
     throw new Constructor(this._buildMessage(msg));
   }
 
-  deprecate(msg: string) {
+  deprecate(msg: string, metadata: object) {
+    // metadata.id, metadata.url, metadata.until
     if (this.file.opts && this.file.opts.suppressDeprecationMessages) return;
 
     msg = this._buildMessage(msg);
@@ -40,7 +41,12 @@ export default class Logger {
     // make sure we don't see it again
     seenDeprecatedMessages.push(msg);
 
-    console.error(msg);
+    if (Object.prototype.hasOwnProperty.call(metadata, "url")) {
+      const viewGuide = `Please view the Deprecation Guide at ${metadata.url}.`;
+      console.error(msg, viewGuide);
+    } else {
+      console.error(msg);
+    }
   }
 
   verbose(msg: string) {

--- a/packages/babel-core/src/transformation/plugin.js
+++ b/packages/babel-core/src/transformation/plugin.js
@@ -4,6 +4,7 @@ import Store from "../store";
 import traverse from "babel-traverse";
 import assign from "lodash/assign";
 import clone from "lodash/clone";
+import logger from "./file/logger";
 
 const GLOBAL_VISITOR_PROPS = ["enter", "exit"];
 
@@ -12,8 +13,22 @@ export default class Plugin extends Store {
     super();
 
     this.initialized = false;
-    this.raw         = assign({}, plugin);
-    this.key         = this.take("name") || key;
+    this.raw = assign({}, plugin);
+    let specifiedName = this.take("name");
+
+    // List of invalid names.
+    if ([undefined, null, false].indexOf(specifiedName) !== -1) {
+      logger.deprecate(
+        `The plugin ${key} does not have a valid name property. In Babel 7 this will throw an Error as the name property will be required.`,
+        {
+          id: "plugin.name",
+          url: "https://babeljs.com/deprecations/plugin.name",
+          until: "7.0.0"
+        }
+      );
+    }
+
+    this.key = this.take("name") || key;
 
     this.manipulateOptions = this.take("manipulateOptions");
     this.post              = this.take("post");


### PR DESCRIPTION

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | yes
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | #5735 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
Deprecates unnamed plugins and adds a deprecation message to Babel 6. Enables us to disallow nameless plugins in Babel 7.

### TODO:
- [ ] Create deprecation guide on the Babel website.
- [ ] Write deprecation guide for nameless plugins.
- [ ] Convince @hzoo that requiring plugin names is a good thing.
- [ ] Create PR for Babel 7 that throws an error instead of a deprecation.