### PR TITLE
use before/after instead of dependencies

### DIFF
--- a/packages/babel-core/src/config/plugin.js
+++ b/packages/babel-core/src/config/plugin.js
@@ -20,8 +20,11 @@ export default class Plugin {
     if (plugin.capabilities != null && !Array.isArray(plugin.capabilities)) {
       throw new Error("Plugin .capabilities must be an array");
     }
-    if (plugin.dependencies != null && !Array.isArray(plugin.dependencies)) {
-      throw new Error("Plugin .dependencies must be an array");
+    if (!Array.isArray(plugin.after)) {
+      throw new Error("Plugin .after must be an array");
+    }
+    if (!Array.isArray(plugin.before)) {
+      throw new Error("Plugin .before must be an array");
     }
 
     this.key = plugin.name || key;
@@ -31,7 +34,8 @@ export default class Plugin {
     this.pre = plugin.pre;
     this.visitor = plugin.visitor;
     this.capabilities = plugin.capabilities;
-    this.dependencies = plugin.dependencies;
+    this.after = plugin.after;
+    this.before = plugin.before;
   }
 
   key: ?string;
@@ -40,5 +44,6 @@ export default class Plugin {
   pre: ?Function;
   visitor: ?{};
   capabilities: ?Array<any>;
-  dependencies: ?Array<any>;
+  after: ?Array<any>;
+  before: ?Array<any>;
 }

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/plugin.js
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/plugin.js
@@ -1,9 +1,10 @@
-module.exports = function(name, capabilities, dependencies) {
+module.exports = function(name, capabilities, before, after) {
   return function(babel) {
     return {
       name: name,
       capabilities: capabilities,
-      dependencies: dependencies,
+      before: before,
+      after: after,
       visitor: {
         Program: function(path) {
           path.pushContainer("body", [

--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -40,8 +40,6 @@ export default function ({ types: t }) {
   );
 
   return {
-    name: "classProperties",
-
     inherits: syntaxClassProperties,
 
     capabilities: ["classProperties"],

--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -284,7 +284,7 @@ export default function({ types: t }) {
   return {
     inherits: syntaxDecorators,
 
-    dependencies: ["classProperties"],
+    before: ["classProperties"],
     capabilities: ["decorators"],
 
     visitor: {


### PR DESCRIPTION
dependencies isn't that great of a name - I believe others have suggested before/after (dependencies only suggests before and also makes it sound like it's required).

Sometimes it's only that if the capability is provided/included should it go before, otherwise nothing.