### PR TITLE
Fix silent error when class properties can't get injected in the constructor

### DIFF
--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -158,11 +158,16 @@ export default function({ types: t }) {
             ];
           }
 
-          //
-
           if (isDerived) {
             const bareSupers = [];
             constructor.traverse(findBareSupers, bareSupers);
+
+            if (!bareSupers.length) {
+              throw constructor.buildCodeFrameError(
+                "missing super() call in constructor",
+              );
+            }
+
             for (const bareSuper of bareSupers) {
               bareSuper.insertAfter(instanceBody);
             }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/missing-super/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/missing-super/actual.js
@@ -1,0 +1,7 @@
+class Foo extends Bar {
+  bar = "bar";
+
+  constructor() {
+    this.foo = "foo";
+  }
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/missing-super/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/missing-super/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["external-helpers", "transform-class-properties"],
+  "throws": "missing super() call in constructor"
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  yes
| Major: Breaking Change?  | no 
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         |  no
| Tests Added/Pass?        |  yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

**Currently:** The `transform-class-property` silently fails to transform the class properties when a class deriving from another class doesn't call `super()` in it constructor: [example](https://babeljs.io/repl/#?babili=false&evaluate=false&lineWrap=true&presets=stage-2&targets=&browsers=&builtIns=false&debug=false&code_lz=MYGwhgzhAEBiD29oFMAeAXZA7AJjAQmAE7QDeAUNNAEbHQC806RArsgNyXTDxYTMtg6eEQAUASjJcqAehnQAqlh4BbFdnRMkEZMhp0wAB0PJiMadDnQILE2PGcqVdAAsAlhAB0AM0QNo3mAgOo7QAL7kYUA).

**Proposal:** Throw an error if the `transform-class-property` doesn't find a `super()` in the constructor.
