### PR TITLE
Do not fix linting errors in precommit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --format=codeframe --fix --rulesdir='./eslint_rules'",
-      "git add"
+      "eslint --format=codeframe --rulesdir='./eslint_rules'"
     ]
   }
 }


### PR DESCRIPTION
It's just damn annoying. Supersedes #5908.