### PR TITLE
Fix block-scoping throwing error when handling loop not in BlockStatement

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -538,9 +538,19 @@ class BlockScoping {
     let fnPath;
     if (this.loop) {
       const ref = this.scope.generateUidIdentifier("loop");
-      const p = this.loopPath.insertBefore(
+      let transformedToBlockStatement = false;
+      if (this.loopPath.isStatementOrBlock()) {
+        transformedToBlockStatement = true;
+      }
+
+      let p = this.loopPath.insertBefore(
         t.variableDeclaration("var", [t.variableDeclarator(ref, fn)]),
       );
+
+      if (transformedToBlockStatement) {
+        p = [p[0].get("body.0")];
+        this.loopPath.requeue();
+      }
 
       placeholder.replaceWith(ref);
       fnPath = p[0].get("declarations.0.init");

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4363/actual.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4363/actual.js
@@ -1,0 +1,18 @@
+function WithoutCurlyBraces() {
+  if (true)
+    for (let k in kv) {
+        function foo() { return this }
+        function bar() { return foo.call(this) }
+        console.log(this, k) // => undefined
+    }
+}
+
+function WithCurlyBraces() {
+  if (true) {
+    for (let k in kv) {
+        function foo() { return this }
+        function bar() { return foo.call(this) }
+        console.log(this, k) // => 777
+    }
+  }
+}

--- a/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4363/expected.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/issue-4363/expected.js
@@ -1,0 +1,43 @@
+function WithoutCurlyBraces() {
+  var _this = this;
+
+  if (true) {
+    var _loop = function (k) {
+      function foo() {
+        return this;
+      }
+
+      function bar() {
+        return foo.call(this);
+      }
+
+      console.log(_this, k); // => undefined
+    };
+
+    for (var k in kv) {
+      _loop(k);
+    }
+  }
+}
+
+function WithCurlyBraces() {
+  var _this2 = this;
+
+  if (true) {
+    var _loop2 = function (k) {
+      function foo() {
+        return this;
+      }
+
+      function bar() {
+        return foo.call(this);
+      }
+
+      console.log(_this2, k); // => 777
+    };
+
+    for (var k in kv) {
+      _loop2(k);
+    }
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #4363
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 👍
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | 
| Any Dependency Changes?  | 


Since #5677 was merged this example is making babel throw:

```js
function WithoutCurlyBraces() {
    if (true)
      for (let k in kv) {
          function foo() { return this }
          function bar() { return foo.call(this) }
          console.log(bar.call(this))
      }
}
```

```
TypeError: /Users/danieltschinder/Documents/Github/babel/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/general/forifabc/actual.js: Cannot read property '0' of undefined
      at NodePath._getKey (packages/babel-traverse/lib/path/family.js:124:26)
      at NodePath.get (packages/babel-traverse/lib/path/family.js:116:17)
      at NodePath._getPattern (packages/babel-traverse/lib/path/family.js:156:21)
      at NodePath.get (packages/babel-traverse/lib/path/family.js:118:17)
      at BlockScoping.wrapClosure (packages/babel-plugin-transform-es2015-block-scoping/lib/index.js:482:21)
      at BlockScoping.run (packages/babel-plugin-transform-es2015-block-scoping/lib/index.js:344:12)
```

In babel v6 the output was simply wrong (see #4363), but in v7 it does not work anymore. After looking at the changes the problem is that we are relying on the return of `path.insertBefore()` and expecting it to always be the `Path` to the `Node` we just inserted.
This is not the case in certain cases, the return value of `insertBefore` can be:
* The Path itself (https://github.com/babel/babel/blob/7.0/packages/babel-traverse/src/path/modification.js#L40)
* The Path itself after it was replaced (For example if it was replaced with a `BlockStatement` https://github.com/babel/babel/blob/7.0/packages/babel-traverse/src/path/modification.js#L32)
* The Path of the newly inserted nodes if the container of the path is an array. (https://github.com/babel/babel/blob/7.0/packages/babel-traverse/src/path/modification.js#L29)

This is very inconsistent and relying on the output is a little bit risky.
I did not change babel-traverse, but only fixed the issue inside the block-scoping transform for now as I don't know what the expected return should be.

After fixing this in the block-scoping itself there is good news: The hoisting works correctly now and both functions use the correct `this`. 🎉

The only remaining issue was that in the output was still a `let` declaration. After investigating it is because the implicitly created `BlockStatement` in `insertBefore()` will not be visited as it is added to an already visited key. Simply requeueing the newly created `BlockStatement` fixed the last issue.
I also tried to add the requeueing call to `insertBefore()` itself and all tests worked, but I also only added it to blockHoisting for now as I wasn't sure.

So my questions are:

What should the return value of `insertBefore()` be? Maybe that was the reason why it wasn't used in the block-scoping-transform before #5677 

Should we try to always return the inserted path?

Do you think it is save to add the `path.requeue()` call to `insertBefore()` after creating a `BlockStatement`?

> Probably also the same thing would then also need to be done for `insertAfter()`
