### PR TITLE
Update output-file-sync to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package-lock.json
 /packages/babel-runtime/helpers/es6/*.js
 !/packages/babel-runtime/helpers/es6/toArray.js
 /packages/babel-register/test/.babel
+/packages/babel-cli/test/tmp
 /packages/*/lib
 .nyc_output
 /babel.sublime-workspace

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.2.0",
     "mocha": "^3.0.0",
     "nyc": "^11.0.3",
-    "output-file-sync": "^1.1.1",
+    "output-file-sync": "^2.0.0",
     "prettier": "^1.5.0",
     "rimraf": "^2.4.3",
     "semver": "^5.0.0",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -24,7 +24,7 @@
     "fs-readdir-recursive": "^1.0.0",
     "glob": "^7.0.0",
     "lodash": "^4.2.0",
-    "output-file-sync": "^1.1.0",
+    "output-file-sync": "^2.0.0",
     "slash": "^1.0.0",
     "source-map": "^0.5.0",
     "v8flags": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,7 +3196,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -4265,13 +4265,21 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-output-file-sync@^1.1.0, output-file-sync@^1.1.1:
+output-file-sync@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
   dependencies:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
+
+output-file-sync@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.0.tgz#5d348a1a1eaed1ad168648a01a2d6d13078ce987"
+  dependencies:
+    graceful-fs "^4.1.11"
+    is-plain-obj "^1.1.0"
+    mkdirp "^0.5.1"
 
 p-finally@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | n
| Tests Added/Pass?        | n
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

Breaking change is the drop of node <4

Also ignore the tmp directory of babel-cli tests that always show up as new.