### PR TITLE
Move parser plugin from babel-preset-typescript to babel-plugin-syntax-typescript

### DIFF
--- a/packages/babel-plugin-syntax-typescript/src/index.js
+++ b/packages/babel-plugin-syntax-typescript/src/index.js
@@ -1,7 +1,11 @@
 export default function() {
   return {
     manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push("typescript");
+      parserOpts.plugins.push(
+        "typescript",
+        "objectRestSpread",
+        "classProperties",
+      );
     },
   };
 }

--- a/packages/babel-preset-typescript/README.md
+++ b/packages/babel-preset-typescript/README.md
@@ -5,7 +5,6 @@
 This preset includes the following plugins:
 
 - [transform-typescript](https://babeljs.io/docs/plugins/transform-typescript/)
-- [syntax-object-rest-spread](https://babeljs.io/docs/plugins/syntax-object-rest-spread/)
 
 ## Example
 

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -10,7 +10,6 @@
     "typescript"
   ],
   "dependencies": {
-    "babel-plugin-syntax-object-rest-spread": "7.0.0-alpha.19",
     "babel-plugin-transform-typescript": "7.0.0-alpha.19"
   }
 }

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -1,8 +1,7 @@
 import transformTypeScript from "babel-plugin-transform-typescript";
-import syntaxObjectRestSpread from "babel-plugin-syntax-object-rest-spread";
 
 export default function() {
   return {
-    plugins: [transformTypeScript, syntaxObjectRestSpread],
+    plugins: [transformTypeScript],
   };
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Tests pass
| Fixed Tickets            | https://github.com/babel/babel/pull/5899#discussion_r131689622
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | Yes, a dependency is removed

If this is merged, I will make a PR to babylon removing the special handling for TypeScript in https://github.com/babel/babylon/blob/c88af90c0a88ec756ad7c27f0a1c6f92bffbcd24/src/parser/statement.js#L1148.
