### PR TITLE
TypeParameterInstantiation params can be "Flow" nodes, not "FlowType"

### DIFF
--- a/packages/babel-types/src/definitions/tsFlowCommon.js
+++ b/packages/babel-types/src/definitions/tsFlowCommon.js
@@ -25,7 +25,7 @@ defineType("TypeParameterInstantiation", {
     params: {
       validate: chain(
         assertValueType("array"),
-        assertEach(assertNodeType("TSType", "FlowType")),
+        assertEach(assertNodeType("TSType", "Flow")),
       ),
     },
   },


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

I just found this bug while implementing a plugin.