### PR TITLE
just inline the type

### DIFF
--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-types": "7.0.0-beta.0",
     "lodash": "^4.2.0"
   }
 }

--- a/packages/babel-helper-regex/src/index.js
+++ b/packages/babel-helper-regex/src/index.js
@@ -1,8 +1,7 @@
 import pull from "lodash/pull";
-import * as t from "babel-types";
 
 export function is(node: Object, flag: string): boolean {
-  return t.isRegExpLiteral(node) && node.flags.indexOf(flag) >= 0;
+  return node.type === "RegExpLiteral" && node.flags.indexOf(flag) >= 0;
 }
 
 export function pullFlag(node: Object, flag: string) {


### PR DESCRIPTION
ideally https://github.com/mathiasbynens/babel-plugin-transform-unicode-property-regex would just be in this repo though, but we can not worry about babel-types incompat moving forward?