### PR TITLE
Fixup builder-binary-assignment-operator-visitor

### DIFF
--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/src/index.js
@@ -2,53 +2,30 @@ import explode from "babel-helper-explode-assignable-expression";
 import * as t from "babel-types";
 
 export default function(opts: { build: Function, operator: string }): Object {
-  const visitor = {};
+  const { build, operator } = opts;
 
-  function isAssignment(node) {
-    return node && node.operator === opts.operator + "=";
-  }
+  return {
+    AssignmentExpression(path) {
+      const { node, scope } = path;
+      if (node.operator !== operator + "=") return;
 
-  function buildAssignment(left, right) {
-    return t.assignmentExpression("=", left, right);
-  }
+      const nodes = [];
+      const exploded = explode(node.left, nodes, this, scope);
+      nodes.push(
+        t.assignmentExpression(
+          "=",
+          exploded.ref,
+          build(exploded.uid, node.right),
+        ),
+      );
+      path.replaceWith(t.sequenceExpression(nodes));
+    },
 
-  visitor.ExpressionStatement = function(path, file) {
-    // hit the `AssignmentExpression` one below
-    if (path.isCompletionRecord()) return;
-
-    const expr = path.node.expression;
-    if (!isAssignment(expr)) return;
-
-    const nodes = [];
-    const exploded = explode(expr.left, nodes, file, path.scope, true);
-
-    nodes.push(
-      t.expressionStatement(
-        buildAssignment(exploded.ref, opts.build(exploded.uid, expr.right)),
-      ),
-    );
-
-    path.replaceWithMultiple(nodes);
+    BinaryExpression(path) {
+      const { node } = path;
+      if (node.operator === operator) {
+        path.replaceWith(build(node.left, node.right));
+      }
+    },
   };
-
-  visitor.AssignmentExpression = function(path, file) {
-    const { node, scope } = path;
-    if (!isAssignment(node)) return;
-
-    const nodes = [];
-    const exploded = explode(node.left, nodes, file, scope);
-    nodes.push(
-      buildAssignment(exploded.ref, opts.build(exploded.uid, node.right)),
-    );
-    path.replaceWithMultiple(nodes);
-  };
-
-  visitor.BinaryExpression = function(path) {
-    const { node } = path;
-    if (node.operator === opts.operator) {
-      path.replaceWith(opts.build(node.left, node.right));
-    }
-  };
-
-  return visitor;
 }

--- a/packages/babel-helper-explode-assignable-expression/src/index.js
+++ b/packages/babel-helper-explode-assignable-expression/src/index.js
@@ -32,7 +32,8 @@ function getObjRef(node, nodes, file, scope) {
   }
 
   const temp = scope.generateUidIdentifierBasedOnNode(ref);
-  nodes.push(t.variableDeclaration("var", [t.variableDeclarator(temp, ref)]));
+  scope.push({ id: temp });
+  nodes.push(t.assignmentExpression("=", temp, ref));
   return temp;
 }
 
@@ -42,7 +43,8 @@ function getPropRef(node, nodes, file, scope) {
   if (t.isLiteral(key) && t.isPureish(key)) return key;
 
   const temp = scope.generateUidIdentifierBasedOnNode(prop);
-  nodes.push(t.variableDeclaration("var", [t.variableDeclarator(temp, prop)]));
+  scope.push({ id: temp });
+  nodes.push(t.assignmentExpression("=", temp, prop));
   return temp;
 }
 

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4403/expected.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4403/expected.js
@@ -1,3 +1,4 @@
+var _ref;
+
 var a, b;
-var _ref = `${b++}`;
-a[_ref] = Math.pow(a[_ref], 1)
+_ref = `${b++}`, a[_ref] = Math.pow(a[_ref], 1);


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Maybe?
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

Using a `SequenceExpression` instead, we avoid awkward
`AssignmentExpression`s as direct children of `BlockStatement`s.