### PR TITLE
Fix async-to-generator ForAwait transform

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/for-await.js
+++ b/packages/babel-helper-remap-async-to-generator/src/for-await.js
@@ -1,8 +1,7 @@
 import * as t from "babel-types";
 import template from "babel-template";
-import traverse from "babel-traverse";
 
-const buildForAwait = template(`
+const awaitTemplate = `
   function* wrapper() {
     var ITERATOR_COMPLETION = true;
     var ITERATOR_HAD_ERROR_KEY = false;
@@ -33,26 +32,9 @@ const buildForAwait = template(`
       }
     }
   }
-`);
-
-const forAwaitVisitor = {
-  noScope: true,
-
-  Identifier(path, replacements) {
-    if (path.node.name in replacements) {
-      path.replaceInline(replacements[path.node.name]);
-    }
-  },
-
-  CallExpression(path, replacements) {
-    const callee = path.node.callee;
-
-    // if no await wrapping is being applied, unwrap the call expression
-    if (t.isIdentifier(callee) && callee.name === "AWAIT" && !replacements.AWAIT) {
-      path.replaceWith(path.node.arguments[0]);
-    }
-  }
-};
+`;
+const buildForAwait = template(awaitTemplate);
+const buildForAwaitWithoutWrapping = template(awaitTemplate.replace(/\bAWAIT\b/g, ""));
 
 export default function (path, helpers) {
   const { node, scope, parent } = path;
@@ -72,9 +54,9 @@ export default function (path, helpers) {
     ]);
   }
 
-  let template = buildForAwait();
+  const build = helpers.wrapAwait ? buildForAwait : buildForAwaitWithoutWrapping;
 
-  traverse(template, forAwaitVisitor, null, {
+  let template = build({
     ITERATOR_HAD_ERROR_KEY: scope.generateUidIdentifier("didIteratorError"),
     ITERATOR_COMPLETION: scope.generateUidIdentifier("iteratorNormalCompletion"),
     ITERATOR_ERROR_KEY: scope.generateUidIdentifier("iteratorError"),

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -68,7 +68,6 @@ const awaitVisitor = {
 
     if (build.replaceParent) {
       path.parentPath.replaceWithMultiple(build.node);
-      path.remove();
     } else {
       path.replaceWithMultiple(build.node);
     }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/actual.js
@@ -1,0 +1,3 @@
+(async () => {
+  for await (const [value] of iterable) {}
+})()

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
@@ -1,0 +1,27 @@
+babelHelpers.asyncToGenerator(function* () {
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  try {
+    for (var _iterator = babelHelpers.asyncIterator(iterable), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
+      var _value2 = _value,
+          _value3 = babelHelpers.slicedToArray(_value2, 1);
+
+      const value = _value3[0];
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return) {
+        yield _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
+  }
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "transform-es2015-destructuring",
+    "syntax-async-generators"
+  ]
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Fixes #5880
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

This was a fun one. The issue wasn't actually `transform-es2015-destructuring`, but `transform-async-to-generator` using `babel-traverse` directly.

I'll also [submit this for 7.0](https://github.com/babel/babel/pull/5932).