### PR TITLE
Ignore the standalone output bundle so it will require() faster.

### DIFF
--- a/.babelignore
+++ b/.babelignore
@@ -1,3 +1,4 @@
 # Ensure babel-register won't compile fixtures, or try to recompile compiled code.
 packages/*/test/fixtures
 packages/*/lib
+packages/babel-standalone/babel.js


### PR DESCRIPTION
Quick fix. We load this file in the unit tests and it's re-processed through `babel-register` which we both don't want, and also slows things down.