### PR TITLE
Rewritten babel helpers using the latest syntax

### DIFF
--- a/packages/babel-cli/test/fixtures/babel-external-helpers/--whitelist/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel-external-helpers/--whitelist/stdout.txt
@@ -2,8 +2,8 @@
   var babelHelpers = global.babelHelpers = {};
 
   function _defineProperties(target, props) {
-    for (var i = 0; i < props.length; i++) {
-      var descriptor = props[i];
+    for (let i = 0; i < props.length; i++) {
+      const descriptor = props[i];
       descriptor.enumerable = descriptor.enumerable || false;
       descriptor.configurable = true;
       if ("value" in descriptor) descriptor.writable = true;

--- a/packages/babel-core/src/tools/build-external-helpers.js
+++ b/packages/babel-core/src/tools/build-external-helpers.js
@@ -74,7 +74,7 @@ function buildModule(namespace, builder) {
         ? `_${originalIdentifier}`
         : originalIdentifier;
 
-      const variableDeclaration = t.variableDeclaration("var", [
+      const variableDeclaration = t.variableDeclaration("const", [
         t.variableDeclarator(
           t.identifier(helperIndentifier),
           helper.expression.right,

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -51,7 +51,7 @@ var foo = function () {
 
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
-function _asyncToGenerator(fn) { return function () { var _this = this, _arguments = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(_this, _arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var _this = this; for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) { args[_key] = arguments[_key]; } return new Promise(function (resolve, reject) { var gen = fn.apply(_this, args); function step(key, arg) { var info = void 0; try { info = gen[key](arg); } catch (error) { reject(error); return; } if (info.done) { resolve(info.value); } else { Promise.resolve(info.value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/expected.js
@@ -8,6 +8,6 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function (...args) { return new Promise((resolve, reject) => { const gen = fn.apply(this, args); function step(key, arg) { let info; try { info = gen[key](arg); } catch (error) { reject(error); return; } if (info.done) { resolve(info.value); } else { Promise.resolve(info.value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 import _Promise from 'somewhere';

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/expected.js
@@ -19,6 +19,6 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function (...args) { return new Promise((resolve, reject) => { const gen = fn.apply(this, args); function step(key, arg) { let info; try { info = gen[key](arg); } catch (error) { reject(error); return; } if (info.done) { resolve(info.value); } else { Promise.resolve(info.value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 let _Promise;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/expected.js
@@ -10,6 +10,6 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function (...args) { return new Promise((resolve, reject) => { const gen = fn.apply(this, args); function step(key, arg) { let info; try { info = gen[key](arg); } catch (error) { reject(error); return; } if (info.done) { resolve(info.value); } else { Promise.resolve(info.value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 let _Promise;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
@@ -13,7 +13,7 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) { args[_key] = arguments[_key]; } return new Promise((resolve, reject) => { const gen = fn.apply(this, args); function step(key, arg) { let info; try { info = gen[key](arg); } catch (error) { reject(error); return; } if (info.done) { resolve(info.value); } else { Promise.resolve(info.value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/misc/import-const-throw/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/misc/import-const-throw/expected.js
@@ -6,7 +6,7 @@ var Bar = _interopRequireWildcard(require("bar"));
 
 var _baz = require("baz");
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { const newObj = {}; if (obj != null) { for (const key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7199/expected.js
@@ -4,7 +4,7 @@ var _foo = _interopRequireDefault(require("foo"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _sliceIterator(arr, i) { const _arr = []; let _n = true; let _d = false; let _e, _i; try { let _s; for (_i = arr[Symbol.iterator](); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _slicedToArray(arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return _sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }
 

--- a/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/expected.js
+++ b/packages/babel-plugin-transform-es2015-object-super/test/fixtures/object-super/super-exponentiation/expected.js
@@ -1,8 +1,8 @@
 var _obj;
 
-function _set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
+function _set(object, property, value, receiver) { const desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { const parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { const setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
 
-function _get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return _get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } }
+function _get(object, property, receiver) { if (object === null) object = Function.prototype; const desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { const parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return _get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { const getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } }
 
 foo = _obj = {
   bar: function () {

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/shadow/expected.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/shadow/expected.js
@@ -1,4 +1,4 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = obj => typeof obj; } else { _typeof = obj => { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 var _Symbol = foo();
 

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/expected.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/expected.js
@@ -1,8 +1,8 @@
 var _obj;
 
-function _set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
+function _set(object, property, value, receiver) { const desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { const parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { const setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
 
-function _get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return _get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } }
+function _get(object, property, receiver) { if (object === null) object = Function.prototype; const desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { const parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return _get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { const getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } }
 
 foo = _obj = {
   bar() {

--- a/packages/babel-plugin-transform-function-bind/test/fixtures/regression/T6984/expected.js
+++ b/packages/babel-plugin-transform-function-bind/test/fixtures/regression/T6984/expected.js
@@ -1,6 +1,6 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+function _defineProperties(target, props) { for (let i = 0; i < props.length; i++) { const descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/function-sent/basic/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/function-sent/basic/expected.js
@@ -10,4 +10,4 @@ let gen = (() => {
   };
 })();
 
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/function-sent/multiple/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/function-sent/multiple/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 _skipFirstGeneratorNext(function* () {
   let _functionSent = yield;

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/function-sent/yield-function-sent/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/function-sent/yield-function-sent/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 _skipFirstGeneratorNext(function* () {
   let _functionSent = yield;

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/class-method/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/class-method/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 class Foo {
   gen() {

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/export-default-anonymous/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/export-default-anonymous/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 export default _skipFirstGeneratorNext(function* () {
   let _functionSent = yield;

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/export-default-named/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/export-default-named/expected.js
@@ -10,6 +10,6 @@ let gen = (() => {
   };
 })();
 
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 export { gen as default };

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/export/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/export/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 export let gen = (() => {
   var _ref = _skipFirstGeneratorNext(function* () {

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/expression-anonymous/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/expression-anonymous/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 _skipFirstGeneratorNext(function* () {
   let _functionSent = yield;

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/expression-named/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/expression-named/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 const foo = (() => {
   var _ref = _skipFirstGeneratorNext(function* () {

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/object-method/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/object-method/expected.js
@@ -1,4 +1,4 @@
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }
 
 const obj = {
   gen() {

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/statement/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/statement/expected.js
@@ -10,4 +10,4 @@ let gen = (() => {
   };
 })();
 
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+function _skipFirstGeneratorNext(fn) { return function (...args) { const it = fn.apply(this, args); it.next(); return it; }; }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/assignment/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/assignment/expected.js
@@ -1,4 +1,4 @@
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+var _extends = Object.assign || function (target, ...sources) { for (let i = 0; i < sources.length; i++) { const source = sources[i]; for (const key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 z = _extends({
   x

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/expression/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/expression/expected.js
@@ -1,4 +1,4 @@
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+var _extends = Object.assign || function (target, ...sources) { for (let i = 0; i < sources.length; i++) { const source = sources[i]; for (const key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 _extends({
   x

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/variable-declaration/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/variable-declaration/expected.js
@@ -1,3 +1,3 @@
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+var _extends = Object.assign || function (target, ...sources) { for (let i = 0; i < sources.length; i++) { const source = sources[i]; for (const key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var z = _extends({}, x);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
@@ -1,4 +1,4 @@
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function (...args) { return new Promise((resolve, reject) => { const gen = fn.apply(this, args); function step(key, arg) { let info; try { info = gen[key](arg); } catch (error) { reject(error); return; } if (info.done) { resolve(info.value); } else { Promise.resolve(info.value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 export default {
   function(name) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inline-elements/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/inline-elements/expected.js
@@ -1,6 +1,6 @@
-var REACT_ELEMENT_TYPE;
+const REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7;
 
-function _jsx(type, props, key, children) { if (!REACT_ELEMENT_TYPE) { REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7; } var defaultProps = type && type.defaultProps; var childrenLength = arguments.length - 3; if (!props && childrenLength !== 0) { props = {}; } if (props && defaultProps) { for (var propName in defaultProps) { if (props[propName] === void 0) { props[propName] = defaultProps[propName]; } } } else if (!props) { props = defaultProps || {}; } if (childrenLength === 1) { props.children = children; } else if (childrenLength > 1) { var childArray = new Array(childrenLength); for (var i = 0; i < childrenLength; i++) { childArray[i] = arguments[i + 3]; } props.children = childArray; } return { $$typeof: REACT_ELEMENT_TYPE, type: type, key: key === undefined ? null : '' + key, ref: null, props: props, _owner: null }; }
+function _jsx(type, props, key, ...children) { const defaultProps = type && type.defaultProps; if (!props && children.length !== 0) { props = {}; } if (props && defaultProps) { for (const propName in defaultProps) { if (props[propName] === undefined) { props[propName] = defaultProps[propName]; } } } else if (!props) { props = defaultProps || {}; } if (children.length === 1) { props.children = children[0]; } else if (children.length > 1) { props.children = children; } return { $$typeof: REACT_ELEMENT_TYPE, type, key: key === undefined ? null : '' + key, ref: null, props, _owner: null }; }
 
 var _ref = _jsx("foo", {});
 


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | n/a
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added/Pass?        | yes
| Spec Compliancy?         | n/a
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes?  | somewhat - new helper package added

This PR adds a `#__PURE__` annotation to the generated babel helpers which are IIFEs. While I find this useful as first step and for the future I think at least some of those IIFEs could be revisited. From what I see they ([`jsx`](https://github.com/babel/babel/blob/1cdacf85ae774783ead6c2b9ac8184344bf2c6d5/packages/babel-helpers/src/helpers.js#L18), [`asyncGenerator`](https://github.com/babel/babel/blob/1cdacf85ae774783ead6c2b9ac8184344bf2c6d5/packages/babel-helpers/src/helpers.js#L79), [`createClass`](https://github.com/babel/babel/blob/1cdacf85ae774783ead6c2b9ac8184344bf2c6d5/packages/babel-helpers/src/helpers.js#L253), [`slicedToArray`](https://github.com/babel/babel/blob/1cdacf85ae774783ead6c2b9ac8184344bf2c6d5/packages/babel-helpers/src/helpers.js#L516)) do not need to be IIFEs at all, I think they are wrapped as IIFEs to avoid naming conflicts - this could be probably solved if helpers could spit out more than 1 thing and all things could be renamed if necessary by the calling code. WDYT?

cc @xtuc 
