### PR TITLE
Fix numeric-separator transform

### DIFF
--- a/packages/babel-plugin-transform-numeric-separator/src/index.js
+++ b/packages/babel-plugin-transform-numeric-separator/src/index.js
@@ -1,33 +1,29 @@
 import syntaxNumericSeparator from "babel-plugin-syntax-numeric-separator";
 
 export default function({ types: t }) {
-  function replacer(value) {
-    return value.replace(/_/g, "");
-  }
-
   function replaceNumberArg({ node }) {
     if (node.callee.name !== "Number") {
       return;
     }
+
     const arg = node.arguments[0];
     if (!t.isStringLiteral(arg)) {
       return;
     }
-    arg.value = replacer(arg.value);
-  }
 
-  const CallExpression = replaceNumberArg;
-  const NewExpression = replaceNumberArg;
+    arg.value = arg.value.replace(/_/g, "");
+  }
 
   return {
     inherits: syntaxNumericSeparator,
 
     visitor: {
-      CallExpression,
-      NewExpression,
+      CallExpression: replaceNumberArg,
+      NewExpression: replaceNumberArg,
       NumericLiteral({ node }) {
-        if (node.extra && /_/.test(node.extra.raw)) {
-          node.value = replacer(node.extra.raw);
+        const { extra } = node;
+        if (extra && /_/.test(extra.raw)) {
+          extra.raw = extra.raw.replace(/_/g, "");
         }
       },
     },

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -38,7 +38,7 @@ suite("validators", function() {
         t.objectProperty(
           t.identifier("a"),
           t.objectPattern([
-            t.objectProperty(t.identifier("b"), t.stringLiteral("foo")),
+            t.objectProperty(t.identifier("b"), t.identifier("foo")),
             t.objectProperty(
               t.identifier("c"),
               t.arrayPattern([t.identifier("value")]),


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | No
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       |

Fixes the numeric-separator transform. `NumericLiteral`s can't have a string value, it has to be a number. And babylon's already processed that number into the appropriate value, so we really only need to fix the `raw` string.