### PR TITLE
Remove maybePopFromStatements

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-4855/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-4855/expected.js
@@ -3,4 +3,5 @@
 var _values = values;
 value = _values[fieldName];
 rest = babelHelpers.objectWithoutProperties(_values, [fieldName]);
+_values;
 var error = void 0;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/assignment-expression/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/assignment-expression/expected.js
@@ -8,6 +8,7 @@ var _c = c2;
   a2
 } = _c);
 b2 = babelHelpers.objectWithoutProperties(_c, ["a2"]);
+_c;
 console.log((_c2 = c3, ({
   a3
 } = _c2), b3 = babelHelpers.objectWithoutProperties(_c2, ["a3"]), _c2));

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -239,6 +239,7 @@ export function _getQueueContexts() {
   let contexts = this.contexts;
   while (!contexts.length) {
     path = path.parentPath;
+    if (!path) break;
     contexts = path.contexts;
   }
   return contexts;

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -205,20 +205,7 @@ export function replaceExpressionWithStatements(nodes: Array<Object>) {
 
   const toSequenceExpression = t.toSequenceExpression(nodes, this.scope);
 
-  if (t.isSequenceExpression(toSequenceExpression)) {
-    const exprs = toSequenceExpression.expressions;
-
-    if (exprs.length >= 2 && this.parentPath.isExpressionStatement()) {
-      this._maybePopFromStatements(exprs);
-    }
-
-    // could be just one element due to the previous maybe popping
-    if (exprs.length === 1) {
-      this.replaceWith(exprs[0]);
-    } else {
-      this.replaceWith(toSequenceExpression);
-    }
-  } else if (toSequenceExpression) {
+  if (toSequenceExpression) {
     this.replaceWith(toSequenceExpression);
   } else {
     const container = t.arrowFunctionExpression([], t.blockStatement(nodes));

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -1,0 +1,59 @@
+import traverse from "../lib";
+import assert from "assert";
+import { parse } from "babylon";
+import generate from "babel-generator";
+import * as t from "babel-types";
+
+function getPath(code) {
+  const ast = parse(code);
+  let path;
+  traverse(ast, {
+    Program: function(_path) {
+      path = _path;
+      _path.stop();
+    },
+  });
+
+  return path;
+}
+
+function generateCode(path) {
+  return generate(path.node).code;
+}
+
+describe("modification", function() {
+  describe("pushContainer", function() {
+    it("pushes identifier into params", function() {
+      const rootPath = getPath("function test(a) {}");
+      const path = rootPath.get("body.0");
+      path.pushContainer("params", t.identifier("b"));
+
+      assert.equal(generateCode(rootPath), "function test(a, b) {}");
+    });
+
+    it("pushes identifier into block", function() {
+      const rootPath = getPath("function test(a) {}");
+      const path = rootPath.get("body.0.body");
+      path.pushContainer("body", t.expressionStatement(t.identifier("b")));
+
+      assert.equal(generateCode(rootPath), "function test(a) {\n  b;\n}");
+    });
+  });
+  describe("unshiftContainer", function() {
+    it("unshifts identifier into params", function() {
+      const rootPath = getPath("function test(a) {}");
+      const path = rootPath.get("body.0");
+      path.unshiftContainer("params", t.identifier("b"));
+
+      assert.equal(generateCode(rootPath), "function test(b, a) {}");
+    });
+
+    it("unshifts identifier into block", function() {
+      const rootPath = getPath("function test(a) {}");
+      const path = rootPath.get("body.0.body");
+      path.unshiftContainer("body", t.expressionStatement(t.identifier("b")));
+
+      assert.equal(generateCode(rootPath), "function test(a) {\n  b;\n}");
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

It prevented you from pushing into the `params` of a function.

```js
fnpath.pushContainer("params", t.identifier("memo"))
```