### PR TITLE
Swap github/twitter links for Sebastian McKenzie

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ These are mostly for internal use in various plugins: `babel-helper-x`.
 [![Amjad Masad](https://avatars.githubusercontent.com/u/587518?s=64)](https://github.com/amasad) | [![James Kyle](https://avatars.githubusercontent.com/u/952783?s=64)](https://github.com/thejameskyle) | [![Jesse McCarthy](https://avatars.githubusercontent.com/u/129203?s=64)](https://github.com/jmm) | [![Sebastian McKenzie](https://avatars.githubusercontent.com/u/853712?s=64)](https://github.com/kittens) (Creator) | 
 |---|---|---|---|
 Amjad Masad | James Kyle | Jesse McCarthy | Sebastian McKenzie | 
-[@amasad](https://github.com/amasad) | [@thejameskyle](https://github.com/thejameskyle) | [@jmm](https://github.com/jmm) | [@sebmck](https://twitter.com/sebmck) |
-| [@amasad](https://twitter.com/amasad) | [@thejameskyle](https://twitter.com/thejameskyle) | [@mccjm](https://twitter.com/mccjm) | [@kittens](https://github.com/kittens) 
+[@amasad](https://github.com/amasad) | [@thejameskyle](https://github.com/thejameskyle) | [@jmm](https://github.com/jmm) | [@kittens](https://github.com/kittens) |
+| [@amasad](https://twitter.com/amasad) | [@thejameskyle](https://twitter.com/thejameskyle) | [@mccjm](https://twitter.com/mccjm) | [@sebmck](https://twitter.com/sebmck)
 
 ## License
 


### PR DESCRIPTION
README change only.

All the contributor listings do github link then twitter link. This makes Sebastian's profile links match that pattern.
