### PR TITLE
Fix typeof and instanceof exception in exported anon functions

### DIFF
--- a/packages/babel-plugin-transform-es2015-instanceof/src/index.js
+++ b/packages/babel-plugin-transform-es2015-instanceof/src/index.js
@@ -9,6 +9,7 @@ export default function({ types: t }) {
             return (
               (path.isVariableDeclarator() && path.node.id === helper) ||
               (path.isFunctionDeclaration() &&
+                path.node.id &&
                 path.node.id.name === helper.name)
             );
           });

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/src/index.js
@@ -33,7 +33,9 @@ export default function({ types: t }) {
         const isUnderHelper = path.findParent(path => {
           return (
             (path.isVariableDeclarator() && path.node.id === helper) ||
-            (path.isFunctionDeclaration() && path.node.id.name === helper.name)
+            (path.isFunctionDeclaration() &&
+              path.node.id &&
+              path.node.id.name === helper.name)
           );
         });
 

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/default-export/actual.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/default-export/actual.js
@@ -1,0 +1,3 @@
+export default function() {
+  typeof {} === "object";
+}

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/default-export/expected.js
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/default-export/expected.js
@@ -1,0 +1,5 @@
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+export default function () {
+  _typeof({}) === "object";
+}

--- a/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/default-export/options.json
+++ b/packages/babel-plugin-transform-es2015-typeof-symbol/test/fixtures/symbols/default-export/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-typeof-symbol"]
+}


### PR DESCRIPTION
Already reviewed as part of https://github.com/babel/babel/pull/6318.