### PR TITLE
Don't merge test options.

### DIFF
--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -2,7 +2,7 @@ import cloneDeep from "lodash/cloneDeep";
 import trimEnd from "lodash/trimEnd";
 import resolve from "try-resolve";
 import clone from "lodash/clone";
-import merge from "lodash/merge";
+import extend from "lodash/extend";
 import semver from "semver";
 import path from "path";
 import fs from "fs";
@@ -106,7 +106,7 @@ export default function get(entryLoc): Array<Suite> {
       const taskOpts = cloneDeep(suite.options);
 
       const taskOptsLoc = resolve(taskDir + "/options");
-      if (taskOptsLoc) merge(taskOpts, require(taskOptsLoc));
+      if (taskOptsLoc) extend(taskOpts, require(taskOptsLoc));
 
       const test = {
         optionsDir: taskOptsLoc ? path.dirname(taskOptsLoc) : null,

--- a/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/class/options.json
+++ b/packages/babel-plugin-transform-async-to-module-method/test/fixtures/bluebird-coroutines/class/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["external-helpers"]
-}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/loose/foobar/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/loose/foobar/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["external-helpers"],
-  "presets": ["stage-0", "es2015"]
+  "plugins": ["external-helpers", ["transform-class-properties", {"loose": true}]],
+  "presets": ["es2015"]
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/for-const-closure/options.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/for-const-closure/options.json
@@ -1,3 +1,4 @@
 {
+  "plugins": [["transform-es2015-block-scoping", { "throwIfClosureRequired": true }]],
   "throws": "Compiling let/const in this block would add a closure (throwIfClosureRequired)."
 }

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/options.json
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/throwIfClosureRequired/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": [["transform-es2015-block-scoping", { "throwIfClosureRequired": true }], "syntax-jsx", "transform-react-jsx", "transform-es2015-block-scoped-functions", "transform-es2015-arrow-functions"]
+  "plugins": [["transform-es2015-block-scoping", { "throwIfClosureRequired": true }]]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-must-call-super/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-must-call-super/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "missing super() call in constructor"
+  "throws": "missing super() call in constructor",
+  "plugins": ["transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-call-only-allowed-in-derived-constructor/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-call-only-allowed-in-derived-constructor/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "super() is only allowed in a derived constructor"
+  "throws": "super() is only allowed in a derived constructor",
+  "plugins": ["transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super-inline/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super-inline/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "'super.*' is not allowed before super()"
+  "throws": "'super.*' is not allowed before super()",
+  "plugins": ["transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-bare-super/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "'super.*' is not allowed before super()"
+  "throws": "'super.*' is not allowed before super()",
+  "plugins": ["transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "'super.*' is not allowed before super()"
+  "throws": "'super.*' is not allowed before super()",
+  "plugins": ["external-helpers", "transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-es2015-classes", "transform-es2015-block-scoping"]
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "'this' is not allowed before super()"
+  "throws": "'this' is not allowed before super()",
+  "plugins": ["transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "'this' is not allowed before super()"
+  "throws": "'this' is not allowed before super()",
+  "plugins": ["transform-es2015-classes"]
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/illegal-export-esmodule-2/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/illegal-export-esmodule-2/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "Illegal export \"__esModule\""
+  "throws": "Illegal export \"__esModule\"",
+  "plugins": ["transform-es2015-modules-commonjs"]
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/illegal-export-esmodule/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/illegal-export-esmodule/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "Illegal export \"__esModule\""
+  "throws": "Illegal export \"__esModule\"",
+  "plugins": ["transform-es2015-modules-commonjs"]
 }

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-default/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["external-helpers"]
-}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["external-helpers"]
-}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/options.json
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["external-helpers"]
-}

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/options.json
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["transform-es2015-object-super"]
+  "plugins": ["transform-es2015-object-super", "transform-es2015-shorthand-properties"]
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4333/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/regression-4333/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["transform-es2015-parameters"]
+  "plugins": ["transform-es2015-parameters", "transform-es2015-block-scoping"]
 }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-async-arrow-functions/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["external-helpers", "transform-es2015-parameters", "transform-async-to-generator"]
+  "plugins": ["external-helpers", "transform-es2015-parameters", "transform-async-to-generator", "transform-es2015-arrow-functions"]
 }

--- a/packages/babel-plugin-transform-new-target/test/fixtures/errors/new-target-arrow/options.json
+++ b/packages/babel-plugin-transform-new-target/test/fixtures/errors/new-target-arrow/options.json
@@ -1,3 +1,4 @@
 {
+  "plugins": ["transform-new-target"],
   "throws": "new.target must be under a (non-arrow) function or a class."
 }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/symbol-exec/options.json
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/symbol-exec/options.json
@@ -1,6 +1,3 @@
 {
-  "parserOpts": {
-    "allowReturnOutsideFunction": true
-  },
-  "plugins": [ "transform-es2015-destructuring" ]
+  "plugins": [ "transform-es2015-destructuring", "transform-object-rest-spread" ]
 }


### PR DESCRIPTION
Particularly, I don't want `lodash/merge` to merge my specific plugins
with the general test plugins. It led to odd behavior where I could
enable a loose transform in my specific test, just to have it overridden
by the test fixture's general options.