### PR TITLE
addMapping method call missing name parameter

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -355,6 +355,8 @@ export default class File extends Store {
                   },
 
             generated: generatedPosition,
+
+            name: mapping.name,
           });
         }
       });


### PR DESCRIPTION
Cherry-picked https://github.com/babel/babel/pull/5461 to fix the conflict.