### PR TITLE
Consistent const violations

### DIFF
--- a/packages/babel-plugin-check-es2015-constants/src/index.js
+++ b/packages/babel-plugin-check-es2015-constants/src/index.js
@@ -40,9 +40,9 @@ export default function({ messages, types: t }) {
               violation.replaceWith(
                 statementBeforeExpression(throwNode, violation.node),
               );
-            } else if (violation.parentPath.isForXStatement()) {
-              violation.parentPath.ensureBlock();
-              violation.parentPath.node.body.body.unshift(throwNode);
+            } else if (violation.isForXStatement()) {
+              violation.ensureBlock();
+              violation.node.body.body.unshift(throwNode);
             }
           }
         }

--- a/packages/babel-plugin-check-es2015-constants/src/index.js
+++ b/packages/babel-plugin-check-es2015-constants/src/index.js
@@ -36,9 +36,9 @@ export default function({ messages, types: t }) {
                     violation.get("right").node,
                   ),
                 );
-            } else if (violation.parentPath.isUpdateExpression()) {
-              violation.parentPath.replaceWith(
-                statementBeforeExpression(throwNode, violation.parent),
+            } else if (violation.isUpdateExpression()) {
+              violation.replaceWith(
+                statementBeforeExpression(throwNode, violation.node),
               );
             } else if (violation.parentPath.isForXStatement()) {
               violation.parentPath.ensureBlock();

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -140,7 +140,7 @@ const collectorVisitor = {
   },
 
   UpdateExpression(path, state) {
-    state.constantViolations.push(path.get("argument"));
+    state.constantViolations.push(path);
   },
 
   UnaryExpression(path, state) {

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -104,7 +104,7 @@ const collectorVisitor = {
   ForXStatement(path, state) {
     const left = path.get("left");
     if (left.isPattern() || left.isIdentifier()) {
-      state.constantViolations.push(left);
+      state.constantViolations.push(path);
     }
   },
 

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -145,7 +145,7 @@ const collectorVisitor = {
 
   UnaryExpression(path, state) {
     if (path.node.operator === "delete") {
-      state.constantViolations.push(path.get("argument"));
+      state.constantViolations.push(path);
     }
   },
 

--- a/packages/babel-types/src/retrievers.js
+++ b/packages/babel-types/src/retrievers.js
@@ -89,6 +89,9 @@ getBindingIdentifiers.keys = {
   FunctionDeclaration: ["id", "params"],
   FunctionExpression: ["id", "params"],
 
+  ForInStatement: ["left"],
+  ForOfStatement: ["left"],
+
   ClassDeclaration: ["id"],
   ClassExpression: ["id"],
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | no
| Spec Compliancy?         | no
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

When I updated the check constants plugin from compile time to runtime errors in https://github.com/babel/babel/pull/5930, I discovered a weird inconsistency in the way violations are collected. A violating `UpdateExpression` for example stores the `identifier` as violation, while `assignmentExpression` stores itself. As @buunguyen suggested [here](https://github.com/babel/babel/pull/5930/files/fc0327a3724ad17a4fe44968a5235bd584731307#r127080022), this PR cleans up this inconsistency, so its only internal. Because the mechanism for collecting violations relies on `getBindingIdentifiers` I had to include `forXStatement`'s into this method in `babel-types`. Is there a specific reason why it is currently not there? 

**UPDATE:** One test case concerning rest parameter optimization is currently failing. The reason seems to be the updated way of how `UpdateExpression` marks a const violation. I have not figured out the exact reason yet, but I will leave this PR here anyway since I think this change would be a nice cleanup.