### PR TITLE
Fixing options parser that was looking for babelrc when it should not

### DIFF
--- a/packages/babel/src/transformation/file/options/option-manager.js
+++ b/packages/babel/src/transformation/file/options/option-manager.js
@@ -178,7 +178,7 @@ export default class OptionManager {
     }
 
     // resolve all .babelrc files
-    if (opts.babelrc !== false) {
+    if (opts.babelrc && opts.babelrc.length) {
       this.findConfigs(opts.filename);
     }
 


### PR DESCRIPTION
setting babel option `babelrc` to `false` does not seems to have any effect. Still the "global" `.babelrc` will be picked up because `babelrc` gets normalized to an empty array.

This should fix https://github.com/babel/ember-cli-babel/issues/92