### PR TITLE
Reject invalid plugin names

### DIFF
--- a/packages/babel-core/src/config/plugin.js
+++ b/packages/babel-core/src/config/plugin.js
@@ -2,8 +2,8 @@
 
 export default class Plugin {
   constructor(plugin: {}, key?: string) {
-    if (plugin.name != null && typeof plugin.name !== "string") {
-      throw new Error("Plugin .name must be a string, null, or undefined");
+    if (!plugin.name || typeof plugin.name !== "string") {
+      throw new Error("Plugin .name must be a string");
     }
     if (plugin.manipulateOptions != null && typeof plugin.manipulateOptions !== "function") {
       throw new Error("Plugin .manipulateOptions must be a function, null, or undefined");

--- a/packages/babel-plugin-check-es2015-constants/src/index.js
+++ b/packages/babel-plugin-check-es2015-constants/src/index.js
@@ -1,5 +1,7 @@
 export default function ({ messages }) {
   return {
+    name: "babel-plugin-check-es2015-constants",
+
     visitor: {
       Scope({ scope }) {
         for (const name in scope.bindings) {
@@ -11,6 +13,6 @@ export default function ({ messages }) {
           }
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-external-helpers/src/index.js
+++ b/packages/babel-plugin-external-helpers/src/index.js
@@ -1,7 +1,9 @@
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-external-helpers",
+
     pre(file) {
       file.set("helpersNamespace", t.identifier("babelHelpers"));
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-async-functions/src/index.js
+++ b/packages/babel-plugin-syntax-async-functions/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-async-functions",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("asyncFunctions");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-async-generators/src/index.js
+++ b/packages/babel-plugin-syntax-async-generators/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-async-generators",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("asyncGenerators");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-class-properties/src/index.js
+++ b/packages/babel-plugin-syntax-class-properties/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-class-properties",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("classProperties");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-decorators",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("decorators");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-do-expressions/src/index.js
+++ b/packages/babel-plugin-syntax-do-expressions/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-do-expressions",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("doExpressions");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-dynamic-import/src/index.js
+++ b/packages/babel-plugin-syntax-dynamic-import/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-dynamic-import",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("dynamicImport");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-syntax-exponentiation-operator/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-exponentiation-operator",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("exponentiationOperator");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-export-extensions/src/index.js
+++ b/packages/babel-plugin-syntax-export-extensions/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-export-extensions",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("exportExtensions");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-flow/src/index.js
+++ b/packages/babel-plugin-syntax-flow/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-flow",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("flow");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-function-bind/src/index.js
+++ b/packages/babel-plugin-syntax-function-bind/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-function-bind",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("functionBind");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-function-sent/src/index.js
+++ b/packages/babel-plugin-syntax-function-sent/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-function-sent",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("functionSent");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-jsx/src/index.js
+++ b/packages/babel-plugin-syntax-jsx/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-jsx",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-numeric-separator/src/index.js
+++ b/packages/babel-plugin-syntax-numeric-separator/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-numeric-separator",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("numericSeparator");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-syntax-object-rest-spread/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-object-rest-spread",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("objectRestSpread");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-syntax-trailing-function-commas/src/index.js
+++ b/packages/babel-plugin-syntax-trailing-function-commas/src/index.js
@@ -1,7 +1,9 @@
 export default function () {
   return {
+    name: "babel-plugin-syntax-trailing-function-commas",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("trailingFunctionCommas");
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-async-functions/src/index.js
+++ b/packages/babel-plugin-transform-async-functions/src/index.js
@@ -2,6 +2,7 @@ import asyncSyntaxPlugin from "babel-plugin-syntax-async-functions";
 
 export default function () {
   return {
-    inherits: asyncSyntaxPlugin,
+    name: "babel-plugin-transform-async-functions",
+    inherits: asyncSyntaxPlugin
   };
 }

--- a/packages/babel-plugin-transform-async-generator-functions/src/index.js
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.js
@@ -19,6 +19,8 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxAsyncGenerators,
+    name: "babel-plugin-transform-async-generator-functions",
+
     visitor: {
       Function(path, state) {
         if (!path.node.async || !path.node.generator) return;
@@ -32,6 +34,6 @@ export default function ({ types: t }) {
             state.addHelper("asyncGenerator"), t.identifier("await")),
         });
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-async-to-generator/src/index.js
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.js
@@ -3,6 +3,7 @@ import syntaxAsyncFunctions from "babel-plugin-syntax-async-functions";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-async-to-generator",
     inherits: syntaxAsyncFunctions,
 
     visitor: {
@@ -20,6 +21,6 @@ export default function () {
           wrapAsync: state.addHelper("asyncToGenerator"),
         });
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-async-to-module-method/src/index.js
+++ b/packages/babel-plugin-transform-async-to-module-method/src/index.js
@@ -3,6 +3,7 @@ import syntaxAsyncFunctions from "babel-plugin-syntax-async-functions";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-async-to-module-method",
     inherits: syntaxAsyncFunctions,
 
     visitor: {
@@ -13,6 +14,6 @@ export default function () {
           wrapAsync: state.addImport(state.opts.module, state.opts.method),
         });
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -283,9 +283,9 @@ export default function({ types: t }) {
 
   return {
     inherits: syntaxDecorators,
-
     dependencies: ["classProperties"],
     capabilities: ["decorators"],
+    name: "babel-plugin-transform-decorators",
 
     visitor: {
       ExportDefaultDeclaration(path) {
@@ -340,6 +340,6 @@ export default function({ types: t }) {
           path.get("right.arguments")[1].node,
         ]));
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-do-expressions/src/index.js
+++ b/packages/babel-plugin-transform-do-expressions/src/index.js
@@ -2,6 +2,7 @@ import syntaxDoExpressions from "babel-plugin-syntax-do-expressions";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-do-expressions",
     inherits: syntaxDoExpressions,
 
     visitor: {
@@ -15,6 +16,6 @@ export default function () {
           }
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-arrow-functions/src/index.js
+++ b/packages/babel-plugin-transform-es2015-arrow-functions/src/index.js
@@ -4,6 +4,8 @@ import type NodePath from "babel-traverse";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-arrow-functions",
+
     visitor: {
       ArrowFunctionExpression(path: NodePath<BabelNodeArrowFunctionExpression>, state: Object) {
         // In some conversion cases, it may have already been converted to a function while this callback
@@ -17,6 +19,6 @@ export default function () {
           specCompliant: !!state.opts.spec,
         });
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-block-scoped-functions/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoped-functions/src/index.js
@@ -21,6 +21,8 @@ export default function ({ types: t }) {
   }
 
   return {
+    name: "babel-plugin-transform-es2015-block-scoped-functions",
+
     visitor: {
       BlockStatement(path) {
         const { node, parent } = path;
@@ -34,6 +36,6 @@ export default function ({ types: t }) {
       SwitchCase(path) {
         statementList("consequent", path);
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -10,6 +10,8 @@ import template from "babel-template";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-block-scoping",
+
     visitor: {
       VariableDeclaration(path, file) {
         const { node, parent, scope } = path;
@@ -61,7 +63,7 @@ export default function () {
           blockScoping.run();
         }
       },
-    },
+    }
   };
 }
 

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -7,6 +7,8 @@ export default function ({ types: t }) {
   const VISITED = Symbol();
 
   return {
+    name: "babel-plugin-transform-es2015-classes",
+
     visitor: {
       ExportDefaultDeclaration(path) {
         if (!path.get("declaration").isClassDeclaration()) return;
@@ -51,6 +53,6 @@ export default function ({ types: t }) {
           path.get("callee").arrowFunctionToExpression();
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-computed-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/src/index.js
@@ -84,6 +84,8 @@ export default function ({ types: t, template }) {
   }
 
   return {
+    name: "babel-plugin-transform-es2015-computed-properties",
+
     visitor: {
       ObjectExpression: {
         exit(path, state) {
@@ -164,6 +166,6 @@ export default function ({ types: t, template }) {
           }
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/src/index.js
@@ -329,6 +329,8 @@ export default function ({ types: t }) {
 
 
   return {
+    name: "babel-plugin-transform-es2015-destructuring",
+
     visitor: {
       ExportNamedDeclaration(path) {
         const declaration = path.get("declaration");
@@ -523,6 +525,6 @@ export default function ({ types: t }) {
           path.replaceWithMultiple(nodesOut);
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-duplicate-keys/src/index.js
+++ b/packages/babel-plugin-transform-es2015-duplicate-keys/src/index.js
@@ -9,6 +9,8 @@ function getName(key) {
 
 export default function() {
   return {
+    name: "babel-plugin-transform-es2015-duplicate-keys",
+
     visitor: {
       ObjectExpression(path) {
         const { node } = path;
@@ -57,6 +59,6 @@ export default function() {
           }
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-for-of/src/index.js
+++ b/packages/babel-plugin-transform-es2015-for-of/src/index.js
@@ -91,6 +91,8 @@ export default function ({ messages, template, types: t }) {
 
 
   return {
+    name: "babel-plugin-transform-es2015-for-of",
+
     visitor: {
       ForOfStatement(path, state) {
         if (path.get("right").isArrayExpression()) {
@@ -131,7 +133,7 @@ export default function ({ messages, template, types: t }) {
           path.replaceWithMultiple(build.node);
         }
       },
-    },
+    }
   };
 
   function loose(path, file) {

--- a/packages/babel-plugin-transform-es2015-function-name/src/index.js
+++ b/packages/babel-plugin-transform-es2015-function-name/src/index.js
@@ -2,6 +2,8 @@ import nameFunction from "babel-helper-function-name";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-function-name",
+
     visitor: {
       FunctionExpression: {
         exit(path) {
@@ -19,6 +21,6 @@ export default function () {
           if (newNode) value.replaceWith(newNode);
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-instanceof/src/index.js
+++ b/packages/babel-plugin-transform-es2015-instanceof/src/index.js
@@ -1,5 +1,7 @@
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-es2015-instanceof",
+
     visitor: {
       BinaryExpression(path) {
         const { node } = path;
@@ -7,6 +9,6 @@ export default function ({ types: t }) {
           path.replaceWith(t.callExpression(this.addHelper("instanceof"), [node.left, node.right]));
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-literals/src/index.js
@@ -1,5 +1,7 @@
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-literals",
+
     visitor: {
       NumericLiteral({ node }) {
         // number octal like 0b10 or 0o70
@@ -14,6 +16,6 @@ export default function () {
           node.extra = undefined;
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/src/index.js
@@ -95,6 +95,8 @@ export default function ({ types: t }) {
       this.hasModule = false;
     },
 
+    name: "babel-plugin-transform-es2015-modules-amd",
+
     visitor: {
       Program: {
         exit(path) {
@@ -133,6 +135,6 @@ export default function ({ types: t }) {
           })];
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -129,6 +129,7 @@ export default function () {
 
   return {
     inherits: transformStrictMode,
+    name: "babel-plugin-transform-es2015-modules-commonjs",
 
     visitor: {
       ThisExpression(path, state) {
@@ -482,6 +483,6 @@ export default function () {
           });
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -69,6 +69,8 @@ export default function ({ types: t }) {
   };
 
   return {
+    name: "babel-plugin-transform-es2015-modules-systemjs",
+
     visitor: {
 
       CallExpression(path, state) {
@@ -309,6 +311,6 @@ export default function ({ types: t }) {
           ];
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/src/index.js
@@ -44,6 +44,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: transformAMD,
+    name: "babel-plugin-transform-es2015-modules-umd",
 
     visitor: {
       Program: {
@@ -134,6 +135,6 @@ export default function ({ types: t }) {
           }));
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-object-super/src/index.js
+++ b/packages/babel-plugin-transform-es2015-object-super/src/index.js
@@ -15,6 +15,8 @@ function replacePropertySuper(path, node, scope, getObjectRef, file) {
 
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-es2015-object-super",
+
     visitor: {
       ObjectExpression(path, state) {
         let objectRef;
@@ -35,6 +37,6 @@ export default function ({ types: t }) {
           path.replaceWith(t.assignmentExpression("=", objectRef, path.node));
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-parameters/src/index.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/index.js
@@ -7,6 +7,8 @@ import * as rest from "./rest";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-parameters",
+
     visitor: visitors.merge([{
       ArrowFunctionExpression(path) {
         // In some conversion cases, it may have already been converted to a function while this callback
@@ -22,6 +24,6 @@ export default function () {
           }
         }
       },
-    }, destructuring.visitor, rest.visitor, def.visitor]),
+    }, destructuring.visitor, rest.visitor, def.visitor])
   };
 }

--- a/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
+++ b/packages/babel-plugin-transform-es2015-shorthand-properties/src/index.js
@@ -2,6 +2,8 @@ import * as t from "babel-types";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-shorthand-properties",
+
     visitor: {
       ObjectMethod(path) {
         const { node } = path;
@@ -22,6 +24,6 @@ export default function () {
           node.shorthand = false;
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-spread/src/index.js
+++ b/packages/babel-plugin-transform-es2015-spread/src/index.js
@@ -42,6 +42,8 @@ export default function ({ types: t }) {
   }
 
   return {
+    name: "babel-plugin-transform-es2015-spread",
+
     visitor: {
       ArrayExpression(path, state) {
         const { node, scope } = path;
@@ -137,6 +139,6 @@ export default function ({ types: t }) {
           []
         ));
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-sticky-regex/src/index.js
+++ b/packages/babel-plugin-transform-es2015-sticky-regex/src/index.js
@@ -3,6 +3,8 @@ import * as t from "babel-types";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-sticky-regex",
+
     visitor: {
       RegExpLiteral(path) {
         const { node } = path;
@@ -13,6 +15,6 @@ export default function () {
           t.stringLiteral(node.flags),
         ]));
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -21,6 +21,8 @@ export default function ({ types: t }) {
   }
 
   return {
+    name: "babel-plugin-transform-es2015-template-literals",
+
     visitor: {
       TaggedTemplateExpression(path, state) {
 
@@ -93,6 +95,6 @@ export default function ({ types: t }) {
 
         path.replaceWith(root);
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
@@ -2,6 +2,8 @@ export default function ({ types: t }) {
   const IGNORE = Symbol();
 
   return {
+    name: "babel-plugin-transform-es2015-typeof-symbol",
+
     visitor: {
       Scope({ scope }) {
         if (!scope.getBinding("Symbol")) {
@@ -47,6 +49,6 @@ export default function ({ types: t }) {
           }
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es2015-unicode-regex/src/index.js
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/src/index.js
@@ -3,12 +3,14 @@ import * as regex from "babel-helper-regex";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-es2015-unicode-regex",
+
     visitor: {
       RegExpLiteral({ node }) {
         if (!regex.is(node, "u")) return;
         node.pattern = rewritePattern(node.pattern, node.flags);
         regex.pullFlag(node, "u");
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es3-member-expression-literals/src/index.js
+++ b/packages/babel-plugin-transform-es3-member-expression-literals/src/index.js
@@ -1,5 +1,7 @@
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-es3-member-expression-literals",
+
     visitor: {
       MemberExpression: {
         exit({ node }) {
@@ -11,6 +13,6 @@ export default function ({ types: t }) {
           }
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es3-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-es3-property-literals/src/index.js
@@ -1,5 +1,7 @@
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-es3-property-literals",
+
     visitor: {
       ObjectProperty: {
         exit({ node }) {
@@ -10,6 +12,6 @@ export default function ({ types: t }) {
           }
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-es5-property-mutators/src/index.js
+++ b/packages/babel-plugin-transform-es5-property-mutators/src/index.js
@@ -2,6 +2,8 @@ import * as defineMap from "babel-helper-define-map";
 
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-es5-property-mutators",
+
     visitor: {
       ObjectExpression(path, file) {
         const { node } = path;
@@ -30,6 +32,6 @@ export default function ({ types: t }) {
           [node, defineMap.toDefineObject(mutatorMap)]
         ));
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-eval/src/index.js
+++ b/packages/babel-plugin-transform-eval/src/index.js
@@ -1,5 +1,7 @@
 export default function ({ parse, traverse }) {
   return {
+    name: "babel-plugin-transform-eval",
+
     visitor: {
       CallExpression(path) {
         if (path.get("callee").isIdentifier({ name: "eval" }) && path.node.arguments.length === 1) {
@@ -14,6 +16,6 @@ export default function ({ parse, traverse }) {
           return ast.program;
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/src/index.js
@@ -3,6 +3,7 @@ import syntaxExponentiationOperator from "babel-plugin-syntax-exponentiation-ope
 
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-exponentiation-operator",
     inherits: syntaxExponentiationOperator,
 
     visitor: build({
@@ -11,6 +12,6 @@ export default function ({ types: t }) {
       build(left, right) {
         return t.callExpression(t.memberExpression(t.identifier("Math"), t.identifier("pow")), [left, right]);
       },
-    }),
+    })
   };
 }

--- a/packages/babel-plugin-transform-export-extensions/src/index.js
+++ b/packages/babel-plugin-transform-export-extensions/src/index.js
@@ -23,6 +23,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxExportExtensions,
+    name: "babel-plugin-transform-export-extensions",
 
     visitor: {
       ExportNamedDeclaration(path) {
@@ -36,6 +37,6 @@ export default function ({ types: t }) {
         }
         path.replaceWithMultiple(nodes);
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -15,6 +15,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxFlow,
+    name: "babel-plugin-transform-flow-comments",
 
     visitor: {
       TypeCastExpression(path) {
@@ -68,6 +69,6 @@ export default function ({ types: t }) {
         }
         wrapInFlowComment(path, parent);
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -5,6 +5,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxFlow,
+    name: "babel-plugin-transform-flow-strip-types",
 
     visitor: {
       Program(path, { file: { ast: { comments } } }) {
@@ -76,6 +77,6 @@ export default function ({ types: t }) {
         } while (t.isTypeCastExpression(node));
         path.replaceWith(node);
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-function-bind/src/index.js
+++ b/packages/babel-plugin-transform-function-bind/src/index.js
@@ -32,6 +32,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxFunctionBind,
+    name: "babel-plugin-transform-function-bind",
 
     visitor: {
       CallExpression({ node, scope }) {
@@ -48,6 +49,6 @@ export default function ({ types: t }) {
         const context = inferBindContext(node, scope);
         path.replaceWith(t.callExpression(t.memberExpression(node.callee, t.identifier("bind")), [context]));
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-jscript/src/index.js
+++ b/packages/babel-plugin-transform-jscript/src/index.js
@@ -1,5 +1,7 @@
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-jscript",
+
     visitor: {
       FunctionExpression: {
         exit(path) {
@@ -16,6 +18,6 @@ export default function ({ types: t }) {
           ));
         },
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-numeric-separator/src/index.js
+++ b/packages/babel-plugin-transform-numeric-separator/src/index.js
@@ -22,6 +22,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxNumericSeparator,
+    name: "babel-plugin-transform-numeric-separator",
 
     visitor: {
       CallExpression,
@@ -31,6 +32,6 @@ export default function ({ types: t }) {
           node.value = replacer(node.extra.raw);
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-object-assign/src/index.js
+++ b/packages/babel-plugin-transform-object-assign/src/index.js
@@ -1,11 +1,13 @@
 export default function () {
   return {
+    name: "babel-plugin-transform-object-assign",
+
     visitor: {
       CallExpression: function (path, file) {
         if (path.get("callee").matchesPattern("Object.assign")) {
           path.node.callee = file.addHelper("extends");
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -74,6 +74,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: syntaxObjectRestSpread,
+    name: "babel-plugin-transform-object-rest-spread",
 
     visitor: {
       // taken from transform-es2015-parameters/src/destructuring.js
@@ -301,6 +302,6 @@ export default function ({ types: t }) {
 
         path.replaceWith(t.callExpression(helper, args));
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.js
@@ -1,11 +1,13 @@
 export default function () {
   return {
+    name: "babel-plugin-transform-object-set-prototype-of-to-assign",
+
     visitor: {
       CallExpression(path, file) {
         if (path.get("callee").matchesPattern("Object.setPrototypeOf")) {
           path.node.callee = file.addHelper("defaults");
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-proto-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-proto-to-assign/src/index.js
@@ -16,6 +16,8 @@ export default function ({ types: t }) {
   }
 
   return {
+    name: "babel-plugin-transform-proto-to-assign",
+
     visitor: {
       AssignmentExpression(path, file) {
         if (!isProtoAssignmentExpression(path.node)) return;
@@ -57,6 +59,6 @@ export default function ({ types: t }) {
           path.replaceWith(t.callExpression(file.addHelper("extends"), args));
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -48,6 +48,8 @@ export default function ({ types: t }) {
   };
 
   return {
+    name: "babel-plugin-transform-react-constant-elements",
+
     visitor: {
       JSXElement(path) {
         if (path.node._hoisted) return;
@@ -61,6 +63,6 @@ export default function ({ types: t }) {
           path.node._hoisted = true;
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -43,6 +43,8 @@ export default function ({ types: t }) {
   }
 
   return {
+    name: "babel-plugin-transform-react-display-name",
+
     visitor: {
       ExportDefaultDeclaration({ node }, state) {
         if (isCreateClass(node.declaration)) {
@@ -93,6 +95,6 @@ export default function ({ types: t }) {
           addDisplayName(id.name, node);
         }
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -20,6 +20,8 @@ export default function ({ types: t }) {
   }
 
   return {
+    name: "babel-plugin-transform-react-inline-elements",
+
     visitor: {
       JSXElement(path, file) {
         const { node } = path;
@@ -64,6 +66,6 @@ export default function ({ types: t }) {
         const el = t.callExpression(file.addHelper("jsx"), args);
         path.replaceWith(el);
       },
-    },
+    }
   };
 }

--- a/packages/babel-plugin-transform-react-jsx-compat/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-compat/src/index.js
@@ -2,6 +2,8 @@ import helper from "babel-helper-builder-react-jsx";
 
 export default function ({ types: t }) {
   return {
+    name: "babel-plugin-transform-react-jsx-compat",
+
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");
     },
@@ -23,6 +25,6 @@ export default function ({ types: t }) {
           );
         }
       },
-    }),
+    })
   };
 }

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.js
@@ -25,6 +25,7 @@ export default function ({ types: t }) {
   };
 
   return {
-    visitor,
+    name: "babel-plugin-transform-react-jsx-self",
+    visitor
   };
 }

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -58,6 +58,7 @@ export default function ({ types: t }) {
   };
 
   return {
-    visitor,
+    name: "babel-plugin-transform-react-jsx-source",
+    visitor
   };
 }

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -47,6 +47,7 @@ export default function ({ types: t }) {
 
   return {
     inherits: jsx,
-    visitor,
+    name: "babel-plugin-transform-react-jsx",
+    visitor
   };
 }

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
   "main": "lib/index.js",
   "dependencies": {
-    "regenerator-transform": "0.9.11"
+    "regenerator-transform": "0.9.12"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -34,6 +34,8 @@ export default function ({ types: t }) {
       });
     },
 
+    name: "babel-plugin-transform-runtime",
+
     visitor: {
       ReferencedIdentifier(path, state) {
         const { node, parent, scope } = path;
@@ -155,7 +157,7 @@ export default function ({ types: t }) {
           ));
         },
       },
-    },
+    }
   };
 }
 

--- a/packages/babel-plugin-transform-strict-mode/src/index.js
+++ b/packages/babel-plugin-transform-strict-mode/src/index.js
@@ -2,6 +2,8 @@ import * as t from "babel-types";
 
 export default function () {
   return {
+    name: "babel-plugin-transform-strict-mode",
+
     visitor: {
       Program(path, state) {
         if (state.opts.strict === false || state.opts.strictMode === false) return;
@@ -14,6 +16,6 @@ export default function () {
 
         path.unshiftContainer("directives", t.directive(t.directiveLiteral("use strict")));
       },
-    },
+    }
   };
 }


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | Progress on #5735 and #5827
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 


⚠️ This change enforces plugins to have a valid name, that is of type string, and is a valid JS identifier