### PR TITLE
babel-generator: Make plugins list explicit for test cases

### DIFF
--- a/packages/babel-generator/test/fixtures/auto-string/jsx/options.json
+++ b/packages/babel-generator/test/fixtures/auto-string/jsx/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx"] }

--- a/packages/babel-generator/test/fixtures/compact/expression-statement/options.json
+++ b/packages/babel-generator/test/fixtures/compact/expression-statement/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["objectRestSpread"] }

--- a/packages/babel-generator/test/fixtures/flow/def-site-variance/options.json
+++ b/packages/babel-generator/test/fixtures/flow/def-site-variance/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["classProperties", "flow"] }

--- a/packages/babel-generator/test/fixtures/flow/options.json
+++ b/packages/babel-generator/test/fixtures/flow/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["flow"] }

--- a/packages/babel-generator/test/fixtures/flowUsesCommas/ObjectExpression/options.json
+++ b/packages/babel-generator/test/fixtures/flowUsesCommas/ObjectExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["flow"] }

--- a/packages/babel-generator/test/fixtures/parentheses/do-expression/options.json
+++ b/packages/babel-generator/test/fixtures/parentheses/do-expression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["doExpressions"] }

--- a/packages/babel-generator/test/fixtures/types/BindExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/BindExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["functionBind"] }

--- a/packages/babel-generator/test/fixtures/types/ClassBody-ClassProperty/options.json
+++ b/packages/babel-generator/test/fixtures/types/ClassBody-ClassProperty/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["classProperties"] }

--- a/packages/babel-generator/test/fixtures/types/Decorator/options.json
+++ b/packages/babel-generator/test/fixtures/types/Decorator/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["decorators"] }

--- a/packages/babel-generator/test/fixtures/types/DoExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/DoExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["doExpressions"] }

--- a/packages/babel-generator/test/fixtures/types/ExportSpecifier16/options.json
+++ b/packages/babel-generator/test/fixtures/types/ExportSpecifier16/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["exportExtensions"] }

--- a/packages/babel-generator/test/fixtures/types/ExportSpecifier2/options.json
+++ b/packages/babel-generator/test/fixtures/types/ExportSpecifier2/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["exportExtensions"] }

--- a/packages/babel-generator/test/fixtures/types/ExportSpecifier3/options.json
+++ b/packages/babel-generator/test/fixtures/types/ExportSpecifier3/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["exportExtensions"] }

--- a/packages/babel-generator/test/fixtures/types/ExportSpecifier4/options.json
+++ b/packages/babel-generator/test/fixtures/types/ExportSpecifier4/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["exportExtensions"] }

--- a/packages/babel-generator/test/fixtures/types/ExportSpecifier5/options.json
+++ b/packages/babel-generator/test/fixtures/types/ExportSpecifier5/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["exportExtensions"] }

--- a/packages/babel-generator/test/fixtures/types/Import/options.json
+++ b/packages/babel-generator/test/fixtures/types/Import/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["dynamicImport"] }

--- a/packages/babel-generator/test/fixtures/types/Optional-CallExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/Optional-CallExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["optionalChaining"] }

--- a/packages/babel-generator/test/fixtures/types/Optional-MemberExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/Optional-MemberExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["optionalChaining"] }

--- a/packages/babel-generator/test/fixtures/types/Optional-NewExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/Optional-NewExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["optionalChaining"] }

--- a/packages/babel-generator/test/fixtures/types/Optional-TryStatement-CatchClause/options.json
+++ b/packages/babel-generator/test/fixtures/types/Optional-TryStatement-CatchClause/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["optionalCatchBinding"] }

--- a/packages/babel-generator/test/fixtures/types/RestProperty/options.json
+++ b/packages/babel-generator/test/fixtures/types/RestProperty/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["objectRestSpread"] }

--- a/packages/babel-generator/test/fixtures/types/XJSAttribute/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSAttribute/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSElement-XJSOpeningElement-XJSClosingElement-XJSIdentifier/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSElement-XJSOpeningElement-XJSClosingElement-XJSIdentifier/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSEmptyExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSEmptyExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSExpressionContainer/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSExpressionContainer/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSMemberExpression/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSMemberExpression/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSNamespacedName/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSNamespacedName/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSSpreadAttribute/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSSpreadAttribute/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSSpreadChildren/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/fixtures/types/XJSText/options.json
+++ b/packages/babel-generator/test/fixtures/types/XJSText/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["jsx" ] }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -376,21 +376,7 @@ suites.forEach(function(testSuite) {
             if (actualCode) {
               const actualAst = parse(actualCode, {
                 filename: actual.loc,
-                plugins: [
-                  "asyncGenerators",
-                  "classProperties",
-                  "decorators",
-                  "doExpressions",
-                  "dynamicImport",
-                  "exportExtensions",
-                  "flow",
-                  "functionBind",
-                  "functionSent",
-                  "jsx",
-                  "objectRestSpread",
-                  "optionalChaining",
-                  "optionalCatchBinding",
-                ],
+                plugins: task.options.plugins || [],
                 strictMode: false,
                 sourceType: "module",
               });


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | Tests pass
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

No longer provide a default list of every plugin. Instead, have each test specify the plugins it needs.
This is necessary since the TypeScript and Flow plugins cannot both be used at once.