### PR TITLE
Fix returning an object in a derived class constructor without super

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -445,10 +445,13 @@ helpers.objectWithoutProperties = template(`
 
 helpers.possibleConstructorReturn = template(`
   (function (self, call) {
+    if (call && (typeof call === "object" || typeof call === "function")) {
+      return call;
+    }
     if (!self) {
       throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
     }
-    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+    return self;
   });
 `);
 

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
@@ -2,10 +2,10 @@ var Foo = function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {
-    var _temp, _this, _ret;
+    var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _ret = (_temp = (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, ...args)), _this), _this.bar = "foo", _temp), babelHelpers.possibleConstructorReturn(_this, _ret);
+    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, ...args)), _this.bar = "foo", _temp));
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
@@ -4,9 +4,10 @@ var Child = function (_Parent) {
   babelHelpers.inherits(Child, _Parent);
 
   function Child() {
-    babelHelpers.classCallCheck(this, Child);
+    var _this;
 
-    var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
+    babelHelpers.classCallCheck(this, Child);
+    _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
 
     _this.scopedFunctionWithThis = function () {
       _this.name = {};

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-expression/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-expression/expected.js
@@ -5,7 +5,7 @@ var Foo = function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), _this), _this.bar = "foo", _temp));
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), _this.bar = "foo", _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-statement/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-statement/expected.js
@@ -2,10 +2,10 @@ var Foo = function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {
+    var _this;
+
     babelHelpers.classCallCheck(this, Foo);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
     _this.bar = "foo";
     return _this;
   }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/derived/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/derived/expected.js
@@ -2,14 +2,14 @@ var Foo = function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {
-    var _temp, _this, _ret;
+    var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _ret = (_temp = (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, ...args)), _this), Object.defineProperty(_this, "bar", {
+    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this, ...args)), Object.defineProperty(_this, "bar", {
       enumerable: true,
       writable: true,
       value: "foo"
-    }), _temp), babelHelpers.possibleConstructorReturn(_this, _ret);
+    }), _temp));
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/foobar/expected.js
@@ -4,10 +4,10 @@ var Child = function (_Parent) {
   babelHelpers.inherits(Child, _Parent);
 
   function Child() {
+    var _this;
+
     babelHelpers.classCallCheck(this, Child);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Child.__proto__ || Object.getPrototypeOf(Child)).call(this));
     Object.defineProperty(_this, "scopedFunctionWithThis", {
       enumerable: true,
       writable: true,

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/super-call/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/super-call/expected.js
@@ -16,14 +16,14 @@ var B = function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B(...args) {
-    var _temp, _this, _ret;
+    var _temp, _this;
 
     babelHelpers.classCallCheck(this, B);
-    return _ret = (_temp = (_this = babelHelpers.possibleConstructorReturn(this, (B.__proto__ || Object.getPrototypeOf(B)).call(this, ...args)), _this), Object.defineProperty(_this, "foo", {
+    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, (B.__proto__ || Object.getPrototypeOf(B)).call(this, ...args)), Object.defineProperty(_this, "foo", {
       enumerable: true,
       writable: true,
       value: babelHelpers.get(B.prototype.__proto__ || Object.getPrototypeOf(B.prototype), "foo", _this).call(_this)
-    }), _temp), babelHelpers.possibleConstructorReturn(_this, _ret);
+    }), _temp));
   }
 
   return B;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/super-expression/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/super-expression/expected.js
@@ -5,7 +5,7 @@ var Foo = function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), _this), Object.defineProperty(_this, "bar", {
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), Object.defineProperty(_this, "bar", {
       enumerable: true,
       writable: true,
       value: "foo"

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/super-statement/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/super-statement/expected.js
@@ -2,10 +2,10 @@ var Foo = function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {
+    var _this;
+
     babelHelpers.classCallCheck(this, Foo);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
     Object.defineProperty(_this, "bar", {
       enumerable: true,
       writable: true,

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-superClass/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-superClass/expected.js
@@ -6,12 +6,9 @@ let A = function (_B) {
   _inheritsLoose(A, _B);
 
   function A(track) {
-    if (track !== undefined) {
-      var _this = _B.call(this, track) || this;
-    } else {
-      var _this = _B.call(this) || this;
-    }
+    var _this;
 
+    if (track !== undefined) _this = _B.call(this, track) || this;else _this = _B.call(this) || this;
     return _this;
   }
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-class/expected.js
@@ -4,15 +4,15 @@ var Test = function (_Foo) {
   function Test() {
     var _Foo$prototype$test, _Foo$prototype$test2;
 
-    woops.super.test();
+    var _this;
 
-    var _this = _Foo.call(this) || this;
+    woops.super.test();
+    _this = _Foo.call(this) || this;
 
     _Foo.prototype.test.call(_this);
 
-    var _this = _Foo.apply(this, arguments) || this;
-
-    var _this = _Foo.call.apply(_Foo, [this, "test"].concat(Array.prototype.slice.call(arguments))) || this;
+    _this = _Foo.apply(this, arguments) || this;
+    _this = _Foo.call.apply(_Foo, [this, "test"].concat(Array.prototype.slice.call(arguments))) || this;
 
     (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [_this].concat(Array.prototype.slice.call(arguments)));
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-properties/expected.js
@@ -2,8 +2,9 @@ var Test = function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {
-    var _this = _Foo.call(this) || this;
+    var _this;
 
+    _this = _Foo.call(this) || this;
     _Foo.prototype.test;
     _Foo.prototype.test.whatever;
     return _this;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/calling-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/calling-super-properties/expected.js
@@ -2,7 +2,9 @@ var Test = function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {
-    var _this = _Foo.call(this) || this;
+    var _this;
+
+    _this = _Foo.call(this) || this;
 
     _Foo.prototype.test.whatever();
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/returning-from-derived-constructor/exec.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/returning-from-derived-constructor/exec.js
@@ -42,17 +42,3 @@ assert.equal(instance, singleton);
 
 instance = new Sub;
 assert.equal(instance, singleton);
-
-class Null extends Foo {
-  constructor() {
-    if (false) {
-      super();
-    }
-    return null;
-    super();
-  }
-}
-
-assert.throws(() => {
-  new Null();
-}, "this");

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
@@ -20,10 +20,10 @@ var Connection = function (_EventEmitter) {
   babelHelpers.inherits(Connection, _EventEmitter);
 
   function Connection(endpoint, joinKey, joinData, roomId) {
+    var _this;
+
     babelHelpers.classCallCheck(this, Connection);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Connection.__proto__ || Object.getPrototypeOf(Connection)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Connection.__proto__ || Object.getPrototypeOf(Connection)).call(this));
     _this.isConnected = false;
     _this.roomId = roomId; // ...
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
@@ -12,9 +12,10 @@ var a1 = function (_b) {
   babelHelpers.inherits(a1, _b);
 
   function a1() {
-    babelHelpers.classCallCheck(this, a1);
+    var _this;
 
-    var _this = babelHelpers.possibleConstructorReturn(this, (a1.__proto__ || Object.getPrototypeOf(a1)).call(this));
+    babelHelpers.classCallCheck(this, a1);
+    _this = babelHelpers.possibleConstructorReturn(this, (a1.__proto__ || Object.getPrototypeOf(a1)).call(this));
 
     _this.x = function () {
       return _this;
@@ -30,9 +31,10 @@ var a2 = function (_b2) {
   babelHelpers.inherits(a2, _b2);
 
   function a2() {
-    babelHelpers.classCallCheck(this, a2);
+    var _this2;
 
-    var _this2 = babelHelpers.possibleConstructorReturn(this, (a2.__proto__ || Object.getPrototypeOf(a2)).call(this));
+    babelHelpers.classCallCheck(this, a2);
+    _this2 = babelHelpers.possibleConstructorReturn(this, (a2.__proto__ || Object.getPrototypeOf(a2)).call(this));
 
     _this2.x = function () {
       return _this2;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
@@ -8,10 +8,10 @@ var B = function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B() {
-    var _this, _ret;
+    var _this;
 
     babelHelpers.classCallCheck(this, B);
-    return _ret = (_this = babelHelpers.possibleConstructorReturn(this, (B.__proto__ || Object.getPrototypeOf(B)).call(this)), _this), babelHelpers.possibleConstructorReturn(_this, _ret);
+    return babelHelpers.possibleConstructorReturn(_this, _this = babelHelpers.possibleConstructorReturn(this, (B.__proto__ || Object.getPrototypeOf(B)).call(this)));
   }
 
   return B;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
@@ -14,14 +14,11 @@ var A = function (_B) {
   _inherits(A, _B);
 
   function A(track) {
+    var _this;
+
     _classCallCheck(this, A);
 
-    if (track !== undefined) {
-      var _this = _possibleConstructorReturn(this, (A.__proto__ || Object.getPrototypeOf(A)).call(this, track));
-    } else {
-      var _this = _possibleConstructorReturn(this, (A.__proto__ || Object.getPrototypeOf(A)).call(this));
-    }
-
+    if (track !== undefined) _this = _possibleConstructorReturn(this, (A.__proto__ || Object.getPrototypeOf(A)).call(this, track));else _this = _possibleConstructorReturn(this, (A.__proto__ || Object.getPrototypeOf(A)).call(this));
     return _possibleConstructorReturn(_this);
   }
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-class/expected.js
@@ -4,17 +4,14 @@ var Test = function (_Foo) {
   function Test() {
     var _ref, _babelHelpers$get;
 
+    var _this;
+
     babelHelpers.classCallCheck(this, Test);
     woops.super.test();
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
     babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).call(_this);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).apply(this, arguments));
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (_ref = Test.__proto__ || Object.getPrototypeOf(Test)).call.apply(_ref, [this, "test"].concat(Array.prototype.slice.call(arguments))));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).apply(this, arguments));
+    _this = babelHelpers.possibleConstructorReturn(this, (_ref = Test.__proto__ || Object.getPrototypeOf(Test)).call.apply(_ref, [this, "test"].concat(Array.prototype.slice.call(arguments))));
     babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).apply(_this, arguments);
 
     (_babelHelpers$get = babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this)).call.apply(_babelHelpers$get, [_this, "test"].concat(Array.prototype.slice.call(arguments)));

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-properties/expected.js
@@ -2,10 +2,10 @@ var Test = function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {
+    var _this;
+
     babelHelpers.classCallCheck(this, Test);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
     babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this);
     babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).whatever;
     return _this;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/calling-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/calling-super-properties/expected.js
@@ -2,10 +2,10 @@ var Test = function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {
+    var _this;
+
     babelHelpers.classCallCheck(this, Test);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
     babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).whatever();
     babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _this).call(_this);
     return _this;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
@@ -7,10 +7,10 @@ var Foo = function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {
+    var _this;
+
     babelHelpers.classCallCheck(this, Foo);
-
-    var _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
-
+    _this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this));
     _this.state = "test";
     return _this;
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/expected.js
@@ -5,7 +5,7 @@ var Foo = function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.get(Foo.prototype.__proto__ || Object.getPrototypeOf(Foo.prototype), (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this)), _this).method, _this).call(_this);
+    babelHelpers.get(Foo.prototype.__proto__ || Object.getPrototypeOf(Foo.prototype), (_this = babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).call(this))).method, _this).call(_this);
     return _this;
   }
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | Yes
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Fixes #5862
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

Allows derived constructors to return an object without calling `super`.