### PR TITLE
Don't insert the same node into the AST multiple times (fixes babel/babili#56)

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -73,7 +73,11 @@ export default function() {
           ),
         );
       } else {
-        path.replaceWith(remap);
+        path.replaceWith(
+          // Clone the node before inserting it to ensure that different nodes in the AST are represented
+          // by different objects.
+          t.cloneWithoutLoc(remap),
+        );
       }
       this.requeueInParent(path);
     },

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/copied-nodes.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/copied-nodes.js
@@ -1,0 +1,19 @@
+const assert = require("assert");
+const babel = require("babel-core");
+
+test("Doesn't use the same object for two different nodes in the AST", function() {
+  const code = 'import Foo from "bar"; Foo; Foo;';
+
+  const ast = babel.transform(code, {
+    plugins: [[require("../"), { loose: true }]],
+  }).ast;
+
+  assert.equal(ast.program.body[3].expression.type, "MemberExpression");
+  assert.equal(ast.program.body[4].expression.type, "MemberExpression");
+
+  assert.notEqual(
+    ast.program.body[3].expression,
+    ast.program.body[4].expression,
+    "Expected different nodes in the AST to not be the same object",
+  );
+});


### PR DESCRIPTION


<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | yes
| Fixed Tickets            | Fixes https://github.com/babel/babili/issues/556
| License                  | MIT
| Doc PR                   | no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->

This updates `babel-plugin-transform-es2015-modules-commonjs` to avoid inserting the same object for multiple AST nodes. 

The issue in https://github.com/babel/babili/issues/556 is that when `babili` is used in combination with `babel-plugin-transform-es2015-modules-commonjs`, the `path.scope` property [here](https://github.com/babel/babili/blob/f8669f7e501f323f12ce596ecbdb38a3dcea7011/packages/babel-plugin-minify-mangle-names/src/index.js#L162) is sometimes incorrect. (From the code sample in https://github.com/babel/babili/issues/556#issuecomment-320084416, the issue, the `scope` when traversing `extends _baz2.default` was actually the scope from the following function expression.) This causes an error because `babel-plugin-transform-es2015-modules-commonjs` encounters a scope it hasn't seen before.

I *think* the issue is that `babel-plugin-transform-es2015-modules-commonjs` is reusing the same JavaScript object to insert a node into multiple places into an AST, and this causes problems with the scope cache [here](https://github.com/babel/babel/blob/a1debae8f070f88114ea03b99f78fc7d6e202766/packages/babel-traverse/src/cache.js#L2), which is a WeakMap whose keys are AST node objects. This PR updates `babel-plugin-transform-es2015-modules-commonjs` to avoid using the same object for multiple different node locations, and it seems to fix the problem in `babili`. However, if inserting the same object at multiple node locations is supposed to be supported, then it's possible that this is fixing a side-effect and not the root cause. I'm unfamiliar with a lot of babel's internals, so I'm unsure whether that's the case.