### PR TITLE
Fix babel-standalone for realz

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,7 +9,6 @@ const watch = require("gulp-watch");
 const gutil = require("gulp-util");
 const gulp = require("gulp");
 const path = require("path");
-const registerBabelStandaloneTasks = require("./packages/babel-standalone/src/gulpTasks");
 
 const base = path.join(__dirname, "packages");
 const scripts = "./packages/*/src/**/*.js";
@@ -60,5 +59,3 @@ gulp.task("watch", ["build"], function() {
     gulp.start("build");
   });
 });
-
-registerBabelStandaloneTasks(gulp);

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(BABEL_ENV), "cov")
 	make build-standalone
 endif
 
-build-standalone: build
+build-standalone:
 	./node_modules/.bin/gulp build-babel-standalone --cwd=packages/babel-standalone/
 
 build-dist: build

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,11 @@ build: clean
 	rm -rf packages/*/lib
 	./node_modules/.bin/gulp build
 ifneq ($(BABEL_ENV), "cov")
-	./node_modules/.bin/gulp build-babel-standalone
+	make build-standalone
 endif
+
+build-standalone: build
+	./node_modules/.bin/gulp build-babel-standalone --cwd=packages/babel-standalone/
 
 build-dist: build
 	cd packages/babel-polyfill; \

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-cli": "7.0.0-alpha.18",
     "babel-core": "7.0.0-alpha.18",
     "babel-eslint": "8.0.0-alpha.15",
-    "babel-loader": "^7.1.1",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-preset-env": "2.0.0-alpha.18",
     "babel-preset-flow": "7.0.0-alpha.18",

--- a/packages/babel-standalone/Gulpfile.js
+++ b/packages/babel-standalone/Gulpfile.js
@@ -1,0 +1,6 @@
+const registerBabelStandaloneTask = require("./src/gulpTasks")
+  .registerBabelStandaloneTask;
+const gulp = require("gulp");
+
+const version = require("./package.json").version;
+registerBabelStandaloneTask(gulp, "babel", "Babel", __dirname, version);

--- a/packages/babel-standalone/src/gulpTasks.js
+++ b/packages/babel-standalone/src/gulpTasks.js
@@ -9,6 +9,9 @@
  * to make standalone builds of other Babel plugins/presets (such as babel-minify)
  */
 
+// Must run first
+require("./overrideModuleResolution")();
+
 const pump = require("pump");
 const rename = require("gulp-rename");
 const RootMostResolvePlugin = require("webpack-dependency-suite").RootMostResolvePlugin;

--- a/packages/babel-standalone/src/gulpTasks.js
+++ b/packages/babel-standalone/src/gulpTasks.js
@@ -4,6 +4,9 @@
  * compilation of all the JavaScript files. This is because it targets web
  * browsers, so more transforms are needed than the regular Babel builds that
  * only target Node.js.
+ *
+ * The tasks in this file are designed to be reusable, so that they can be used
+ * to make standalone builds of other Babel plugins/presets (such as babel-minify)
  */
 
 const pump = require("pump");
@@ -100,24 +103,27 @@ function webpackBuild(filename, libraryName, version) {
   });*/
 }
 
-function registerGulpTasks(gulp) {
-  gulp.task("build-babel-standalone", ["build"], cb => {
+function registerBabelStandaloneTask(gulp, name, exportName, path, version) {
+  gulp.task("build-" + name + "-standalone", cb => {
     pump(
       [
-        gulp.src(__dirname + "/index.js"),
+        gulp.src(path + "/src/index.js"),
         webpackBuild(
-          "babel.js",
-          "Babel",
-          require(__dirname + "/../package.json").version
+          name + ".js",
+          exportName,
+          version
         ),
-        gulp.dest(__dirname + "/../"),
+        gulp.dest(path),
         uglify(),
         rename({ extname: ".min.js" }),
-        gulp.dest(__dirname + "/../"),
+        gulp.dest(path),
       ],
       cb
     );
   });
 }
 
-module.exports = registerGulpTasks;
+module.exports = {
+  webpackBuild: webpackBuild,
+  registerBabelStandaloneTask: registerBabelStandaloneTask,
+}

--- a/packages/babel-standalone/src/overrideModuleResolution.js
+++ b/packages/babel-standalone/src/overrideModuleResolution.js
@@ -1,0 +1,24 @@
+/**
+ * babel-loader causes problems as it's not part of the monorepo. It pulls in
+ * an older version of babel-core (the version referenced by the root
+ * package.json), rather than the version of babel-core that's in the repo. The
+ * only way to solve this without moving babel-loader into the monorepo is to
+ * override Node's module resolution algorithm to specify a custom resolver for
+ * babel-core to *force* it to use our version.
+ *
+ * Here be dragons.
+ */
+
+const Module = require("module");
+
+module.exports = function overrideModuleResolution() {
+  const originalLoader = Module._load.bind(Module);
+
+  Module._load = function babelStandaloneLoader(request, parent, isMain) {
+    // Redirect babel-core to version in the repo.
+    if (request === "babel-core") {
+      request = __dirname + "/../../babel-core";
+    }
+    return originalLoader(request, parent, isMain);
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,7 +563,7 @@ babel-helpers@7.0.0-alpha.18:
   dependencies:
     babel-template "7.0.0-alpha.18"
 
-babel-loader@7.1.1, babel-loader@^7.1.1:
+babel-loader@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.1.tgz#b87134c8b12e3e4c2a94e0546085bc680a2b8488"
   dependencies:
@@ -5366,6 +5366,18 @@ regenerate@^1.3.2:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-transform@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.0.tgz#f9ab3eac9cc2de38431d996a6a8abf1c50f2e459"
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
 
 regenerator-transform@0.9.11:
   version "0.9.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,7 +563,7 @@ babel-helpers@7.0.0-alpha.18:
   dependencies:
     babel-template "7.0.0-alpha.18"
 
-babel-loader@^7.1.1:
+babel-loader@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.1.tgz#b87134c8b12e3e4c2a94e0546085bc680a2b8488"
   dependencies:


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Closes #6132, Closes #6135, References #6120
| Patch: Bug Fix?          |  Yes
| Major: Breaking Change?  |  No
| Minor: New Feature?      |  No
| Tests Added/Pass?        |  N/A / Yes
| Spec Compliancy?         |  N/A
| License                  | MIT
| Doc PR                   | No
| Any Dependency Changes?  | 

The root `package.json` has a reference to `babel-loader` and `babel-core`. The root babel-core comes from npm (for some reason) rather than the version in the repo itself, which causes odd issues. By installing babel-loader into babel-standalone's `node_modules` directory rather than the root `node_modules` directory, it picks up the correct version of babel-core and everything works fine.

Also made `gulpTasks.js` properly modular so babel-minify can reuse it.

Huge thanks to @jridgewell for the initial investigation into this issue.