### PR TITLE
wrap JSX element attributes in expression

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -47,6 +47,12 @@ export default function({ types: t }) {
     );
   };
 
+  visitor.JSXAttribute = function(path) {
+    if (t.isJSXElement(path.node.value)) {
+      path.node.value = t.jSXExpressionContainer(path.node.value);
+    }
+  };
+
   return {
     inherits: jsx,
     visitor,

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-allow-elements-as-attributes/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-allow-elements-as-attributes/actual.js
@@ -1,0 +1,1 @@
+<div attr=<div /> />

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-allow-elements-as-attributes/expected.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-allow-elements-as-attributes/expected.js
@@ -1,0 +1,3 @@
+React.createElement("div", {
+  attr: React.createElement("div", null)
+});


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | ✔️ 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        |  ✔️  ✔️ 
| Fixed Tickets            | Fixes https://github.com/babel/babel/issues/6004
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

Adds `JSXAttribute` visitor function in https://github.com/babel/babel/blob/7.0/packages/babel-plugin-transform-react-jsx/src/index.js

If the value of a `JSXAttribute` is a `JSXElement`, wrap it in a `JSXExpressionContainer`