### PR TITLE
Remove unused functions from renamer.js.

### DIFF
--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -70,39 +70,6 @@ export default class Renamer {
     }
   }
 
-  maybeConvertFromClassFunctionDeclaration(path) {
-    return; // TODO
-
-    // retain the `name` of a class/function declaration
-
-    if (!path.isFunctionDeclaration() && !path.isClassDeclaration()) return;
-    if (this.binding.kind !== "hoisted") return;
-
-    path.node.id = t.identifier(this.oldName);
-    path.node._blockHoist = 3;
-
-    path.replaceWith(t.variableDeclaration("let", [
-      t.variableDeclarator(t.identifier(this.newName), t.toExpression(path.node))
-    ]));
-  }
-
-  maybeConvertFromClassFunctionExpression(path) {
-    return; // TODO
-
-    // retain the `name` of a class/function expression
-
-    if (!path.isFunctionExpression() && !path.isClassExpression()) return;
-    if (this.binding.kind !== "local") return;
-
-    path.node.id = t.identifier(this.oldName);
-
-    this.binding.scope.parent.push({
-      id: t.identifier(this.newName)
-    });
-
-    path.replaceWith(t.assignmentExpression("=", t.identifier(this.newName), path.node));
-  }
-
   rename(block?) {
     const { binding, oldName, newName } = this;
     const { scope, path } = binding;
@@ -123,11 +90,6 @@ export default class Renamer {
     if (binding.type === "hoisted") {
       // https://github.com/babel/babel/issues/2435
       // todo: hoist and convert function to a let
-    }
-
-    if (parentDeclar) {
-      this.maybeConvertFromClassFunctionDeclaration(parentDeclar);
-      this.maybeConvertFromClassFunctionExpression(parentDeclar);
     }
   }
 }


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

Firefox emits warnings about unreachable code after return statements. This patch removes those unused functions entirely (as suggested in babel/babel#5962) to silence these errors.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | n/a
| Tests Added/Pass?        | n/a
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
