### PR TITLE
Add option to indicate when files are being processed

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -84,9 +84,9 @@ export default function(commander, filenames, opts) {
   }
 
   if (!commander.skipInitialBuild) {
-    console.log(startMsg);
+    if (commander.noisey) console.log(startMsg);
     filenames.forEach(handle);
-    console.log(endMsg);
+    if (commander.noisey) console.log(endMsg);
   }
 
   if (commander.watch) {
@@ -108,7 +108,7 @@ export default function(commander, filenames, opts) {
           const relative = path.relative(dirname, filename) || filename;
           try {
             if (timer == null || processing == false) {
-              console.log(startMsg);
+              if (commander.noisey) console.log(startMsg);
             }
             processing = true;
             handleFile(filename, relative);
@@ -118,7 +118,7 @@ export default function(commander, filenames, opts) {
             if (processing == true) {
               clearTimeout(timer);
               timer = setTimeout(function() {
-                console.log(endMsg);
+                if (commander.noisey) console.log(endMsg);
                 processing = false;
                 timer = null;
               }, 250);

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -6,8 +6,8 @@ import fs from "fs";
 
 import * as util from "./util";
 
-const startMsg = ">>Started transpiling";
-const endMsg = ">>Finished transpiling";
+const startMsg = "Detected change to watched files. Rebuilding..";
+const endMsg = "Rebuild complete. Waiting for changes.";
 
 export default function(commander, filenames, opts) {
   function write(src, relative, base) {

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -160,7 +160,7 @@ commander.option(
   "Delete's the out directory before compilation",
 );
 commander.option(
-  "-n --noisy",
+  "-n --noisey",
   "Output indication of when files are being processed",
 );
 /* eslint-enable max-len */
@@ -240,7 +240,7 @@ delete opts.quiet;
 delete opts.configFile;
 delete opts.deleteDirOnStart;
 delete opts.keepFileExtension;
-delete opts.noisy;
+delete opts.noisey;
 
 // Commander will default the "--no-" arguments to true, but we want to leave them undefined so that
 // babel-core can handle the default-assignment logic on its own.

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -159,6 +159,10 @@ commander.option(
   "--delete-dir-on-start",
   "Delete's the out directory before compilation",
 );
+commander.option(
+  "-n --noisy",
+  "Output indication of when files are being processed",
+);
 /* eslint-enable max-len */
 
 commander.version(pkg.version + " (babel-core " + version + ")");
@@ -166,7 +170,6 @@ commander.usage("[options] <files ...>");
 commander.parse(process.argv);
 
 //
-
 const errors = [];
 
 let filenames = commander.args.reduce(function(globbed, input) {
@@ -237,6 +240,7 @@ delete opts.quiet;
 delete opts.configFile;
 delete opts.deleteDirOnStart;
 delete opts.keepFileExtension;
+delete opts.noisy;
 
 // Commander will default the "--no-" arguments to true, but we want to leave them undefined so that
 // babel-core can handle the default-assignment logic on its own.


### PR DESCRIPTION

| Q                        | A 
| ------------------------ | ---|
| Fixed Issues             | None|
| Patch: Bug Fix?          | No|
| Major: Breaking Change?  |No| 
| Minor: New Feature?      | Yes|
| Tests Added/Pass?        | Existing tests still pass, did not add new tests to cover this options output|
| Spec Compliancy?         | doesn't change anything spec related|
| License                  | MIT|
| Doc PR                   | No|
| Any Dependency Changes?  | No|


I added the flag -n or --noisy to add output when files are being processed in watch mode.
This should make it easier to integrate with external debugging tools like [VSCode](https://code.visualstudio.com/docs/editor/tasks#_background-watching-tasks) that can be configured to wait for a background watching task to finish processing the files before it attempts to run or debug them.