### PR TITLE
Development Only: drop Node 4-5 and npm 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Feel free to check out the `#discussion`/`#development` channels on our [Slack](
 
 **Note:** Versions `< 5.1.10` can't be built.
 
-Babel is built for Node.js 4 and up but we develop using Node.js 6. Make sure you are on npm 3.
+Babel is built for Node.js 4 and up but we develop using Node.js 6/8 and yarn.
 
 You can check this with `node -v` and `npm -v`.
 

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "uglify-js": "^2.4.16"
   },
   "engines": {
-    "node": ">= 4.x <= 8.x",
-    "npm": ">= 2.x <= 5.x"
+    "node": ">= 6.x <= 8.x",
+    "npm": ">= 3.x <= 5.x"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
Node versions 4 and 5 are obsolete. Version of npm bundled in Node 6 is 3 so npm 2 could be dropped as well.

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            |  yes
| Spec Compliancy?         | no
| Tests Added/Pass?        | no
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

