### PR TITLE
Preserve _blockHoist values for injected binding references.

### DIFF
--- a/packages/babel-helper-modules/src/rewrite-live-references.js
+++ b/packages/babel-helper-modules/src/rewrite-live-references.js
@@ -88,6 +88,7 @@ const rewriteBindingInitVisitor = {
           t.identifier(localName),
         ),
       );
+      statement._blockHoist = path.node._blockHoist;
 
       requeueInParent(path.insertAfter(statement)[0]);
     }
@@ -105,6 +106,7 @@ const rewriteBindingInitVisitor = {
             t.identifier(localName),
           ),
         );
+        statement._blockHoist = path.node._blockHoist;
 
         requeueInParent(path.insertAfter(statement)[0]);
       }
@@ -338,6 +340,7 @@ const rewriteReferencesVisitor = {
           let node = t.sequenceExpression(items);
           if (path.parentPath.isExpressionStatement()) {
             node = t.expressionStatement(node);
+            node._blockHoist = path.parentPath.node._blockHoist;
           }
 
           const statement = path.insertAfter(node)[0];


### PR DESCRIPTION
Just a tiny tweak I noticed. This is kind of a pain to test since it only matters for blockHoisted things, so I skipped adding a test. Hopefully at some point here we'll kill blockHoist and it won't matter anyway :)

Basically if the declarations got hoisted, the export assignment would get left in their original position, but they are really supposed to be a tightly-grouped pair of nodes.