### PR TITLE
Fix react-inline-elements bug

### DIFF
--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -16,7 +16,7 @@ export default function({ types: t }) {
 
   function getAttributeValue(attr) {
     let value = attr.value;
-    if (!value) return t.identifier("true");
+    if (!value) return t.booleanLiteral(true);
     if (t.isJSXExpressionContainer(value)) value = value.expression;
     return value;
   }


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes
| Tests Added/Pass?        | No
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

This one's obviously a bug. You can't have `true` identifier, only a boolean literal.