### PR TITLE
Fix newlines before the update suffix operator in babel-generator

### DIFF
--- a/packages/babel-generator/src/generators/expressions.js
+++ b/packages/babel-generator/src/generators/expressions.js
@@ -33,7 +33,9 @@ export function UpdateExpression(node: Object) {
     this.token(node.operator);
     this.print(node.argument, node);
   } else {
+    this.startTerminatorless(true);
     this.print(node.argument, node);
+    this.endTerminatorless();
     this.token(node.operator);
   }
 }

--- a/packages/babel-generator/test/fixtures/types/UpdateExpression/actual.js
+++ b/packages/babel-generator/test/fixtures/types/UpdateExpression/actual.js
@@ -1,3 +1,4 @@
 ++i;
 i++;
 (foo++).test();
+obj.foo/*comment*/++;

--- a/packages/babel-generator/test/fixtures/types/UpdateExpression/expected.js
+++ b/packages/babel-generator/test/fixtures/types/UpdateExpression/expected.js
@@ -1,3 +1,4 @@
 ++i;
 i++;
 (foo++).test();
+obj.foo /*comment*/++;


### PR DESCRIPTION

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6253
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n 
| Minor: New Feature?      | n
| Tests Added/Pass?        | y/y
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | n

I added `.startTerminatorless(true)` and `.endTerminatorless()` at `UpdateExpression`. And I also added a test using `obj.foo/*comment*/++;`