### PR TITLE
Add support for flow predicates in babel-generator

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -41,7 +41,26 @@ export function DeclareFunction(node: Object, parent: Object) {
   this.space();
   this.print(node.id, node);
   this.print(node.id.typeAnnotation.typeAnnotation, node);
+
+  if (node.predicate) {
+    this.space();
+    this.print(node.predicate, node);
+  }
+
   this.semicolon();
+}
+
+export function InferredPredicate(/*node: Object*/) {
+  this.token("%");
+  this.word("checks");
+}
+
+export function DeclaredPredicate(node: Object) {
+  this.token("%");
+  this.word("checks");
+  this.token("(");
+  this.print(node.value, node);
+  this.token(")");
 }
 
 export function DeclareInterface(node: Object) {

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -49,6 +49,16 @@ export function _method(node: Object) {
   this.print(node.body, node);
 }
 
+export function _predicate(node: Object) {
+  if (node.predicate) {
+    if (!node.returnType) {
+      this.token(":");
+    }
+    this.space();
+    this.print(node.predicate, node);
+  }
+}
+
 export function FunctionExpression(node: Object) {
   if (node.async) {
     this.word("async");
@@ -65,6 +75,8 @@ export function FunctionExpression(node: Object) {
   }
 
   this._params(node);
+  this._predicate(node);
+
   this.space();
   this.print(node.body, node);
 }
@@ -88,6 +100,8 @@ export function ArrowFunctionExpression(node: Object) {
   } else {
     this._params(node);
   }
+
+  this._predicate(node);
 
   this.space();
   this.token("=>");

--- a/packages/babel-generator/test/fixtures/flow/predicates/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/predicates/actual.js
@@ -1,0 +1,17 @@
+declare function foo(x: mixed): boolean %checks(x !== null);
+
+declare function my_filter<T, P: $Pred<1>>(v: Array<T>, cb: P): Array<$Refine<T,P,1>>;
+
+declare function f2(x: mixed): string %checks(Array.isArray(x));
+
+function foo(x: mixed): %checks { return typeof x === "string"; }
+
+function is_string(x): boolean %checks {
+  return typeof x === "string";
+}
+
+var f = (x: mixed): %checks => typeof x === "string";
+
+const foo = (x: mixed): boolean %checks => typeof x === "string";
+
+(x): %checks => x !== null;

--- a/packages/babel-generator/test/fixtures/flow/predicates/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/predicates/expected.js
@@ -1,0 +1,17 @@
+declare function foo(x: mixed): boolean %checks(x !== null);
+declare function my_filter<T, P: $Pred<1>>(v: Array<T>, cb: P): Array<$Refine<T, P, 1>>;
+declare function f2(x: mixed): string %checks(Array.isArray(x));
+
+function foo(x: mixed): %checks {
+  return typeof x === "string";
+}
+
+function is_string(x): boolean %checks {
+  return typeof x === "string";
+}
+
+var f = (x: mixed): %checks => typeof x === "string";
+
+const foo = (x: mixed): boolean %checks => typeof x === "string";
+
+x: %checks => x !== null;

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -67,6 +67,8 @@ export default function({ types: t }) {
           const param = node.params[i];
           param.optional = false;
         }
+
+        node.predicate = null;
       },
 
       TypeCastExpression(path) {

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declared-checks-annotation/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-declared-checks-annotation/actual.js
@@ -1,0 +1,1 @@
+declare function foo(x: mixed): boolean %checks(typeof x === "string");

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-inferred-checks-annotation/actual.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-inferred-checks-annotation/actual.js
@@ -1,0 +1,5 @@
+var f = (x): %checks => typeof x === "string";
+var g = (x: mixed): boolean %checks => typeof x === "string";
+function h(x: mixed): %checks {
+  return typeof x === "string";
+}

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-inferred-checks-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/strip-types/strip-inferred-checks-annotation/expected.js
@@ -1,0 +1,7 @@
+var f = x => typeof x === "string";
+
+var g = x => typeof x === "string";
+
+function h(x) {
+  return typeof x === "string";
+}

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -520,6 +520,19 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
 ---
 
+### declaredPredicate
+```javascript
+t.declaredPredicate(value)
+```
+
+See also `t.isDeclaredPredicate(node, opts)` and `t.assertDeclaredPredicate(node, opts)`.
+
+Aliases: `Flow`, `FlowPredicate`
+
+ - `value` (required)
+
+---
+
 ### decorator
 ```javascript
 t.decorator(expression)
@@ -946,6 +959,18 @@ Aliases: `ModuleSpecifier`
  - `local`: `Identifier` (required)
  - `imported`: `Identifier` (required)
  - `importKind`: `null | 'type' | 'typeof'` (default: `null`)
+
+---
+
+### inferredPredicate
+```javascript
+t.inferredPredicate()
+```
+
+See also `t.isInferredPredicate(node, opts)` and `t.assertInferredPredicate(node, opts)`.
+
+Aliases: `Flow`, `FlowPredicate`
+
 
 ---
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -125,6 +125,14 @@ defineType("DeclareExportAllDeclaration", {
   },
 });
 
+defineType("DeclaredPredicate", {
+  visitor: ["value"],
+  aliases: ["Flow", "FlowPredicate"],
+  fields: {
+    // todo
+  },
+});
+
 defineType("ExistsTypeAnnotation", {
   aliases: ["Flow"],
 });
@@ -148,6 +156,13 @@ defineType("FunctionTypeParam", {
 defineType("GenericTypeAnnotation", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"],
+  fields: {
+    // todo
+  },
+});
+
+defineType("InferredPredicate", {
+  aliases: ["Flow", "FlowPredicate"],
   fields: {
     // todo
   },


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | y
| Tests Added/Pass?        | y/y
| Fixed Tickets            | Closes #3700
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

Based on #3700 with updated predicate handling in flow/babylon:  https://github.com/babel/babylon/pull/428
