### PR TITLE
Annotating transformed classes with #__PURE__ comment

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1155/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1155/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(options) {

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -54,7 +54,9 @@ function _asyncToGenerator(fn) { return function () { var _this = this, _argumen
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var Foo = function () {
+var Foo =
+/*#__PURE__*/
+function () {
   function Foo() {
     _classCallCheck(this, Foo);
   }

--- a/packages/babel-core/test/fixtures/transformation/source-maps/class/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/class/expected.js
@@ -1,4 +1,6 @@
-var Test = function () {
+var Test =
+/*#__PURE__*/
+function () {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
   }

--- a/packages/babel-core/test/fixtures/transformation/source-maps/class/source-mappings.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/class/source-mappings.json
@@ -4,7 +4,7 @@
     "column": 10
   },
   "generated": {
-    "line": 9,
+    "line": 11,
     "column": 15
   }
 }]

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/derived/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/foobar/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var Child = function (_Parent) {
+var Child =
+/*#__PURE__*/
+function (_Parent) {
   babelHelpers.inherits(Child, _Parent);
 
   function Child() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/non-block-arrow-func/expected.js
@@ -1,7 +1,9 @@
 export default (param => {
   var _class, _temp;
 
-  return _temp = _class = function () {
+  return _temp = _class =
+  /*#__PURE__*/
+  function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/regression-T6719/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/regression-T6719/expected.js
@@ -1,7 +1,9 @@
 function withContext(ComposedComponent) {
   var _class, _temp;
 
-  return _temp = _class = function (_Component) {
+  return _temp = _class =
+  /*#__PURE__*/
+  function (_Component) {
     babelHelpers.inherits(WithContext, _Component);
 
     function WithContext() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-call/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-call/expected.js
@@ -1,4 +1,6 @@
-var A = function () {
+var A =
+/*#__PURE__*/
+function () {
   function A() {
     babelHelpers.classCallCheck(this, A);
   }
@@ -12,7 +14,9 @@ var A = function () {
   return A;
 }();
 
-var B = function (_A) {
+var B =
+/*#__PURE__*/
+function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B(...args) {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-expression/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-expression/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-statement/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/general/super-statement/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/loose/derived/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/loose/derived/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/loose/foobar/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/loose/foobar/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var Child = function (_Parent) {
+var Child =
+/*#__PURE__*/
+function (_Parent) {
   babelHelpers.inherits(Child, _Parent);
 
   function Child() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/loose/non-block-arrow-func/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/loose/non-block-arrow-func/expected.js
@@ -1,7 +1,9 @@
 export default (param => {
   var _class, _temp;
 
-  return _temp = _class = function () {
+  return _temp = _class =
+  /*#__PURE__*/
+  function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/loose/super-expression/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/loose/super-expression/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/loose/super-statement/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/loose/super-statement/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/expected.js
@@ -15,7 +15,9 @@ var Test = function Test() {
 
   _classCallCheck(this, Test);
 
-  var Other = function (_Test) {
+  var Other =
+  /*#__PURE__*/
+  function (_Test) {
     _inherits(Other, _Test);
 
     function Other() {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/expected.js
@@ -1,7 +1,9 @@
 function withContext(ComposedComponent) {
   var _class, _temp;
 
-  return _temp = _class = function (_Component) {
+  return _temp = _class =
+  /*#__PURE__*/
+  function (_Component) {
     babelHelpers.inherits(WithContext, _Component);
 
     function WithContext() {

--- a/packages/babel-plugin-transform-es2015-classes/src/index.js
+++ b/packages/babel-plugin-transform-es2015-classes/src/index.js
@@ -2,6 +2,8 @@ import LooseTransformer from "./loose";
 import VanillaTransformer from "./vanilla";
 import nameFunction from "babel-helper-function-name";
 
+const PURE_ANNOTATION = "#__PURE__";
+
 export default function({ types: t }) {
   // todo: investigate traversal requeueing
   const VISITED = Symbol();
@@ -51,11 +53,11 @@ export default function({ types: t }) {
 
         path.replaceWith(new Constructor(path, state.file).run());
 
-        if (
-          path.isCallExpression() &&
-          path.get("callee").isArrowFunctionExpression()
-        ) {
-          path.get("callee").arrowFunctionToExpression();
+        if (path.isCallExpression()) {
+          path.addComment("leading", PURE_ANNOTATION);
+          if (path.get("callee").isArrowFunctionExpression()) {
+            path.get("callee").arrowFunctionToExpression();
+          }
         }
       },
     },

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-constructor/expected.js
@@ -2,7 +2,9 @@ let A = function A() {
   console.log('a');
 };
 
-let B = function () {
+let B =
+/*#__PURE__*/
+function () {
   function B() {}
 
   var _proto = B.prototype;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-superClass/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-superClass/expected.js
@@ -2,7 +2,9 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
 
 let B = function B() {};
 
-let A = function (_B) {
+let A =
+/*#__PURE__*/
+function (_B) {
   _inheritsLoose(A, _B);
 
   function A(track) {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-class/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/accessing-super-properties/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/calling-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/calling-super-properties/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/constructor-order/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/constructor-order/expected.js
@@ -1,4 +1,6 @@
-var x = function () {
+var x =
+/*#__PURE__*/
+function () {
   var _proto = x.prototype;
 
   _proto.f = function f() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/expected.js
@@ -1,4 +1,6 @@
-var Child = function (_Base) {
+var Child =
+/*#__PURE__*/
+function (_Base) {
   babelHelpers.inheritsLoose(Child, _Base);
 
   function Child() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-object/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/derived-constructor-no-super-return-object/expected.js
@@ -1,4 +1,6 @@
-var Child = function (_Base) {
+var Child =
+/*#__PURE__*/
+function (_Base) {
   babelHelpers.inheritsLoose(Child, _Base);
 
   function Child() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/literal-key/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/literal-key/expected.js
@@ -1,4 +1,6 @@
-var Foo = function () {
+var Foo =
+/*#__PURE__*/
+function () {
   function Foo() {}
 
   var _proto = Foo.prototype;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
@@ -1,5 +1,7 @@
 // @flow
-var C = function () {
+var C =
+/*#__PURE__*/
+function () {
   function C() {}
 
   var _proto = C.prototype;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/expected.js
@@ -1,4 +1,6 @@
-var Test = function () {
+var Test =
+/*#__PURE__*/
+function () {
   function Test() {}
 
   var _proto = Test.prototype;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/super-class-id-member-expression/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/super-class-id-member-expression/expected.js
@@ -1,4 +1,6 @@
-var BaseController = function (_Chaplin$Controller) {
+var BaseController =
+/*#__PURE__*/
+function (_Chaplin$Controller) {
   babelHelpers.inheritsLoose(BaseController, _Chaplin$Controller);
 
   function BaseController() {
@@ -8,7 +10,9 @@ var BaseController = function (_Chaplin$Controller) {
   return BaseController;
 }(Chaplin.Controller);
 
-var BaseController2 = function (_Chaplin$Controller$A) {
+var BaseController2 =
+/*#__PURE__*/
+function (_Chaplin$Controller$A) {
   babelHelpers.inheritsLoose(BaseController2, _Chaplin$Controller$A);
 
   function BaseController2() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/super-class/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inheritsLoose(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
@@ -16,7 +16,9 @@ var _binarySerializer = require("./helpers/binary-serializer");
 var _binarySerializer2 = babelHelpers.interopRequireDefault(_binarySerializer);
 
 // import ...
-var Connection = function (_EventEmitter) {
+var Connection =
+/*#__PURE__*/
+function (_EventEmitter) {
   babelHelpers.inherits(Connection, _EventEmitter);
 
   function Connection(endpoint, joinKey, joinData, roomId) {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
@@ -9,7 +9,9 @@ var _BaseFoo2 = require("./BaseFoo");
 
 var _BaseFoo3 = babelHelpers.interopRequireDefault(_BaseFoo2);
 
-var SubFoo = function (_BaseFoo) {
+var SubFoo =
+/*#__PURE__*/
+function (_BaseFoo) {
   babelHelpers.inherits(SubFoo, _BaseFoo);
 
   function SubFoo() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
@@ -9,7 +9,9 @@ var _react = require("react");
 
 var _react2 = babelHelpers.interopRequireDefault(_react);
 
-var RandomComponent = function (_Component) {
+var RandomComponent =
+/*#__PURE__*/
+function (_Component) {
   babelHelpers.inherits(RandomComponent, _Component);
 
   function RandomComponent() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
@@ -8,7 +8,9 @@ var b = function b() {
   babelHelpers.classCallCheck(this, b);
 };
 
-var a1 = function (_b) {
+var a1 =
+/*#__PURE__*/
+function (_b) {
   babelHelpers.inherits(a1, _b);
 
   function a1() {
@@ -27,7 +29,9 @@ var a1 = function (_b) {
   return a1;
 }(b);
 
-var a2 = function (_b2) {
+var a2 =
+/*#__PURE__*/
+function (_b2) {
   babelHelpers.inherits(a2, _b2);
 
   function a2() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/5817/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var A = function (_B) {
+var A =
+/*#__PURE__*/
+function (_B) {
   babelHelpers.inherits(A, _B);
 
   function A() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2494/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
 var x = {
-  Foo: function (_Foo) {
+  Foo:
+  /*#__PURE__*/
+  function (_Foo) {
     babelHelpers.inherits(_class, _Foo);
 
     function _class() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T2997/expected.js
@@ -4,7 +4,9 @@ var A = function A() {
   babelHelpers.classCallCheck(this, A);
 };
 
-var B = function (_A) {
+var B =
+/*#__PURE__*/
+function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6712/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6712/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var A = function () {
+var A =
+/*#__PURE__*/
+function () {
   function A() {
     babelHelpers.classCallCheck(this, A);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/expected.js
@@ -5,17 +5,20 @@ Object.defineProperty(exports, "__esModule", {
 });
 
 function _default() {
-  return function () {
-    function Select() {
-      babelHelpers.classCallCheck(this, Select);
-    }
+  return (
+    /*#__PURE__*/
+    function () {
+      function Select() {
+        babelHelpers.classCallCheck(this, Select);
+      }
 
-    babelHelpers.createClass(Select, [{
-      key: "query",
-      value: function query(_query) {}
-    }]);
-    return Select;
-  }();
+      babelHelpers.createClass(Select, [{
+        key: "query",
+        value: function query(_query) {}
+      }]);
+      return Select;
+    }()
+  );
 }
 
 exports.default = _default;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6755/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6755/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var Example = function () {
+var Example =
+/*#__PURE__*/
+function () {
   function Example() {}
 
   var _proto = Example.prototype;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7010/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var Foo = function () {
+var Foo =
+/*#__PURE__*/
+function () {
   function Foo(val) {
     babelHelpers.classCallCheck(this, Foo);
     this._val = val;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T7537/expected.js
@@ -12,7 +12,9 @@ var B = function B() {
   _classCallCheck(this, B);
 };
 
-var A = function (_B) {
+var A =
+/*#__PURE__*/
+function (_B) {
   _inherits(A, _B);
 
   function A(track) {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-class/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/accessing-super-properties/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/calling-super-properties/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/calling-super-properties/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/computed-methods/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/computed-methods/expected.js
@@ -1,4 +1,6 @@
-var Foo = function () {
+var Foo =
+/*#__PURE__*/
+function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
@@ -3,7 +3,9 @@ var Test = function Test() {
   this.state = "test";
 };
 
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/expected.js
@@ -1,4 +1,6 @@
-var Child = function (_Base) {
+var Child =
+/*#__PURE__*/
+function (_Base) {
   babelHelpers.inherits(Child, _Base);
 
   function Child() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-object/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/derived-constructor-no-super-return-object/expected.js
@@ -1,4 +1,6 @@
-var Child = function (_Base) {
+var Child =
+/*#__PURE__*/
+function (_Base) {
   babelHelpers.inherits(Child, _Base);
 
   function Child() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/export-super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/export-super-class/expected.js
@@ -1,4 +1,6 @@
-var _class = function (_A) {
+var _class =
+/*#__PURE__*/
+function (_A) {
   babelHelpers.inherits(_class, _A);
 
   function _class() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-getter-and-setter/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-getter-and-setter/expected.js
@@ -1,4 +1,6 @@
-var Test = function () {
+var Test =
+/*#__PURE__*/
+function () {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-getter/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-getter/expected.js
@@ -1,4 +1,6 @@
-var Test = function () {
+var Test =
+/*#__PURE__*/
+function () {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-method/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-method/expected.js
@@ -1,4 +1,6 @@
-var Test = function () {
+var Test =
+/*#__PURE__*/
+function () {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-setter/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/instance-setter/expected.js
@@ -1,4 +1,6 @@
-var Test = function () {
+var Test =
+/*#__PURE__*/
+function () {
   function Test() {
     babelHelpers.classCallCheck(this, Test);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/method-return-type-annotation/expected.js
@@ -1,5 +1,7 @@
 // @flow
-var C = function () {
+var C =
+/*#__PURE__*/
+function () {
   function C() {
     babelHelpers.classCallCheck(this, C);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/name-method-collision/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/name-method-collision/expected.js
@@ -2,7 +2,9 @@
 
 var _a2 = require("./a");
 
-var Foo = function () {
+var Foo =
+/*#__PURE__*/
+function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/relaxed-method-coercion/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/relaxed-method-coercion/expected.js
@@ -1,5 +1,7 @@
 // #1649
-var Foo = function () {
+var Foo =
+/*#__PURE__*/
+function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/statement/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/statement/expected.js
@@ -8,7 +8,9 @@ var BaseView = function BaseView() {
   this.autoRender = true;
 };
 
-var BaseView = function () {
+var BaseView =
+/*#__PURE__*/
+function () {
   function BaseView() {
     babelHelpers.classCallCheck(this, BaseView);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/static/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/static/expected.js
@@ -1,4 +1,6 @@
-var A = function () {
+var A =
+/*#__PURE__*/
+function () {
   function A() {
     babelHelpers.classCallCheck(this, A);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-anonymous/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-anonymous/expected.js
@@ -1,4 +1,6 @@
-var TestEmpty = function (_ref) {
+var TestEmpty =
+/*#__PURE__*/
+function (_ref) {
   babelHelpers.inherits(TestEmpty, _ref);
 
   function TestEmpty() {
@@ -7,7 +9,9 @@ var TestEmpty = function (_ref) {
   }
 
   return TestEmpty;
-}(function () {
+}(
+/*#__PURE__*/
+function () {
   function _class() {
     babelHelpers.classCallCheck(this, _class);
   }
@@ -15,7 +19,9 @@ var TestEmpty = function (_ref) {
   return _class;
 }());
 
-var TestConstructorOnly = function (_ref2) {
+var TestConstructorOnly =
+/*#__PURE__*/
+function (_ref2) {
   babelHelpers.inherits(TestConstructorOnly, _ref2);
 
   function TestConstructorOnly() {
@@ -24,7 +30,9 @@ var TestConstructorOnly = function (_ref2) {
   }
 
   return TestConstructorOnly;
-}(function () {
+}(
+/*#__PURE__*/
+function () {
   function _class2() {
     babelHelpers.classCallCheck(this, _class2);
   }
@@ -32,7 +40,9 @@ var TestConstructorOnly = function (_ref2) {
   return _class2;
 }());
 
-var TestMethodOnly = function (_ref3) {
+var TestMethodOnly =
+/*#__PURE__*/
+function (_ref3) {
   babelHelpers.inherits(TestMethodOnly, _ref3);
 
   function TestMethodOnly() {
@@ -41,7 +51,9 @@ var TestMethodOnly = function (_ref3) {
   }
 
   return TestMethodOnly;
-}(function () {
+}(
+/*#__PURE__*/
+function () {
   function _class3() {
     babelHelpers.classCallCheck(this, _class3);
   }
@@ -53,7 +65,9 @@ var TestMethodOnly = function (_ref3) {
   return _class3;
 }());
 
-var TestConstructorAndMethod = function (_ref4) {
+var TestConstructorAndMethod =
+/*#__PURE__*/
+function (_ref4) {
   babelHelpers.inherits(TestConstructorAndMethod, _ref4);
 
   function TestConstructorAndMethod() {
@@ -62,7 +76,9 @@ var TestConstructorAndMethod = function (_ref4) {
   }
 
   return TestConstructorAndMethod;
-}(function () {
+}(
+/*#__PURE__*/
+function () {
   function _class4() {
     babelHelpers.classCallCheck(this, _class4);
   }
@@ -74,7 +90,9 @@ var TestConstructorAndMethod = function (_ref4) {
   return _class4;
 }());
 
-var TestMultipleMethods = function (_ref5) {
+var TestMultipleMethods =
+/*#__PURE__*/
+function (_ref5) {
   babelHelpers.inherits(TestMultipleMethods, _ref5);
 
   function TestMultipleMethods() {
@@ -83,7 +101,9 @@ var TestMultipleMethods = function (_ref5) {
   }
 
   return TestMultipleMethods;
-}(function () {
+}(
+/*#__PURE__*/
+function () {
   function _class5() {
     babelHelpers.classCallCheck(this, _class5);
   }

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-id-member-expression/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class-id-member-expression/expected.js
@@ -1,4 +1,6 @@
-var BaseController = function (_Chaplin$Controller) {
+var BaseController =
+/*#__PURE__*/
+function (_Chaplin$Controller) {
   babelHelpers.inherits(BaseController, _Chaplin$Controller);
 
   function BaseController() {
@@ -9,7 +11,9 @@ var BaseController = function (_Chaplin$Controller) {
   return BaseController;
 }(Chaplin.Controller);
 
-var BaseController2 = function (_Chaplin$Controller$A) {
+var BaseController2 =
+/*#__PURE__*/
+function (_Chaplin$Controller$A) {
   babelHelpers.inherits(BaseController2, _Chaplin$Controller$A);
 
   function BaseController2() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-class/expected.js
@@ -1,4 +1,6 @@
-var Test = function (_Foo) {
+var Test =
+/*#__PURE__*/
+function (_Foo) {
   babelHelpers.inherits(Test, _Foo);
 
   function Test() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-before-in-lambda/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/super-reference-in-prop-exression/expected.js
@@ -1,4 +1,6 @@
-var Foo = function (_Bar) {
+var Foo =
+/*#__PURE__*/
+function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/class-method/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/class-method/expected.js
@@ -1,4 +1,6 @@
-let Foo = function () {
+let Foo =
+/*#__PURE__*/
+function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
   }

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-2/expected.js
@@ -9,7 +9,9 @@ var _last2 = require("lodash/last");
 
 var _last3 = babelHelpers.interopRequireDefault(_last2);
 
-let Container = function () {
+let Container =
+/*#__PURE__*/
+function () {
   function Container() {
     babelHelpers.classCallCheck(this, Container);
   }

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-3/expected.js
@@ -7,7 +7,9 @@ exports.default = void 0;
 
 var _store = require("./store");
 
-let Login = function (_React$Component) {
+let Login =
+/*#__PURE__*/
+function (_React$Component) {
   babelHelpers.inherits(Login, _React$Component);
 
   function Login() {

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules/expected.js
@@ -4,7 +4,9 @@ var _events2 = require("events");
 
 var _events3 = babelHelpers.interopRequireDefault(_events2);
 
-let Template = function () {
+let Template =
+/*#__PURE__*/
+function () {
   function Template() {
     babelHelpers.classCallCheck(this, Template);
   }

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-iife/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-nested-iife/expected.js
@@ -1,6 +1,8 @@
 function broken(x) {
   if (true) {
-    var Foo = function (_Bar) {
+    var Foo =
+    /*#__PURE__*/
+    function (_Bar) {
       babelHelpers.inherits(Foo, _Bar);
 
       function Foo() {

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/6057-expanded/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/6057-expanded/expected.js
@@ -21,7 +21,9 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var App = function (_Component) {
+var App =
+/*#__PURE__*/
+function (_Component) {
   _inherits(App, _Component);
 
   function App() {

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
 // @flow
-var C = function () {
+var C =
+/*#__PURE__*/
+function () {
   function C() {}
 
   var _proto = C.prototype;

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-return-type-annotation/expected.js
@@ -1,7 +1,9 @@
 "use strict";
 
 // @flow
-var C = function () {
+var C =
+/*#__PURE__*/
+function () {
   function C() {
     babelHelpers.classCallCheck(this, C);
   }

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var C = function () {
+var C =
+/*#__PURE__*/
+function () {
   function C() {}
 
   var _proto = C.prototype;

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-return-type-annotation/expected.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var C = function () {
+var C =
+/*#__PURE__*/
+function () {
   function C() {
     babelHelpers.classCallCheck(this, C);
   }

--- a/packages/babel-plugin-transform-function-bind/test/fixtures/regression/T6984/expected.js
+++ b/packages/babel-plugin-transform-function-bind/test/fixtures/regression/T6984/expected.js
@@ -6,7 +6,9 @@ function _one() {}
 
 function _two() {}
 
-let Test1 = function () {
+let Test1 =
+/*#__PURE__*/
+function () {
   function Test1() {
     _classCallCheck(this, Test1);
   }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/expected.js
@@ -2,7 +2,9 @@ import _classCallCheck from "babel-runtime/helpers/builtin/es6/classCallCheck";
 import _possibleConstructorReturn from "babel-runtime/helpers/builtin/es6/possibleConstructorReturn";
 import _inherits from "babel-runtime/helpers/builtin/es6/inherits";
 
-let Foo = function (_Bar) {
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/expected.js
@@ -2,7 +2,9 @@ import _classCallCheck from "babel-runtime/helpers/builtin/classCallCheck";
 import _possibleConstructorReturn from "babel-runtime/helpers/builtin/possibleConstructorReturn";
 import _inherits from "babel-runtime/helpers/builtin/inherits";
 
-let Foo = function (_Bar) {
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/expected.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/expected.js
@@ -3,7 +3,9 @@ import _classCallCheck from "babel-runtime/helpers/es6/classCallCheck";
 import _possibleConstructorReturn from "babel-runtime/helpers/es6/possibleConstructorReturn";
 import _inherits from "babel-runtime/helpers/es6/inherits";
 
-let Foo = function (_Bar) {
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
   _inherits(Foo, _Bar);
 
   function Foo() {


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | fixes #5632
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added/Pass?        | yes
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes?  | no

This is a simple change which annotate created by `transform-es2015-classes` IIFEs with `#__PURE__` comments. This allows UglifyJS to remove those IIFE calls if their result is unused - generally speaking it allows for better Dead Code Elimination.

The core of the change is [here](https://github.com/babel/babel/pull/6209/files#diff-6416e1ea4c3b7962dadc06f4740ece48). The rest are only adjusted tests.