### PR TITLE
Add failing test case for object rest after array rest, and fix it.

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -146,6 +146,13 @@ export default function({ types: t }) {
         path.get("id").traverse(
           {
             RestElement(path) {
+              if (!path.parentPath.isObjectPattern()) {
+                // Return early if the parent is not an ObjectPattern, but
+                // (for example) an ArrayPattern or Function, because that
+                // means this RestElement is an not an object property.
+                return;
+              }
+
               if (
                 // skip single-property case, e.g.
                 // const { ...x } = foo();
@@ -175,13 +182,6 @@ export default function({ types: t }) {
 
               let ref = this.originalPath.node.init;
               const refPropertyPath = [];
-
-              if (!path.parentPath.isObjectPattern()) {
-                // Return early if the parent is not an ObjectPattern, but
-                // (for example) an ArrayPattern or Function, because that
-                // means this RestElement is an not an object property.
-                return;
-              }
 
               path.findParent(path => {
                 if (path.isObjectProperty()) {

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -176,10 +176,10 @@ export default function({ types: t }) {
               let ref = this.originalPath.node.init;
               const refPropertyPath = [];
 
-              if (path.parentPath.isArrayPattern()) {
-                // Return early if we encounter an ArrayPattern parent,
-                // because that means this RestElement is an array element
-                // rather than an object property.
+              if (!path.parentPath.isObjectPattern()) {
+                // Return early if the parent is not an ObjectPattern, but
+                // (for example) an ArrayPattern or Function, because that
+                // means this RestElement is an not an object property.
                 return;
               }
 

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/actual.js
@@ -1,4 +1,8 @@
-let { a: [b, ...arrayRest], ...objectRest } = {
+let {
+  a: [b, ...arrayRest],
+  c = function(...functionRest){},
+  ...objectRest
+} = {
   a: [1, 2, 3, 4],
-  c: "zxcv"
+  d: "oyez"
 };

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/actual.js
@@ -1,0 +1,4 @@
+let { a: [b, ...arrayRest], ...objectRest } = {
+  a: [1, 2, 3, 4],
+  c: "zxcv"
+};

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/expected.js
@@ -1,0 +1,8 @@
+let _a$c = {
+  a: [1, 2, 3, 4],
+  c: "zxcv"
+},
+    {
+  a: [b, ...arrayRest]
+} = _a$c,
+    objectRest = babelHelpers.objectWithoutProperties(_a$c, ["a"]);

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/expected.js
@@ -1,8 +1,9 @@
-let _a$c = {
+let _a$d = {
   a: [1, 2, 3, 4],
-  c: "zxcv"
+  d: "oyez"
 },
     {
-  a: [b, ...arrayRest]
-} = _a$c,
-    objectRest = babelHelpers.objectWithoutProperties(_a$c, ["a"]);
+  a: [b, ...arrayRest],
+  c = function (...functionRest) {}
+} = _a$d,
+    objectRest = babelHelpers.objectWithoutProperties(_a$d, ["a", "c"]);


### PR DESCRIPTION
Discovered while upgrading https://github.com/meteor/babel to Babel 7.

The error is:
```
  1) babel-plugin-transform-object-rest-spread/object rest with array rest:
     TypeError: /Users/ben/dev/babel/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/with-array-rest/actual.js: Property id of VariableDeclarator expected node to be of a type ["LVal"] but instead got null
      at Object.validate (packages/babel-types/lib/definitions/index.js:73:13)
      at validate (packages/babel-types/lib/index.js:460:9)
      at Object.builder (packages/babel-types/lib/index.js:428:7)
      at Object.RestElement (packages/babel-plugin-transform-object-rest-spread/lib/index.js:157:41)
      at NodePath._call (packages/babel-traverse/lib/path/context.js:53:20)
      at NodePath.call (packages/babel-traverse/lib/path/context.js:40:17)
      at NodePath.visit (packages/babel-traverse/lib/path/context.js:84:12)
      ...
```

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | ∅
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added/Pass?        | **Yes/No**
| Spec Compliancy?         | No
| License                  | MIT
| Doc PR                   | No
| Any Dependency Changes?  | No

Since Babel 7 is failing to compile this code, I wasn't sure what to put in the `expected.js` file, though of course we'll want to add that once the bug is fixed.