### PR TITLE
babel-generator: Comment TypeScript-specific code

### DIFF
--- a/packages/babel-generator/src/generators/classes.js
+++ b/packages/babel-generator/src/generators/classes.js
@@ -9,11 +9,13 @@ export function ClassDeclaration(node: Object, parent: Object) {
   }
 
   if (node.declare) {
+    // TS
     this.word("declare");
     this.space();
   }
 
   if (node.abstract) {
+    // TS
     this.word("abstract");
     this.space();
   }
@@ -70,6 +72,7 @@ export function ClassProperty(node: Object) {
   this.printJoin(node.decorators, node);
 
   if (node.accessibility) {
+    // TS
     this.word(node.accessibility);
     this.space();
   }
@@ -78,10 +81,12 @@ export function ClassProperty(node: Object) {
     this.space();
   }
   if (node.abstract) {
+    // TS
     this.word("abstract");
     this.space();
   }
   if (node.readonly) {
+    // TS
     this.word("readonly");
     this.space();
   }
@@ -95,6 +100,7 @@ export function ClassProperty(node: Object) {
   }
 
   if (node.optional) {
+    // TS
     this.token("?");
   }
 
@@ -118,11 +124,13 @@ export function _classMethodHead(node) {
   this.printJoin(node.decorators, node);
 
   if (node.accessibility) {
+    // TS
     this.word(node.accessibility);
     this.space();
   }
 
   if (node.abstract) {
+    // TS
     this.word("abstract");
     this.space();
   }

--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -65,7 +65,7 @@ export function NewExpression(node: Object, parent: Object) {
     return;
   }
 
-  this.print(node.typeParameters, node);
+  this.print(node.typeParameters, node); // TS
 
   if (node.optional) {
     this.token("?.");
@@ -96,7 +96,7 @@ export function Decorator(node: Object) {
 export function CallExpression(node: Object) {
   this.print(node.callee, node);
 
-  this.print(node.typeParameters, node);
+  this.print(node.typeParameters, node); // TS
 
   if (node.optional) {
     this.token("?.");

--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -23,8 +23,8 @@ export function _parameters(parameters, parent) {
 export function _param(parameter, parent) {
   this.printJoin(parameter.decorators, parameter);
   this.print(parameter, parent);
-  if (parameter.optional) this.token("?");
-  this.print(parameter.typeAnnotation, parameter);
+  if (parameter.optional) this.token("?"); // TS / flow
+  this.print(parameter.typeAnnotation, parameter); // TS / flow
 }
 
 export function _methodHead(node: Object) {
@@ -56,6 +56,7 @@ export function _methodHead(node: Object) {
   }
 
   if (node.optional) {
+    // TS
     this.token("?");
   }
 

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -237,6 +237,7 @@ function constDeclarationIndent() {
 
 export function VariableDeclaration(node: Object, parent: Object) {
   if (node.declare) {
+    // TS
     this.word("declare");
     this.space();
   }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | tests pass
| Fixed Tickets            | https://github.com/babel/babel/pull/5896#pullrequestreview-53004298
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

Adds a `// TS` comment to statements that handle TypeScript-specific syntax.