### PR TITLE
Quick fix for default import that also uses names.

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = babelHelpers.interopRequireDefault(require("react"));
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
 var RandomComponent =
 /*#__PURE__*/

--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/imports-mixing/expected.js
@@ -1,7 +1,7 @@
 define(["foo"], function (_foo) {
   "use strict";
 
-  _foo = babelHelpers.interopRequireDefault(_foo);
+  _foo = babelHelpers.interopRequireWildcard(_foo);
   _foo.default;
   _foo.baz;
 });

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/imports-mixing/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _foo = babelHelpers.interopRequireDefault(require("foo"));
+var _foo = babelHelpers.interopRequireWildcard(require("foo"));
 
 _foo.default;
 _foo.baz;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-mixing/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/imports-mixing/expected.js
@@ -13,6 +13,6 @@
 })(this, function (_foo) {
   "use strict";
 
-  _foo = babelHelpers.interopRequireDefault(_foo);
+  _foo = babelHelpers.interopRequireWildcard(_foo);
   _foo.baz;
 });


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6275
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

I don't love this fix because using the wildcard helper here is more work that necessary, but I'm adding this for now so that we can get things stabilized.

From Slack:

So the issue is a simple mistake on my part, but the fix for it raises an issue that conflicts with some of the other goals, so I'm curious for people's thoughts. Babel 6.x generated code like
```
var _express = require("express");
var _express2 = babelHelpers.interopRequireDefault(_express);

var router = (0, _express.Router)();
console.log(_express2.default);
```
Note that the `.default` is accessed on the result of `interopRequireDefault` (`_express2`) while `.Router` is accessed from `_express`.

With my refactor I merged this as
```
var _express = babelHelpers.interopRequireDefault(require("express"));
const router = (0, _express.Router)();
console.log(_express.default);
```
which is indeed broken because there is no `.Router` property on the object returned by `interopRequireDefault`.

The _quick_ fix is to use the other helper as
```
var _express = babelHelpers.interopRequireWildcard(require("express"));
```
but that has the downside of having to iterate and copy all of the properties onto a new object.