### PR TITLE
Don't use _possibleConstructorReturn inside arrow functions

### DIFF
--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -53,7 +53,9 @@ const visitor = {
   },
 
   ReturnStatement(path, state) {
-    state.returns.push(path);
+    if (!path.getFunctionParent().isArrowFunctionExpression()) {
+      state.returns.push(path);
+    }
   },
 
   ThisExpression(path, state) {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/actual.js
@@ -1,0 +1,8 @@
+class A extends B {
+  constructor() {
+    super();
+
+    this.arrow1 = (x) => { return x; };
+    this.arrow2 = (x) => x;
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/exec.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/exec.js
@@ -1,0 +1,16 @@
+// https://github.com/babel/babel/issues/5817
+
+class Parent {}
+
+class Table extends Parent {
+  constructor() {
+    super();
+    this.returnParam = (param) => {
+      return param;
+    }
+  }
+}
+
+const table = new Table();
+
+assert(table.returnParam(false) === false);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/expected.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var A = function (_B) {
+  babelHelpers.inherits(A, _B);
+
+  function A() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, A);
+    _this = babelHelpers.possibleConstructorReturn(this, (A.__proto__ || Object.getPrototypeOf(A)).call(this));
+
+    _this.arrow1 = function (x) {
+      return x;
+    };
+
+    _this.arrow2 = function (x) {
+      return x;
+    };
+
+    return _this;
+  }
+
+  return A;
+}(B);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #5817
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 👍 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

Arrow functions can't be entrly skipped while traversing because this references inside of them needs to be transformed, so I added a check which prevents return statements inside arrow functions from being saved for the transformation.
