### PR TITLE
add TEST_GREP example clarification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,12 @@ Use the `TEST_GREP` variable to run a subset of tests by name:
 $ TEST_GREP=transformation make test
 ```
 
+Substitute spaces for hyphens and forward slashes when targeting specific test names:
+
+```sh
+$ TEST_GREP="arrow functions destructuring parameters" make test
+```
+
 To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment variable:
 
 ```sh


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | ✔️ 
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->

While working on my first babel PR, it took me a minute to figure out exactly how to target a particular test using `TEST_GREP` based on the example in CONTRIBUTING.md.

Does this clarification have a place here? If so, would it be better to explicitly mention its relationship to mocha's `grep` option, and that it supports a regex pattern?
