### PR TITLE
Update globals to v10

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -14,7 +14,7 @@
     "babel-types": "7.0.0-alpha.15",
     "babylon": "7.0.0-beta.15",
     "debug": "^2.2.0",
-    "globals": "^9.0.0",
+    "globals": "^10.0.0",
     "invariant": "^2.2.0",
     "lodash": "^4.2.0"
   },


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | n
| Tests Added/Pass?        | n
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

The package was changed to use node v4 minimum. And some old jest globals were removed