### PR TITLE
Fix invalid block-scoped loop

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -459,8 +459,8 @@ class BlockScoping {
     this.hoistVarDeclarations();
 
     // turn outsideLetReferences into an array
-    const params = values(outsideRefs);
     const args = values(outsideRefs);
+    const params = args.map(id => t.clone(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();
 

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/actual.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/actual.js
@@ -1,0 +1,8 @@
+for (let path of c) {
+  path;
+  () => path;
+}
+
+if (true) {
+  let path = false;
+}

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/expected.js
@@ -1,0 +1,36 @@
+var _loop = function _loop(path) {
+  path;
+
+  (function () {
+    return path;
+  });
+};
+
+var _iteratorNormalCompletion = true;
+var _didIteratorError = false;
+var _iteratorError = undefined;
+
+try {
+  for (var _iterator = c[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+    var path = _step.value;
+
+    _loop(path);
+  }
+} catch (err) {
+  _didIteratorError = true;
+  _iteratorError = err;
+} finally {
+  try {
+    if (!_iteratorNormalCompletion && _iterator.return) {
+      _iterator.return();
+    }
+  } finally {
+    if (_didIteratorError) {
+      throw _iteratorError;
+    }
+  }
+}
+
+if (true) {
+  var path = false;
+}

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/expected.js
@@ -12,9 +12,9 @@ var _iteratorError = undefined;
 
 try {
   for (var _iterator = c[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-    var path = _step.value;
+    var _path = _step.value;
 
-    _loop(path);
+    _loop(_path);
   }
 } catch (err) {
   _didIteratorError = true;

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/6025/options.json
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/6025/options.json
@@ -1,0 +1,27 @@
+{
+  "plugins": [
+    "check-es2015-constants",
+    "transform-es2015-arrow-functions",
+    "transform-es2015-block-scoped-functions",
+    "transform-es2015-block-scoping",
+    "transform-es2015-classes",
+    "transform-es2015-computed-properties",
+    "transform-es2015-destructuring",
+    "transform-es2015-duplicate-keys",
+    "transform-es2015-for-of",
+    "transform-es2015-function-name",
+    "transform-es2015-literals",
+    "transform-es2015-object-super",
+    "transform-es2015-parameters",
+    "transform-es2015-shorthand-properties",
+    "transform-es2015-spread",
+    "transform-es2015-sticky-regex",
+    "transform-es2015-template-literals",
+    "transform-es2015-typeof-symbol",
+    "transform-es2015-unicode-regex",
+    "transform-regenerator",
+    "transform-exponentiation-operator",
+    "transform-async-to-generator",
+    "syntax-trailing-function-commas"
+  ]
+}


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes?
| Tests Added/Pass?        | Yes
| Fixed Tickets            | Closes https://github.com/babel/babel/pull/6038
| License                  | MIT
| Doc PR                   | 
| Dependency Changes       | 

The issue is we're reusing the same identifier in two scopes (in as the hoisted loop's function params, and as that function's call expression arguments). Well, when we remap in the context of the loop call, we changed the param's name, too.