### PR TITLE
Fix jsx-source to not fail without filename

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -51,7 +51,7 @@ export default function({ types: t }) {
 
       if (!state.fileNameIdentifier) {
         // Default to an empty string in case no filename was supplied in the transform
-        const fileName = state.file.opts.filename || "";
+        const fileName = state.file.opts.filename || "";
 
         const fileNameIdentifier = path.scope.generateUidIdentifier(
           FILE_NAME_VAR,

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -50,7 +50,6 @@ export default function({ types: t }) {
       }
 
       if (!state.fileNameIdentifier) {
-        // Default to an empty string in case no filename was supplied in the transform
         const fileName = state.file.opts.filename || "";
 
         const fileNameIdentifier = path.scope.generateUidIdentifier(

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -50,7 +50,8 @@ export default function({ types: t }) {
       }
 
       if (!state.fileNameIdentifier) {
-        const fileName = state.file.opts.filename;
+        // Default to an empty string in case no filename was supplied in the transform
+        const fileName = state.file.opts.filename || "";
 
         const fileNameIdentifier = path.scope.generateUidIdentifier(
           FILE_NAME_VAR,


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #5909
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | 
| Any Dependency Changes?  | 

This is an easy fix for the jsx-source transform to not throw in case the filename was not provided.

Should I add a test?

