### PR TITLE
Remove noop

### DIFF
--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -2,8 +2,14 @@ import syntaxFlow from "babel-plugin-syntax-flow";
 
 export default function({ types: t }) {
   function wrapInFlowComment(path, parent) {
-    path.addComment("trailing", generateComment(path, parent));
-    path.replaceWith(t.noop());
+    let attach = path.getPrevSibling();
+    let where = "trailing";
+    if (!attach.node) {
+      attach = path.parentPath;
+      where = "inner";
+    }
+    attach.addComment(where, generateComment(path, parent));
+    path.remove();
   }
 
   function generateComment(path, parent) {
@@ -30,40 +36,79 @@ export default function({ types: t }) {
 
       // support function a(b?) {}
       Identifier(path) {
-        const { node } = path;
-        if (!node.optional || node.typeAnnotation) {
+        if (path.parentPath.isFlow()) {
           return;
         }
-        path.addComment("trailing", ":: ?");
+
+        const { node } = path;
+        if (node.typeAnnotation) {
+          const typeAnnotation = path.get("typeAnnotation");
+          path.addComment("trailing", generateComment(typeAnnotation, node));
+          typeAnnotation.remove();
+          if (node.optional) {
+            node.optional = false;
+          }
+        } else if (node.optional) {
+          path.addComment("trailing", ":: ?");
+          node.optional = false;
+        }
       },
 
       AssignmentPattern: {
         exit({ node }) {
-          node.left.optional = false;
+          const { left } = node;
+          if (left.optional) {
+            left.optional = false;
+          }
         },
       },
 
       // strip optional property from function params - facebook/fbjs#17
-      Function: {
-        exit({ node }) {
-          node.params.forEach(param => (param.optional = false));
-        },
+      Function(path) {
+        if (path.isDeclareFunction()) return;
+        const { node } = path;
+        if (node.returnType) {
+          const returnType = path.get("returnType");
+          const typeAnnotation = returnType.get("typeAnnotation");
+          const block = path.get("body");
+          block.addComment(
+            "leading",
+            generateComment(returnType, typeAnnotation.node),
+          );
+          returnType.remove();
+        }
+        if (node.typeParameters) {
+          const typeParameters = path.get("typeParameters");
+          const id = path.get("id");
+          id.addComment(
+            "trailing",
+            generateComment(typeParameters, typeParameters.node),
+          );
+          typeParameters.remove();
+        }
       },
 
       // support for `class X { foo: string }` - #4622
       ClassProperty(path) {
         const { node, parent } = path;
-        if (!node.value) wrapInFlowComment(path, parent);
+        if (!node.value) {
+          wrapInFlowComment(path, parent);
+        } else if (node.typeAnnotation) {
+          const typeAnnotation = path.get("typeAnnotation");
+          path
+            .get("key")
+            .addComment(
+              "trailing",
+              generateComment(typeAnnotation, typeAnnotation.node),
+            );
+          typeAnnotation.remove();
+        }
       },
 
       // support `export type a = {}` - #8 Error: You passed path.replaceWith() a falsy node
-      "ExportNamedDeclaration|Flow"(path) {
+      ExportNamedDeclaration(path) {
         const { node, parent } = path;
-        if (
-          t.isExportNamedDeclaration(node) &&
-          node.exportKind !== "type" &&
-          !t.isFlow(node.declaration)
-        ) {
+        if (node.exportKind !== "type" && !t.isFlow(node.declaration)) {
           return;
         }
         wrapInFlowComment(path, parent);
@@ -72,14 +117,28 @@ export default function({ types: t }) {
       // support `import type A` and `import typeof A` #10
       ImportDeclaration(path) {
         const { node, parent } = path;
-        if (
-          t.isImportDeclaration(node) &&
-          node.importKind !== "type" &&
-          node.importKind !== "typeof"
-        ) {
+        if (node.importKind !== "type" && node.importKind !== "typeof") {
           return;
         }
         wrapInFlowComment(path, parent);
+      },
+
+      Flow(path) {
+        const { parent } = path;
+        wrapInFlowComment(path, parent);
+      },
+
+      Class(path) {
+        const { node } = path;
+        if (node.typeParameters) {
+          const typeParameters = path.get("typeParameters");
+          const block = path.get("body");
+          block.addComment(
+            "leading",
+            generateComment(typeParameters, typeParameters.node),
+          );
+          typeParameters.remove();
+        }
       },
     },
   };

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-2/expected.js
@@ -2,5 +2,4 @@ class X {
   /*:: a: number*/
 
   /*:: b: ?string*/
-
 }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values/expected.js
@@ -3,7 +3,6 @@ class X {
   bar
   /*: number*/
   = 3;
-
   /*:: baz: ?string*/
 
 }

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/def-site-variance/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/def-site-variance/expected.js
@@ -5,5 +5,4 @@ class C
 function f
 /*:: <+T, -U>*/
 () {}
-
 /*:: type T<+T, -U> = {};*/

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/actual.js
@@ -1,3 +1,4 @@
+export type { A } from './types';
 import lib from 'library';
 export { foo } from 'foo';
 export type { B, C } from './types';

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-export/expected.js
@@ -1,4 +1,4 @@
+/*:: export type { A } from './types';*/
 import lib from 'library';
 export { foo } from 'foo';
-
 /*:: export type { B, C } from './types';*/

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-type-alias/actual.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-type-alias/actual.js
@@ -1,3 +1,4 @@
-import lib from 'library';
 import type A, { B, C } from './types';
-import typeof D, { E, F } from './types';
+import lib from 'library';
+import type D from './types';
+import typeof E, { F, G } from './types';

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-type-alias/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/import-type-alias/expected.js
@@ -1,5 +1,5 @@
-import lib from 'library';
-
 /*:: import type A, { B, C } from './types';*/
+import lib from 'library';
+/*:: import type D from './types';*/
 
-/*:: import typeof D, { E, F } from './types';*/
+/*:: import typeof E, { F, G } from './types';*/

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/type-alias/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/type-alias/expected.js
@@ -1,5 +1,4 @@
 function a() {}
-
 /*:: type A = number;*/
 
 /*:: type B = {


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Probably
| Minor: New Feature?      | No
| Deprecations?            | Noop
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

It’s ugly, but it gets the job done. And it unblocks my babel-type changes.

There are probably breaking changes. The flow ast is completely unknown, so I'm not really concerned. It at least removes them.