### PR TITLE
Fix async-to-generator ForAwait transform

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -65,7 +65,6 @@ const awaitVisitor = {
 
     if (build.replaceParent) {
       path.parentPath.replaceWithMultiple(build.node);
-      path.remove();
     } else {
       path.replaceWithMultiple(build.node);
     }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/actual.js
@@ -1,0 +1,3 @@
+(async () => {
+  for await (const [value] of iterable) {}
+})()

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
@@ -1,0 +1,26 @@
+babelHelpers.asyncToGenerator(function* () {
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  try {
+    for (var _iterator = babelHelpers.asyncIterator(iterable), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
+      const _value2 = _value,
+            _value3 = babelHelpers.slicedToArray(_value2, 1),
+            value = _value3[0];
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return) {
+        yield _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
+  }
+})();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "transform-es2015-destructuring",
+    "syntax-async-generators"
+  ]
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Fixes #5880
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

This was a fun one. The issue wasn't actually `transform-es2015-destructuring`, but `transform-async-to-generator` using `babel-traverse` directly.

6.0 backport is https://github.com/babel/babel/pull/5931.