### PR TITLE
Remove the unused 'scope' param from 'traverse.hasType'.

### DIFF
--- a/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/index.js
@@ -480,7 +480,6 @@ class BlockScoping {
     // handle generators
     const hasYield = traverse.hasType(
       fn.body,
-      this.scope,
       "YieldExpression",
       t.FUNCTION_TYPES,
     );
@@ -493,7 +492,6 @@ class BlockScoping {
     // handlers async functions
     const hasAsync = traverse.hasType(
       fn.body,
-      this.scope,
       "AwaitExpression",
       t.FUNCTION_TYPES,
     );

--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -81,7 +81,6 @@ function hasBlacklistedType(path, state) {
 
 traverse.hasType = function(
   tree: Object,
-  scope: Object,
   type: Object,
   blacklistTypes: Array<string>,
 ): boolean {
@@ -99,10 +98,11 @@ traverse.hasType = function(
   traverse(
     tree,
     {
+      noScope: true,
       blacklist: blacklistTypes,
       enter: hasBlacklistedType,
     },
-    scope,
+    null,
     state,
   );
 

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -85,20 +85,18 @@ describe("traverse", function() {
   });
 
   it("hasType", function() {
-    assert.ok(traverse.hasType(ast, null, "ThisExpression"));
+    assert.ok(traverse.hasType(ast, "ThisExpression"));
     assert.ok(
-      !traverse.hasType(ast, null, "ThisExpression", ["AssignmentExpression"]),
+      !traverse.hasType(ast, "ThisExpression", ["AssignmentExpression"]),
     );
 
-    assert.ok(traverse.hasType(ast, null, "ThisExpression"));
-    assert.ok(traverse.hasType(ast, null, "Program"));
+    assert.ok(traverse.hasType(ast, "ThisExpression"));
+    assert.ok(traverse.hasType(ast, "Program"));
 
-    assert.ok(
-      !traverse.hasType(ast, null, "ThisExpression", ["MemberExpression"]),
-    );
-    assert.ok(!traverse.hasType(ast, null, "ThisExpression", ["Program"]));
+    assert.ok(!traverse.hasType(ast, "ThisExpression", ["MemberExpression"]));
+    assert.ok(!traverse.hasType(ast, "ThisExpression", ["Program"]));
 
-    assert.ok(!traverse.hasType(ast, null, "ArrowFunctionExpression"));
+    assert.ok(!traverse.hasType(ast, "ArrowFunctionExpression"));
   });
 
   it("clearCache", function() {


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | Y
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

The `scope` param is passed to `traverse`, but never used in the traversal. It was added in https://github.com/babel/babel/commit/3205c78f019afae34ab3d783bd561fd04f19c716 which looks to be before `noScope` was an option on `traverse` so it made sense at the time.

I was running into a random bug that I unfortunately don't know how to trigger exactly, but it was because the scope was assuming that `path.parentPath` would go all the way back to the `Program` which does not do unless you pass _both_ `scope` and `parentPath` to `traverse`, which `hasType` does not, and cannot do.