### PR TITLE
Comment out unreachable code to silence Firefox warnings.

### DIFF
--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -73,34 +73,34 @@ export default class Renamer {
   maybeConvertFromClassFunctionDeclaration(path) {
     return; // TODO
 
-    // retain the `name` of a class/function declaration
+    // // retain the `name` of a class/function declaration
 
-    if (!path.isFunctionDeclaration() && !path.isClassDeclaration()) return;
-    if (this.binding.kind !== "hoisted") return;
+    // if (!path.isFunctionDeclaration() && !path.isClassDeclaration()) return;
+    // if (this.binding.kind !== "hoisted") return;
 
-    path.node.id = t.identifier(this.oldName);
-    path.node._blockHoist = 3;
+    // path.node.id = t.identifier(this.oldName);
+    // path.node._blockHoist = 3;
 
-    path.replaceWith(t.variableDeclaration("let", [
-      t.variableDeclarator(t.identifier(this.newName), t.toExpression(path.node))
-    ]));
+    // path.replaceWith(t.variableDeclaration("let", [
+    //   t.variableDeclarator(t.identifier(this.newName), t.toExpression(path.node))
+    // ]));
   }
 
   maybeConvertFromClassFunctionExpression(path) {
     return; // TODO
 
-    // retain the `name` of a class/function expression
+    // // retain the `name` of a class/function expression
 
-    if (!path.isFunctionExpression() && !path.isClassExpression()) return;
-    if (this.binding.kind !== "local") return;
+    // if (!path.isFunctionExpression() && !path.isClassExpression()) return;
+    // if (this.binding.kind !== "local") return;
 
-    path.node.id = t.identifier(this.oldName);
+    // path.node.id = t.identifier(this.oldName);
 
-    this.binding.scope.parent.push({
-      id: t.identifier(this.newName)
-    });
+    // this.binding.scope.parent.push({
+    //   id: t.identifier(this.newName)
+    // });
 
-    path.replaceWith(t.assignmentExpression("=", t.identifier(this.newName), path.node));
+    // path.replaceWith(t.assignmentExpression("=", t.identifier(this.newName), path.node));
   }
 
   rename(block?) {


### PR DESCRIPTION
`renamer.js` contains unreachable code after return statements; modern versions of Firefox produce warnings when unreachable code is detected. This silences those warnings when babel is run within the browser.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | n/a
| Tests Added/Pass?        | n/a
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
