### PR TITLE
babel-types: Have NewExpression inherit from CallExpression

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -118,7 +118,7 @@ defineType("BreakStatement", {
   aliases: ["Statement", "Terminatorless", "CompletionStatement"],
 });
 
-const callOrNew = {
+defineType("CallExpression", {
   visitor: ["callee", "arguments", "typeParameters"],
   builder: ["callee", "arguments"],
   aliases: ["Expression"],
@@ -141,9 +141,7 @@ const callOrNew = {
       optional: true,
     },
   },
-};
-
-defineType("CallExpression", callOrNew);
+});
 
 defineType("CatchClause", {
   visitor: ["param", "body"],
@@ -511,7 +509,7 @@ defineType("MemberExpression", {
   },
 });
 
-defineType("NewExpression", callOrNew);
+defineType("NewExpression", { inherits: "CallExpression" });
 
 defineType("Program", {
   visitor: ["directives", "body"],


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | Tests pass
| Fixed Tickets            | https://github.com/babel/babel/pull/5856#discussion_r127375789
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

Forgot to address this in #5856.