### PR TITLE
Move template object creation from core into the template transform.

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -263,34 +263,10 @@ export default class File extends Store {
     return uid;
   }
 
-  addTemplateObject(
-    helperName: string,
-    strings: Array<Object>,
-    raw: Object,
-  ): Object {
-    // Generate a unique name based on the string literals so we dedupe
-    // identical strings used in the program.
-    const stringIds = raw.elements.map(function(string) {
-      return string.value;
-    });
-    const name = `${helperName}_${raw.elements.length}_${stringIds.join(",")}`;
-
-    const declar = this.declarations[name];
-    if (declar) return declar;
-
-    const uid = (this.declarations[name] = this.scope.generateUidIdentifier(
-      "templateObject",
-    ));
-
-    const helperId = this.addHelper(helperName);
-    const init = t.callExpression(helperId, [strings, raw]);
-    init._compact = true;
-    this.scope.push({
-      id: uid,
-      init: init,
-      _blockHoist: 1.9, // This ensures that we don't fail if not using function expression helpers
-    });
-    return uid;
+  addTemplateObject() {
+    throw new Error(
+      "This function has been moved into the template literal transform itself.",
+    );
   }
 
   buildCodeFrameError(

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -83,7 +83,7 @@ export default function({ types: t }) {
           init._compact = true;
           programPath.scope.push({
             id: templateObject,
-            init: init,
+            init,
             // This ensures that we don't fail if not using function expression helpers
             _blockHoist: 1.9,
           });

--- a/packages/babel-plugin-transform-es2015-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-es2015-template-literals/src/index.js
@@ -35,6 +35,9 @@ export default function({ types: t }) {
   }
 
   return {
+    pre() {
+      this.templates = new Map();
+    },
     visitor: {
       TaggedTemplateExpression(path, state) {
         const { node } = path;
@@ -54,18 +57,41 @@ export default function({ types: t }) {
           raws.push(t.stringLiteral(raw));
         }
 
-        let templateName = "taggedTemplateLiteral";
-        if (state.opts.loose) templateName += "Loose";
+        let helperName = "taggedTemplateLiteral";
+        if (state.opts.loose) helperName += "Loose";
 
-        const templateObject = state.file.addTemplateObject(
-          templateName,
-          t.arrayExpression(strings),
-          t.arrayExpression(raws),
+        // Generate a unique name based on the string literals so we dedupe
+        // identical strings used in the program.
+        const rawParts = raws.map(s => s.value).join(",");
+        const name = `${helperName}_${raws.length}_${rawParts}`;
+
+        let templateObject = this.templates.get(name);
+        if (templateObject) {
+          templateObject = t.clone(templateObject);
+        } else {
+          const programPath = path.find(p => p.isProgram());
+          templateObject = programPath.scope.generateUidIdentifier(
+            "templateObject",
+          );
+          this.templates.set(name, templateObject);
+
+          const helperId = this.addHelper(helperName);
+          const init = t.callExpression(helperId, [
+            t.arrayExpression(strings),
+            t.arrayExpression(raws),
+          ]);
+          init._compact = true;
+          programPath.scope.push({
+            id: templateObject,
+            init: init,
+            // This ensures that we don't fail if not using function expression helpers
+            _blockHoist: 1.9,
+          });
+        }
+
+        path.replaceWith(
+          t.callExpression(node.tag, [templateObject, ...quasi.expressions]),
         );
-
-        const args = [templateObject].concat(quasi.expressions);
-
-        path.replaceWith(t.callExpression(node.tag, args));
       },
 
       TemplateLiteral(path, state) {


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | 
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | Y
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

It has always seemed weird to me that this was part of `babel-core`, so I'm moving it. Thoughts?