### PR TITLE
Add "classProperties" plugin to babel-generator typescript tests

### DIFF
--- a/packages/babel-generator/test/fixtures/typescript/options.json
+++ b/packages/babel-generator/test/fixtures/typescript/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "plugins": ["typescript"]
+  "plugins": ["typescript", "classProperties"]
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Deprecations?            | no
| Spec Compliancy?         | no
| Tests Added/Pass?        | tests pass
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | 

Companion to babel/babylon#666 -- we would now require the `"classProperties"` plugin to be enabled to use those.
