### PR TITLE
Derived constructors don't always need a super call

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-must-call-super/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-must-call-super/actual.js
@@ -1,0 +1,5 @@
+class Foo extends Bar {
+  constructor() {
+
+  }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-must-call-super/options.json
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-must-call-super/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "missing super() call in constructor",
+  "plugins": ["transform-es2015-classes"]
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/actual.js
@@ -1,0 +1,5 @@
+class Child extends Base {
+    constructor(){
+      return false;
+    }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/expected.js
@@ -1,0 +1,11 @@
+var Child = function (_Base) {
+  babelHelpers.inheritsLoose(Child, _Base);
+
+  function Child() {
+    var _this;
+
+    return false || _this;
+  }
+
+  return Child;
+}(Base);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-object/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-object/actual.js
@@ -1,0 +1,5 @@
+class Child extends Base {
+    constructor(){
+      return {};
+    }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-object/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-object/expected.js
@@ -1,0 +1,11 @@
+var Child = function (_Base) {
+  babelHelpers.inheritsLoose(Child, _Base);
+
+  function Child() {
+    var _this;
+
+    return {} || _this;
+  }
+
+  return Child;
+}(Base);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/actual.js
@@ -1,0 +1,5 @@
+class Child extends Base {
+    constructor(){
+        return false;
+    }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/expected.js
@@ -1,0 +1,12 @@
+var Child = function (_Base) {
+  babelHelpers.inherits(Child, _Base);
+
+  function Child() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Child);
+    return babelHelpers.possibleConstructorReturn(_this, false);
+  }
+
+  return Child;
+}(Base);

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-object/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-object/actual.js
@@ -1,0 +1,5 @@
+class Child extends Base {
+    constructor(){
+        return {};
+    }
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-object/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-object/expected.js
@@ -1,0 +1,12 @@
+var Child = function (_Base) {
+  babelHelpers.inherits(Child, _Base);
+
+  function Child() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Child);
+    return babelHelpers.possibleConstructorReturn(_this, {});
+  }
+
+  return Child;
+}(Base);


### PR DESCRIPTION
Fixes #4210.