### PR TITLE
Fixed asyncToGenerator helper using arrow function

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -51,7 +51,7 @@ var foo = function () {
 
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
-function _asyncToGenerator(fn) { return function () { var _this = this, _arguments = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(_this, _arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -224,8 +224,9 @@ helpers.asyncGeneratorDelegate = defineHelper(`
 helpers.asyncToGenerator = defineHelper(`
   export default function _asyncToGenerator(fn) {
     return function () {
-      return new Promise((resolve, reject) => {
-        var gen = fn.apply(this, arguments);
+      var self = this, args = arguments;
+      return new Promise(function (resolve, reject) {
+        var gen = fn.apply(self, args);
         function step(key, arg) {
           try {
             var info = gen[key](arg);

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/expected.js
@@ -8,6 +8,6 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 import _Promise from 'somewhere';

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/expected.js
@@ -19,6 +19,6 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 let _Promise;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/expected.js
@@ -10,6 +10,6 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 let _Promise;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
@@ -13,7 +13,7 @@ let foo = (() => {
   };
 })();
 
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/expected.js
@@ -1,4 +1,4 @@
-function _asyncToGenerator(fn) { return function () { return new Promise((resolve, reject) => { var gen = fn.apply(this, arguments); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 export default {
   function(name) {


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | no
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | yes
| Spec Compliancy?         | n/a
| License                  | MIT
| Doc PR                   | n/a
| Any Dependency Changes?  | no

Fixes babel helper using syntax beyond es5.
