### PR TITLE
Fix lerna version and remove bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,7 @@ publish:
 
 bootstrap:
 	make clean-all
-	yarn
-	./node_modules/.bin/lerna bootstrap
+	yarn install
 	make build
 	cd packages/babel-runtime; \
 	node scripts/build-dist.js

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-rc.4",
+  "lerna": "2.0.0",
   "version": "7.0.0-alpha.20",
   "changelog": {
     "repo": "babel/babel",


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

lerna bootstrap is not necessary anymore now as we use workspaces.
