### PR TITLE
Update v8flags to version 3.0.0

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -27,7 +27,7 @@
     "output-file-sync": "^1.1.0",
     "slash": "^1.0.0",
     "source-map": "^0.5.0",
-    "v8flags": "^2.0.10"
+    "v8flags": "^3.0.0"
   },
   "optionalDependencies": {
     "chokidar": "^1.6.1"


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | ?
| Tests Added/Pass?        | yes
| Fixed Tickets            | no
| License                  | MIT
| Doc PR                   | no
| Dependency Changes       | v8flags

<!-- Describe your changes below in as much detail as possible -->
The v8flags dependency got updated so that it follows the OS cache location conventions. See [the PR](https://github.com/js-cli/js-v8flags/pull/38) for more information.