### PR TITLE
Skip adding explicit undefined for let declarations when it is not ne…

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1130/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1130/expected.js
@@ -1,7 +1,7 @@
 function A() {
-  var a = void 0;
+  var a;
 }
 
 function B() {
-  var a = void 0;
+  var a;
 }

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-4855/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-4855/expected.js
@@ -5,4 +5,4 @@ var _fieldName = fieldName;
 value = _values[_fieldName];
 rest = babelHelpers.objectWithoutProperties(_values, [_fieldName].map(babelHelpers.toPropertyKey));
 _values;
-var error = void 0;
+var error;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/spec/constructor/expected.js
@@ -22,8 +22,8 @@ function (_Bar) {
 
 var ConstructorScoping = function ConstructorScoping() {
   babelHelpers.classCallCheck(this, ConstructorScoping);
-  var bar = void 0;
+  var bar;
   {
-    var _bar = void 0;
+    var _bar;
   }
 };

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-5628/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-5628/expected.js
@@ -1,7 +1,7 @@
 (function () {
-  var q = void 0;
-  var w = void 0;
-  var e = void 0;
+  var q;
+  var w;
+  var e;
 
   if (true) {
     var _map = [1, 2, 3].map(function () {

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -76,7 +76,7 @@ describe("babel-standalone", () => {
     const output = Babel.transform("export let x", {
       presets: [["es2015", { modules: false }]],
     }).code;
-    assert.equal(output, "export var x = void 0;");
+    assert.equal(output, "export var x;");
   });
 
   it("handles specifying a plugin by name", () => {


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6278 
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added/Pass?        | yes
| Spec Compliancy?         | n/a
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes?  | no

This is a simple, small optimization for the generated code. It skips initializing let declaractions with `undefined` if its not technically needed.