### PR TITLE
Tests for whitespace nodes in babel-generator

### DIFF
--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -296,17 +296,17 @@ describe("whitespace", function () {
 
 describe("whitespace nodes", function () {
   it("logical expression containing a function", function () {
-    const noopFunction = t.arrowFunctionExpression([], t.numericLiteral(0))
+    const noopFunction = t.arrowFunctionExpression([], t.numericLiteral(0));
     const num = t.numericLiteral(1);
 
-    const functionOnLeft = t.logicalExpression('||', noopFunction, num);
-    const functionOnRight = t.logicalExpression('||', num, noopFunction);
+    const functionOnLeft = t.logicalExpression("||", noopFunction, num);
+    const functionOnRight = t.logicalExpression("||", num, noopFunction);
 
-    assert.deepEqual(whitespaceNodes.LogicalExpression(functionOnLeft), {after: true});
-    assert.deepEqual(whitespaceNodes.LogicalExpression(functionOnRight), {after: true});
+    assert.deepEqual(whitespaceNodes.LogicalExpression(functionOnLeft), { after: true });
+    assert.deepEqual(whitespaceNodes.LogicalExpression(functionOnRight), { after: true });
   });
   it("literal containing use strict", function () {
-    assert.deepEqual(whitespaceNodes.Literal(t.stringLiteral("use strict")), {after: true});
+    assert.deepEqual(whitespaceNodes.Literal(t.stringLiteral("use strict")), { after: true });
   });
 });
 

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,4 +1,5 @@
 import Whitespace from "../lib/whitespace";
+import { nodes as whitespaceNodes } from "../lib/node/whitespace";
 import Printer from "../lib/printer";
 import generate from "../lib";
 import assert from "assert";
@@ -290,6 +291,22 @@ describe("whitespace", function () {
   it("empty token list", function () {
     const w = new Whitespace([]);
     assert.equal(w.getNewlinesBefore(t.stringLiteral("1")), 0);
+  });
+});
+
+describe("whitespace nodes", function () {
+  it("logical expression containing a function", function () {
+    const noopFunction = t.arrowFunctionExpression([], t.numericLiteral(0))
+    const num = t.numericLiteral(1);
+
+    const functionOnLeft = t.logicalExpression('||', noopFunction, num);
+    const functionOnRight = t.logicalExpression('||', num, noopFunction);
+
+    assert.deepEqual(whitespaceNodes.LogicalExpression(functionOnLeft), {after: true});
+    assert.deepEqual(whitespaceNodes.LogicalExpression(functionOnRight), {after: true});
+  });
+  it("literal containing use strict", function () {
+    assert.deepEqual(whitespaceNodes.Literal(t.stringLiteral("use strict")), {after: true});
   });
 });
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | yes
| Fixed Tickets            | #5326
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->



Added a few more tests in regards to https://github.com/babel/babel/issues/5326:
- Test that `nodes.LogicalExpression` called with a function on the left or right producing `{after: true}`.
- Test that `nodes.Literal` passed "use strict" produces `{after: true}`.