### PR TITLE
Spec compliancy of check-es2015-constants plugin

### DIFF
--- a/packages/babel-plugin-check-es2015-constants/src/index.js
+++ b/packages/babel-plugin-check-es2015-constants/src/index.js
@@ -44,7 +44,15 @@ export default function({ messages, types: t }) {
                 ]),
               );
             } else if (violation.parentPath.isForXStatement()) {
-              violation.parentPath.insertBefore(throwNode);
+              // Transform single statement body into BlockStatement
+              if (!violation.parentPath.get("body").isBlockStatement()) {
+                violation.parentPath
+                  .get("body")
+                  .replaceWith(
+                    t.blockStatement([violation.parentPath.get("body").node]),
+                  );
+              }
+              violation.parentPath.node.body.body.unshift(throwNode);
             }
           }
         }

--- a/packages/babel-plugin-check-es2015-constants/src/index.js
+++ b/packages/babel-plugin-check-es2015-constants/src/index.js
@@ -1,9 +1,9 @@
 export default function({ messages, types: t }) {
   return {
     visitor: {
-      Scope(path) {
-        for (const name in path.scope.bindings) {
-          const binding = path.scope.bindings[name];
+      Scope({ scope }) {
+        for (const name in scope.bindings) {
+          const binding = scope.bindings[name];
           if (binding.kind !== "const" && binding.kind !== "module") continue;
 
           for (const violation of (binding.constantViolations: Array)) {

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/actual.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/actual.js
@@ -1,0 +1,7 @@
+(function(){
+  const a = "foo";
+
+  if (false) a = "false";
+
+  return a;
+})();

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/exec.js
@@ -1,0 +1,9 @@
+function f() {
+  const a = "foo";
+
+  if (false) a = "false";
+
+  return a;
+}
+
+assert.equal(f(), "foo", 'Const violation in not taken branch should be ignored.')

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/expected.js
@@ -1,10 +1,7 @@
 (function () {
   var a = "foo";
-
-  if (false) {
+  if (false) a = (function () {
     throw new Error("\"a\" is read-only");
-    a = "false";
-  }
-
+  }(), "false");
   return a;
 })();

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/deadcode-violation/expected.js
@@ -1,0 +1,10 @@
+(function () {
+  var a = "foo";
+
+  if (false) {
+    throw new Error("\"a\" is read-only");
+    a = "false";
+  }
+
+  return a;
+})();

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/exec.js
@@ -1,0 +1,14 @@
+assert.throws(function() {
+  const [a, b] = [1, 2];
+  a = 3;
+}, '"a" is read-only')
+
+assert.throws(function() {
+  const a = 1;
+  [a] = [2];
+}, '"a" is read-only');
+
+assert.throws(function() {
+  const b = 1;
+  ({b} = {b: 2});
+}, '"b" is read-only');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/expected.js
@@ -1,0 +1,4 @@
+var a = 1,
+    b = 2;
+throw new Error("\"a\" is read-only");
+a = 3;

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/expected.js
@@ -1,4 +1,5 @@
 var a = 1,
     b = 2;
-throw new Error("\"a\" is read-only");
-a = 3;
+a = (function () {
+  throw new Error("\"a\" is read-only");
+}(), 3);

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/options.json
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/destructuring-assignment/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "\"a\" is read-only"
-}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/exec.js
@@ -1,0 +1,5 @@
+assert.throws(function() {
+  for (const i = 0; i < 3; i = i + 1) {
+    // whatever
+  }
+}, '"i" is read-only');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/expected.js
@@ -1,0 +1,5 @@
+throw new Error("\"i\" is read-only");
+
+for (var i = 0; i < 3; i = i + 1) {
+  console.log(i);
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/expected.js
@@ -1,5 +1,5 @@
-throw new Error("\"i\" is read-only");
-
-for (var i = 0; i < 3; i = i + 1) {
+for (var i = 0; i < 3; i = (function () {
+  throw new Error("\"i\" is read-only");
+}(), i + 1)) {
   console.log(i);
 }

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/options.json
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/loop/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "\"i\" is read-only"
-}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/nested-update-expressions/actual.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/nested-update-expressions/actual.js
@@ -1,0 +1,6 @@
+const c = 17;
+let a = 0;
+
+function f() {
+  return ++c+--a;
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/nested-update-expressions/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/nested-update-expressions/exec.js
@@ -1,0 +1,11 @@
+assert.throws(function() {
+  const c = 17;
+  let a = 0;
+
+  function f() {
+    return ++c+--a;
+  }
+
+  f();
+
+}, '"c" is read-only');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/nested-update-expressions/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/nested-update-expressions/expected.js
@@ -1,0 +1,8 @@
+var c = 17;
+var a = 0;
+
+function f() {
+  return (function () {
+    throw new Error("\"c\" is read-only");
+  }(), ++c) + --a;
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/exec.js
@@ -1,0 +1,4 @@
+assert.throws(function() {
+  const a = 3;
+  a = 7;
+}, '"a" is read-only');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/expected.js
@@ -1,3 +1,4 @@
 var MULTIPLIER = 5;
-throw new Error("\"MULTIPLIER\" is read-only");
-MULTIPLIER = "overwrite";
+MULTIPLIER = (function () {
+  throw new Error("\"MULTIPLIER\" is read-only");
+}(), "overwrite");

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/expected.js
@@ -1,0 +1,3 @@
+var MULTIPLIER = 5;
+throw new Error("\"MULTIPLIER\" is read-only");
+MULTIPLIER = "overwrite";

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/options.json
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-assignment/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "\"MULTIPLIER\" is read-only"
-}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/exec.js
@@ -1,0 +1,12 @@
+function f(arr) {
+  const MULTIPLIER = 5;
+  for (MULTIPLIER in arr);
+
+  return 'survived';
+}
+
+assert.throws(function() {
+  f([1,2,3]);
+}, '"MULTIPLIER" is read-only');
+
+assert.equal(f([]), 'survived', 'For-in over empty array should not throw.');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/expected.js
@@ -1,0 +1,4 @@
+var MULTIPLIER = 5;
+throw new Error("\"MULTIPLIER\" is read-only");
+
+for (MULTIPLIER in arr) {}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/expected.js
@@ -1,4 +1,6 @@
 var MULTIPLIER = 5;
-throw new Error("\"MULTIPLIER\" is read-only");
 
-for (MULTIPLIER in arr) {}
+for (MULTIPLIER in arr) {
+  throw new Error("\"MULTIPLIER\" is read-only");
+  ;
+}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/expected.js
@@ -2,5 +2,4 @@ var MULTIPLIER = 5;
 
 for (MULTIPLIER in arr) {
   throw new Error("\"MULTIPLIER\" is read-only");
-  ;
 }

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/options.json
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/no-for-in/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "\"MULTIPLIER\" is read-only"
-}

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression-prefix/actual.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression-prefix/actual.js
@@ -1,0 +1,2 @@
+const a = "str";
+--a;

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression-prefix/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression-prefix/exec.js
@@ -1,0 +1,4 @@
+assert.throws(function() {
+  const a = "str";
+  --a;
+}, '"a" is read-only');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression-prefix/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression-prefix/expected.js
@@ -1,0 +1,4 @@
+var a = "str";
+(function () {
+  throw new Error("\"a\" is read-only");
+})(), --a;

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/exec.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/exec.js
@@ -1,0 +1,4 @@
+assert.throws(function() {
+  const foo = 1;
+  foo++;
+}, '"foo" is read-only');

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/expected.js
@@ -1,4 +1,3 @@
 var foo = 1;
-(function () {
-  throw new TypeError("\"foo\" is read-only");
-})();
+throw new Error("\"foo\" is read-only");
+foo++;

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/expected.js
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/expected.js
@@ -1,3 +1,4 @@
 var foo = 1;
-throw new Error("\"foo\" is read-only");
-foo++;
+(function () {
+  throw new Error("\"foo\" is read-only");
+})(), foo++;

--- a/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/options.json
+++ b/packages/babel-plugin-check-es2015-constants/test/fixtures/general/update-expression/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "\"foo\" is read-only"
-}


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Fixes #5728 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

I started working on the proposed change to the check-es2015-constants plugin: Instead of throwing a compile time error when `const` is violated, Babel should insert a throw statement before the violation. This will make it a runtime error and violations in code that is not executed are fine. I added the example from the issue as a test case and changed existing test cases.

I am not sure if this covers all possible violations besides modules. Is there a list of all possible violation types somewhere? Variable declarations via module import statements are not yet covered by this PR. Let me know if this is going into the right direction or if I should take a different route.