### PR TITLE
Fix generate interfaces script

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -68,8 +68,8 @@ declare class BabelNodeDirectiveLiteral extends BabelNode {
 
 declare class BabelNodeBlockStatement extends BabelNode {
   type: "BlockStatement";
-  directives?: any;
   body: any;
+  directives?: any;
 }
 
 declare class BabelNodeBreakStatement extends BabelNode {
@@ -81,11 +81,13 @@ declare class BabelNodeCallExpression extends BabelNode {
   type: "CallExpression";
   callee: BabelNodeExpression;
   arguments: any;
+  optional?: true | false;
+  typeParameters?: ?BabelNodeTypeParameterInstantiation;
 }
 
 declare class BabelNodeCatchClause extends BabelNode {
   type: "CatchClause";
-  param: BabelNodeIdentifier;
+  param?: ?BabelNodeIdentifier;
   body: BabelNodeBlockStatement;
 }
 
@@ -144,13 +146,14 @@ declare class BabelNodeForStatement extends BabelNode {
 
 declare class BabelNodeFunctionDeclaration extends BabelNode {
   type: "FunctionDeclaration";
-  id: BabelNodeIdentifier;
+  id?: ?BabelNodeIdentifier;
   params: any;
   body: BabelNodeBlockStatement;
   generator?: boolean;
   async?: boolean;
-  returnType: any;
-  typeParameters: any;
+  declare?: boolean;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeFunctionExpression extends BabelNode {
@@ -160,14 +163,16 @@ declare class BabelNodeFunctionExpression extends BabelNode {
   body: BabelNodeBlockStatement;
   generator?: boolean;
   async?: boolean;
-  returnType: any;
-  typeParameters: any;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeIdentifier extends BabelNode {
   type: "Identifier";
   name: any;
-  typeAnnotation: any;
+  decorators?: any;
+  optional?: boolean;
+  typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
 }
 
 declare class BabelNodeIfStatement extends BabelNode {
@@ -220,18 +225,22 @@ declare class BabelNodeMemberExpression extends BabelNode {
   object: BabelNodeExpression;
   property: any;
   computed?: boolean;
+  optional?: true | false;
 }
 
 declare class BabelNodeNewExpression extends BabelNode {
   type: "NewExpression";
   callee: BabelNodeExpression;
   arguments: any;
+  optional?: true | false;
+  typeParameters?: ?BabelNodeTypeParameterInstantiation;
 }
 
 declare class BabelNodeProgram extends BabelNode {
   type: "Program";
-  directives?: any;
   body: any;
+  directives?: any;
+  sourceFile?: string;
 }
 
 declare class BabelNodeObjectExpression extends BabelNode {
@@ -242,22 +251,22 @@ declare class BabelNodeObjectExpression extends BabelNode {
 declare class BabelNodeObjectMethod extends BabelNode {
   type: "ObjectMethod";
   kind?: any;
-  computed?: boolean;
   key: any;
-  decorators: any;
-  body: BabelNodeBlockStatement;
-  generator?: boolean;
-  async?: boolean;
   params: any;
-  returnType: any;
-  typeParameters: any;
+  body: BabelNodeBlockStatement;
+  computed?: boolean;
+  async?: boolean;
+  decorators?: any;
+  generator?: boolean;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeObjectProperty extends BabelNode {
   type: "ObjectProperty";
-  computed?: boolean;
   key: any;
-  value: BabelNodeExpression;
+  value: BabelNodeExpression | BabelNodePatternLike;
+  computed?: boolean;
   shorthand?: boolean;
   decorators?: any;
 }
@@ -265,7 +274,8 @@ declare class BabelNodeObjectProperty extends BabelNode {
 declare class BabelNodeRestElement extends BabelNode {
   type: "RestElement";
   argument: BabelNodeLVal;
-  typeAnnotation: any;
+  decorators?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
 }
 
 declare class BabelNodeReturnStatement extends BabelNode {
@@ -301,30 +311,31 @@ declare class BabelNodeThrowStatement extends BabelNode {
 
 declare class BabelNodeTryStatement extends BabelNode {
   type: "TryStatement";
-  body: BabelNodeBlockStatement;
-  handler?: any;
-  finalizer?: ?BabelNodeBlockStatement;
   block: any;
+  handler?: ?BabelNodeBlockStatement;
+  finalizer?: ?BabelNodeBlockStatement;
+  body?: ?BabelNodeBlockStatement;
 }
 
 declare class BabelNodeUnaryExpression extends BabelNode {
   type: "UnaryExpression";
-  prefix?: boolean;
+  operator: "void" | "delete" | "!" | "+" | "-" | "~" | "typeof";
   argument: BabelNodeExpression;
-  operator: "void" | "delete" | "!" | "+" | "-" | "++" | "--" | "~" | "typeof";
+  prefix?: boolean;
 }
 
 declare class BabelNodeUpdateExpression extends BabelNode {
   type: "UpdateExpression";
-  prefix?: boolean;
-  argument: BabelNodeExpression;
   operator: "++" | "--";
+  argument: BabelNodeExpression;
+  prefix?: boolean;
 }
 
 declare class BabelNodeVariableDeclaration extends BabelNode {
   type: "VariableDeclaration";
   kind: any;
   declarations: any;
+  declare?: boolean;
 }
 
 declare class BabelNodeVariableDeclarator extends BabelNode {
@@ -347,14 +358,17 @@ declare class BabelNodeWithStatement extends BabelNode {
 
 declare class BabelNodeAssignmentPattern extends BabelNode {
   type: "AssignmentPattern";
-  left: BabelNodeIdentifier;
+  left: BabelNodeIdentifier | BabelNodeObjectPattern | BabelNodeArrayPattern;
   right: BabelNodeExpression;
+  decorators?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
 }
 
 declare class BabelNodeArrayPattern extends BabelNode {
   type: "ArrayPattern";
   elements: any;
-  typeAnnotation: any;
+  decorators?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
 }
 
 declare class BabelNodeArrowFunctionExpression extends BabelNode {
@@ -362,7 +376,10 @@ declare class BabelNodeArrowFunctionExpression extends BabelNode {
   params: any;
   body: BabelNodeBlockStatement | BabelNodeExpression;
   async?: boolean;
-  returnType: any;
+  expression?: boolean;
+  generator?: boolean;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeClassBody extends BabelNode {
@@ -372,24 +389,26 @@ declare class BabelNodeClassBody extends BabelNode {
 
 declare class BabelNodeClassDeclaration extends BabelNode {
   type: "ClassDeclaration";
-  id: BabelNodeIdentifier;
-  body: BabelNodeClassBody;
+  id?: ?BabelNodeIdentifier;
   superClass?: ?BabelNodeExpression;
-  decorators: any;
-  mixins: any;
-  typeParameters: any;
-  superTypeParameters: any;
+  body: BabelNodeClassBody;
+  decorators?: any;
+  abstract?: boolean;
+  declare?: boolean;
+  mixins?: any;
+  superTypeParameters?: ?BabelNodeTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeClassExpression extends BabelNode {
   type: "ClassExpression";
   id?: ?BabelNodeIdentifier;
-  body: BabelNodeClassBody;
   superClass?: ?BabelNodeExpression;
-  decorators: any;
-  mixins: any;
-  typeParameters: any;
-  superTypeParameters: any;
+  body: BabelNodeClassBody;
+  decorators?: any;
+  mixins?: any;
+  superTypeParameters?: ?BabelNodeTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeExportAllDeclaration extends BabelNode {
@@ -399,7 +418,7 @@ declare class BabelNodeExportAllDeclaration extends BabelNode {
 
 declare class BabelNodeExportDefaultDeclaration extends BabelNode {
   type: "ExportDefaultDeclaration";
-  declaration: BabelNodeFunctionDeclaration | BabelNodeClassDeclaration | BabelNodeExpression;
+  declaration: BabelNodeFunctionDeclaration | BabelNodeTSDeclareFunction | BabelNodeClassDeclaration | BabelNodeExpression;
 }
 
 declare class BabelNodeExportNamedDeclaration extends BabelNode {
@@ -412,8 +431,7 @@ declare class BabelNodeExportNamedDeclaration extends BabelNode {
 declare class BabelNodeExportSpecifier extends BabelNode {
   type: "ExportSpecifier";
   local: BabelNodeIdentifier;
-  imported: BabelNodeIdentifier;
-  exported: any;
+  exported: BabelNodeIdentifier;
 }
 
 declare class BabelNodeForOfStatement extends BabelNode {
@@ -443,32 +461,38 @@ declare class BabelNodeImportSpecifier extends BabelNode {
   type: "ImportSpecifier";
   local: BabelNodeIdentifier;
   imported: BabelNodeIdentifier;
+  importKind?: null | "type" | "typeof";
 }
 
 declare class BabelNodeMetaProperty extends BabelNode {
   type: "MetaProperty";
-  meta: string;
-  property: string;
+  meta: BabelNodeIdentifier;
+  property: BabelNodeIdentifier;
 }
 
 declare class BabelNodeClassMethod extends BabelNode {
   type: "ClassMethod";
   kind?: any;
-  computed?: boolean;
   key: any;
   params: any;
   body: BabelNodeBlockStatement;
-  generator?: boolean;
+  computed?: boolean;
+  abstract?: boolean;
+  access?: any;
+  accessibility?: any;
   async?: boolean;
-  decorators: any;
-  returnType: any;
-  typeParameters: any;
+  decorators?: any;
+  generator?: boolean;
+  optional?: boolean;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeObjectPattern extends BabelNode {
   type: "ObjectPattern";
   properties: any;
-  typeAnnotation: any;
+  decorators?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
 }
 
 declare class BabelNodeSpreadElement extends BabelNode {
@@ -500,8 +524,8 @@ declare class BabelNodeTemplateLiteral extends BabelNode {
 
 declare class BabelNodeYieldExpression extends BabelNode {
   type: "YieldExpression";
-  delegate?: boolean;
   argument?: ?BabelNodeExpression;
+  delegate?: boolean;
 }
 
 declare class BabelNodeAnyTypeAnnotation extends BabelNode {
@@ -529,14 +553,6 @@ declare class BabelNodeClassImplements extends BabelNode {
   type: "ClassImplements";
   id: any;
   typeParameters: any;
-}
-
-declare class BabelNodeClassProperty extends BabelNode {
-  type: "ClassProperty";
-  key: any;
-  value: any;
-  typeAnnotation: any;
-  decorators: any;
 }
 
 declare class BabelNodeDeclareClass extends BabelNode {
@@ -581,6 +597,23 @@ declare class BabelNodeDeclareVariable extends BabelNode {
   id: any;
 }
 
+declare class BabelNodeDeclareExportDeclaration extends BabelNode {
+  type: "DeclareExportDeclaration";
+  declaration: any;
+  specifiers: any;
+  source: any;
+}
+
+declare class BabelNodeDeclareExportAllDeclaration extends BabelNode {
+  type: "DeclareExportAllDeclaration";
+  source: any;
+}
+
+declare class BabelNodeDeclaredPredicate extends BabelNode {
+  type: "DeclaredPredicate";
+  value: any;
+}
+
 declare class BabelNodeExistsTypeAnnotation extends BabelNode {
   type: "ExistsTypeAnnotation";
 }
@@ -605,6 +638,10 @@ declare class BabelNodeGenericTypeAnnotation extends BabelNode {
   typeParameters: any;
 }
 
+declare class BabelNodeInferredPredicate extends BabelNode {
+  type: "InferredPredicate";
+}
+
 declare class BabelNodeInterfaceExtends extends BabelNode {
   type: "InterfaceExtends";
   id: any;
@@ -625,6 +662,10 @@ declare class BabelNodeIntersectionTypeAnnotation extends BabelNode {
 
 declare class BabelNodeMixedTypeAnnotation extends BabelNode {
   type: "MixedTypeAnnotation";
+}
+
+declare class BabelNodeEmptyTypeAnnotation extends BabelNode {
+  type: "EmptyTypeAnnotation";
 }
 
 declare class BabelNodeNullableTypeAnnotation extends BabelNode {
@@ -669,25 +710,10 @@ declare class BabelNodeTypeAlias extends BabelNode {
   right: any;
 }
 
-declare class BabelNodeTypeAnnotation extends BabelNode {
-  type: "TypeAnnotation";
-  typeAnnotation: any;
-}
-
 declare class BabelNodeTypeCastExpression extends BabelNode {
   type: "TypeCastExpression";
   expression: any;
   typeAnnotation: any;
-}
-
-declare class BabelNodeTypeParameterDeclaration extends BabelNode {
-  type: "TypeParameterDeclaration";
-  params: any;
-}
-
-declare class BabelNodeTypeParameterInstantiation extends BabelNode {
-  type: "TypeParameterInstantiation";
-  params: any;
 }
 
 declare class BabelNodeObjectTypeAnnotation extends BabelNode {
@@ -713,6 +739,11 @@ declare class BabelNodeObjectTypeProperty extends BabelNode {
   type: "ObjectTypeProperty";
   key: any;
   value: any;
+}
+
+declare class BabelNodeObjectTypeSpreadProperty extends BabelNode {
+  type: "ObjectTypeSpreadProperty";
+  argument: any;
 }
 
 declare class BabelNodeQualifiedTypeIdentifier extends BabelNode {
@@ -758,6 +789,11 @@ declare class BabelNodeJSXExpressionContainer extends BabelNode {
   expression: BabelNodeExpression;
 }
 
+declare class BabelNodeJSXSpreadChild extends BabelNode {
+  type: "JSXSpreadChild";
+  expression: BabelNodeExpression;
+}
+
 declare class BabelNodeJSXIdentifier extends BabelNode {
   type: "JSXIdentifier";
   name: string;
@@ -778,8 +814,8 @@ declare class BabelNodeJSXNamespacedName extends BabelNode {
 declare class BabelNodeJSXOpeningElement extends BabelNode {
   type: "JSXOpeningElement";
   name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression;
-  selfClosing?: boolean;
   attributes: any;
+  selfClosing?: boolean;
 }
 
 declare class BabelNodeJSXSpreadAttribute extends BabelNode {
@@ -812,6 +848,10 @@ declare class BabelNodeBindExpression extends BabelNode {
   callee: any;
 }
 
+declare class BabelNodeImport extends BabelNode {
+  type: "Import";
+}
+
 declare class BabelNodeDecorator extends BabelNode {
   type: "Decorator";
   expression: BabelNodeExpression;
@@ -832,22 +872,352 @@ declare class BabelNodeExportNamespaceSpecifier extends BabelNode {
   exported: BabelNodeIdentifier;
 }
 
-declare class BabelNodeRestProperty extends BabelNode {
-  type: "RestProperty";
-  argument: BabelNodeLVal;
+declare class BabelNodeTypeAnnotation extends BabelNode {
+  type: "TypeAnnotation";
+  typeAnnotation: BabelNodeTSType | BabelNodeFlow;
 }
 
-declare class BabelNodeSpreadProperty extends BabelNode {
-  type: "SpreadProperty";
-  argument: BabelNodeExpression;
+declare class BabelNodeTypeParameterInstantiation extends BabelNode {
+  type: "TypeParameterInstantiation";
+  params: any;
 }
 
-type BabelNodeExpression = BabelNodeArrayExpression | BabelNodeAssignmentExpression | BabelNodeBinaryExpression | BabelNodeCallExpression | BabelNodeConditionalExpression | BabelNodeFunctionExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeLogicalExpression | BabelNodeMemberExpression | BabelNodeNewExpression | BabelNodeObjectExpression | BabelNodeSequenceExpression | BabelNodeThisExpression | BabelNodeUnaryExpression | BabelNodeUpdateExpression | BabelNodeArrowFunctionExpression | BabelNodeClassExpression | BabelNodeMetaProperty | BabelNodeSuper | BabelNodeTaggedTemplateExpression | BabelNodeTemplateLiteral | BabelNodeYieldExpression | BabelNodeTypeCastExpression | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeParenthesizedExpression | BabelNodeAwaitExpression | BabelNodeBindExpression | BabelNodeDoExpression;
+declare class BabelNodeTypeParameterDeclaration extends BabelNode {
+  type: "TypeParameterDeclaration";
+  params: any;
+}
+
+declare class BabelNodeTypeParameter extends BabelNode {
+  type: "TypeParameter";
+  bound?: ?BabelNodeTypeAnnotation;
+  constraint?: ?BabelNodeTSType;
+  name?: string;
+}
+
+declare class BabelNodeClassProperty extends BabelNode {
+  type: "ClassProperty";
+  key: any;
+  value?: ?BabelNodeExpression;
+  typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  decorators?: any;
+  computed?: boolean;
+  abstract?: boolean;
+  accessibility?: any;
+  optional?: boolean;
+  readonly?: boolean;
+}
+
+declare class BabelNodeTSParameterProperty extends BabelNode {
+  type: "TSParameterProperty";
+  parameter: BabelNodeIdentifier | BabelNodeAssignmentPattern;
+  accessibility?: "public" | "private" | "protected";
+  readonly?: boolean;
+}
+
+declare class BabelNodeTSDeclareFunction extends BabelNode {
+  type: "TSDeclareFunction";
+  id?: ?BabelNodeIdentifier;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  params: any;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  async?: boolean;
+  declare?: boolean;
+  generator?: boolean;
+}
+
+declare class BabelNodeTSDeclareMethod extends BabelNode {
+  type: "TSDeclareMethod";
+  decorators?: any;
+  key: any;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  params: any;
+  returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop;
+  abstract?: boolean;
+  access?: any;
+  accessibility?: any;
+  async?: boolean;
+  computed?: boolean;
+  generator?: boolean;
+  kind?: any;
+  optional?: boolean;
+}
+
+declare class BabelNodeTSQualifiedName extends BabelNode {
+  type: "TSQualifiedName";
+  left: BabelNodeTSEntityName;
+  right: BabelNodeIdentifier;
+}
+
+declare class BabelNodeTSCallSignatureDeclaration extends BabelNode {
+  type: "TSCallSignatureDeclaration";
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  parameters?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+}
+
+declare class BabelNodeTSConstructSignatureDeclaration extends BabelNode {
+  type: "TSConstructSignatureDeclaration";
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  parameters?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+}
+
+declare class BabelNodeTSPropertySignature extends BabelNode {
+  type: "TSPropertySignature";
+  key: BabelNodeExpression;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+  initializer?: ?BabelNodeExpression;
+  computed?: boolean;
+  optional?: boolean;
+  readonly?: boolean;
+}
+
+declare class BabelNodeTSMethodSignature extends BabelNode {
+  type: "TSMethodSignature";
+  key: BabelNodeExpression;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  parameters?: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+  computed?: boolean;
+  optional?: boolean;
+}
+
+declare class BabelNodeTSIndexSignature extends BabelNode {
+  type: "TSIndexSignature";
+  parameters: any;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+  readonly?: boolean;
+}
+
+declare class BabelNodeTSAnyKeyword extends BabelNode {
+  type: "TSAnyKeyword";
+}
+
+declare class BabelNodeTSNumberKeyword extends BabelNode {
+  type: "TSNumberKeyword";
+}
+
+declare class BabelNodeTSObjectKeyword extends BabelNode {
+  type: "TSObjectKeyword";
+}
+
+declare class BabelNodeTSBooleanKeyword extends BabelNode {
+  type: "TSBooleanKeyword";
+}
+
+declare class BabelNodeTSStringKeyword extends BabelNode {
+  type: "TSStringKeyword";
+}
+
+declare class BabelNodeTSSymbolKeyword extends BabelNode {
+  type: "TSSymbolKeyword";
+}
+
+declare class BabelNodeTSVoidKeyword extends BabelNode {
+  type: "TSVoidKeyword";
+}
+
+declare class BabelNodeTSUndefinedKeyword extends BabelNode {
+  type: "TSUndefinedKeyword";
+}
+
+declare class BabelNodeTSNullKeyword extends BabelNode {
+  type: "TSNullKeyword";
+}
+
+declare class BabelNodeTSNeverKeyword extends BabelNode {
+  type: "TSNeverKeyword";
+}
+
+declare class BabelNodeTSThisType extends BabelNode {
+  type: "TSThisType";
+}
+
+declare class BabelNodeTSFunctionType extends BabelNode {
+  type: "TSFunctionType";
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+  parameters?: any;
+}
+
+declare class BabelNodeTSConstructorType extends BabelNode {
+  type: "TSConstructorType";
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeAnnotation?: ?BabelNodeTypeAnnotation;
+  parameters?: any;
+}
+
+declare class BabelNodeTSTypeReference extends BabelNode {
+  type: "TSTypeReference";
+  typeName: BabelNodeTSEntityName;
+  typeParameters?: ?BabelNodeTypeParameterInstantiation;
+}
+
+declare class BabelNodeTSTypePredicate extends BabelNode {
+  type: "TSTypePredicate";
+  parameterName: BabelNodeIdentifier | BabelNodeTSThisType;
+  typeAnnotation: BabelNodeTypeAnnotation;
+}
+
+declare class BabelNodeTSTypeQuery extends BabelNode {
+  type: "TSTypeQuery";
+  exprName: BabelNodeTSEntityName;
+}
+
+declare class BabelNodeTSTypeLiteral extends BabelNode {
+  type: "TSTypeLiteral";
+  members: any;
+}
+
+declare class BabelNodeTSArrayType extends BabelNode {
+  type: "TSArrayType";
+  elementType: BabelNodeTSType;
+}
+
+declare class BabelNodeTSTupleType extends BabelNode {
+  type: "TSTupleType";
+  elementTypes: any;
+}
+
+declare class BabelNodeTSUnionType extends BabelNode {
+  type: "TSUnionType";
+  types: any;
+}
+
+declare class BabelNodeTSIntersectionType extends BabelNode {
+  type: "TSIntersectionType";
+  types: any;
+}
+
+declare class BabelNodeTSParenthesizedType extends BabelNode {
+  type: "TSParenthesizedType";
+  typeAnnotation: BabelNodeTSType;
+}
+
+declare class BabelNodeTSTypeOperator extends BabelNode {
+  type: "TSTypeOperator";
+  typeAnnotation: BabelNodeTSType;
+  operator?: string;
+}
+
+declare class BabelNodeTSIndexedAccessType extends BabelNode {
+  type: "TSIndexedAccessType";
+  objectType: BabelNodeTSType;
+  indexType: BabelNodeTSType;
+}
+
+declare class BabelNodeTSMappedType extends BabelNode {
+  type: "TSMappedType";
+  typeParameter: BabelNodeTypeParameter;
+  typeAnnotation?: ?BabelNodeTSType;
+  optional?: boolean;
+  readonly?: boolean;
+}
+
+declare class BabelNodeTSLiteralType extends BabelNode {
+  type: "TSLiteralType";
+  literal: BabelNodeNumericLiteral | BabelNodeStringLiteral | BabelNodeBooleanLiteral;
+}
+
+declare class BabelNodeTSExpressionWithTypeArguments extends BabelNode {
+  type: "TSExpressionWithTypeArguments";
+  expression: BabelNodeTSEntityName;
+  typeParameters?: ?BabelNodeTypeParameterInstantiation;
+}
+
+declare class BabelNodeTSInterfaceDeclaration extends BabelNode {
+  type: "TSInterfaceDeclaration";
+  id: BabelNodeIdentifier;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  body: BabelNodeTSInterfaceBody;
+  declare?: boolean;
+}
+
+declare class BabelNodeTSInterfaceBody extends BabelNode {
+  type: "TSInterfaceBody";
+  body: any;
+}
+
+declare class BabelNodeTSTypeAliasDeclaration extends BabelNode {
+  type: "TSTypeAliasDeclaration";
+  id: BabelNodeIdentifier;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeAnnotation: BabelNodeTSType;
+  declare?: boolean;
+}
+
+declare class BabelNodeTSAsExpression extends BabelNode {
+  type: "TSAsExpression";
+  expression: BabelNodeExpression;
+  typeAnnotation: BabelNodeTSType;
+}
+
+declare class BabelNodeTSTypeAssertion extends BabelNode {
+  type: "TSTypeAssertion";
+  typeAnnotation: BabelNodeTSType;
+  expression: BabelNodeExpression;
+}
+
+declare class BabelNodeTSEnumDeclaration extends BabelNode {
+  type: "TSEnumDeclaration";
+  id: BabelNodeIdentifier;
+  members: any;
+  declare?: boolean;
+  initializer?: ?BabelNodeExpression;
+}
+
+declare class BabelNodeTSEnumMember extends BabelNode {
+  type: "TSEnumMember";
+  id: BabelNodeIdentifier | BabelNodeStringLiteral;
+  initializer?: ?BabelNodeExpression;
+}
+
+declare class BabelNodeTSModuleDeclaration extends BabelNode {
+  type: "TSModuleDeclaration";
+  id: BabelNodeIdentifier | BabelNodeStringLiteral;
+  body: BabelNodeTSModuleBlock | BabelNodeTSModuleDeclaration;
+  declare?: boolean;
+  global?: boolean;
+}
+
+declare class BabelNodeTSModuleBlock extends BabelNode {
+  type: "TSModuleBlock";
+  body: any;
+}
+
+declare class BabelNodeTSImportEqualsDeclaration extends BabelNode {
+  type: "TSImportEqualsDeclaration";
+  id: BabelNodeIdentifier;
+  moduleReference: BabelNodeTSEntityName | BabelNodeTSExternalModuleReference;
+  isExport?: boolean;
+}
+
+declare class BabelNodeTSExternalModuleReference extends BabelNode {
+  type: "TSExternalModuleReference";
+  expression: BabelNodeStringLiteral;
+}
+
+declare class BabelNodeTSNonNullExpression extends BabelNode {
+  type: "TSNonNullExpression";
+  expression: BabelNodeExpression;
+}
+
+declare class BabelNodeTSExportAssignment extends BabelNode {
+  type: "TSExportAssignment";
+  expression: BabelNodeExpression;
+}
+
+declare class BabelNodeTSNamespaceExportDeclaration extends BabelNode {
+  type: "TSNamespaceExportDeclaration";
+  id: BabelNodeIdentifier;
+}
+
+type BabelNodeExpression = BabelNodeArrayExpression | BabelNodeAssignmentExpression | BabelNodeBinaryExpression | BabelNodeCallExpression | BabelNodeConditionalExpression | BabelNodeFunctionExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeLogicalExpression | BabelNodeMemberExpression | BabelNodeNewExpression | BabelNodeObjectExpression | BabelNodeSequenceExpression | BabelNodeThisExpression | BabelNodeUnaryExpression | BabelNodeUpdateExpression | BabelNodeArrowFunctionExpression | BabelNodeClassExpression | BabelNodeMetaProperty | BabelNodeSuper | BabelNodeTaggedTemplateExpression | BabelNodeTemplateLiteral | BabelNodeYieldExpression | BabelNodeTypeCastExpression | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeParenthesizedExpression | BabelNodeAwaitExpression | BabelNodeBindExpression | BabelNodeImport | BabelNodeDoExpression | BabelNodeTSAsExpression | BabelNodeTSTypeAssertion | BabelNodeTSNonNullExpression;
 type BabelNodeBinary = BabelNodeBinaryExpression | BabelNodeLogicalExpression;
 type BabelNodeScopable = BabelNodeBlockStatement | BabelNodeCatchClause | BabelNodeDoWhileStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeProgram | BabelNodeObjectMethod | BabelNodeSwitchStatement | BabelNodeWhileStatement | BabelNodeArrowFunctionExpression | BabelNodeClassDeclaration | BabelNodeClassExpression | BabelNodeForOfStatement | BabelNodeClassMethod;
 type BabelNodeBlockParent = BabelNodeBlockStatement | BabelNodeDoWhileStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeProgram | BabelNodeObjectMethod | BabelNodeSwitchStatement | BabelNodeWhileStatement | BabelNodeArrowFunctionExpression | BabelNodeForOfStatement | BabelNodeClassMethod;
 type BabelNodeBlock = BabelNodeBlockStatement | BabelNodeProgram;
-type BabelNodeStatement = BabelNodeBlockStatement | BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeDebuggerStatement | BabelNodeDoWhileStatement | BabelNodeEmptyStatement | BabelNodeExpressionStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeIfStatement | BabelNodeLabeledStatement | BabelNodeReturnStatement | BabelNodeSwitchStatement | BabelNodeThrowStatement | BabelNodeTryStatement | BabelNodeVariableDeclaration | BabelNodeWhileStatement | BabelNodeWithStatement | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeForOfStatement | BabelNodeImportDeclaration | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias;
+type BabelNodeStatement = BabelNodeBlockStatement | BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeDebuggerStatement | BabelNodeDoWhileStatement | BabelNodeEmptyStatement | BabelNodeExpressionStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeIfStatement | BabelNodeLabeledStatement | BabelNodeReturnStatement | BabelNodeSwitchStatement | BabelNodeThrowStatement | BabelNodeTryStatement | BabelNodeVariableDeclaration | BabelNodeWhileStatement | BabelNodeWithStatement | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeForOfStatement | BabelNodeImportDeclaration | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias | BabelNodeTSDeclareFunction | BabelNodeTSInterfaceDeclaration | BabelNodeTSTypeAliasDeclaration | BabelNodeTSEnumDeclaration | BabelNodeTSModuleDeclaration | BabelNodeTSImportEqualsDeclaration | BabelNodeTSExportAssignment | BabelNodeTSNamespaceExportDeclaration;
 type BabelNodeTerminatorless = BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeReturnStatement | BabelNodeThrowStatement | BabelNodeYieldExpression | BabelNodeAwaitExpression;
 type BabelNodeCompletionStatement = BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeReturnStatement | BabelNodeThrowStatement;
 type BabelNodeConditional = BabelNodeConditionalExpression | BabelNodeIfStatement;
@@ -859,24 +1229,29 @@ type BabelNodeForXStatement = BabelNodeForInStatement | BabelNodeForOfStatement;
 type BabelNodeFunction = BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeObjectMethod | BabelNodeArrowFunctionExpression | BabelNodeClassMethod;
 type BabelNodeFunctionParent = BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeProgram | BabelNodeObjectMethod | BabelNodeArrowFunctionExpression | BabelNodeClassMethod;
 type BabelNodePureish = BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeArrowFunctionExpression | BabelNodeClassDeclaration | BabelNodeClassExpression;
-type BabelNodeDeclaration = BabelNodeFunctionDeclaration | BabelNodeVariableDeclaration | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeImportDeclaration | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias;
-type BabelNodeLVal = BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeRestElement | BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern;
+type BabelNodeDeclaration = BabelNodeFunctionDeclaration | BabelNodeVariableDeclaration | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeImportDeclaration | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias | BabelNodeTSDeclareFunction | BabelNodeTSInterfaceDeclaration | BabelNodeTSTypeAliasDeclaration | BabelNodeTSEnumDeclaration | BabelNodeTSModuleDeclaration;
+type BabelNodePatternLike = BabelNodeIdentifier | BabelNodeRestElement | BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern;
+type BabelNodeLVal = BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeRestElement | BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern | BabelNodeTSParameterProperty;
+type BabelNodeTSEntityName = BabelNodeIdentifier | BabelNodeTSQualifiedName;
 type BabelNodeLiteral = BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeTemplateLiteral;
-type BabelNodeImmutable = BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXExpressionContainer | BabelNodeJSXOpeningElement;
-type BabelNodeUserWhitespacable = BabelNodeObjectMethod | BabelNodeObjectProperty | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty;
+type BabelNodeImmutable = BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXOpeningElement | BabelNodeJSXText;
+type BabelNodeUserWhitespacable = BabelNodeObjectMethod | BabelNodeObjectProperty | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty;
 type BabelNodeMethod = BabelNodeObjectMethod | BabelNodeClassMethod;
 type BabelNodeObjectMember = BabelNodeObjectMethod | BabelNodeObjectProperty;
 type BabelNodeProperty = BabelNodeObjectProperty | BabelNodeClassProperty;
-type BabelNodeUnaryLike = BabelNodeUnaryExpression | BabelNodeSpreadElement | BabelNodeRestProperty | BabelNodeSpreadProperty;
+type BabelNodeUnaryLike = BabelNodeUnaryExpression | BabelNodeSpreadElement;
 type BabelNodePattern = BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern;
 type BabelNodeClass = BabelNodeClassDeclaration | BabelNodeClassExpression;
 type BabelNodeModuleDeclaration = BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeImportDeclaration;
 type BabelNodeExportDeclaration = BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration;
 type BabelNodeModuleSpecifier = BabelNodeExportSpecifier | BabelNodeImportDefaultSpecifier | BabelNodeImportNamespaceSpecifier | BabelNodeImportSpecifier | BabelNodeExportDefaultSpecifier | BabelNodeExportNamespaceSpecifier;
-type BabelNodeFlow = BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeClassImplements | BabelNodeClassProperty | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeExistsTypeAnnotation | BabelNodeFunctionTypeAnnotation | BabelNodeFunctionTypeParam | BabelNodeGenericTypeAnnotation | BabelNodeInterfaceExtends | BabelNodeInterfaceDeclaration | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumberLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeTypeAlias | BabelNodeTypeAnnotation | BabelNodeTypeCastExpression | BabelNodeTypeParameterDeclaration | BabelNodeTypeParameterInstantiation | BabelNodeObjectTypeAnnotation | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeQualifiedTypeIdentifier | BabelNodeUnionTypeAnnotation | BabelNodeVoidTypeAnnotation;
-type BabelNodeFlowBaseAnnotation = BabelNodeAnyTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeVoidTypeAnnotation;
-type BabelNodeFlowDeclaration = BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias;
-type BabelNodeJSX = BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXExpressionContainer | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName | BabelNodeJSXOpeningElement | BabelNodeJSXSpreadAttribute | BabelNodeJSXText;
+type BabelNodeFlow = BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeClassImplements | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeDeclaredPredicate | BabelNodeExistsTypeAnnotation | BabelNodeFunctionTypeAnnotation | BabelNodeFunctionTypeParam | BabelNodeGenericTypeAnnotation | BabelNodeInferredPredicate | BabelNodeInterfaceExtends | BabelNodeInterfaceDeclaration | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeEmptyTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumberLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeTypeAlias | BabelNodeTypeCastExpression | BabelNodeObjectTypeAnnotation | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty | BabelNodeQualifiedTypeIdentifier | BabelNodeUnionTypeAnnotation | BabelNodeVoidTypeAnnotation | BabelNodeTypeAnnotation | BabelNodeTypeParameterInstantiation | BabelNodeTypeParameterDeclaration | BabelNodeTypeParameter;
+type BabelNodeFlowBaseAnnotation = BabelNodeAnyTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeEmptyTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeVoidTypeAnnotation;
+type BabelNodeFlowDeclaration = BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeInterfaceDeclaration | BabelNodeTypeAlias;
+type BabelNodeFlowPredicate = BabelNodeDeclaredPredicate | BabelNodeInferredPredicate;
+type BabelNodeJSX = BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName | BabelNodeJSXOpeningElement | BabelNodeJSXSpreadAttribute | BabelNodeJSXText;
+type BabelNodeTSTypeElement = BabelNodeTSCallSignatureDeclaration | BabelNodeTSConstructSignatureDeclaration | BabelNodeTSPropertySignature | BabelNodeTSMethodSignature | BabelNodeTSIndexSignature;
+type BabelNodeTSType = BabelNodeTSAnyKeyword | BabelNodeTSNumberKeyword | BabelNodeTSObjectKeyword | BabelNodeTSBooleanKeyword | BabelNodeTSStringKeyword | BabelNodeTSSymbolKeyword | BabelNodeTSVoidKeyword | BabelNodeTSUndefinedKeyword | BabelNodeTSNullKeyword | BabelNodeTSNeverKeyword | BabelNodeTSThisType | BabelNodeTSFunctionType | BabelNodeTSConstructorType | BabelNodeTSTypeReference | BabelNodeTSTypePredicate | BabelNodeTSTypeQuery | BabelNodeTSTypeLiteral | BabelNodeTSArrayType | BabelNodeTSTupleType | BabelNodeTSUnionType | BabelNodeTSIntersectionType | BabelNodeTSParenthesizedType | BabelNodeTSTypeOperator | BabelNodeTSIndexedAccessType | BabelNodeTSMappedType | BabelNodeTSLiteralType | BabelNodeTSExpressionWithTypeArguments;
 
 declare module "babel-types" {
   declare function arrayExpression(elements?: any): BabelNodeArrayExpression;
@@ -884,10 +1259,10 @@ declare module "babel-types" {
   declare function binaryExpression(operator: "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=", left: BabelNodeExpression, right: BabelNodeExpression): BabelNodeBinaryExpression;
   declare function directive(value: BabelNodeDirectiveLiteral): BabelNodeDirective;
   declare function directiveLiteral(value: string): BabelNodeDirectiveLiteral;
-  declare function blockStatement(directives?: any, body: any): BabelNodeBlockStatement;
+  declare function blockStatement(body: any, directives?: any): BabelNodeBlockStatement;
   declare function breakStatement(label?: ?BabelNodeIdentifier): BabelNodeBreakStatement;
-  declare function callExpression(callee: BabelNodeExpression, _arguments: any): BabelNodeCallExpression;
-  declare function catchClause(param: BabelNodeIdentifier, body: BabelNodeBlockStatement): BabelNodeCatchClause;
+  declare function callExpression(callee: BabelNodeExpression, _arguments: any, optional?: true | false, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeCallExpression;
+  declare function catchClause(param?: ?BabelNodeIdentifier, body: BabelNodeBlockStatement): BabelNodeCatchClause;
   declare function conditionalExpression(test: BabelNodeExpression, consequent: BabelNodeExpression, alternate: BabelNodeExpression): BabelNodeConditionalExpression;
   declare function continueStatement(label?: ?BabelNodeIdentifier): BabelNodeContinueStatement;
   declare function debuggerStatement(): BabelNodeDebuggerStatement;
@@ -897,9 +1272,9 @@ declare module "babel-types" {
   declare function file(program: BabelNodeProgram, comments: any, tokens: any): BabelNodeFile;
   declare function forInStatement(left: BabelNodeVariableDeclaration | BabelNodeLVal, right: BabelNodeExpression, body: BabelNodeStatement): BabelNodeForInStatement;
   declare function forStatement(init?: ?BabelNodeVariableDeclaration | BabelNodeExpression, test?: ?BabelNodeExpression, update?: ?BabelNodeExpression, body: BabelNodeStatement): BabelNodeForStatement;
-  declare function functionDeclaration(id: BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, returnType: any, typeParameters: any): BabelNodeFunctionDeclaration;
-  declare function functionExpression(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, returnType: any, typeParameters: any): BabelNodeFunctionExpression;
-  declare function identifier(name: any, typeAnnotation: any): BabelNodeIdentifier;
+  declare function functionDeclaration(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, declare?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeFunctionDeclaration;
+  declare function functionExpression(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeFunctionExpression;
+  declare function identifier(name: any, decorators?: any, optional?: boolean, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop): BabelNodeIdentifier;
   declare function ifStatement(test: BabelNodeExpression, consequent: BabelNodeStatement, alternate?: ?BabelNodeStatement): BabelNodeIfStatement;
   declare function labeledStatement(label: BabelNodeIdentifier, body: BabelNodeStatement): BabelNodeLabeledStatement;
   declare function stringLiteral(value: string): BabelNodeStringLiteral;
@@ -908,56 +1283,55 @@ declare module "babel-types" {
   declare function booleanLiteral(value: boolean): BabelNodeBooleanLiteral;
   declare function regExpLiteral(pattern: string, flags?: string): BabelNodeRegExpLiteral;
   declare function logicalExpression(operator: "||" | "&&", left: BabelNodeExpression, right: BabelNodeExpression): BabelNodeLogicalExpression;
-  declare function memberExpression(object: BabelNodeExpression, property: any, computed?: boolean): BabelNodeMemberExpression;
-  declare function newExpression(callee: BabelNodeExpression, _arguments: any): BabelNodeNewExpression;
-  declare function program(directives?: any, body: any): BabelNodeProgram;
+  declare function memberExpression(object: BabelNodeExpression, property: any, computed?: boolean, optional?: true | false): BabelNodeMemberExpression;
+  declare function newExpression(callee: BabelNodeExpression, _arguments: any, optional?: true | false, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeNewExpression;
+  declare function program(body: any, directives?: any, sourceFile?: string): BabelNodeProgram;
   declare function objectExpression(properties: any): BabelNodeObjectExpression;
-  declare function objectMethod(kind?: any, computed?: boolean, key: any, decorators: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, params: any, returnType: any, typeParameters: any): BabelNodeObjectMethod;
-  declare function objectProperty(computed?: boolean, key: any, value: BabelNodeExpression, shorthand?: boolean, decorators?: any): BabelNodeObjectProperty;
-  declare function restElement(argument: BabelNodeLVal, typeAnnotation: any): BabelNodeRestElement;
+  declare function objectMethod(kind?: any, key: any, params: any, body: BabelNodeBlockStatement, computed?: boolean, async?: boolean, decorators?: any, generator?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeObjectMethod;
+  declare function objectProperty(key: any, value: BabelNodeExpression | BabelNodePatternLike, computed?: boolean, shorthand?: boolean, decorators?: any): BabelNodeObjectProperty;
+  declare function restElement(argument: BabelNodeLVal, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop): BabelNodeRestElement;
   declare function returnStatement(argument?: ?BabelNodeExpression): BabelNodeReturnStatement;
   declare function sequenceExpression(expressions: any): BabelNodeSequenceExpression;
   declare function switchCase(test?: ?BabelNodeExpression, consequent: any): BabelNodeSwitchCase;
   declare function switchStatement(discriminant: BabelNodeExpression, cases: any): BabelNodeSwitchStatement;
   declare function thisExpression(): BabelNodeThisExpression;
   declare function throwStatement(argument: BabelNodeExpression): BabelNodeThrowStatement;
-  declare function tryStatement(body: BabelNodeBlockStatement, handler?: any, finalizer?: ?BabelNodeBlockStatement, block: any): BabelNodeTryStatement;
-  declare function unaryExpression(prefix?: boolean, argument: BabelNodeExpression, operator: "void" | "delete" | "!" | "+" | "-" | "++" | "--" | "~" | "typeof"): BabelNodeUnaryExpression;
-  declare function updateExpression(prefix?: boolean, argument: BabelNodeExpression, operator: "++" | "--"): BabelNodeUpdateExpression;
-  declare function variableDeclaration(kind: any, declarations: any): BabelNodeVariableDeclaration;
+  declare function tryStatement(block: any, handler?: ?BabelNodeBlockStatement, finalizer?: ?BabelNodeBlockStatement, body?: ?BabelNodeBlockStatement): BabelNodeTryStatement;
+  declare function unaryExpression(operator: "void" | "delete" | "!" | "+" | "-" | "~" | "typeof", argument: BabelNodeExpression, prefix?: boolean): BabelNodeUnaryExpression;
+  declare function updateExpression(operator: "++" | "--", argument: BabelNodeExpression, prefix?: boolean): BabelNodeUpdateExpression;
+  declare function variableDeclaration(kind: any, declarations: any, declare?: boolean): BabelNodeVariableDeclaration;
   declare function variableDeclarator(id: BabelNodeLVal, init?: ?BabelNodeExpression): BabelNodeVariableDeclarator;
   declare function whileStatement(test: BabelNodeExpression, body: BabelNodeBlockStatement | BabelNodeStatement): BabelNodeWhileStatement;
   declare function withStatement(object: any, body: BabelNodeBlockStatement | BabelNodeStatement): BabelNodeWithStatement;
-  declare function assignmentPattern(left: BabelNodeIdentifier, right: BabelNodeExpression): BabelNodeAssignmentPattern;
-  declare function arrayPattern(elements: any, typeAnnotation: any): BabelNodeArrayPattern;
-  declare function arrowFunctionExpression(params: any, body: BabelNodeBlockStatement | BabelNodeExpression, async?: boolean, returnType: any): BabelNodeArrowFunctionExpression;
+  declare function assignmentPattern(left: BabelNodeIdentifier | BabelNodeObjectPattern | BabelNodeArrayPattern, right: BabelNodeExpression, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop): BabelNodeAssignmentPattern;
+  declare function arrayPattern(elements: any, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop): BabelNodeArrayPattern;
+  declare function arrowFunctionExpression(params: any, body: BabelNodeBlockStatement | BabelNodeExpression, async?: boolean, expression?: boolean, generator?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeArrowFunctionExpression;
   declare function classBody(body: any): BabelNodeClassBody;
-  declare function classDeclaration(id: BabelNodeIdentifier, body: BabelNodeClassBody, superClass?: ?BabelNodeExpression, decorators: any, mixins: any, typeParameters: any, superTypeParameters: any, _implements: any): BabelNodeClassDeclaration;
-  declare function classExpression(id?: ?BabelNodeIdentifier, body: BabelNodeClassBody, superClass?: ?BabelNodeExpression, decorators: any, mixins: any, typeParameters: any, superTypeParameters: any, _implements: any): BabelNodeClassExpression;
+  declare function classDeclaration(id?: ?BabelNodeIdentifier, superClass?: ?BabelNodeExpression, body: BabelNodeClassBody, decorators?: any, abstract?: boolean, declare?: boolean, _implements?: any, mixins?: any, superTypeParameters?: ?BabelNodeTypeParameterInstantiation, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassDeclaration;
+  declare function classExpression(id?: ?BabelNodeIdentifier, superClass?: ?BabelNodeExpression, body: BabelNodeClassBody, decorators?: any, _implements?: any, mixins?: any, superTypeParameters?: ?BabelNodeTypeParameterInstantiation, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassExpression;
   declare function exportAllDeclaration(source: BabelNodeStringLiteral): BabelNodeExportAllDeclaration;
-  declare function exportDefaultDeclaration(declaration: BabelNodeFunctionDeclaration | BabelNodeClassDeclaration | BabelNodeExpression): BabelNodeExportDefaultDeclaration;
+  declare function exportDefaultDeclaration(declaration: BabelNodeFunctionDeclaration | BabelNodeTSDeclareFunction | BabelNodeClassDeclaration | BabelNodeExpression): BabelNodeExportDefaultDeclaration;
   declare function exportNamedDeclaration(declaration?: ?BabelNodeDeclaration, specifiers: any, source?: ?BabelNodeStringLiteral): BabelNodeExportNamedDeclaration;
-  declare function exportSpecifier(local: BabelNodeIdentifier, imported: BabelNodeIdentifier, exported: any): BabelNodeExportSpecifier;
-  declare function forOfStatement(left: BabelNodeVariableDeclaration | BabelNodeLVal, right: BabelNodeExpression, body: BabelNodeStatement): BabelNodeForOfStatement;
+  declare function exportSpecifier(local: BabelNodeIdentifier, exported: BabelNodeIdentifier): BabelNodeExportSpecifier;
+  declare function forOfStatement(left: BabelNodeVariableDeclaration | BabelNodeLVal, right: BabelNodeExpression, body: BabelNodeStatement, _await?: boolean): BabelNodeForOfStatement;
   declare function importDeclaration(specifiers: any, source: BabelNodeStringLiteral): BabelNodeImportDeclaration;
   declare function importDefaultSpecifier(local: BabelNodeIdentifier): BabelNodeImportDefaultSpecifier;
   declare function importNamespaceSpecifier(local: BabelNodeIdentifier): BabelNodeImportNamespaceSpecifier;
-  declare function importSpecifier(local: BabelNodeIdentifier, imported: BabelNodeIdentifier): BabelNodeImportSpecifier;
-  declare function metaProperty(meta: string, property: string): BabelNodeMetaProperty;
-  declare function classMethod(kind?: any, computed?: boolean, _static?: boolean, key: any, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, decorators: any, returnType: any, typeParameters: any): BabelNodeClassMethod;
-  declare function objectPattern(properties: any, typeAnnotation: any): BabelNodeObjectPattern;
+  declare function importSpecifier(local: BabelNodeIdentifier, imported: BabelNodeIdentifier, importKind?: null | "type" | "typeof"): BabelNodeImportSpecifier;
+  declare function metaProperty(meta: BabelNodeIdentifier, property: BabelNodeIdentifier): BabelNodeMetaProperty;
+  declare function classMethod(kind?: any, key: any, params: any, body: BabelNodeBlockStatement, computed?: boolean, _static?: boolean, abstract?: boolean, access?: any, accessibility?: any, async?: boolean, decorators?: any, generator?: boolean, optional?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassMethod;
+  declare function objectPattern(properties: any, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop): BabelNodeObjectPattern;
   declare function spreadElement(argument: BabelNodeExpression): BabelNodeSpreadElement;
   declare function taggedTemplateExpression(tag: BabelNodeExpression, quasi: BabelNodeTemplateLiteral): BabelNodeTaggedTemplateExpression;
   declare function templateElement(value: any, tail?: boolean): BabelNodeTemplateElement;
   declare function templateLiteral(quasis: any, expressions: any): BabelNodeTemplateLiteral;
-  declare function yieldExpression(delegate?: boolean, argument?: ?BabelNodeExpression): BabelNodeYieldExpression;
+  declare function yieldExpression(argument?: ?BabelNodeExpression, delegate?: boolean): BabelNodeYieldExpression;
   declare function anyTypeAnnotation(): BabelNodeAnyTypeAnnotation;
   declare function arrayTypeAnnotation(elementType: any): BabelNodeArrayTypeAnnotation;
   declare function booleanTypeAnnotation(): BabelNodeBooleanTypeAnnotation;
   declare function booleanLiteralTypeAnnotation(): BabelNodeBooleanLiteralTypeAnnotation;
   declare function nullLiteralTypeAnnotation(): BabelNodeNullLiteralTypeAnnotation;
   declare function classImplements(id: any, typeParameters: any): BabelNodeClassImplements;
-  declare function classProperty(key: any, value: any, typeAnnotation: any, decorators: any): BabelNodeClassProperty;
   declare function declareClass(id: any, typeParameters: any, _extends: any, body: any): BabelNodeDeclareClass;
   declare function declareFunction(id: any): BabelNodeDeclareFunction;
   declare function declareInterface(id: any, typeParameters: any, _extends: any, body: any): BabelNodeDeclareInterface;
@@ -965,14 +1339,19 @@ declare module "babel-types" {
   declare function declareModuleExports(typeAnnotation: any): BabelNodeDeclareModuleExports;
   declare function declareTypeAlias(id: any, typeParameters: any, right: any): BabelNodeDeclareTypeAlias;
   declare function declareVariable(id: any): BabelNodeDeclareVariable;
+  declare function declareExportDeclaration(declaration: any, specifiers: any, source: any): BabelNodeDeclareExportDeclaration;
+  declare function declareExportAllDeclaration(source: any): BabelNodeDeclareExportAllDeclaration;
+  declare function declaredPredicate(value: any): BabelNodeDeclaredPredicate;
   declare function existsTypeAnnotation(): BabelNodeExistsTypeAnnotation;
   declare function functionTypeAnnotation(typeParameters: any, params: any, rest: any, returnType: any): BabelNodeFunctionTypeAnnotation;
   declare function functionTypeParam(name: any, typeAnnotation: any): BabelNodeFunctionTypeParam;
   declare function genericTypeAnnotation(id: any, typeParameters: any): BabelNodeGenericTypeAnnotation;
+  declare function inferredPredicate(): BabelNodeInferredPredicate;
   declare function interfaceExtends(id: any, typeParameters: any): BabelNodeInterfaceExtends;
   declare function interfaceDeclaration(id: any, typeParameters: any, _extends: any, body: any): BabelNodeInterfaceDeclaration;
   declare function intersectionTypeAnnotation(types: any): BabelNodeIntersectionTypeAnnotation;
   declare function mixedTypeAnnotation(): BabelNodeMixedTypeAnnotation;
+  declare function emptyTypeAnnotation(): BabelNodeEmptyTypeAnnotation;
   declare function nullableTypeAnnotation(typeAnnotation: any): BabelNodeNullableTypeAnnotation;
   declare function numberLiteralTypeAnnotation(): BabelNodeNumberLiteralTypeAnnotation;
   declare function numberTypeAnnotation(): BabelNodeNumberTypeAnnotation;
@@ -982,14 +1361,12 @@ declare module "babel-types" {
   declare function tupleTypeAnnotation(types: any): BabelNodeTupleTypeAnnotation;
   declare function typeofTypeAnnotation(argument: any): BabelNodeTypeofTypeAnnotation;
   declare function typeAlias(id: any, typeParameters: any, right: any): BabelNodeTypeAlias;
-  declare function typeAnnotation(typeAnnotation: any): BabelNodeTypeAnnotation;
   declare function typeCastExpression(expression: any, typeAnnotation: any): BabelNodeTypeCastExpression;
-  declare function typeParameterDeclaration(params: any): BabelNodeTypeParameterDeclaration;
-  declare function typeParameterInstantiation(params: any): BabelNodeTypeParameterInstantiation;
   declare function objectTypeAnnotation(properties: any, indexers: any, callProperties: any): BabelNodeObjectTypeAnnotation;
   declare function objectTypeCallProperty(value: any): BabelNodeObjectTypeCallProperty;
   declare function objectTypeIndexer(id: any, key: any, value: any): BabelNodeObjectTypeIndexer;
   declare function objectTypeProperty(key: any, value: any): BabelNodeObjectTypeProperty;
+  declare function objectTypeSpreadProperty(argument: any): BabelNodeObjectTypeSpreadProperty;
   declare function qualifiedTypeIdentifier(id: any, qualification: any): BabelNodeQualifiedTypeIdentifier;
   declare function unionTypeAnnotation(types: any): BabelNodeUnionTypeAnnotation;
   declare function voidTypeAnnotation(): BabelNodeVoidTypeAnnotation;
@@ -998,10 +1375,11 @@ declare module "babel-types" {
   declare function jSXElement(openingElement: BabelNodeJSXOpeningElement, closingElement?: ?BabelNodeJSXClosingElement, children: any, selfClosing: any): BabelNodeJSXElement;
   declare function jSXEmptyExpression(): BabelNodeJSXEmptyExpression;
   declare function jSXExpressionContainer(expression: BabelNodeExpression): BabelNodeJSXExpressionContainer;
+  declare function jSXSpreadChild(expression: BabelNodeExpression): BabelNodeJSXSpreadChild;
   declare function jSXIdentifier(name: string): BabelNodeJSXIdentifier;
   declare function jSXMemberExpression(object: BabelNodeJSXMemberExpression | BabelNodeJSXIdentifier, property: BabelNodeJSXIdentifier): BabelNodeJSXMemberExpression;
   declare function jSXNamespacedName(namespace: BabelNodeJSXIdentifier, name: BabelNodeJSXIdentifier): BabelNodeJSXNamespacedName;
-  declare function jSXOpeningElement(name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression, selfClosing?: boolean, attributes: any): BabelNodeJSXOpeningElement;
+  declare function jSXOpeningElement(name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression, attributes: any, selfClosing?: boolean): BabelNodeJSXOpeningElement;
   declare function jSXSpreadAttribute(argument: BabelNodeExpression): BabelNodeJSXSpreadAttribute;
   declare function jSXText(value: string): BabelNodeJSXText;
   declare function noop(): BabelNodeNoop;
@@ -1012,8 +1390,61 @@ declare module "babel-types" {
   declare function doExpression(body: BabelNodeBlockStatement): BabelNodeDoExpression;
   declare function exportDefaultSpecifier(exported: BabelNodeIdentifier): BabelNodeExportDefaultSpecifier;
   declare function exportNamespaceSpecifier(exported: BabelNodeIdentifier): BabelNodeExportNamespaceSpecifier;
-  declare function restProperty(argument: BabelNodeLVal): BabelNodeRestProperty;
-  declare function spreadProperty(argument: BabelNodeExpression): BabelNodeSpreadProperty;
+  declare function typeAnnotation(typeAnnotation: BabelNodeTSType | BabelNodeFlow): BabelNodeTypeAnnotation;
+  declare function typeParameterInstantiation(params: any): BabelNodeTypeParameterInstantiation;
+  declare function typeParameterDeclaration(params: any): BabelNodeTypeParameterDeclaration;
+  declare function typeParameter(bound?: ?BabelNodeTypeAnnotation, constraint?: ?BabelNodeTSType, _default?: ?BabelNodeTSType | BabelNodeFlow, name?: string): BabelNodeTypeParameter;
+  declare function classProperty(key: any, value?: ?BabelNodeExpression, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeNoop, decorators?: any, computed?: boolean, abstract?: boolean, accessibility?: any, optional?: boolean, readonly?: boolean, _static?: boolean): BabelNodeClassProperty;
+  declare function tSParameterProperty(parameter: BabelNodeIdentifier | BabelNodeAssignmentPattern, accessibility?: "public" | "private" | "protected", readonly?: boolean): BabelNodeTSParameterProperty;
+  declare function tSDeclareFunction(id?: ?BabelNodeIdentifier, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop, params: any, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, async?: boolean, declare?: boolean, generator?: boolean): BabelNodeTSDeclareFunction;
+  declare function tSDeclareMethod(decorators?: any, key: any, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop, params: any, returnType?: ?BabelNodeTypeAnnotation | BabelNodeNoop, abstract?: boolean, access?: any, accessibility?: any, async?: boolean, computed?: boolean, generator?: boolean, kind?: any, optional?: boolean, _static?: boolean): BabelNodeTSDeclareMethod;
+  declare function tSQualifiedName(left: BabelNodeTSEntityName, right: BabelNodeIdentifier): BabelNodeTSQualifiedName;
+  declare function tSCallSignatureDeclaration(typeParameters?: ?BabelNodeTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTypeAnnotation): BabelNodeTSCallSignatureDeclaration;
+  declare function tSConstructSignatureDeclaration(typeParameters?: ?BabelNodeTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTypeAnnotation): BabelNodeTSConstructSignatureDeclaration;
+  declare function tSPropertySignature(key: BabelNodeExpression, typeAnnotation?: ?BabelNodeTypeAnnotation, initializer?: ?BabelNodeExpression, computed?: boolean, optional?: boolean, readonly?: boolean): BabelNodeTSPropertySignature;
+  declare function tSMethodSignature(key: BabelNodeExpression, typeParameters?: ?BabelNodeTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTypeAnnotation, computed?: boolean, optional?: boolean): BabelNodeTSMethodSignature;
+  declare function tSIndexSignature(parameters: any, typeAnnotation?: ?BabelNodeTypeAnnotation, readonly?: boolean): BabelNodeTSIndexSignature;
+  declare function tSAnyKeyword(): BabelNodeTSAnyKeyword;
+  declare function tSNumberKeyword(): BabelNodeTSNumberKeyword;
+  declare function tSObjectKeyword(): BabelNodeTSObjectKeyword;
+  declare function tSBooleanKeyword(): BabelNodeTSBooleanKeyword;
+  declare function tSStringKeyword(): BabelNodeTSStringKeyword;
+  declare function tSSymbolKeyword(): BabelNodeTSSymbolKeyword;
+  declare function tSVoidKeyword(): BabelNodeTSVoidKeyword;
+  declare function tSUndefinedKeyword(): BabelNodeTSUndefinedKeyword;
+  declare function tSNullKeyword(): BabelNodeTSNullKeyword;
+  declare function tSNeverKeyword(): BabelNodeTSNeverKeyword;
+  declare function tSThisType(): BabelNodeTSThisType;
+  declare function tSFunctionType(typeParameters?: ?BabelNodeTypeParameterDeclaration, typeAnnotation?: ?BabelNodeTypeAnnotation, parameters?: any): BabelNodeTSFunctionType;
+  declare function tSConstructorType(typeParameters?: ?BabelNodeTypeParameterDeclaration, typeAnnotation?: ?BabelNodeTypeAnnotation, parameters?: any): BabelNodeTSConstructorType;
+  declare function tSTypeReference(typeName: BabelNodeTSEntityName, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeTSTypeReference;
+  declare function tSTypePredicate(parameterName: BabelNodeIdentifier | BabelNodeTSThisType, typeAnnotation: BabelNodeTypeAnnotation): BabelNodeTSTypePredicate;
+  declare function tSTypeQuery(exprName: BabelNodeTSEntityName): BabelNodeTSTypeQuery;
+  declare function tSTypeLiteral(members: any): BabelNodeTSTypeLiteral;
+  declare function tSArrayType(elementType: BabelNodeTSType): BabelNodeTSArrayType;
+  declare function tSTupleType(elementTypes: any): BabelNodeTSTupleType;
+  declare function tSUnionType(types: any): BabelNodeTSUnionType;
+  declare function tSIntersectionType(types: any): BabelNodeTSIntersectionType;
+  declare function tSParenthesizedType(typeAnnotation: BabelNodeTSType): BabelNodeTSParenthesizedType;
+  declare function tSTypeOperator(typeAnnotation: BabelNodeTSType, operator?: string): BabelNodeTSTypeOperator;
+  declare function tSIndexedAccessType(objectType: BabelNodeTSType, indexType: BabelNodeTSType): BabelNodeTSIndexedAccessType;
+  declare function tSMappedType(typeParameter: BabelNodeTypeParameter, typeAnnotation?: ?BabelNodeTSType, optional?: boolean, readonly?: boolean): BabelNodeTSMappedType;
+  declare function tSLiteralType(literal: BabelNodeNumericLiteral | BabelNodeStringLiteral | BabelNodeBooleanLiteral): BabelNodeTSLiteralType;
+  declare function tSExpressionWithTypeArguments(expression: BabelNodeTSEntityName, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeTSExpressionWithTypeArguments;
+  declare function tSInterfaceDeclaration(id: BabelNodeIdentifier, typeParameters?: ?BabelNodeTypeParameterDeclaration, _extends?: any, body: BabelNodeTSInterfaceBody, declare?: boolean): BabelNodeTSInterfaceDeclaration;
+  declare function tSInterfaceBody(body: any): BabelNodeTSInterfaceBody;
+  declare function tSTypeAliasDeclaration(id: BabelNodeIdentifier, typeParameters?: ?BabelNodeTypeParameterDeclaration, typeAnnotation: BabelNodeTSType, declare?: boolean): BabelNodeTSTypeAliasDeclaration;
+  declare function tSAsExpression(expression: BabelNodeExpression, typeAnnotation: BabelNodeTSType): BabelNodeTSAsExpression;
+  declare function tSTypeAssertion(typeAnnotation: BabelNodeTSType, expression: BabelNodeExpression): BabelNodeTSTypeAssertion;
+  declare function tSEnumDeclaration(id: BabelNodeIdentifier, members: any, _const?: boolean, declare?: boolean, initializer?: ?BabelNodeExpression): BabelNodeTSEnumDeclaration;
+  declare function tSEnumMember(id: BabelNodeIdentifier | BabelNodeStringLiteral, initializer?: ?BabelNodeExpression): BabelNodeTSEnumMember;
+  declare function tSModuleDeclaration(id: BabelNodeIdentifier | BabelNodeStringLiteral, body: BabelNodeTSModuleBlock | BabelNodeTSModuleDeclaration, declare?: boolean, global?: boolean): BabelNodeTSModuleDeclaration;
+  declare function tSModuleBlock(body: any): BabelNodeTSModuleBlock;
+  declare function tSImportEqualsDeclaration(id: BabelNodeIdentifier, moduleReference: BabelNodeTSEntityName | BabelNodeTSExternalModuleReference, isExport?: boolean): BabelNodeTSImportEqualsDeclaration;
+  declare function tSExternalModuleReference(expression: BabelNodeStringLiteral): BabelNodeTSExternalModuleReference;
+  declare function tSNonNullExpression(expression: BabelNodeExpression): BabelNodeTSNonNullExpression;
+  declare function tSExportAssignment(expression: BabelNodeExpression): BabelNodeTSExportAssignment;
+  declare function tSNamespaceExportDeclaration(id: BabelNodeIdentifier): BabelNodeTSNamespaceExportDeclaration;
   declare function isArrayExpression(node: Object, opts?: Object): boolean;
   declare function isAssignmentExpression(node: Object, opts?: Object): boolean;
   declare function isBinaryExpression(node: Object, opts?: Object): boolean;
@@ -1093,7 +1524,6 @@ declare module "babel-types" {
   declare function isBooleanLiteralTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isNullLiteralTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isClassImplements(node: Object, opts?: Object): boolean;
-  declare function isClassProperty(node: Object, opts?: Object): boolean;
   declare function isDeclareClass(node: Object, opts?: Object): boolean;
   declare function isDeclareFunction(node: Object, opts?: Object): boolean;
   declare function isDeclareInterface(node: Object, opts?: Object): boolean;
@@ -1101,14 +1531,19 @@ declare module "babel-types" {
   declare function isDeclareModuleExports(node: Object, opts?: Object): boolean;
   declare function isDeclareTypeAlias(node: Object, opts?: Object): boolean;
   declare function isDeclareVariable(node: Object, opts?: Object): boolean;
+  declare function isDeclareExportDeclaration(node: Object, opts?: Object): boolean;
+  declare function isDeclareExportAllDeclaration(node: Object, opts?: Object): boolean;
+  declare function isDeclaredPredicate(node: Object, opts?: Object): boolean;
   declare function isExistsTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isFunctionTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isFunctionTypeParam(node: Object, opts?: Object): boolean;
   declare function isGenericTypeAnnotation(node: Object, opts?: Object): boolean;
+  declare function isInferredPredicate(node: Object, opts?: Object): boolean;
   declare function isInterfaceExtends(node: Object, opts?: Object): boolean;
   declare function isInterfaceDeclaration(node: Object, opts?: Object): boolean;
   declare function isIntersectionTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isMixedTypeAnnotation(node: Object, opts?: Object): boolean;
+  declare function isEmptyTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isNullableTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isNumberLiteralTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isNumberTypeAnnotation(node: Object, opts?: Object): boolean;
@@ -1118,14 +1553,12 @@ declare module "babel-types" {
   declare function isTupleTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isTypeofTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isTypeAlias(node: Object, opts?: Object): boolean;
-  declare function isTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isTypeCastExpression(node: Object, opts?: Object): boolean;
-  declare function isTypeParameterDeclaration(node: Object, opts?: Object): boolean;
-  declare function isTypeParameterInstantiation(node: Object, opts?: Object): boolean;
   declare function isObjectTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isObjectTypeCallProperty(node: Object, opts?: Object): boolean;
   declare function isObjectTypeIndexer(node: Object, opts?: Object): boolean;
   declare function isObjectTypeProperty(node: Object, opts?: Object): boolean;
+  declare function isObjectTypeSpreadProperty(node: Object, opts?: Object): boolean;
   declare function isQualifiedTypeIdentifier(node: Object, opts?: Object): boolean;
   declare function isUnionTypeAnnotation(node: Object, opts?: Object): boolean;
   declare function isVoidTypeAnnotation(node: Object, opts?: Object): boolean;
@@ -1134,6 +1567,7 @@ declare module "babel-types" {
   declare function isJSXElement(node: Object, opts?: Object): boolean;
   declare function isJSXEmptyExpression(node: Object, opts?: Object): boolean;
   declare function isJSXExpressionContainer(node: Object, opts?: Object): boolean;
+  declare function isJSXSpreadChild(node: Object, opts?: Object): boolean;
   declare function isJSXIdentifier(node: Object, opts?: Object): boolean;
   declare function isJSXMemberExpression(node: Object, opts?: Object): boolean;
   declare function isJSXNamespacedName(node: Object, opts?: Object): boolean;
@@ -1144,12 +1578,66 @@ declare module "babel-types" {
   declare function isParenthesizedExpression(node: Object, opts?: Object): boolean;
   declare function isAwaitExpression(node: Object, opts?: Object): boolean;
   declare function isBindExpression(node: Object, opts?: Object): boolean;
+  declare function isImport(node: Object, opts?: Object): boolean;
   declare function isDecorator(node: Object, opts?: Object): boolean;
   declare function isDoExpression(node: Object, opts?: Object): boolean;
   declare function isExportDefaultSpecifier(node: Object, opts?: Object): boolean;
   declare function isExportNamespaceSpecifier(node: Object, opts?: Object): boolean;
-  declare function isRestProperty(node: Object, opts?: Object): boolean;
-  declare function isSpreadProperty(node: Object, opts?: Object): boolean;
+  declare function isTypeAnnotation(node: Object, opts?: Object): boolean;
+  declare function isTypeParameterInstantiation(node: Object, opts?: Object): boolean;
+  declare function isTypeParameterDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTypeParameter(node: Object, opts?: Object): boolean;
+  declare function isClassProperty(node: Object, opts?: Object): boolean;
+  declare function isTSParameterProperty(node: Object, opts?: Object): boolean;
+  declare function isTSDeclareFunction(node: Object, opts?: Object): boolean;
+  declare function isTSDeclareMethod(node: Object, opts?: Object): boolean;
+  declare function isTSQualifiedName(node: Object, opts?: Object): boolean;
+  declare function isTSCallSignatureDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSConstructSignatureDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSPropertySignature(node: Object, opts?: Object): boolean;
+  declare function isTSMethodSignature(node: Object, opts?: Object): boolean;
+  declare function isTSIndexSignature(node: Object, opts?: Object): boolean;
+  declare function isTSAnyKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSNumberKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSObjectKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSBooleanKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSStringKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSSymbolKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSVoidKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSUndefinedKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSNullKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSNeverKeyword(node: Object, opts?: Object): boolean;
+  declare function isTSThisType(node: Object, opts?: Object): boolean;
+  declare function isTSFunctionType(node: Object, opts?: Object): boolean;
+  declare function isTSConstructorType(node: Object, opts?: Object): boolean;
+  declare function isTSTypeReference(node: Object, opts?: Object): boolean;
+  declare function isTSTypePredicate(node: Object, opts?: Object): boolean;
+  declare function isTSTypeQuery(node: Object, opts?: Object): boolean;
+  declare function isTSTypeLiteral(node: Object, opts?: Object): boolean;
+  declare function isTSArrayType(node: Object, opts?: Object): boolean;
+  declare function isTSTupleType(node: Object, opts?: Object): boolean;
+  declare function isTSUnionType(node: Object, opts?: Object): boolean;
+  declare function isTSIntersectionType(node: Object, opts?: Object): boolean;
+  declare function isTSParenthesizedType(node: Object, opts?: Object): boolean;
+  declare function isTSTypeOperator(node: Object, opts?: Object): boolean;
+  declare function isTSIndexedAccessType(node: Object, opts?: Object): boolean;
+  declare function isTSMappedType(node: Object, opts?: Object): boolean;
+  declare function isTSLiteralType(node: Object, opts?: Object): boolean;
+  declare function isTSExpressionWithTypeArguments(node: Object, opts?: Object): boolean;
+  declare function isTSInterfaceDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSInterfaceBody(node: Object, opts?: Object): boolean;
+  declare function isTSTypeAliasDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSAsExpression(node: Object, opts?: Object): boolean;
+  declare function isTSTypeAssertion(node: Object, opts?: Object): boolean;
+  declare function isTSEnumDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSEnumMember(node: Object, opts?: Object): boolean;
+  declare function isTSModuleDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSModuleBlock(node: Object, opts?: Object): boolean;
+  declare function isTSImportEqualsDeclaration(node: Object, opts?: Object): boolean;
+  declare function isTSExternalModuleReference(node: Object, opts?: Object): boolean;
+  declare function isTSNonNullExpression(node: Object, opts?: Object): boolean;
+  declare function isTSExportAssignment(node: Object, opts?: Object): boolean;
+  declare function isTSNamespaceExportDeclaration(node: Object, opts?: Object): boolean;
   declare function isExpression(node: Object, opts?: Object): boolean;
   declare function isBinary(node: Object, opts?: Object): boolean;
   declare function isScopable(node: Object, opts?: Object): boolean;
@@ -1168,7 +1656,9 @@ declare module "babel-types" {
   declare function isFunctionParent(node: Object, opts?: Object): boolean;
   declare function isPureish(node: Object, opts?: Object): boolean;
   declare function isDeclaration(node: Object, opts?: Object): boolean;
+  declare function isPatternLike(node: Object, opts?: Object): boolean;
   declare function isLVal(node: Object, opts?: Object): boolean;
+  declare function isTSEntityName(node: Object, opts?: Object): boolean;
   declare function isLiteral(node: Object, opts?: Object): boolean;
   declare function isImmutable(node: Object, opts?: Object): boolean;
   declare function isUserWhitespacable(node: Object, opts?: Object): boolean;
@@ -1184,17 +1674,10 @@ declare module "babel-types" {
   declare function isFlow(node: Object, opts?: Object): boolean;
   declare function isFlowBaseAnnotation(node: Object, opts?: Object): boolean;
   declare function isFlowDeclaration(node: Object, opts?: Object): boolean;
+  declare function isFlowPredicate(node: Object, opts?: Object): boolean;
   declare function isJSX(node: Object, opts?: Object): boolean;
+  declare function isTSTypeElement(node: Object, opts?: Object): boolean;
+  declare function isTSType(node: Object, opts?: Object): boolean;
   declare function isNumberLiteral(node: Object, opts?: Object): boolean;
   declare function isRegexLiteral(node: Object, opts?: Object): boolean;
-  declare function isReferencedIdentifier(node: Object, opts?: Object): boolean;
-  declare function isReferencedMemberExpression(node: Object, opts?: Object): boolean;
-  declare function isBindingIdentifier(node: Object, opts?: Object): boolean;
-  declare function isScope(node: Object, opts?: Object): boolean;
-  declare function isReferenced(node: Object, opts?: Object): boolean;
-  declare function isBlockScoped(node: Object, opts?: Object): boolean;
-  declare function isVar(node: Object, opts?: Object): boolean;
-  declare function isUser(node: Object, opts?: Object): boolean;
-  declare function isGenerated(node: Object, opts?: Object): boolean;
-  declare function isPure(node: Object, opts?: Object): boolean;
 }

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -2183,7 +2183,7 @@ Aliases: `TSTypeElement`
 
  - `key`: `Expression` (required)
  - `typeAnnotation`: `TypeAnnotation` (default: `null`)
- - `initializer`: `Expresssion` (default: `null`)
+ - `initializer`: `Expression` (default: `null`)
  - `computed`: `boolean` (default: `null`)
  - `optional`: `boolean` (default: `null`)
  - `readonly`: `boolean` (default: `null`)

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -115,7 +115,7 @@ defineType("TSPropertySignature", {
     ...namedTypeElementCommon,
     readonly: validateOptional(bool),
     typeAnnotation: validateOptionalType("TypeAnnotation"),
-    initializer: validateOptionalType("Expresssion"),
+    initializer: validateOptionalType("Expression"),
   },
 });
 

--- a/scripts/generate-interfaces.js
+++ b/scripts/generate-interfaces.js
@@ -54,56 +54,67 @@ for (const type in t.NODE_FIELDS) {
   const struct = ['type: "' + type + '";'];
   const args = [];
 
-  for (const fieldName in fields) {
-    const field = fields[fieldName];
+  Object.keys(t.NODE_FIELDS[type])
+    .sort((fieldA, fieldB) => {
+      const indexA = t.BUILDER_KEYS[type].indexOf(fieldA);
+      const indexB = t.BUILDER_KEYS[type].indexOf(fieldB);
+      if (indexA === indexB) return fieldA < fieldB ? -1 : 1;
+      if (indexA === -1) return 1;
+      if (indexB === -1) return -1;
+      return indexA - indexB;
+    })
+    .forEach(fieldName => {
+      const field = fields[fieldName];
 
-    let suffix = "";
-    if (field.optional || field.default != null) suffix += "?";
+      let suffix = "";
+      if (field.optional || field.default != null) suffix += "?";
 
-    let typeAnnotation = "any";
+      let typeAnnotation = "any";
 
-    const validate = field.validate;
-    if (validate) {
-      if (validate.oneOf) {
-        typeAnnotation = validate.oneOf
-          .map(function(val) {
-            return JSON.stringify(val);
-          })
-          .join(" | ");
-      }
+      const validate = field.validate;
+      if (validate) {
+        if (validate.oneOf) {
+          typeAnnotation = validate.oneOf
+            .map(function(val) {
+              return JSON.stringify(val);
+            })
+            .join(" | ");
+        }
 
-      if (validate.type) {
-        typeAnnotation = validate.type;
+        if (validate.type) {
+          typeAnnotation = validate.type;
 
-        if (typeAnnotation === "array") {
-          typeAnnotation = "Array<any>";
+          if (typeAnnotation === "array") {
+            typeAnnotation = "Array<any>";
+          }
+        }
+
+        if (validate.oneOfNodeTypes) {
+          const types = validate.oneOfNodeTypes.map(
+            type => `${NODE_PREFIX}${type}`
+          );
+          typeAnnotation = types.join(" | ");
+          if (suffix === "?") typeAnnotation = "?" + typeAnnotation;
         }
       }
 
-      if (validate.oneOfNodeTypes) {
-        const types = validate.oneOfNodeTypes.map(
-          type => `${NODE_PREFIX}${type}`
-        );
-        typeAnnotation = types.join(" | ");
-        if (suffix === "?") typeAnnotation = "?" + typeAnnotation;
+      if (typeAnnotation) {
+        suffix += ": " + typeAnnotation;
       }
-    }
 
-    if (typeAnnotation) {
-      suffix += ": " + typeAnnotation;
-    }
+      args.push(t.toBindingIdentifierName(fieldName) + suffix);
 
-    args.push(t.toBindingIdentifierName(fieldName) + suffix);
-    if (!t.isValidIdentifier(fieldName)) continue;
-    struct.push(fieldName + suffix + ";");
-  }
+      if (t.isValidIdentifier(fieldName)) {
+        struct.push(fieldName + suffix + ";");
+      }
+    });
 
   code += `declare class ${NODE_PREFIX}${type} extends ${NODE_PREFIX} {
   ${struct.join("\n  ").trim()}
 }\n\n`;
 
-  // Flow chokes on super() :/
-  if (type !== "Super") {
+  // Flow chokes on super() and import() :/
+  if (type !== "Super" && type !== "Import") {
     lines.push(
       `declare function ${type[0].toLowerCase() + type.slice(1)}(${args.join(
         ", "


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Deprecations?            | n
| Spec Compliancy?         | n
| Tests Added/Pass?        | 
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

While looking at the CI failure in https://github.com/babel/babel/pull/5990, I noticed:

* A small typo in TSPropertySignature
* Because we now spread a bunch of common fields, `generate-interfaces` was creating a number of types with out of order params. It now matches what we do in `generate-babel-types-docs`
* `import()` needs to be blacklisted similarly to `super()`