### PR TITLE
Adding failing test for 6025

### DIFF
--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/actual.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/actual.js
@@ -1,0 +1,8 @@
+for (let path of c) {
+  path;
+  () => path;
+}
+
+if (true) {
+  let path = false;
+}

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/expected.js
@@ -1,0 +1,36 @@
+var _loop = function _loop(path) {
+  path;
+
+  (function () {
+    return path;
+  });
+};
+
+var _iteratorNormalCompletion = true;
+var _didIteratorError = false;
+var _iteratorError = undefined;
+
+try {
+  for (var _iterator = c[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+    var path = _step.value;
+
+    _loop(path);
+  }
+} catch (err) {
+  _didIteratorError = true;
+  _iteratorError = err;
+} finally {
+  try {
+    if (!_iteratorNormalCompletion && _iterator.return) {
+      _iterator.return();
+    }
+  } finally {
+    if (_didIteratorError) {
+      throw _iteratorError;
+    }
+  }
+}
+
+if (true) {
+  var path = false;
+}

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/options.json
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/options.json
@@ -1,0 +1,27 @@
+{
+  "plugins": [
+    "check-es2015-constants",
+    "transform-es2015-arrow-functions",
+    "transform-es2015-block-scoped-functions",
+    "transform-es2015-block-scoping",
+    "transform-es2015-classes",
+    "transform-es2015-computed-properties",
+    "transform-es2015-destructuring",
+    "transform-es2015-duplicate-keys",
+    "transform-es2015-for-of",
+    "transform-es2015-function-name",
+    "transform-es2015-literals",
+    "transform-es2015-object-super",
+    "transform-es2015-parameters",
+    "transform-es2015-shorthand-properties",
+    "transform-es2015-spread",
+    "transform-es2015-sticky-regex",
+    "transform-es2015-template-literals",
+    "transform-es2015-typeof-symbol",
+    "transform-es2015-unicode-regex",
+    "transform-regenerator",
+    "transform-exponentiation-operator",
+    "transform-async-to-generator",
+    "syntax-trailing-function-commas"
+  ]
+}


### PR DESCRIPTION
Ref https://github.com/babel/babel/issues/6025

Ok finally got it failing and then did a git bisect (ok we need a bot to do this automatically 😄 😄 )

Looks like it's coming from https://github.com/babel/babel/pull/5963

![screen shot 2017-08-01 at 4 28 47 pm](https://user-images.githubusercontent.com/588473/28845589-8fa57cb8-76d6-11e7-9d20-e9bbb82467c1.png)

Ok I don't know why but it's because of ^


reduced test case

```
for (let path of c) {
  () => path;
}

if (true) {
  let path = false;
}
```