### PR TITLE
add --config-file option to CLI to pass in .babelrc location

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -48,6 +48,7 @@ commander.option(
   "comma-separated list of plugin names",
   collect,
 );
+commander.option("--config-file [path]", "Path a to .babelrc file to use");
 
 // Basic file input configuration.
 commander.option("--source-type [script|module]", "");
@@ -200,6 +201,10 @@ if (errors.length) {
 //
 
 const opts = commander.opts();
+//the configFile CLI option maps to the extends option in the node API
+if (opts.configFile) {
+  opts.extends = opts.configFile;
+}
 
 // Delete options that are specific to babel-cli and shouldn't be passed to babel-core.
 delete opts.version;
@@ -210,6 +215,7 @@ delete opts.outFile;
 delete opts.outDir;
 delete opts.copyFiles;
 delete opts.quiet;
+delete opts.configFile;
 
 // Commander will default the "--no-" arguments to true, but we want to leave them undefined so that
 // babel-core can handle the default-assignment logic on its own.

--- a/packages/babel-cli/test/.othername_babelrc
+++ b/packages/babel-cli/test/.othername_babelrc
@@ -1,0 +1,3 @@
+{
+  "comments": false
+}

--- a/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/options.json
+++ b/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--config-file", "../.othername_babelrc"]
+}

--- a/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdin.txt
+++ b/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdin.txt
@@ -1,0 +1,7 @@
+/*
+ Test comment
+ */
+
+arr.map(x => x * MULTIPLIER);
+
+// END OF FILE

--- a/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--config-file babelrc nocomment/stdout.txt
@@ -1,0 +1,5 @@
+"use strict";
+
+arr.map(function (x) {
+  return x * MULTIPLIER;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5361,6 +5361,18 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-transform@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.0.tgz#f9ab3eac9cc2de38431d996a6a8abf1c50f2e459"
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"


### PR DESCRIPTION
7.0 version of #6125 

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #5689 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 👍
| Tests Added/Pass?        | 👍
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

This Fixes #5689  by adding the --config-file option in the CLI. Now you can point babel to any .babelrc file when running it with the CLI.