### PR TITLE
Backport fix from 7.x - wrong replace transform defautExports

### DIFF
--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -125,7 +125,8 @@ export function replaceWith(replacement) {
   if (this.isNodeType("Statement") && t.isExpression(replacement)) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
-      !this.canSwapBetweenExpressionAndStatement(replacement)
+      !this.canSwapBetweenExpressionAndStatement(replacement) && 
+      !this.parentPath.isExportDefaultDeclaration()
     ) {
       // replacing a statement with an expression so wrap it in an expression statement
       replacement = t.expressionStatement(replacement);


### PR DESCRIPTION
Fixes: 
https://github.com/rollup/rollup-plugin-babel/issues/155 which in turn fixes the ability to build babily(master)

All info is in the link above.

Until this gets merged, everyone using `rollup-plugin-babel` with peer dependency on 6.x will be broken.