### PR TITLE
Fix hoisting of arguments in class properties with arrow

### DIFF
--- a/packages/babel-plugin-transform-class-properties/src/index.js
+++ b/packages/babel-plugin-transform-class-properties/src/index.js
@@ -23,6 +23,25 @@ export default function({ types: t }) {
     },
   };
 
+  const argumentsHoistVisitor = {
+    TypeAnnotation(path) {
+      path.skip();
+    },
+    ReferencedIdentifier(path) {
+      if (
+        path.node.name === "arguments" &&
+        !this.scope.hasOwnBinding(path.node.name)
+      ) {
+        const uid = this.functionScope.generateUid("arguments");
+        this.functionScope.push({
+          id: t.identifier(uid),
+          init: t.identifier("arguments"),
+        });
+        path.replaceWith(t.identifier(uid));
+      }
+    },
+  };
+
   const buildObjectDefineProperty = template(`
     Object.defineProperty(REF, KEY, {
       configurable: true,
@@ -89,6 +108,20 @@ export default function({ types: t }) {
           if (propNode.decorators && propNode.decorators.length > 0) continue;
 
           const isStatic = propNode.static;
+
+          // If the value of the property is an arrow function, then hoist arguments to
+          // the parent function scope of the class if it exists
+          const value = prop.get("value");
+          if (value.isArrowFunctionExpression()) {
+            const parentClassFunctionScope = path.scope.getFunctionParent();
+
+            if (parentClassFunctionScope) {
+              value.traverse(argumentsHoistVisitor, {
+                scope: value.scope,
+                functionScope: parentClassFunctionScope,
+              });
+            }
+          }
 
           if (isStatic) {
             nodes.push(buildClassProperty(ref, propNode, path.scope));

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/2347/actual.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/2347/actual.js
@@ -1,0 +1,13 @@
+var MyClass = (function() {
+  var stuff = 'outer stuff!';
+  return class {
+    constructor() {
+      var stuff = 'constructor stuff!';
+    }
+    myProp = () => {
+      console.log(arguments);
+      console.log(stuff);
+      console.log(this);
+    };
+  }
+})(42);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/2347/expected.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/2347/expected.js
@@ -1,0 +1,28 @@
+var MyClass = function () {
+  var _arguments = arguments,
+      _class,
+      _temp,
+      _initialiseProps;
+
+  var stuff = 'outer stuff!';
+  return _temp = _class = function _class() {
+    babelHelpers.classCallCheck(this, _class);
+
+    _initialiseProps.call(this);
+
+    var stuff = 'constructor stuff!';
+  }, _initialiseProps = function () {
+    var _this = this;
+
+    Object.defineProperty(this, "myProp", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function () {
+        console.log(_arguments);
+        console.log(stuff);
+        console.log(_this);
+      }
+    });
+  }, _temp;
+}(42);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/2347/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/2347/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-class-properties", "transform-es2015-classes", "transform-es2015-arrow-functions","transform-es2015-block-scoping", "syntax-class-properties"]
+}


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #2347
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 👍
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

This is another take on fixing #2347. Previous PR #4641

This ensures that `arguments` inside an arrow function in an class property refers to the function scope outside the class. (see https://github.com/babel/babel/issues/2347#issuecomment-139066201 if that is still correct, @jeffmo )


