### PR TITLE
Fix backslash escaping in unicode regexs

### DIFF
--- a/packages/babel-plugin-transform-es2015-unicode-regex/src/index.js
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/src/index.js
@@ -2,11 +2,21 @@ import rewritePattern from "regexpu-core";
 import * as regex from "babel-helper-regex";
 
 export default function() {
+  function escape(pattern) {
+    return pattern.replace(/\\/g, "\\\\");
+  }
+
+  function unescape(pattern) {
+    return pattern.replace(/\\\\/g, "\\");
+  }
+
   return {
     visitor: {
       RegExpLiteral({ node }) {
         if (!regex.is(node, "u")) return;
-        node.pattern = rewritePattern(node.pattern, node.flags);
+        node.pattern = unescape(
+          rewritePattern(escape(node.pattern), node.flags),
+        );
         regex.pullFlag(node, "u");
       },
     },

--- a/packages/babel-plugin-transform-es2015-unicode-regex/test/fixtures/unicode-regex/escaping/actual.js
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/test/fixtures/unicode-regex/escaping/actual.js
@@ -1,0 +1,1 @@
+/^https?:\/\//u.test(string);

--- a/packages/babel-plugin-transform-es2015-unicode-regex/test/fixtures/unicode-regex/escaping/expected.js
+++ b/packages/babel-plugin-transform-es2015-unicode-regex/test/fixtures/unicode-regex/escaping/expected.js
@@ -1,0 +1,1 @@
+/^https?:\/\//.test(string);


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6246
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added/Pass?        | Yes
| Spec Compliancy?         | Yes
| License                  | MIT
| Doc PR                   |
| Any Dependency Changes?  | 