### PR TITLE
Remove hard-coded package list from babel-standalone

### DIFF
--- a/packages/babel-standalone/src/index.js
+++ b/packages/babel-standalone/src/index.js
@@ -136,88 +136,30 @@ export function registerPresets(newPresets) {
   );
 }
 
-// All the plugins we should bundle
-registerPlugins({
-  "check-es2015-constants": require("babel-plugin-check-es2015-constants"),
-  "external-helpers": require("babel-plugin-external-helpers"),
-  "syntax-async-functions": require("babel-plugin-syntax-async-functions"),
-  "syntax-async-generators": require("babel-plugin-syntax-async-generators"),
-  "syntax-class-properties": require("babel-plugin-syntax-class-properties"),
-  "syntax-decorators": require("babel-plugin-syntax-decorators"),
-  "syntax-do-expressions": require("babel-plugin-syntax-do-expressions"),
-  "syntax-exponentiation-operator": require("babel-plugin-syntax-exponentiation-operator"),
-  "syntax-export-extensions": require("babel-plugin-syntax-export-extensions"),
-  "syntax-flow": require("babel-plugin-syntax-flow"),
-  "syntax-function-bind": require("babel-plugin-syntax-function-bind"),
-  "syntax-function-sent": require("babel-plugin-syntax-function-sent"),
-  "syntax-jsx": require("babel-plugin-syntax-jsx"),
-  "syntax-object-rest-spread": require("babel-plugin-syntax-object-rest-spread"),
-  "syntax-trailing-function-commas": require("babel-plugin-syntax-trailing-function-commas"),
-  "transform-async-functions": require("babel-plugin-transform-async-functions"),
-  "transform-async-to-generator": require("babel-plugin-transform-async-to-generator"),
-  "transform-async-to-module-method": require("babel-plugin-transform-async-to-module-method"),
-  "transform-class-properties": require("babel-plugin-transform-class-properties"),
-  "transform-decorators": require("babel-plugin-transform-decorators"),
-  "transform-do-expressions": require("babel-plugin-transform-do-expressions"),
-  "transform-es2015-arrow-functions": require("babel-plugin-transform-es2015-arrow-functions"),
-  "transform-es2015-block-scoped-functions": require("babel-plugin-transform-es2015-block-scoped-functions"),
-  "transform-es2015-block-scoping": require("babel-plugin-transform-es2015-block-scoping"),
-  "transform-es2015-classes": require("babel-plugin-transform-es2015-classes"),
-  "transform-es2015-computed-properties": require("babel-plugin-transform-es2015-computed-properties"),
-  "transform-es2015-destructuring": require("babel-plugin-transform-es2015-destructuring"),
-  "transform-es2015-duplicate-keys": require("babel-plugin-transform-es2015-duplicate-keys"),
-  "transform-es2015-for-of": require("babel-plugin-transform-es2015-for-of"),
-  "transform-es2015-function-name": require("babel-plugin-transform-es2015-function-name"),
-  "transform-es2015-instanceof": require("babel-plugin-transform-es2015-instanceof"),
-  "transform-es2015-literals": require("babel-plugin-transform-es2015-literals"),
-  "transform-es2015-modules-amd": require("babel-plugin-transform-es2015-modules-amd"),
-  "transform-es2015-modules-commonjs": require("babel-plugin-transform-es2015-modules-commonjs"),
-  "transform-es2015-modules-systemjs": require("babel-plugin-transform-es2015-modules-systemjs"),
-  "transform-es2015-modules-umd": require("babel-plugin-transform-es2015-modules-umd"),
-  "transform-es2015-object-super": require("babel-plugin-transform-es2015-object-super"),
-  "transform-es2015-parameters": require("babel-plugin-transform-es2015-parameters"),
-  "transform-es2015-shorthand-properties": require("babel-plugin-transform-es2015-shorthand-properties"),
-  "transform-es2015-spread": require("babel-plugin-transform-es2015-spread"),
-  "transform-es2015-sticky-regex": require("babel-plugin-transform-es2015-sticky-regex"),
-  "transform-es2015-template-literals": require("babel-plugin-transform-es2015-template-literals"),
-  "transform-es2015-typeof-symbol": require("babel-plugin-transform-es2015-typeof-symbol"),
-  "transform-es2015-unicode-regex": require("babel-plugin-transform-es2015-unicode-regex"),
-  "transform-es3-member-expression-literals": require("babel-plugin-transform-es3-member-expression-literals"),
-  "transform-es3-property-literals": require("babel-plugin-transform-es3-property-literals"),
-  "transform-es5-property-mutators": require("babel-plugin-transform-es5-property-mutators"),
-  "transform-eval": require("babel-plugin-transform-eval"),
-  "transform-exponentiation-operator": require("babel-plugin-transform-exponentiation-operator"),
-  "transform-export-extensions": require("babel-plugin-transform-export-extensions"),
-  "transform-flow-comments": require("babel-plugin-transform-flow-comments"),
-  "transform-flow-strip-types": require("babel-plugin-transform-flow-strip-types"),
-  "transform-function-bind": require("babel-plugin-transform-function-bind"),
-  "transform-jscript": require("babel-plugin-transform-jscript"),
-  "transform-object-assign": require("babel-plugin-transform-object-assign"),
-  "transform-object-rest-spread": require("babel-plugin-transform-object-rest-spread"),
-  "transform-object-set-prototype-of-to-assign": require("babel-plugin-transform-object-set-prototype-of-to-assign"),
-  "transform-proto-to-assign": require("babel-plugin-transform-proto-to-assign"),
-  "transform-react-constant-elements": require("babel-plugin-transform-react-constant-elements"),
-  "transform-react-display-name": require("babel-plugin-transform-react-display-name"),
-  "transform-react-inline-elements": require("babel-plugin-transform-react-inline-elements"),
-  "transform-react-jsx": require("babel-plugin-transform-react-jsx"),
-  "transform-react-jsx-compat": require("babel-plugin-transform-react-jsx-compat"),
-  "transform-react-jsx-self": require("babel-plugin-transform-react-jsx-self"),
-  "transform-react-jsx-source": require("babel-plugin-transform-react-jsx-source"),
-  "transform-regenerator": require("babel-plugin-transform-regenerator"),
-  "transform-runtime": require("babel-plugin-transform-runtime"),
-  "transform-strict-mode": require("babel-plugin-transform-strict-mode"),
+// Bundle all the plugins included in the Babel repo
+const pluginContext = require.context(
+  __dirname + "/../../",
+  /*useSubdirectories*/ true,
+  /*filter*/ /\.\/babel-plugin-.+\/lib\/index\.js/,
+);
+pluginContext.keys().forEach(fileName => {
+  const name = fileName.match(/babel-plugin-([^/]+)\//)[1];
+  registerPlugin(name, pluginContext(fileName));
 });
 
-// All the presets we should bundle
+// Bundle all the presets included in the Babel repo
+const presetContext = require.context(
+  __dirname + "/../../",
+  /*useSubdirectories*/ true,
+  /*filter*/ /\.\/babel-preset-.+\/lib\/index\.js/,
+);
+presetContext.keys().forEach(fileName => {
+  const name = fileName.match(/babel-preset-([^/]+)\//)[1];
+  registerPreset(name, presetContext(fileName));
+});
+
+// Custom presets for backwards compatibility
 registerPresets({
-  es2015: require("babel-preset-es2015"),
-  es2016: require("babel-preset-es2016"),
-  es2017: require("babel-preset-es2017"),
-  react: require("babel-preset-react"),
-  "stage-0": require("babel-preset-stage-0"),
-  "stage-1": require("babel-preset-stage-1"),
-  "stage-2": require("babel-preset-stage-2"),
-  "stage-3": require("babel-preset-stage-3"),
   "es2015-loose": {
     presets: [[require("babel-preset-es2015"), { loose: true }]],
   },
@@ -225,8 +167,6 @@ registerPresets({
   "es2015-no-commonjs": {
     presets: [[require("babel-preset-es2015"), { modules: false }]],
   },
-  typescript: require("babel-preset-typescript"),
-  flow: require("babel-preset-flow"),
 });
 
 export const version = VERSION;


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | N/A
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added/Pass?        | No / Yes (existing babel-standalone test)
| Spec Compliancy?         | N/A
| License                  | MIT
| Doc PR                   | No
| Any Dependency Changes?  | No

Uses some [Webpack magic (context module API)](https://webpack.js.org/guides/dependency-management/#context-module-api) to automatically bundle every plugin and preset, instead of having to use a hard-coded list.

There's a little bit of copypasta (since plugins and presets use very similar code to get the package list) but `require.context` requires all arguments to be literals so there's not much I can do to avoid that.

Tested the example file locally, it works!
![](http://ss.dan.cx/2017/08/babel-standalone_example_-_Google_Chrome_30-21.38.31.png)

Checked `Babel.availablePresets` and `Babel.availablePlugins` to ensure they're all there with the correct names
![](http://ss.dan.cx/2017/08/babel-standalone_example_-_Google_Chrome_30-21.41.16.png)