### PR TITLE
Use `/bin/bash` instead of `/bin/sh` in scripts

### DIFF
--- a/scripts/_get-test-directories.sh
+++ b/scripts/_get-test-directories.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 TEST_DIRS=""

--- a/scripts/grant-npm-owner.sh
+++ b/scripts/grant-npm-owner.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 read -p "Username: " username

--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 testDirs=`TEST_TYPE=cov scripts/_get-test-directories.sh`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 if [ -z "$TEST_GREP" ]; then


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | no
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | no
| Spec Compliancy?         | no
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes?  | no

<!-- Describe your changes below in as much detail as possible -->

`/bin/sh` isn't always an alias of `/bin/bash`, so bash-specific syntax broke the scripts.
(like https://github.com/babel/babel/blob/777a9ae6e42db1c9d57bbbdca8b233c2dc9b89ac/scripts/_get-test-directories.sh#L7)