### PR TITLE
FIX access to the prototype of an instance

### DIFF
--- a/packages/babel-plugin-transform-class-properties/README.md
+++ b/packages/babel-plugin-transform-class-properties/README.md
@@ -24,7 +24,7 @@ Below is a class with four class properties which will be transformed.
   let myBork = new Bork;
 
   //Property initializers are not on the prototype.
-  console.log(myBork.prototype.boundFunction); // > undefined
+  console.log(myBork.__proto__.boundFunction); // > undefined
 
   //Bound functions are bound to the class instance.
   console.log(myBork.boundFunction.call(undefined)); // > "bork"


### PR DESCRIPTION
The right way access to the prototype of an instance is using the `__proto__` rather than the `prototype`.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
