### PR TITLE
Clarify use of bind operator in "prefix position"

### DIFF
--- a/packages/babel-plugin-transform-function-bind/README.md
+++ b/packages/babel-plugin-transform-function-bind/README.md
@@ -9,13 +9,17 @@ obj::func
 // is equivalent to:
 func.bind(obj)
 
+::obj.func
+// is equivalent to:
+obj.func.bind(obj)
+
 obj::func(val)
 // is equivalent to:
 func.call(obj, val)
 
 ::obj.func(val)
 // is equivalent to:
-func.call(obj, val)
+obj.func.call(obj, val)
 ```
 
 


### PR DESCRIPTION
The REPL [shows](https://babeljs.io/repl/#?babili=false&evaluate=false&lineWrap=true&presets=es2015%2Creact%2Cstage-0&targets=&browsers=&builtIns=false&debug=false&code_lz=PYIwVgXBBmCuB2BjA3AKAPToAQEsDOWApgI6w4BuAhgDaHwAuW9wEqcSAdCDvACYAUoMAEo0qKEI7sUGbPiKkKNOo2atJ0rjwFDRqVEKjT-Vansy4CJMqZVMWbBIg6Ia1QeAA0WU3vEQNJxMaczkrRVsGe1ZNV2p3IW9fZCA)
that when the bind operator prefixes `obj.func` (as opposed to being used
between `obj` and `func`), rather than binding a free function `func` to `obj`,
it binds `obj.func` to `obj`.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  N
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Deprecations?            | N
| Spec Compliancy?         | N/A 
| Tests Added/Pass?        | N/A
| Fixed Tickets            | N/A
| License                  | N/A
| Doc PR                   | Y
| Dependency Changes       | N/A