### PR TITLE
Complete export transform split

### DIFF
--- a/packages/babel-plugin-transform-export-default/src/index.js
+++ b/packages/babel-plugin-transform-export-default/src/index.js
@@ -1,44 +1,28 @@
 import syntaxExportExtensions from "babel-plugin-syntax-export-extensions";
 
 export default function({ types: t }) {
-  function build(node, nodes, scope) {
-    const hasNoExportDefault = node.specifiers.every(
-      specifier => !t.isExportDefaultSpecifier(specifier),
-    );
-    if (hasNoExportDefault) return;
-
-    const specifier = node.specifiers.shift();
-    const uid = scope.generateUidIdentifier(specifier.exported.name);
-
-    let newSpecifier;
-    if (t.isExportNamespaceSpecifier(specifier)) {
-      newSpecifier = t.importNamespaceSpecifier(uid);
-    } else {
-      newSpecifier = t.importDefaultSpecifier(uid);
-    }
-    nodes.push(t.importDeclaration([newSpecifier], node.source));
-    nodes.push(
-      t.exportNamedDeclaration(null, [
-        t.exportSpecifier(uid, specifier.exported),
-      ]),
-    );
-
-    build(node, nodes, scope);
-  }
-
   return {
     inherits: syntaxExportExtensions,
 
     visitor: {
       ExportNamedDeclaration(path) {
         const { node, scope } = path;
-        const nodes = [];
-        build(node, nodes, scope);
-        if (!nodes.length) return;
+        const { specifiers } = node;
+        if (!t.isExportDefaultSpecifier(specifiers[0])) return;
 
-        if (node.specifiers.length >= 1) {
+        const specifier = specifiers.shift();
+        const { exported } = specifier;
+        const uid = scope.generateUidIdentifier(exported.name);
+
+        const nodes = [
+          t.importDeclaration([t.importDefaultSpecifier(uid)], node.source),
+          t.exportNamedDeclaration(null, [t.exportSpecifier(uid, exported)]),
+        ];
+
+        if (specifiers.length >= 1) {
           nodes.push(node);
         }
+
         path.replaceWithMultiple(nodes);
       },
     },

--- a/packages/babel-plugin-transform-export-default/test/fixtures/export-default/default-compound-namespace/actual.js
+++ b/packages/babel-plugin-transform-export-default/test/fixtures/export-default/default-compound-namespace/actual.js
@@ -1,0 +1,1 @@
+export v, * as all from "mod";

--- a/packages/babel-plugin-transform-export-default/test/fixtures/export-default/default-compound-namespace/expected.js
+++ b/packages/babel-plugin-transform-export-default/test/fixtures/export-default/default-compound-namespace/expected.js
@@ -1,0 +1,3 @@
+import _v from "mod";
+export { _v as v };
+export * as all from "mod";

--- a/packages/babel-plugin-transform-export-default/test/fixtures/export-default/namespace-es6/actual.js
+++ b/packages/babel-plugin-transform-export-default/test/fixtures/export-default/namespace-es6/actual.js
@@ -1,0 +1,1 @@
+export * as foo from "bar";

--- a/packages/babel-plugin-transform-export-default/test/fixtures/export-default/namespace-es6/expected.js
+++ b/packages/babel-plugin-transform-export-default/test/fixtures/export-default/namespace-es6/expected.js
@@ -1,0 +1,1 @@
+export * as foo from "bar";

--- a/packages/babel-plugin-transform-export-namespace/test/fixtures/export-namespace/default-es6/actual.js
+++ b/packages/babel-plugin-transform-export-namespace/test/fixtures/export-namespace/default-es6/actual.js
@@ -1,0 +1,1 @@
+export foo from "bar";

--- a/packages/babel-plugin-transform-export-namespace/test/fixtures/export-namespace/default-es6/expected.js
+++ b/packages/babel-plugin-transform-export-namespace/test/fixtures/export-namespace/default-es6/expected.js
@@ -1,0 +1,1 @@
+export foo from "bar";

--- a/packages/babel-plugin-transform-export-namespace/test/fixtures/export-namespace/namespace-compound-es6/expected.js
+++ b/packages/babel-plugin-transform-export-namespace/test/fixtures/export-namespace/namespace-compound-es6/expected.js
@@ -1,4 +1,3 @@
-import _v from "mod";
-export { _v as v };
+export v from "mod";
 import * as _ns from "mod";
 export { _ns as ns };

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -234,7 +234,13 @@ defineType("ExportNamedDeclaration", {
     specifiers: {
       validate: chain(
         assertValueType("array"),
-        assertEach(assertNodeType("ExportSpecifier")),
+        assertEach(
+          assertNodeType(
+            "ExportSpecifier",
+            "ExportDefaultSpecifier",
+            "ExportNamespaceSpecifier",
+          ),
+        ),
       ),
     },
     source: {


### PR DESCRIPTION
They were each transforming the other's syntax (including namespace
transform would transform default, too, and vice-versa).