### PR TITLE
remove left transform-class-properties from stage

### DIFF
--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-plugin-transform-class-properties": "7.0.0-alpha.19",
     "babel-plugin-transform-function-sent": "7.0.0-alpha.19",
     "babel-plugin-transform-numeric-separator": "7.0.0-alpha.19",
     "babel-preset-stage-3": "7.0.0-alpha.19"


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6087 <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | no
| Spec Compliancy?         | yes
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

solve this issue https://github.com/babel/babel/issues/6087
`transform-class-properties` is still on `preset-stage-2` so I removed it.