### PR TITLE
Replace decache with direct removal in babel-register tests

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -18,7 +18,6 @@
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {
-    "decache": "^4.1.0",
     "default-require-extensions": "^2.0.0"
   }
 }

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import fs from "fs";
 import path from "path";
-import decache from "decache";
 
 const testCacheFilename = path.join(__dirname, ".babel");
 const oldBabelDisableCacheValue = process.env.BABEL_DISABLE_CACHE;
@@ -36,7 +35,7 @@ describe("babel register", () => {
 
     beforeEach(() => {
       // Since lib/cache is a singleton we need to fully reload it
-      decache("../lib/cache");
+      delete require.cache[require.resolve("../lib/cache")];
       const cache = require("../lib/cache");
 
       load = cache.load;

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -1,6 +1,5 @@
 import chai from "chai";
 import path from "path";
-import decache from "decache";
 
 const DATA_ES2015 = require.resolve("./__data__/es2015");
 
@@ -40,7 +39,7 @@ describe("babel-register", function() {
 
   afterEach(() => {
     revertRegister();
-    decache(DATA_ES2015);
+    delete require.cache[DATA_ES2015];
   });
 
   it("registers correctly", () => {
@@ -53,7 +52,7 @@ describe("babel-register", function() {
     setupRegister();
 
     chai.expect(require(DATA_ES2015)).to.be.ok;
-    decache(DATA_ES2015);
+    delete require.cache[DATA_ES2015];
 
     revertRegister();
 


### PR DESCRIPTION
Fixes CI on node 8.3, not as involved as what `decache` was doing but probably fine for our use case?

(Also, however we handle this, we should be consistent with what we do in [babel-register/node](https://github.com/babel/babel/blob/7.0/packages/babel-register/src/node.js#L92))