### PR TITLE
Allow NodeJS v8.4 experimental HTTP2

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -53,7 +53,7 @@ getV8Flags(function(err, v8Flags) {
       case "-gc":
         args.unshift("--expose-gc");
         break;
-        
+
       case "--expose-http2":
         args.unshift("--expose-http2");
         break;

--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -53,6 +53,10 @@ getV8Flags(function(err, v8Flags) {
       case "-gc":
         args.unshift("--expose-gc");
         break;
+        
+      case "--expose-http2":
+        args.unshift("--expose-http2");
+        break;
 
       case "--nolazy":
         args.unshift(flag);


### PR DESCRIPTION
Native NodeJS HTTP/2 support experimental though, so might not be worth merging this

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Node Runtime Flag `--expose-http2` was ignored
| Patch: Bug Fix?          |  Bug Fix (Experimental Feature)
| Major: Breaking Change?  |  No
| Minor: New Feature?      |  Allow babel-node to pass `--expose-http2` to node process
| Tests Added/Pass?        |  None, Yes
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | No, <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  |  Requires Node 8.4+, until `--expose-http2` is removed.

<!-- Describe your changes below in as much detail as possible -->
Pass the experimental `--expose-http2` flag to the node process