### PR TITLE
babel-plugin-transform-class-properties: Ignore type annotations when looking for name collisions

### DIFF
--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -12,6 +12,9 @@ export default function({ types: t }) {
   };
 
   const referenceVisitor = {
+    TypeAnnotation(path) {
+      path.skip();
+    },
     ReferencedIdentifier(path) {
       if (this.scope.hasOwnBinding(path.node.name)) {
         this.collision = true;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/actual.js
@@ -1,0 +1,6 @@
+class C {
+    // Output should not use `_initialiseProps`
+    x: T;
+    y = 0;
+    constructor(T) {}
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/expected.js
@@ -1,0 +1,7 @@
+class C {
+  // Output should not use `_initialiseProps`
+  constructor(T) {
+    this.y = 0;
+  }
+
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typescript", "transform-class-properties"]
+}


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | No
| Tests Added/Pass?        | Yes
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   |
| Dependency Changes       | No

Skip `TypeAnnotation` nodes when looking for name collisions. This avoids unnecessary calls to `_initialiseProps`.
Note: I had to put the test in its own directory because otherwise it would inherit plugins from its parent directory's options, and I needed to compile to a class to reproduce this problem.