### PR TITLE
Fix babel-standalone builds

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,4 +12,4 @@ packages/babel-standalone/babel.min.js
 
 # Prettier tries to insert trailing commas in function calls, which Node.js
 # doesn't natively support. This causes an error when loading the Gulp tasks.
-packages/babel-standalone/src/gulpTasks.js
+packages/babel-standalone/Gulpfile.js

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,7 +9,6 @@ const watch = require("gulp-watch");
 const gutil = require("gulp-util");
 const gulp = require("gulp");
 const path = require("path");
-const registerBabelStandaloneTasks = require("./packages/babel-standalone/src/gulpTasks");
 
 const base = path.join(__dirname, "packages");
 const scripts = "./packages/*/src/**/*.js";
@@ -60,5 +59,3 @@ gulp.task("watch", ["build"], function() {
     gulp.start("build");
   });
 });
-
-registerBabelStandaloneTasks(gulp);

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-dist: build
 	node scripts/generate-babel-types-docs.js
 
 build-babel-standalone:
-	cd packages/babel-standalone
+	cd packages/babel-standalone; \
 	./node_modules/.bin/gulp build
 
 watch: clean

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: clean
 	rm -rf packages/*/lib
 	./node_modules/.bin/gulp build
 ifneq ($(BABEL_ENV), "cov")
-	./node_modules/.bin/gulp build-babel-standalone
+	make build-babel-standalone
 endif
 
 build-dist: build
@@ -20,6 +20,10 @@ build-dist: build
 	cd packages/babel-runtime; \
 	node scripts/build-dist.js
 	node scripts/generate-babel-types-docs.js
+
+build-babel-standalone:
+	cd packages/babel-standalone
+	./node_modules/.bin/gulp build
 
 watch: clean
 	rm -rf packages/*/lib

--- a/packages/babel-standalone/Gulpfile.js
+++ b/packages/babel-standalone/Gulpfile.js
@@ -6,9 +6,11 @@
  * only target Node.js.
  */
 
+const gulp = require("gulp");
 const pump = require("pump");
 const rename = require("gulp-rename");
-const RootMostResolvePlugin = require("webpack-dependency-suite").RootMostResolvePlugin;
+const RootMostResolvePlugin = require("webpack-dependency-suite")
+  .RootMostResolvePlugin;
 const webpack = require("webpack");
 const webpackStream = require("webpack-stream");
 const uglify = require("gulp-uglify");
@@ -17,7 +19,7 @@ function webpackBuild(filename, libraryName, version) {
   // If this build is part of a pull request, include the pull request number in
   // the version number.
   if (process.env.CIRCLE_PR_NUMBER) {
-    version += '+pr.' + process.env.CIRCLE_PR_NUMBER;
+    version += "+pr." + process.env.CIRCLE_PR_NUMBER;
   }
   const typeofPlugin = require("babel-plugin-transform-es2015-typeof-symbol")
     .default;
@@ -61,14 +63,15 @@ function webpackBuild(filename, libraryName, version) {
     plugins: [
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": '"production"',
-        BABEL_VERSION:
-          JSON.stringify(require("babel-core/package.json").version),
+        BABEL_VERSION: JSON.stringify(
+          require("babel-core/package.json").version,
+        ),
         VERSION: JSON.stringify(version),
       }),
       // Use browser version of visionmedia-debug
       new webpack.NormalModuleReplacementPlugin(
         /debug\/node/,
-        "debug/src/browser"
+        "debug/src/browser",
       ),
       /*new webpack.NormalModuleReplacementPlugin(
         /..\/..\/package/,
@@ -80,7 +83,7 @@ function webpackBuild(filename, libraryName, version) {
       plugins: [
         // Dedupe packages that are used across multiple plugins.
         // This replaces DedupePlugin from Webpack 1.x
-        new RootMostResolvePlugin(__dirname + '/../../../', true),
+        new RootMostResolvePlugin(__dirname + "/../../../", true),
       ],
     },
   };
@@ -100,24 +103,20 @@ function webpackBuild(filename, libraryName, version) {
   });*/
 }
 
-function registerGulpTasks(gulp) {
-  gulp.task("build-babel-standalone", ["build"], cb => {
-    pump(
-      [
-        gulp.src(__dirname + "/index.js"),
-        webpackBuild(
-          "babel.js",
-          "Babel",
-          require(__dirname + "/../package.json").version
-        ),
-        gulp.dest(__dirname + "/../"),
-        uglify(),
-        rename({ extname: ".min.js" }),
-        gulp.dest(__dirname + "/../"),
-      ],
-      cb
-    );
-  });
-}
-
-module.exports = registerGulpTasks;
+gulp.task("build", cb => {
+  pump(
+    [
+      gulp.src(__dirname + "/src/index.js"),
+      webpackBuild(
+        "babel.js",
+        "Babel",
+        require(__dirname + "/package.json").version,
+      ),
+      gulp.dest(__dirname),
+      uglify(),
+      rename({ extname: ".min.js" }),
+      gulp.dest(__dirname),
+    ],
+    cb,
+  );
+});

--- a/packages/babel-standalone/Gulpfile.js
+++ b/packages/babel-standalone/Gulpfile.js
@@ -64,14 +64,14 @@ function webpackBuild(filename, libraryName, version) {
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": '"production"',
         BABEL_VERSION: JSON.stringify(
-          require("babel-core/package.json").version,
+          require("babel-core/package.json").version
         ),
         VERSION: JSON.stringify(version),
       }),
       // Use browser version of visionmedia-debug
       new webpack.NormalModuleReplacementPlugin(
         /debug\/node/,
-        "debug/src/browser",
+        "debug/src/browser"
       ),
       /*new webpack.NormalModuleReplacementPlugin(
         /..\/..\/package/,
@@ -110,13 +110,13 @@ gulp.task("build", cb => {
       webpackBuild(
         "babel.js",
         "Babel",
-        require(__dirname + "/package.json").version,
+        require(__dirname + "/package.json").version
       ),
       gulp.dest(__dirname),
       uglify(),
       rename({ extname: ".min.js" }),
       gulp.dest(__dirname),
     ],
-    cb,
+    cb
   );
 });

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -90,6 +90,7 @@
     "babel-preset-stage-1": "7.0.0-alpha.19",
     "babel-preset-stage-2": "7.0.0-alpha.19",
     "babel-preset-stage-3": "7.0.0-alpha.19",
+    "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^3.0.0",
     "json-loader": "^0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,7 +3231,7 @@ gulp-watch@^4.3.5:
     vinyl "^1.2.0"
     vinyl-file "^2.0.0"
 
-gulp@^3.9.0:
+gulp@^3.9.0, gulp@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-3.9.1.tgz#571ce45928dd40af6514fc4011866016c13845b4"
   dependencies:
@@ -5360,6 +5360,18 @@ regenerate@^1.3.2:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-transform@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.0.tgz#f9ab3eac9cc2de38431d996a6a8abf1c50f2e459"
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
Because we were building it from the main gulp file, it was including
the packages that the monorepo depends on (version alpha.18 currently).
But, alpha.18 doesn’t have `PrivateName` (cause it’s going into
alpha.19). So when I tried to build alpha.19, it failed.

Now, we have babel-standalone’s own gulp do the build. And it correctly
depends on the alpha.19 packages (and they include `PrivateName` now),
so it builds.