### PR TITLE
Add noFlow option to React preset

### DIFF
--- a/packages/babel-preset-react/README.md
+++ b/packages/babel-preset-react/README.md
@@ -118,3 +118,22 @@ module.exports = {
   }
 }
 ```
+
+### `noFlow`
+
+`boolean`, defaults to `false`.
+
+Toggle [transform-flow-strip-types](https://babeljs.io/docs/plugins/transform-flow-strip-types/) plugin.
+
+This is useful if you want to use the typescript preset:
+
+#### .babelrc
+
+```json
+{
+  "presets": [
+    ["react", { "noFlow": true }],
+    "typescript"
+  ]
+}
+```

--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -7,9 +7,14 @@ import transformReactJSXSelf from "babel-plugin-transform-react-jsx-self";
 
 export default function(context, opts = {}) {
   const development = opts.development || false;
+  const noFlow = opts.noFlow || false;
 
   if (typeof development !== "boolean") {
     throw new Error("Preset react 'development' option must be a boolean.");
+  }
+
+  if (typeof noFlow !== "boolean") {
+    throw new Error("Preset react 'noFlow' option must be a boolean.");
   }
 
   return {
@@ -20,7 +25,7 @@ export default function(context, opts = {}) {
 
       development && transformReactJSXSource,
       development && transformReactJSXSelf,
-      [transformFlowStripTypes, { requireDirective: true }],
+      !noFlow && [transformFlowStripTypes, { requireDirective: true }],
     ].filter(Boolean),
   };
 }

--- a/packages/babel-preset-react/test/fixtures/preset-options/noFlow/actual.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/noFlow/actual.js
@@ -1,0 +1,2 @@
+// @flow
+function foo(numVal: number, strVal: string) {}

--- a/packages/babel-preset-react/test/fixtures/preset-options/noFlow/options.json
+++ b/packages/babel-preset-react/test/fixtures/preset-options/noFlow/options.json
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    ["react", { "noFlow": true }]
+  ],
+  "throws": "Unexpected token"
+}

--- a/packages/babel-preset-react/test/index.js
+++ b/packages/babel-preset-react/test/index.js
@@ -16,5 +16,12 @@ describe("react preset", () => {
         }).to.throw(/must be a boolean/);
       });
     });
+    describe("noFlow", () => {
+      it("throws on non-boolean value", () => {
+        expect(function() {
+          react(null, { noFlow: 1 });
+        }).to.throw(/must be a boolean/);
+      });
+    });
   });
 });


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6095
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | Y
| Minor: New Feature?      | Y
| Tests Added/Pass?        | Y/Y
| Spec Compliancy?         | N
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

Add noFlow option to React preset to make it compatible with typescript preset. Another option could be just drop the support for Flow in React preset.

Idea from https://github.com/babel/babel/issues/6095#issuecomment-322566079