### PR TITLE
expose extends option in CLI

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -43,6 +43,7 @@ commander.option("-o, --out-file [out]", "Compile all input files into a single 
 commander.option("-d, --out-dir [out]", "Compile an input directory of modules into an output directory");
 commander.option("-D, --copy-files", "When compiling a directory copy over non-compilable files");
 commander.option("-q, --quiet", "Don't log anything");
+commander.option("--extends [path]", "Path a to .babelrc file to extend");
 /* eslint-enable max-len */
 
 const pkg = require("../../package.json");


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #5689 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 


This Fixes #5689  by exposing the extends option in the CLI. Now you can point babel to any .babelrc file when running it with the CLI.

I marked this as a bugfix because it's already in the docs as an option (not sure why it was removed from the code) https://babeljs.io/docs/usage/api/#options, so it's really just fixing the code to match the docs.