### PR TITLE
Move plugin-transform-unicode-property-regex to stage 3

### DIFF
--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -9,7 +9,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-plugin-transform-class-properties": "7.0.0-alpha.12",
-    "babel-plugin-transform-unicode-property-regex": "^2.0.0",
     "babel-preset-stage-3": "7.0.0-alpha.12"
   }
 }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -1,7 +1,6 @@
 import presetStage3 from "babel-preset-stage-3";
 
 import transformClassProperties from "babel-plugin-transform-class-properties";
-import transformUnicodePropertyRegex from "babel-plugin-transform-unicode-property-regex";
 
 export default function () {
   return {
@@ -10,7 +9,6 @@ export default function () {
     ],
     plugins: [
       transformClassProperties,
-      transformUnicodePropertyRegex,
     ],
   };
 }

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "7.0.0-alpha.12",
     "babel-plugin-transform-async-generator-functions": "7.0.0-alpha.12",
-    "babel-plugin-transform-object-rest-spread": "7.0.0-alpha.12"
+    "babel-plugin-transform-object-rest-spread": "7.0.0-alpha.12",
+    "babel-plugin-transform-unicode-property-regex": "^2.0.2"
   }
 }

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -1,6 +1,7 @@
 import syntaxDynamicImport from "babel-plugin-syntax-dynamic-import";
-import transformObjectRestSpread from "babel-plugin-transform-object-rest-spread";
 import transformAsyncGeneratorFunctions from "babel-plugin-transform-async-generator-functions";
+import transformObjectRestSpread from "babel-plugin-transform-object-rest-spread";
+import transformUnicodePropertyRegex from "babel-plugin-transform-unicode-property-regex";
 
 export default function () {
   return {
@@ -8,6 +9,7 @@ export default function () {
       syntaxDynamicImport,
       transformAsyncGeneratorFunctions,
       transformObjectRestSpread,
+      transformUnicodePropertyRegex,
     ],
   };
 }


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | yes
| Tests Added/Pass?        | n/a
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | yes

The RegExp Unicode property escapes proposal is at stage 3. This patch moves the transform plugin from stage 2 to stage 3.