### PR TITLE
Add numeric separator to stage 2 preset

### DIFF
--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "babel-plugin-transform-decorators": "7.0.0-alpha.19",
     "babel-plugin-transform-export-extensions": "7.0.0-alpha.19",
-    "babel-plugin-transform-numeric-separator": "7.0.0-alpha.19",
     "babel-plugin-transform-optional-chaining": "7.0.0-alpha.19",
     "babel-preset-stage-2": "7.0.0-alpha.19"
   }

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -2,7 +2,6 @@ import presetStage2 from "babel-preset-stage-2";
 
 import transformDecorators from "babel-plugin-transform-decorators";
 import transformExportExtensions from "babel-plugin-transform-export-extensions";
-import transformNumericSeparator from "babel-plugin-transform-numeric-separator";
 import transformOptionalChaining from "babel-plugin-transform-optional-chaining";
 
 export default function() {
@@ -11,7 +10,6 @@ export default function() {
     plugins: [
       transformDecorators,
       transformExportExtensions,
-      transformNumericSeparator,
       transformOptionalChaining,
     ],
   };

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "babel-plugin-transform-class-properties": "7.0.0-alpha.19",
     "babel-plugin-transform-function-sent": "7.0.0-alpha.19",
+    "babel-plugin-transform-numeric-separator": "7.0.0-alpha.19",
     "babel-preset-stage-3": "7.0.0-alpha.19"
   }
 }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -2,10 +2,15 @@ import presetStage3 from "babel-preset-stage-3";
 
 import transformClassProperties from "babel-plugin-transform-class-properties";
 import transformFunctionSent from "babel-plugin-transform-function-sent";
+import transformNumericSeparator from "babel-plugin-transform-numeric-separator";
 
 export default function() {
   return {
     presets: [presetStage3],
-    plugins: [transformClassProperties, transformFunctionSent],
+    plugins: [
+      transformClassProperties,
+      transformFunctionSent,
+      transformNumericSeparator,
+    ],
   };
 }


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          |  No
| Major: Breaking Change?  | No
| Minor: New Feature?      |  No
| Deprecations?            | No
| Spec Compliancy?         |  Yes
| Tests Pass?        |  Yes
| Fixed Tickets            | 
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       |  "babel-plugin-transform-numeric-separator" moves from stage 1 to stage 2

<!-- Describe your changes below in as much detail as possible -->
