### PR TITLE
expose --config-file option in CLI

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -43,6 +43,7 @@ commander.option("-o, --out-file [out]", "Compile all input files into a single 
 commander.option("-d, --out-dir [out]", "Compile an input directory of modules into an output directory");
 commander.option("-D, --copy-files", "When compiling a directory copy over non-compilable files");
 commander.option("-q, --quiet", "Don't log anything");
+commander.option("--config-file [path]", "Path a to .babelrc file to use");
 /* eslint-enable max-len */
 
 const pkg = require("../../package.json");
@@ -104,6 +105,10 @@ if (errors.length) {
 //
 
 const opts = exports.opts = {};
+
+if (commander.configFile) {
+  opts.extends = commander.configFile;
+}
 
 Object.keys(options).forEach(function (key) {
   const opt = options[key];

--- a/packages/babel-cli/test/.othername_babelrc
+++ b/packages/babel-cli/test/.othername_babelrc
@@ -1,0 +1,3 @@
+{
+  "comments": false
+}

--- a/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/options.json
+++ b/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--config-file", "../.othername_babelrc"]
+}

--- a/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdin.txt
+++ b/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdin.txt
@@ -1,0 +1,7 @@
+/*
+ Test comment
+ */
+
+arr.map(x => x * MULTIPLIER);
+
+// END OF FILE

--- a/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdout.txt
@@ -1,0 +1,5 @@
+"use strict";
+
+arr.map(function (x) {
+  return x * MULTIPLIER;
+});


### PR DESCRIPTION
reopening #6117 pointing to master and with tests

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #5689 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 👍
| Tests Added/Pass?        | 👍
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

This Fixes #5689  by exposing the extends option in the CLI. Now you can point babel to any .babelrc file when running it with the CLI.

@hzoo @loganfsmyth I'm happy to rename the option or something if that will get it in now. I think it's the best approach in the short term though to allow a configurable location for babelrc