### PR TITLE
Allow users to specify a module for inline scripts

### DIFF
--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -161,7 +161,7 @@ function loadScripts(transformFn, scripts) {
         ...scriptData,
         content: script.innerHTML,
         loaded: true,
-        url: null,
+        url: script.getAttribute('data-module')
       };
     }
   });

--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -161,7 +161,7 @@ function loadScripts(transformFn, scripts) {
         ...scriptData,
         content: script.innerHTML,
         loaded: true,
-        url: script.getAttribute('data-module')
+        url: script.getAttribute("data-module")
       };
     }
   });


### PR DESCRIPTION
Currently inline scripts cannot be referenced via imports. With this change they can be if you specify a `data-module` attribute on the script tag:

```
<!doctype html>
<html>
<head>
  <title>Babel Test</title>
</head>
<body>
  <script src="./babel.js"></script>
  <script data-plugins="transform-es2015-modules-umd" data-module="cube" type="text/babel">
    export default function cube(x) {
      return x * x * x;
    }
  </script>
  <script data-plugins="transform-es2015-modules-umd" type="text/babel">
    import cube from 'cube'
    console.log(cube(3))
  </script>
</body>
</html>
```

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
