### PR TITLE
fix(requeue): Always requeue implicitly created BlockStatements

### DIFF
--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -443,7 +443,7 @@ export default class Printer {
   }
 
   printAndIndentOnComments(node, parent) {
-    const indent = !!node.leadingComments;
+    const indent = node.leadingComments && node.leadingComments.length > 0;
     if (indent) this.indent();
     this.print(node, parent);
     if (indent) this.dedent();
@@ -468,7 +468,7 @@ export default class Printer {
   }
 
   printInnerComments(node, indent = true) {
-    if (!node.innerComments) return;
+    if (!node.innerComments || !node.innerComments.length) return;
     if (indent) this.indent();
     this._printComments(node.innerComments);
     if (indent) this.dedent();

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -29,7 +29,7 @@ export function insertBefore(nodes) {
     return this._containerInsertBefore(nodes);
   } else if (this.isStatementOrBlock()) {
     if (this.node) nodes.push(this.node);
-    this._replaceWith(t.blockStatement(nodes));
+    this.replaceWith(t.blockStatement(nodes));
   } else {
     throw new Error(
       "We don't know what to do with this node type. " +
@@ -104,10 +104,6 @@ export function _containerInsertAfter(nodes) {
  */
 
 export function insertAfter(nodes) {
-  return this._insertAfter(nodes);
-}
-
-export function _insertAfter(nodes, shouldRequeue = false) {
   this._assertUnremoved();
 
   nodes = this._verifyNodeList(nodes);
@@ -116,10 +112,7 @@ export function _insertAfter(nodes, shouldRequeue = false) {
     this.parentPath.isExpressionStatement() ||
     this.parentPath.isLabeledStatement()
   ) {
-    // `replaceWithMultiple` requeues if there's a replacement for this.node,
-    // but not for an ancestor's. Set `shouldRequeue` to true so that any replacement
-    // for an ancestor node can be enqueued. Fix #5628 and #5023.
-    return this.parentPath._insertAfter(nodes, true);
+    return this.parentPath.insertAfter(nodes);
   } else if (
     this.isNodeType("Expression") ||
     (this.parentPath.isForStatement() && this.key === "init")
@@ -142,10 +135,7 @@ export function _insertAfter(nodes, shouldRequeue = false) {
     ) {
       nodes.unshift(this.node);
     }
-    this._replaceWith(t.blockStatement(nodes));
-    if (shouldRequeue) {
-      this.requeue();
-    }
+    this.replaceWith(t.blockStatement(nodes));
   } else {
     throw new Error(
       "We don't know what to do with this node type. " +


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | 
| Tests Added/Pass?        | y
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

This reverts the former fix done in #5743 and always requeues BlockStatements when they get created. One case where this was still happening was #6160. 
The new fix simply changes from `this._replaceWith()` to `this.replaceWith()`. This will correctly requeue the path and the additional checks probably won't hurt.
 
This also fixes a bug in babel-generator which would indent code even though no comments are present.
