### PR TITLE
Added --delete-dir-on-start option for babel

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -63,6 +63,9 @@ export default function(commander, filenames, opts) {
     if (stat.isDirectory(filename)) {
       const dirname = filename;
 
+      if (commander.deleteDirOnStart) {
+        util.deleteDir(dirname);
+      }
       util.readdir(dirname).forEach(function(filename) {
         const src = path.join(dirname, filename);
         handleFile(src, filename);

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -64,7 +64,7 @@ export default function(commander, filenames, opts) {
       const dirname = filename;
 
       if (commander.deleteDirOnStart) {
-        util.deleteDir(dirname);
+        util.deleteDir(commander.outDir);
       }
       util.readdir(dirname).forEach(function(filename) {
         const src = path.join(dirname, filename);

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -223,6 +223,7 @@ delete opts.outDir;
 delete opts.copyFiles;
 delete opts.quiet;
 delete opts.configFile;
+delete opts.deleteDirOnStart;
 
 // Commander will default the "--no-" arguments to true, but we want to leave them undefined so that
 // babel-core can handle the default-assignment logic on its own.

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -147,6 +147,7 @@ commander.option(
   "When compiling a directory copy over non-compilable files",
 );
 commander.option("-q, --quiet", "Don't log anything");
+commander.option("-l, --delete-dir-on-start", "Delete's the out directory before compilation");
 /* eslint-enable max-len */
 
 commander.version(pkg.version + " (babel-core " + version + ")");
@@ -191,6 +192,9 @@ if (commander.watch) {
 
 if (commander.skipInitialBuild && !commander.watch) {
   errors.push("--skip-initial-build requires --watch");
+}
+if (commander.deleteDirOnStart && !commander.outDir) {
+  errors.push("--delete-dir-on-start requires --out-dir");
 }
 
 if (errors.length) {

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -147,7 +147,10 @@ commander.option(
   "When compiling a directory copy over non-compilable files",
 );
 commander.option("-q, --quiet", "Don't log anything");
-commander.option("-l, --delete-dir-on-start", "Delete's the out directory before compilation");
+commander.option(
+  "--delete-dir-on-start",
+  "Delete's the out directory before compilation",
+);
 /* eslint-enable max-len */
 
 commander.version(pkg.version + " (babel-core " + version + ")");

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -59,12 +59,14 @@ export function compile(filename, opts) {
 }
 
 export function deleteDir(path) {
-  if (fs.existsSync(path) ) {
+  if (fs.existsSync(path)) {
     fs.readdirSync(path).forEach(function(file) {
       const curPath = path + "/" + file;
-      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+      if (fs.lstatSync(curPath).isDirectory()) {
+        // recurse
         deleteDir(curPath);
-      } else { // delete file
+      } else {
+        // delete file
         fs.unlinkSync(curPath);
       }
     });

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -58,6 +58,20 @@ export function compile(filename, opts) {
   }
 }
 
+export function deleteDir(path) {
+  if (fs.existsSync(path) ) {
+    fs.readdirSync(path).forEach(function(file) {
+      const curPath = path + "/" + file;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        deleteDir(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(path);
+  }
+}
+
 function toErrorStack(err) {
   if (err._babel && err instanceof SyntaxError) {
     return `${err.name}: ${err.message}\n${err.codeFrame}`;


### PR DESCRIPTION
https://github.com/babel/babel/blob/7.0/CONTRIBUTING.md , added `--delete-dir-on-start` option to remove the deleted files or directory in the source directory from the out directory #5636


| Q | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix? | No
| Major: Breaking Change? | No
| Minor: New Feature? | yes
| Deprecations? | No
| Spec Compliancy? | No
| Tests Added/Pass? | No
| Fixed Tickets | Fixes [#5636 ](https://github.com/babel/babel/issues/5636)
| License | MIT
| Doc PR | yes,  
| Dependency Changes | No


Added deleteDir function in the packages/babel-cli/src/babel/util.js that recursuvely delete all the files and directory in the directory how's path is passed .

Added option with `-l` or` --delete-dir-on-start`  and added checks that this option can only be used with `--out-dir` in packages/babel-cli/src/babel/index.js

called util.deleteDir function in  packages/babel-cli/src/babel/dir.js just before compilation to delete the the out directory

[Original PR](https://github.com/babel/babel/pull/5674)