### PR TITLE
Optimize and remove state from typeof-symbol transform

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -362,7 +362,7 @@ helpers.get = template(`
 helpers.inherits = template(`
   (function (subClass, superClass) {
     if (typeof superClass !== "function" && superClass !== null) {
-      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+      throw new TypeError("Super expression must either be null or a function");
     }
     subClass.prototype = Object.create(superClass && superClass.prototype, {
       constructor: {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/exec/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/exec/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["transform-es2015-classes", "transform-es2015-block-scoping"]
+  "plugins": ["transform-es2015-classes", "transform-es2015-block-scoping", "transform-es2015-typeof-symbol"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/exec/return-symbol.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/exec/return-symbol.js
@@ -1,0 +1,9 @@
+class Foo {
+  constructor() {
+    return Symbol();
+  }
+}
+
+const f = new Foo;
+assert.ok(f instanceof Foo);
+assert.ok(typeof f === "object");

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
@@ -1,8 +1,10 @@
 "use strict";
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/actual.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/actual.js
@@ -3,3 +3,7 @@ assert.ok(typeof s === "symbol");
 assert.equal(typeof s, "symbol");
 assert.equal(typeof typeof s.foo, "symbol");
 typeof s === "string";
+assert.isNotOk(typeof o === "symbol");
+assert.notEqual(typeof o, "symbol");
+assert.notEqual(typeof typeof o.foo, "symbol");
+typeof o === "string";

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/exec.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/exec.js
@@ -2,3 +2,7 @@ var s = Symbol("s");
 assert.equal(typeof s, "symbol");
 assert.ok(typeof s === "symbol");
 assert.ok(typeof Symbol.prototype === 'object', "`typeof Symbol.prototype` should be 'object'");
+assert.isNotOk(typeof o === "symbol");
+assert.notEqual(typeof o, "symbol");
+assert.notEqual(typeof typeof o, "symbol");
+typeof o === "string";

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/expected.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/typeof/expected.js
@@ -1,5 +1,9 @@
 var s = Symbol("s");
-assert.ok((typeof s === "undefined" ? "undefined" : babelHelpers.typeof(s)) === "symbol");
-assert.equal(typeof s === "undefined" ? "undefined" : babelHelpers.typeof(s), "symbol");
+assert.ok(babelHelpers.typeof(s) === "symbol");
+assert.equal(babelHelpers.typeof(s), "symbol");
 assert.equal(babelHelpers.typeof(babelHelpers.typeof(s.foo)), "symbol");
 typeof s === "string";
+assert.isNotOk((typeof o === "undefined" ? "undefined" : babelHelpers.typeof(o)) === "symbol");
+assert.notEqual(typeof o === "undefined" ? "undefined" : babelHelpers.typeof(o), "symbol");
+assert.notEqual(babelHelpers.typeof(babelHelpers.typeof(o.foo)), "symbol");
+typeof o === "string";


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes
| Tests Added/Pass?        | Yes
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

Also fixes a bug with returning a Symbol from a Class constructor
(because the transform wasn’t run on helpers before).

This'll also help in https://github.com/babel/babel/pull/5757, getting rid of the ugly typeof test.