### PR TITLE
Add tests for babel-generator

### DIFF
--- a/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
@@ -35,6 +35,8 @@ class Foo {
   get fooProp(): number {}
 }
 var numVal: number;
+var numVal: empty;
+var numVal: mixed;
 var numVal: number = otherNumVal;
 var a: { numVal: number };
 var a: { numVal: number; };

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
@@ -35,6 +35,8 @@ class Foo {
   get fooProp(): number {}
 }
 var numVal: number;
+var numVal: empty;
+var numVal: mixed;
 var numVal: number = otherNumVal;
 var a: { numVal: number };
 var a: { numVal: number };


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | #5326
| License                  | MIT
| Doc PR                   | no<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

Added two tests for src/generators/flow.js that check if a value is of
type `empty` or `mixed`. The goal was to cover https://codecov.io/gh/babel/babel/src/master/packages/babel-generator/src/generators/flow.js#L172 and https://codecov.io/gh/babel/babel/src/master/packages/babel-generator/src/generators/flow.js#L176, and after running `./scripts/test-cov.sh` locally I confirm those lines are now covered.