### PR TITLE
Add feature to pass array of deps to a helper

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -223,13 +223,12 @@ export default class File extends Store {
     return id;
   }
 
-  addHelper(name: string): Object {
+  addHelper(name: string, deps: Array<string>): Object {
     const declar = this.declarations[name];
     if (declar) return declar;
 
     if (!this.usedHelpers[name]) {
       this.metadata.usedHelpers.push(name);
-      this.usedHelpers[name] = true;
     }
 
     const generator = this.get("helperGenerator");
@@ -241,7 +240,18 @@ export default class File extends Store {
       return t.memberExpression(runtime, t.identifier(name));
     }
 
-    const ref = getHelper(name);
+    const opts = {};
+    if (deps) {
+      for (const dep in deps) {
+        if (!this.usedHelpers[name]) {
+          throw "Helper dependencies must be added to the file first";
+        } else {
+          opts["babelHelpers." + dep] = this.usedHelpers[name];
+        }
+      }
+    }
+
+    const ref = getHelper(name, opts);
     const uid = (this.declarations[name] = this.scope.generateUidIdentifier(
       name,
     ));
@@ -259,6 +269,8 @@ export default class File extends Store {
         unique: true,
       });
     }
+
+    this.usedHelpers[name] = uid.name;
 
     return uid;
   }

--- a/packages/babel-helpers/src/index.js
+++ b/packages/babel-helpers/src/index.js
@@ -1,10 +1,10 @@
 import helpers from "./helpers";
 
-export function get(name) {
+export function get(name, opts) {
   const fn = helpers[name];
   if (!fn) throw new ReferenceError(`Unknown helper ${name}`);
 
-  return fn().expression;
+  return fn(opts).expression;
 }
 
 export const list = Object.keys(helpers)


### PR DESCRIPTION
| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Deprecations?            | No
| Spec Compliancy?         | Yes
| Tests Added/Pass?        | No
| Fixed Tickets            | Closes #6030
| License                  | MIT
| Doc PR                   | No
| Dependency Changes       | No

Hi, this is a simple way to allow for interdependent helpers (see https://github.com/babel/babel/issues/6030 for explanation). I could not wait on #5706 since the upcoming decorator transform uses this feature, and neither could I hack on 5706 myself. 

I couldn't figure a way to add tests for this (since you'd have to introduce new helpers in `helpers.js` just for the sake of this PR) but I've added some new helpers in [a wip branch](https://github.com/peey/babel/tree/decorators-2-transform-wip/packages/babel-plugin-transform-decorators-2) and it works with those.

I suppose this could be repealed after we have an ability to simply import helpers when 5706 makes them modular. 