### PR TITLE
Redeclaring a variable counts as a modification

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -141,9 +141,11 @@ function arrayDestructure() {
     rest[_key15] = arguments[_key15];
   }
 
-  var _x = babelHelpers.slicedToArray(x, 1);
+  var _x = x;
 
-  rest[0] = _x[0];
+  var _x2 = babelHelpers.slicedToArray(_x, 1);
+
+  rest[0] = _x2[0];
 }
 
 function forOf() {

--- a/packages/babel-traverse/src/scope/binding.js
+++ b/packages/babel-traverse/src/scope/binding.js
@@ -12,15 +12,7 @@ import type NodePath from "../path";
  */
 
 export default class Binding {
-  constructor({ existing, identifier, scope, path, kind }) {
-    // this if condition is true only if the re-binding does not result in an error
-    // e.g. if rebinding kind is 'var' or 'hoisted', and previous was 'param'
-    if (existing) {
-      // we maintain the original binding but update constantViolations
-      existing.constantViolations = existing.constantViolations.concat(path);
-      return existing;
-    }
-
+  constructor({ identifier, scope, path, kind }) {
     this.identifier = identifier;
     this.scope = scope;
     this.path = path;

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -535,13 +535,18 @@ export default class Scope {
 
         parent.references[name] = true;
 
-        this.bindings[name] = new Binding({
-          identifier: id,
-          existing: local,
-          scope: this,
-          path: bindingPath,
-          kind: kind,
-        });
+        // A redeclaration of an existing variable is a modification
+        if (local) {
+          this.registerConstantViolation(bindingPath);
+        } else {
+          this.bindings[name] = new Binding({
+            identifier: id,
+            existing: local,
+            scope: this,
+            path: bindingPath,
+            kind: kind,
+          });
+        }
       }
     }
   }

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -541,7 +541,6 @@ export default class Scope {
         } else {
           this.bindings[name] = new Binding({
             identifier: id,
-            existing: local,
             scope: this,
             path: bindingPath,
             kind: kind,

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -73,6 +73,20 @@ describe("scope", function() {
       );
     });
 
+    it("variable constantness", function() {
+      assert.ok(getPath("var a = 1;").scope.getBinding("a").constant === true);
+      assert.ok(
+        getPath("var a = 1; a = 2;").scope.getBinding("a").constant === false,
+      );
+      assert.ok(
+        getPath("var a = 1, a = 2;").scope.getBinding("a").constant === false,
+      );
+      assert.ok(
+        getPath("var a = 1; var a = 2;").scope.getBinding("a").constant ===
+          false,
+      );
+    });
+
     it("purity", function() {
       assert.ok(
         getPath("({ x: 1 })")


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             |  Fixes #6217.
| Patch: Bug Fix?          |  Yes.
| Major: Breaking Change?  |  No.
| Minor: New Feature?      |  No.
| Tests Added/Pass?        |  Yes.
| Spec Compliancy?         |  Yes.
| License                  | MIT
| Doc PR                   |  No.
| Any Dependency Changes?  |  No.

When a variable is redeclared (as in `var a = 1; var a = 2;`), this PR ensures that the second declaration is no longer regarded as a constant.
