### PR TITLE
Fixed buildExternalHelpers tool for var and module output types

### DIFF
--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -1,5 +1,4 @@
 import * as babel from "../lib/index";
-import buildExternalHelpers from "../lib/tools/build-external-helpers";
 import sourceMap from "source-map";
 import assert from "assert";
 import path from "path";
@@ -817,26 +816,44 @@ describe("api", function() {
   });
 
   describe("buildExternalHelpers", function() {
+    describe("smoke tests", function() {
+      it("builds external helpers in global output type", function() {
+        babel.buildExternalHelpers(null, "global");
+      });
+
+      it("builds external helpers in module output type", function() {
+        babel.buildExternalHelpers(null, "module");
+      });
+
+      it("builds external helpers in umd output type", function() {
+        babel.buildExternalHelpers(null, "umd");
+      });
+
+      it("builds external helpers in var output type", function() {
+        babel.buildExternalHelpers(null, "var");
+      });
+    });
+
     it("all", function() {
-      const script = buildExternalHelpers();
+      const script = babel.buildExternalHelpers();
       assert.ok(script.indexOf("classCallCheck") >= -1);
       assert.ok(script.indexOf("inherits") >= 0);
     });
 
     it("whitelist", function() {
-      const script = buildExternalHelpers(["inherits"]);
+      const script = babel.buildExternalHelpers(["inherits"]);
       assert.ok(script.indexOf("classCallCheck") === -1);
       assert.ok(script.indexOf("inherits") >= 0);
     });
 
     it("empty whitelist", function() {
-      const script = buildExternalHelpers([]);
+      const script = babel.buildExternalHelpers([]);
       assert.ok(script.indexOf("classCallCheck") === -1);
       assert.ok(script.indexOf("inherits") === -1);
     });
 
     it("underscored", function() {
-      const script = buildExternalHelpers(["typeof"]);
+      const script = babel.buildExternalHelpers(["typeof"]);
       assert.ok(script.indexOf("typeof") >= 0);
     });
   });

--- a/packages/babel-helpers/src/index.js
+++ b/packages/babel-helpers/src/index.js
@@ -27,7 +27,7 @@ function getHelperMetadata(file) {
 
   traverse(file, {
     ImportDeclaration(child) {
-      throw child.buildCodeFrameError("Helpers may import anything.");
+      throw child.buildCodeFrameError("Helpers may not import anything.");
     },
     ExportDefaultDeclaration(child) {
       const decl = child.get("declaration");


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | n/a
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | yes
| Spec Compliancy?         | n/a
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes? no | 

This fixes regressions introduced with #5706. I've also added simple smoke tests for all output types - they only check if things didnt crash during usage. If you want any other tests added - please specify what type of tests could be added here to be helpful.
