### PR TITLE
babel-types: Add missing field, fix incorrect definitions

### DIFF
--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -244,7 +244,7 @@ t.catchClause(param, body)
 
 See also `t.isCatchClause(node, opts)` and `t.assertCatchClause(node, opts)`.
 
-Aliases: `Scopable`
+Aliases: `Scopable`, `BlockParent`
 
  - `param`: `Identifier` (default: `null`)
  - `body`: `BlockStatement` (required)
@@ -1561,6 +1561,7 @@ Aliases: `Scopable`, `BlockParent`, `Block`
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
  - `sourceFile`: `string` (default: `null`)
+ - `sourceType`: `'script' | 'module'` (default: `null`)
 
 ---
 
@@ -2505,10 +2506,9 @@ See also `t.isTryStatement(node, opts)` and `t.assertTryStatement(node, opts)`.
 
 Aliases: `Statement`
 
- - `block` (required)
- - `handler`: `BlockStatement` (default: `null`)
+ - `block`: `BlockStatement` (required)
+ - `handler`: `CatchClause` (default: `null`)
  - `finalizer`: `BlockStatement` (default: `null`)
- - `body`: `BlockStatement` (default: `null`)
 
 ---
 

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -518,6 +518,9 @@ defineType("Program", {
     sourceFile: {
       validate: assertValueType("string"),
     },
+    sourceType: {
+      validate: assertOneOf("script", "module"),
+    },
     directives: {
       validate: chain(
         assertValueType("array"),
@@ -739,12 +742,12 @@ defineType("TryStatement", {
   visitor: ["block", "handler", "finalizer"],
   aliases: ["Statement"],
   fields: {
-    body: {
+    block: {
       validate: assertNodeType("BlockStatement"),
     },
     handler: {
       optional: true,
-      validate: assertNodeType("BlockStatement"),
+      validate: assertNodeType("CatchClause"),
     },
     finalizer: {
       optional: true,


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | No
| Deprecations?            | No
| Spec Compliancy?         | Yes
| Tests Added/Pass?        | I am working on tests that will use this, but not in this PR
| Fixed Tickets            |
| License                  | MIT
| Doc PR                   | No
| Dependency Changes       | No

A `TryStatement` has a `block`, not a `body`. The handler is a `CatchClause`, not a `BlockStatement`.
Also added missing `sourceType` field on `Program`.
