### PR TITLE
Gitignore package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /coverage
 dist
 /.package.json
+package-lock.json
 /packages/babel-runtime/core-js/**/*.js
 !/packages/babel-runtime/core-js/map.js
 /packages/babel-runtime/helpers/*.js

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "through2": "^2.0.0",
     "uglify-js": "^2.4.16"
   },
-  "devEngines": {
-    "node": ">= 4.x <= 7.x",
-    "npm": "2.x || 3.x || 4.x"
+  "engines": {
+    "node": ">= 4.x <= 8.x",
+    "npm": ">= 2.x <= 5.x"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
Every time I run `make bootstrap`, there are several `package-lock.json` files created in the repo. I wasn't exactly sure if we wanna check them in, so instead of raising an issue asking what everybody thinks, I decided to make a PR anyway. Feel free to close it if it isn't necessary 