### PR TITLE
Ensure the AMD/UMD loaders all have params for each import to avoid lazy-loading

### DIFF
--- a/packages/babel-helper-modules/src/index.js
+++ b/packages/babel-helper-modules/src/index.js
@@ -9,7 +9,7 @@ import normalizeAndLoadModuleMetadata, {
   isSideEffectImport,
 } from "./normalize-and-load-metadata";
 
-export { hasExports };
+export { hasExports, isSideEffectImport };
 
 /**
  * Perform all of the generic ES6 module rewriting needed to handle initial
@@ -53,34 +53,6 @@ export function rewriteModuleStatementsAndPrepareHeader(
   headers.push(...buildExportInitializationStatements(path, meta));
 
   return { meta, headers };
-}
-
-/**
- * Break down the module metadata into a simple array that contains the
- * fields generally needed for compiling ES6 module support.
- */
-export function getSourceMetadataArray(meta: ModuleMetadata) {
-  const lastNonSideEffectBlock = Array.from(
-    meta.source,
-  ).reduceRight((acc, [source, metadata]) => {
-    if (acc !== null) return acc;
-
-    if (isSideEffectImport(metadata)) return null;
-    return source;
-  }, null);
-
-  let inSideEffectBlock = lastNonSideEffectBlock === null;
-
-  const items = [];
-  for (const [source, metadata] of meta.source) {
-    const isSideEffect = isSideEffectImport(metadata);
-
-    items.push([source, metadata, isSideEffect, inSideEffectBlock]);
-
-    if (source === lastNonSideEffectBlock) inSideEffectBlock = true;
-  }
-
-  return items;
 }
 
 /**

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports/expected.js
@@ -1,3 +1,3 @@
-define(["foo", "foo-bar", "./directory/foo-bar"], function () {
+define(["foo", "foo-bar", "./directory/foo-bar"], function (_foo, _fooBar, _fooBar2) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/overview/expected.js
@@ -1,4 +1,4 @@
-define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (_exports, foo2) {
+define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (_exports, foo2, _fooBar, _fooBar2) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js
@@ -1,6 +1,6 @@
 import {
   rewriteModuleStatementsAndPrepareHeader,
-  getSourceMetadataArray,
+  isSideEffectImport,
   buildNamespaceInitStatements,
   ensureStatementsHoisted,
   wrapInterop,
@@ -42,15 +42,13 @@ export default function({ types: t }) {
             noInterop,
           });
 
-          getSourceMetadataArray(
-            meta,
-          ).forEach(([source, metadata, isSideEffect]) => {
+          for (const [source, metadata] of meta.source) {
             const loadExpr = t.callExpression(t.identifier("require"), [
               t.stringLiteral(source),
             ]);
 
             let header;
-            if (isSideEffect) {
+            if (isSideEffectImport(metadata)) {
               header = t.expressionStatement(loadExpr);
             } else {
               header = t.variableDeclaration("var", [
@@ -64,7 +62,7 @@ export default function({ types: t }) {
 
             headers.push(header);
             headers.push(...buildNamespaceInitStatements(meta, metadata));
-          });
+          }
 
           ensureStatementsHoisted(headers);
           path.unshiftContainer("body", headers);

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports/expected.js
@@ -10,6 +10,6 @@
     factory(global.foo, global.fooBar, global.fooBar);
     global.actual = mod.exports;
   }
-})(this, function () {
+})(this, function (_foo, _fooBar, _fooBar2) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-import-name/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/override-import-name/expected.js
@@ -10,6 +10,6 @@
     factory(global.baz);
     global.actual = mod.exports;
   }
-})(this, function () {
+})(this, function (_babelTemplate) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/overview/expected.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo, global.fooBar, global.fooBar);
     global.actual = mod.exports;
   }
-})(this, function (_exports, foo2) {
+})(this, function (_exports, foo2, _fooBar, _fooBar2) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #3802, Fixes #3620 <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

As described in https://github.com/babel/babel/issues/3802, the lack of param names was a problem, and having to compute when to ignore them actually complicated the module transform, so bye!