### PR TITLE
Pass SIGINT signals to the spawned child process

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -90,5 +90,10 @@ getV8Flags(function (err, v8Flags) {
         }
       });
     });
+
+    process.on('SIGINT', () => {
+      proc.kill('SIGINT');
+      process.kill(process.pid, signal);
+    });
   }
 });

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -93,7 +93,7 @@ getV8Flags(function (err, v8Flags) {
 
     process.on('SIGINT', () => {
       proc.kill('SIGINT');
-      process.kill(process.pid, signal);
+      process.kill(process.pid, 'SIGINT');
     });
   }
 });

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -91,9 +91,9 @@ getV8Flags(function (err, v8Flags) {
       });
     });
 
-    process.on('SIGINT', () => {
-      proc.kill('SIGINT');
-      process.kill(process.pid, 'SIGINT');
+    process.on("SIGINT", () => {
+      proc.kill("SIGINT");
+      process.kill(process.pid, "SIGINT");
     });
   }
 });

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -93,7 +93,7 @@ getV8Flags(function (err, v8Flags) {
 
     process.on("SIGINT", () => {
       proc.kill("SIGINT");
-      process.kill(process.pid, "SIGINT");
+      process.exit(1);
     });
   }
 });


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  |  no
| Minor: New Feature?      |  no
| Deprecations?            |  no
| Spec Compliancy?         |  yes (?)
| Tests Added/Pass?        |  yes
| Fixed Tickets            | Fixes #1062
| License                  | MIT
| Doc PR                   |  no
| Dependency Changes       |  no

<!-- Describe your changes below in as much detail as possible -->

Fixes an issue where `SIGINT` was not passed to the running child process when a script was started using `babel-node`. 

NOTE: this issue does not manifest if `kexec` is installed as a dependency.

See #1062
