### PR TITLE
Removed update operators from number unary operators

### DIFF
--- a/packages/babel-types/src/constants.js
+++ b/packages/babel-types/src/constants.js
@@ -43,7 +43,7 @@ export const BINARY_OPERATORS = [
 ];
 
 export const BOOLEAN_UNARY_OPERATORS = ["delete", "!"];
-export const NUMBER_UNARY_OPERATORS = ["+", "-", "++", "--", "~"];
+export const NUMBER_UNARY_OPERATORS = ["+", "-", "~"];
 export const STRING_UNARY_OPERATORS = ["typeof"];
 export const UNARY_OPERATORS = [
   "void",


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  Yes?
| Major: Breaking Change?  | No 
| Minor: New Feature?      |  No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | No/Yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

I discovered that the docs of babel-types on the website have a small mistake: `UnaryExpression` allows update operators `++` and `--`. But these are already covered by the `UpdateExpression` node. I was told by @jridgewell to remove them here in order for correct documentation to be generated.