### PR TITLE
Export default unnamed declaration

### DIFF
--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -71,11 +71,10 @@ export default function({ types: t }) {
         const nodes = [];
         let ref;
 
-        if (path.isClassExpression() || !path.node.id) {
+        if (path.isClassExpression()) {
           nameFunction(path);
           ref = path.scope.generateUidIdentifier("class");
         } else {
-          // path.isClassDeclaration() && path.node.id
           ref = path.node.id;
         }
 
@@ -181,11 +180,6 @@ export default function({ types: t }) {
           path.scope.push({ id: ref });
           path.replaceWith(t.assignmentExpression("=", ref, path.node));
         } else {
-          // path.isClassDeclaration()
-          if (!path.node.id) {
-            path.node.id = ref;
-          }
-
           if (path.parentPath.isExportDeclaration()) {
             path = path.parentPath;
           }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/expected.js
@@ -4,10 +4,10 @@ call((_temp = _class = function _class() {
   babelHelpers.classCallCheck(this, _class);
 }, _class.test = true, _temp));
 
-var _class2 = function _class2() {
-  babelHelpers.classCallCheck(this, _class2);
+var _default = function _default() {
+  babelHelpers.classCallCheck(this, _default);
 };
 
-_class2.test = true;
-export { _class2 as default };
+_default.test = true;
+export { _default as default };
 ;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/spec/regression-T2983/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/spec/regression-T2983/expected.js
@@ -8,14 +8,14 @@ call((_temp = _class = function _class() {
   value: true
 }), _temp));
 
-var _class2 = function _class2() {
-  babelHelpers.classCallCheck(this, _class2);
+var _default = function _default() {
+  babelHelpers.classCallCheck(this, _default);
 };
 
-Object.defineProperty(_class2, "test", {
+Object.defineProperty(_default, "test", {
   enumerable: true,
   writable: true,
   value: true
 });
-export { _class2 as default };
+export { _default as default };
 ;

--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -326,9 +326,7 @@ export default function({ types: t }) {
         if (!path.get("declaration").isClassDeclaration()) return;
 
         const { node } = path;
-        const ref =
-          node.declaration.id || path.scope.generateUidIdentifier("default");
-        node.declaration.id = ref;
+        const ref = node.declaration.id;
 
         // Split the class declaration and the export into two separate statements.
         path.replaceWith(node.declaration);
@@ -341,7 +339,7 @@ export default function({ types: t }) {
       ClassDeclaration(path) {
         const { node } = path;
 
-        const ref = node.id || path.scope.generateUidIdentifier("class");
+        const ref = node.id;
 
         path.replaceWith(
           t.variableDeclaration("let", [

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -12,9 +12,7 @@ export default function({ types: t }) {
         if (!path.get("declaration").isClassDeclaration()) return;
 
         const { node } = path;
-        const ref =
-          node.declaration.id || path.scope.generateUidIdentifier("class");
-        node.declaration.id = ref;
+        const ref = node.declaration.id;
 
         // Split the class declaration and the export into two separate statements.
         path.replaceWith(node.declaration);
@@ -28,7 +26,7 @@ export default function({ types: t }) {
       ClassDeclaration(path) {
         const { node } = path;
 
-        const ref = node.id || path.scope.generateUidIdentifier("class");
+        const ref = node.id;
 
         path.replaceWith(
           t.variableDeclaration("let", [

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2941/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2941/expected.js
@@ -4,8 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _class = function _class() {
-  babelHelpers.classCallCheck(this, _class);
+var _default = function _default() {
+  babelHelpers.classCallCheck(this, _default);
 };
 
-exports.default = _class;
+exports.default = _default;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/export-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/export-super-class/expected.js
@@ -1,12 +1,12 @@
-var _class = function (_A) {
-  babelHelpers.inherits(_class, _A);
+var _default = function (_A) {
+  babelHelpers.inherits(_default, _A);
 
-  function _class() {
-    babelHelpers.classCallCheck(this, _class);
-    return babelHelpers.possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
+  function _default() {
+    babelHelpers.classCallCheck(this, _default);
+    return babelHelpers.possibleConstructorReturn(this, (_default.__proto__ || Object.getPrototypeOf(_default)).apply(this, arguments));
   }
 
-  return _class;
+  return _default;
 }(A);
 
-export { _class as default };
+export { _default as default };

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-default-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-default-5/expected.js
@@ -4,6 +4,7 @@ define(["exports"], function (exports) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+  exports.default = _default;
 
-  exports.default = function () {};
+  function _default() {}
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-default-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-default-6/expected.js
@@ -4,5 +4,8 @@ define(["exports"], function (exports) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-  exports.default = class {};
+
+  class _default {}
+
+  exports.default = _default;
 });

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -307,41 +307,17 @@ export default function() {
               if (declaration.isFunctionDeclaration()) {
                 const id = declaration.node.id;
                 const defNode = t.identifier("default");
-                if (id) {
-                  addTo(exports, id.name, defNode);
-                  topNodes.push(buildExportsAssignment(defNode, id));
-                  path.replaceWith(declaration.node);
-                } else {
-                  topNodes.push(
-                    buildExportsAssignment(
-                      defNode,
-                      t.toExpression(declaration.node),
-                    ),
-                  );
-                  path.remove();
-                }
+                addTo(exports, id.name, defNode);
+                topNodes.push(buildExportsAssignment(defNode, id));
+                path.replaceWith(declaration.node);
               } else if (declaration.isClassDeclaration()) {
                 const id = declaration.node.id;
                 const defNode = t.identifier("default");
-                if (id) {
-                  addTo(exports, id.name, defNode);
-                  path.replaceWithMultiple([
-                    declaration.node,
-                    buildExportsAssignment(defNode, id),
-                  ]);
-                } else {
-                  path.replaceWith(
-                    buildExportsAssignment(
-                      defNode,
-                      t.toExpression(declaration.node),
-                    ),
-                  );
-
-                  // Manualy re-queue `export default class {}` expressions so that the ES3 transform
-                  // has an opportunity to convert them. Ideally this would happen automatically from the
-                  // replaceWith above. See #4140 for more info.
-                  path.parentPath.requeue(path.get("expression.left"));
-                }
+                addTo(exports, id.name, defNode);
+                path.replaceWithMultiple([
+                  declaration.node,
+                  buildExportsAssignment(defNode, id),
+                ]);
               } else {
                 path.replaceWith(
                   buildExportsAssignment(

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-5/expected.js
@@ -3,5 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = _default;
 
-exports.default = function () {};
+function _default() {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-6/expected.js
@@ -3,4 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = class {};
+
+class _default {}
+
+exports.default = _default;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/expected.js
@@ -3,4 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = class {};
+
+class _default {}
+
+exports["default"] = _default;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/expected.js
@@ -3,5 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports["default"] = _default;
 
-exports["default"] = function () {};
+function _default() {}

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/src/index.js
@@ -172,15 +172,9 @@ export default function({ types: t }) {
                 const id = declar.node.id;
                 const nodes = [];
 
-                if (id) {
-                  nodes.push(declar.node);
-                  nodes.push(buildExportCall("default", id));
-                  addExportName(id.name, "default");
-                } else {
-                  nodes.push(
-                    buildExportCall("default", t.toExpression(declar.node)),
-                  );
-                }
+                nodes.push(declar.node);
+                nodes.push(buildExportCall("default", id));
+                addExportName(id.name, "default");
 
                 if (!canHoist || declar.isClassDeclaration()) {
                   path.replaceWithMultiple(nodes);

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/export-default-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/export-default-5/expected.js
@@ -1,7 +1,9 @@
 System.register([], function (_export, _context) {
   "use strict";
 
-  _export("default", function () {});
+  function _default() {}
+
+  _export("default", _default);
 
   return {
     setters: [],

--- a/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/export-default-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-systemjs/test/fixtures/systemjs/export-default-6/expected.js
@@ -1,10 +1,12 @@
 System.register([], function (_export, _context) {
   "use strict";
 
-  _export("default", class {});
-
   return {
     setters: [],
-    execute: function () {}
+    execute: function () {
+      class _default {}
+
+      _export("default", _default);
+    }
   };
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/export-default-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/export-default-5/expected.js
@@ -16,6 +16,7 @@
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+  exports.default = _default;
 
-  exports.default = function () {};
+  function _default() {}
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/export-default-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/export-default-6/expected.js
@@ -16,5 +16,8 @@
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-  exports.default = class {};
+
+  class _default {}
+
+  exports.default = _default;
 });

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/non-typeof/expected.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/non-typeof/expected.js
@@ -1,4 +1,4 @@
-export default function (number) {
+export default function _default(number) {
   if (!isNaN(number)) {
     return 1;
   }

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
@@ -3,13 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = _callee;
+exports.default = _default;
 
-var _marked = [_callee].map(regeneratorRuntime.mark);
+var _marked = [_default].map(regeneratorRuntime.mark);
 
-function _callee() {
+function _default() {
   var x;
-  return regeneratorRuntime.wrap(function _callee$(_context) {
+  return regeneratorRuntime.wrap(function _default$(_context) {
     while (1) {
       switch (_context.prev = _context.next) {
         case 0:

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -46,20 +46,6 @@ export default class Renamer {
 
     // build specifiers that point back to this export declaration
     const isDefault = exportDeclar.isExportDefaultDeclaration();
-
-    if (
-      isDefault &&
-      (parentDeclar.isFunctionDeclaration() ||
-        parentDeclar.isClassDeclaration()) &&
-      !parentDeclar.node.id
-    ) {
-      // Ensure that default class and function exports have a name so they have a identifier to
-      // reference from the export specifier list.
-      parentDeclar.node.id = parentDeclar.scope.generateUidIdentifier(
-        "default",
-      );
-    }
-
     const bindingIdentifiers = parentDeclar.getOuterBindingIdentifiers();
     const specifiers = [];
 


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | [There](https://github.com/babel/babel/blob/d82afb407eaa4ff03b98b85824efcd161913952d/packages/babel-helper-remap-async-to-generator/src/index.js#L146-L149) [are](https://github.com/babel/babel/blob/d82afb407eaa4ff03b98b85824efcd161913952d/packages/babel-traverse/src/path/introspection.js#L290) [some](https://github.com/babel/babel/blob/d82afb407eaa4ff03b98b85824efcd161913952d/packages/babel-plugin-transform-es2015-block-scoped-functions/src/index.js#L7-11), but indirectly
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Closes https://github.com/babel/babylon/pull/630
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

In lieu of https://github.com/babel/babylon/pull/630, this finds unnamed `export default` `FunctionDeclaration`/`ClassDeclaration`s early in Babel's lifecycle (before transforms are run) and names them.

The important commit is https://github.com/jridgewell/babel/commit/93c3b041619aaaf472a740e0f06a03e8deecebbb, everything else is removing edge cases that had to deal with this and test updates (they have a name now).