### PR TITLE
babel-traverse: Mark appropriate template literals as pure

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -616,20 +616,11 @@ export default class Scope {
     } else if (t.isUnaryExpression(node)) {
       return this.isPure(node.argument, constantsOnly);
     } else if (t.isTaggedTemplateExpression(node)) {
-      if (t.isMemberExpression(node.tag)) {
-        const { object, property } = node.tag;
-        const { name } = object;
-        if (
-          t.isIdentifier(object) &&
-          name === "String" &&
-          !this.getBinding(name, true) &&
-          t.isIdentifier(property) &&
-          property.name === "raw"
-        ) {
-          return this.isPure(node.quasi, constantsOnly);
-        }
-      }
-      return false;
+      return (
+        t.matchesPattern(node.tag, "String.raw") &&
+        !this.getBinding("String", true) &&
+        this.isPure(node.quasi, constantsOnly)
+      );
     } else if (t.isTemplateLiteral(node)) {
       for (const expression of (node.expressions: Array<Object>)) {
         if (!this.isPure(expression, constantsOnly)) return false;

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -618,7 +618,7 @@ export default class Scope {
     } else if (t.isTaggedTemplateExpression(node)) {
       return (
         t.matchesPattern(node.tag, "String.raw") &&
-        !this.getBinding("String", true) &&
+        !this.hasBinding("String", true) &&
         this.isPure(node.quasi, constantsOnly)
       );
     } else if (t.isTemplateLiteral(node)) {

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -615,6 +615,13 @@ export default class Scope {
       return this.isPure(node.value, constantsOnly);
     } else if (t.isUnaryExpression(node)) {
       return this.isPure(node.argument, constantsOnly);
+    } else if (t.isTemplateLiteral(node)) {
+      return (
+        !t.isTaggedTemplateExpression(node.parent) &&
+        node.expressions.every(expression =>
+          this.isPure(expression, constantsOnly),
+        )
+      );
     } else {
       return t.isPureish(node);
     }

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -77,17 +77,21 @@ describe("scope", function() {
       assert.ok(
         getPath("({ x: 1 })").get("body")[0].get("expression").isPure(),
       );
+      assert.ok(!getPath("`${a}`").get("body")[0].get("expression").isPure());
       assert.ok(
-        getPath("let a = 1; `${({ x: a })}`")
+        getPath("let a = 1; `${a}`").get("body")[1].get("expression").isPure(),
+      );
+      assert.ok(
+        !getPath("let a = 1; `${a++}`")
           .get("body")[1]
           .get("expression")
           .isPure(),
       );
       assert.ok(
-        !getPath("let a = 2; `${a++}`")
-          .get("body")[1]
-          .get("expression")
-          .isPure(),
+        !getPath("tagged`foo`").get("body")[0].get("expression").isPure(),
+      );
+      assert.ok(
+        getPath("String.raw`foo`").get("body")[0].get("expression").isPure(),
       );
     });
 

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -77,6 +77,18 @@ describe("scope", function() {
       assert.ok(
         getPath("({ x: 1 })").get("body")[0].get("expression").isPure(),
       );
+      assert.ok(
+        getPath("let a = 1; `${({ x: a })}`")
+          .get("body")[1]
+          .get("expression")
+          .isPure(),
+      );
+      assert.ok(
+        !getPath("let a = 2; `${a++}`")
+          .get("body")[1]
+          .get("expression")
+          .isPure(),
+      );
     });
 
     test("label", function() {


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | 
| Tests Added/Pass?        | yes 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | no

This is related to #5900, and enables template literals (and currently `String.raw` tagged template literals) to be marked pure if all interpolated expressions are also pure.

The special-case for `String.raw` tagged template literals uses the same logic as `packages/babel-traverse/src/path/evaluation.js`.

Additional logic will be required to support the case mentioned in #5900 where the tagged template literal is using a custom function.
