### PR TITLE
Allow native Symbols as computed property names

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -278,6 +278,20 @@ helpers.defineEnumerableProperties = template(`
       if ("value" in desc) desc.writable = true;
       Object.defineProperty(obj, key, desc);
     }
+
+    // Symbols are not enumerated over by for-in loops. If native
+    // Symbols are available, fetch all of the descs object's own
+    // symbol properties and define them on our target object too.
+    if (Object.getOwnPropertySymbols) {
+      var objectSymbols = Object.getOwnPropertySymbols(descs);
+      for (var idx in objectSymbols) {
+        var sym = objectSymbols[idx];
+        var desc = descs[sym];
+        desc.configurable = desc.enumerable = true;
+        if ("value" in desc) desc.writable = true;
+        Object.defineProperty(obj, sym, desc);
+      }
+    }
     return obj;
   })
 `);

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -284,8 +284,8 @@ helpers.defineEnumerableProperties = template(`
     // symbol properties and define them on our target object too.
     if (Object.getOwnPropertySymbols) {
       var objectSymbols = Object.getOwnPropertySymbols(descs);
-      for (var idx in objectSymbols) {
-        var sym = objectSymbols[idx];
+      for (var i = 0; i < objectSymbols.length; i++) {
+        var sym = objectSymbols[i];
         var desc = descs[sym];
         desc.configurable = desc.enumerable = true;
         if ("value" in desc) desc.writable = true;

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/ignore-symbol/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/ignore-symbol/actual.js
@@ -1,3 +1,0 @@
-var foo = {
-  [Symbol.iterator]: "foobar"
-};

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/ignore-symbol/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/ignore-symbol/expected.js
@@ -1,3 +1,0 @@
-var _foo;
-
-var foo = (_foo = {}, _foo[Symbol.iterator] = "foobar", _foo);

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/symbol/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/symbol/actual.js
@@ -1,0 +1,7 @@
+var k = Symbol();
+var foo = {
+  [Symbol.iterator]: "foobar",
+  get [k]() {
+    return k;
+  }
+};

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/symbol/exec.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/symbol/exec.js
@@ -1,0 +1,10 @@
+var k = Symbol();
+var foo = {
+  [Symbol.iterator]: "foobar",
+  get [k]() {
+    return k;
+  }
+};
+
+assert(foo[Symbol.iterator], "foobar")
+assert(foo[k], k)

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/symbol/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/loose/symbol/expected.js
@@ -1,0 +1,6 @@
+var _foo, _mutatorMap;
+
+var k = Symbol();
+var foo = (_foo = {}, _foo[Symbol.iterator] = "foobar", _mutatorMap = {}, _mutatorMap[k] = _mutatorMap[k] || {}, _mutatorMap[k].get = function () {
+  return k;
+}, babelHelpers.defineEnumerableProperties(_foo, _mutatorMap), _foo);

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/ignore-symbol/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/ignore-symbol/actual.js
@@ -1,3 +1,0 @@
-var foo = {
-  [Symbol.iterator]: "foobar"
-};

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/ignore-symbol/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/ignore-symbol/expected.js
@@ -1,1 +1,0 @@
-var foo = babelHelpers.defineProperty({}, Symbol.iterator, "foobar");

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/symbol/actual.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/symbol/actual.js
@@ -1,0 +1,7 @@
+var k = Symbol();
+var foo = {
+  [Symbol.iterator]: "foobar",
+  get [k]() {
+    return k;
+  }
+};

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/symbol/exec.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/symbol/exec.js
@@ -1,0 +1,10 @@
+var k = Symbol();
+var foo = {
+  [Symbol.iterator]: "foobar",
+  get [k]() {
+    return k;
+  }
+};
+
+assert(foo[Symbol.iterator], "foobar")
+assert(foo[k], k)

--- a/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/symbol/expected.js
+++ b/packages/babel-plugin-transform-es2015-computed-properties/test/fixtures/spec/symbol/expected.js
@@ -1,0 +1,6 @@
+var _foo, _mutatorMap;
+
+var k = Symbol();
+var foo = (_foo = {}, babelHelpers.defineProperty(_foo, Symbol.iterator, "foobar"), _mutatorMap = {}, _mutatorMap[k] = _mutatorMap[k] || {}, _mutatorMap[k].get = function () {
+  return k;
+}, babelHelpers.defineEnumerableProperties(_foo, _mutatorMap), _foo);


### PR DESCRIPTION
Fixes #3768
Closes #3701.