### PR TITLE
Update default-require-extensions to 2.0

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "decache": "^4.1.0",
-    "default-require-extensions": "^1.0.0"
+    "default-require-extensions": "^2.0.0"
   }
 }


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | n
| Tests Added/Pass?        | n
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

2.0 dropped support for node < 4