### PR TITLE
2nd try: Add loose option for es2015-parameters transformation

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/README.md
+++ b/packages/babel-plugin-transform-es2015-parameters/README.md
@@ -72,3 +72,23 @@ require("babel-core").transform("code", {
   plugins: ["transform-es2015-parameters"]
 });
 ```
+
+## Options
+
+### `loose`
+
+`boolean`, defaults to `false`.
+
+In loose mode, parameters with default values will be counted into the arity of the function. This is not spec behavior where these parameters do not add to function arity.
+
+The `loose` implementation is a more performant solution as JavaScript engines will fully optimize a function that doesn't reference `arguments`. Please do your own benchmarking and determine if this option is the right fit for your application.
+
+```javascript
+// Spec behavior
+function bar1 (arg1 = 1) {}
+bar1.length // 0
+
+// Loose mode
+function bar1 (arg1 = 1) {}
+bar1.length // 1
+```

--- a/packages/babel-plugin-transform-es2015-parameters/src/default.js
+++ b/packages/babel-plugin-transform-es2015-parameters/src/default.js
@@ -54,7 +54,7 @@ const iifeVisitor = {
 };
 
 export const visitor = {
-  Function(path, state) {
+  Function(path) {
     const { node, scope } = path;
     if (!hasDefaults(node)) return;
 
@@ -63,7 +63,7 @@ export const visitor = {
 
     const params = path.get("params");
 
-    if (state.opts.loose) {
+    if (this.opts.loose) {
       const body = [];
       for (let i = 0; i < params.length; ++i) {
         const param = params[i];
@@ -100,8 +100,10 @@ export const visitor = {
       return;
     }
 
-    state.iife = false;
-    state.scope = scope;
+    const state = {
+      iife: false,
+      scope: scope,
+    };
 
     const body = [];
 

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-earlier-params/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/default-earlier-params/exec.js
@@ -1,0 +1,3 @@
+function f(a, b = a, c = b) { return c; }
+
+assert.equal(3, f(3));

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/complex-assignment/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/complex-assignment/actual.js
@@ -1,0 +1,1 @@
+function test({a: b} = {}) {}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/complex-assignment/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/complex-assignment/expected.js
@@ -1,0 +1,4 @@
+function test(_temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      b = _ref.a;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-array-destructuring/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-array-destructuring/actual.js
@@ -1,0 +1,1 @@
+function t([,,a] = [1,2,3]) { return a }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-array-destructuring/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-array-destructuring/exec.js
@@ -1,0 +1,4 @@
+function t([,,a] = [1,2,3]) { return a }
+
+assert.equal(t(), 3);
+assert.equal(t([4,5,6]), 6);

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-array-destructuring/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-array-destructuring/expected.js
@@ -1,0 +1,7 @@
+function t(_temp) {
+  var _ref = _temp === void 0 ? [1, 2, 3] : _temp,
+      _ref2 = babelHelpers.slicedToArray(_ref, 3),
+      a = _ref2[2];
+
+  return a;
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-earlier-params/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-earlier-params/exec.js
@@ -1,0 +1,3 @@
+function f(a, b = a, c = b) { return c; }
+
+assert.equal(3, f(3));

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-iife-1128/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-iife-1128/exec.js
@@ -1,0 +1,9 @@
+const bar = true;
+
+function foo(a = bar, ...b) {
+  const bar = false;
+  assert.equal(b[0], 2);
+  assert.equal(b[1], 3);
+}
+
+foo(1, 2, 3);

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-iife-4253/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-iife-4253/exec.js
@@ -1,0 +1,9 @@
+class Ref {
+  static nextId = 0
+  constructor(id = ++Ref.nextId, n = id) {
+    this.id = n
+  }
+}
+
+assert.equal(1, new Ref().id)
+assert.equal(2, new Ref().id)

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-iife-self/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-iife-self/exec.js
@@ -1,0 +1,7 @@
+class Ref {
+  constructor(ref = Ref) {
+    this.ref = ref
+  }
+}
+
+assert.equal(Ref, new Ref().ref)

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-multiple/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-multiple/actual.js
@@ -1,0 +1,7 @@
+var t = function (e = "foo", f = 5) {
+  return e + " bar " + f;
+};
+
+var a = function (e, f = 5) {
+  return e + " bar " + f;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-multiple/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-multiple/expected.js
@@ -1,0 +1,19 @@
+var t = function (e, f) {
+  if (e === void 0) {
+    e = "foo";
+  }
+
+  if (f === void 0) {
+    f = 5;
+  }
+
+  return e + " bar " + f;
+};
+
+var a = function (e, f) {
+  if (f === void 0) {
+    f = 5;
+  }
+
+  return e + " bar " + f;
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-object-destructuring/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-object-destructuring/exec.js
@@ -1,0 +1,19 @@
+function required(msg) {
+  throw new Error(msg);
+}
+
+function sum(
+  { arr = required('arr is required') } = { arr: arr = [] },
+  length = arr.length
+) {
+  let i = 0;
+  let acc = 0;
+  for (let item of arr) {
+    if (i >= length) return acc;
+    acc += item;
+    i++;
+  }
+  return acc;
+}
+
+assert.equal(sum({arr:[1,2]}), 3);

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-rest/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-rest/exec.js
@@ -1,0 +1,15 @@
+const a = 1;
+function rest(b = a, ...a) {
+  assert.equal(b, 1);
+}
+rest(undefined, 2)
+
+function rest2(b = a, ...a) {
+  assert.equal(a[0], 2);
+}
+rest2(undefined, 2)
+
+function rest3(b = a, ...a) {
+  assert.equal(a.length, 1);
+}
+rest3(undefined, 2)

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-single/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-single/actual.js
@@ -1,0 +1,3 @@
+var t = function (f = "foo") {
+  return f + " bar";
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-single/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/default-single/expected.js
@@ -1,0 +1,7 @@
+var t = function (f) {
+  if (f === void 0) {
+    f = "foo";
+  }
+
+  return f + " bar";
+};

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-class-properties", "external-helpers", "syntax-flow", ["transform-es2015-parameters", { "loose": true } ], "transform-es2015-block-scoping", "transform-es2015-spread", "transform-es2015-classes", "transform-es2015-destructuring", "transform-es2015-arrow-functions", "syntax-async-functions", "transform-es2015-for-of"]
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/overwrite-undefined/exec.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/use-loose-option/overwrite-undefined/exec.js
@@ -1,0 +1,5 @@
+function t(undefined = 17, a = 3) {
+  return a;
+}
+
+assert.equal(t(), 3);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes/Yes
| Fixed Tickets            | Fixes #5776
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

This is a rebuild of my changes discussed and approved in #5778, because I messed up the history of the other too much. This new PR should be up to date with 7.0 and apply all changes from the old PR within a single commit.