### PR TITLE
Update jsesc to the latest version

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel-messages": "7.0.0-alpha.15",
     "babel-types": "7.0.0-alpha.15",
-    "jsesc": "^1.3.0",
+    "jsesc": "^2.5.1",
     "lodash": "^4.2.0",
     "source-map": "^0.5.0",
     "trim-right": "^1.0.1"


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | n
| Tests Added/Pass?        | n
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

2.0 dropped support for everything below node4, which is fine for babel 7.0.
