### PR TITLE
allow PluginPass.file.addImport to create empty import statements

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -180,9 +180,24 @@ export default class File extends Store {
 
   addImport(
     source: string,
-    imported: string,
+    imported?: string = "",
     name?: string = imported,
-  ): Object {
+  ): Object | null {
+    const prependDeclaration = (
+      specifiers: Array<BabelNodeImportSpecifier>,
+    ): void => {
+      const declar = t.importDeclaration(specifiers, t.stringLiteral(source));
+      declar._blockHoist = 3;
+
+      this.path.unshiftContainer("body", declar);
+    };
+
+    // import "module-name";
+    if (!imported) {
+      prependDeclaration([]);
+      return null;
+    }
+
     const alias = `${source}:${imported}`;
     let id = this.dynamicImportIds[alias];
 
@@ -202,10 +217,7 @@ export default class File extends Store {
         specifiers.push(t.importSpecifier(id, t.identifier(imported)));
       }
 
-      const declar = t.importDeclaration(specifiers, t.stringLiteral(source));
-      declar._blockHoist = 3;
-
-      this.path.unshiftContainer("body", declar);
+      prependDeclaration(specifiers);
     }
 
     return id;

--- a/packages/babel-core/test/fixtures/plugins/file-add-import/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/file-add-import/exec.js
@@ -1,30 +1,30 @@
-var res = transform('', {
+var res = transform("", {
   plugins: [
     function (b) {
       return {
         visitor: {
           Program: function(path, state) {
             var file = state.file;
-            file.addImport('import-star', '*', 'lib');
-            file.addImport('import-default', 'default', 'foo');
-            file.addImport('import-alias', 'bar', 'baz');
-            file.addImport('import-default-alias', 'quux');
-            file.addImport('import-none');
-            file.addImport('import-empty', '');
-          },
+            file.addImport("import-star", "*", "lib");
+            file.addImport("import-default", "default", "foo");
+            file.addImport("import-alias", "bar", "baz");
+            file.addImport("import-default-alias", "quux");
+            file.addImport("import-empty", "");
+            file.addImport("import-none");
+          }
         }
-      }
+      };
     }
   ]
 });
 
 var expected = multiline([
-  'import "import-empty";',
   'import "import-none";',
+  'import "import-empty";',
   'import { quux as _quux } from "import-default-alias";',
   'import { bar as _baz } from "import-alias";',
   'import _foo from "import-default";',
-  'import * as _lib from "import-star";'
+  'import * as _lib from "import-star";',
 ]);
 
 assert.equal(res.code, expected);

--- a/packages/babel-core/test/fixtures/plugins/file-add-import/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/file-add-import/exec.js
@@ -1,0 +1,30 @@
+var res = transform('', {
+  plugins: [
+    function (b) {
+      return {
+        visitor: {
+          Program: function(path, state) {
+            var file = state.file;
+            file.addImport('import-star', '*', 'lib');
+            file.addImport('import-default', 'default', 'foo');
+            file.addImport('import-alias', 'bar', 'baz');
+            file.addImport('import-default-alias', 'quux');
+            file.addImport('import-none');
+            file.addImport('import-empty', '');
+          },
+        }
+      }
+    }
+  ]
+});
+
+var expected = multiline([
+  'import "import-empty";',
+  'import "import-none";',
+  'import { quux as _quux } from "import-default-alias";',
+  'import { bar as _baz } from "import-alias";',
+  'import _foo from "import-default";',
+  'import * as _lib from "import-star";'
+]);
+
+assert.equal(res.code, expected);


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No 
| Minor: New Feature?      | Yes
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Fixes #6021
| License                  | MIT

Omitting `addImport`'s second argument creates an import statement with an empty `specifiers` array i.e. an empty import statement:

### plugin

```javascript
    Program (path, { file }) {
        file.addImport('foo-bar/register')
    }
```

### output

    import "foo-bar/register";