### PR TITLE
Remove `git add` in precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --format=codeframe --fix",
-      "git add"
+      "eslint --format=codeframe --fix"
     ]
   }
 }


### PR DESCRIPTION
It frequently fails for no reason (blocking commits!), and even when it does work it breaks incremental commits.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | No
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 