### PR TITLE
Run generate-babel-types-docs on ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-ci:
 	make bootstrap
 	make test-only
 
-update-babel-types-docs:
+check-babel-types-docs:
 	sh ./scripts/check-babel-types-docs.sh
 
 test-ci-coverage:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-dist: build
 	scripts/build-dist.sh
 	cd packages/babel-runtime; \
 	node scripts/build-dist.js
-	node scripts/generate-babel-types-docs.js
+	make babel-types-docs
 
 watch: clean
 	rm -rf packages/*/lib
@@ -58,6 +58,9 @@ test-ci:
 	make bootstrap
 	make test-only
 
+update-babel-types-docs:
+	sh ./scripts/check-babel-types-docs.sh
+
 test-ci-coverage:
 	BABEL_ENV=cov make bootstrap
 	./scripts/test-cov.sh
@@ -80,3 +83,6 @@ bootstrap:
 	make build
 	cd packages/babel-runtime; \
 	node scripts/build-dist.js
+
+babel-types-docs:
+	node ./scripts/generate-babel-types-docs.js

--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,4 @@ dependencies:
 test:
   override:
     - make test-ci-coverage
-    - make update-babel-types-docs
+    - make check-babel-types-docs

--- a/circle.yml
+++ b/circle.yml
@@ -14,3 +14,4 @@ dependencies:
 test:
   override:
     - make test-ci-coverage
+    - make update-babel-types-docs

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -106,7 +106,7 @@ See also `t.isAssignmentPattern(node, opts)` and `t.assertAssignmentPattern(node
 
 Aliases: `Pattern`, `LVal`
 
- - `left`: `Identifier` (required)
+ - `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
  - `right`: `Expression` (required)
  - `decorators`: `Array<Decorator>` (default: `null`)
 
@@ -229,6 +229,7 @@ Aliases: `Expression`
 
  - `callee`: `Expression` (required)
  - `arguments`: `Array<Expression | SpreadElement>` (required)
+ - `optional`: `true | false` (default: `null`)
 
 ---
 
@@ -1185,7 +1186,7 @@ Aliases: `Binary`, `Expression`
 
 ### memberExpression
 ```javascript
-t.memberExpression(object, property, computed)
+t.memberExpression(object, property, computed, optional)
 ```
 
 See also `t.isMemberExpression(node, opts)` and `t.assertMemberExpression(node, opts)`.
@@ -1195,6 +1196,7 @@ Aliases: `Expression`, `LVal`
  - `object`: `Expression` (required)
  - `property`: if computed then `Expression` else `Identifier` (required)
  - `computed`: `boolean` (default: `false`)
+ - `optional`: `true | false` (default: `null`)
 
 ---
 
@@ -1235,6 +1237,7 @@ Aliases: `Expression`
 
  - `callee`: `Expression` (required)
  - `arguments`: `Array<Expression | SpreadElement>` (required)
+ - `optional`: `true | false` (default: `null`)
 
 ---
 

--- a/scripts/check-babel-types-docs.sh
+++ b/scripts/check-babel-types-docs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+cp packages/babel-types/README.md babel-types_README
+make babel-types-docs
+
+cmp --silent packages/babel-types/README.md babel-types_README

--- a/scripts/check-babel-types-docs.sh
+++ b/scripts/check-babel-types-docs.sh
@@ -5,3 +5,4 @@ cp packages/babel-types/README.md babel-types_README
 make babel-types-docs
 
 cmp --silent packages/babel-types/README.md babel-types_README
+rm babel-types_README


### PR DESCRIPTION
Started a fresh branch from `7.0`, ran the script, and found some changes => must mean that it wasn't run the last time an update to the script was made on `7.0`

Instead of reporting an issue, just thought to make a PR, feel free to reject if it's already done and I missed something.