### PR TITLE
Preserve object identity when loading config, for improved future caching.

### DIFF
--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -37,7 +37,16 @@ export default function buildConfigChain(opts: {}): Array<ConfigItem> | null {
 
     // resolve all .babelrc files
     if (opts.babelrc !== false && filename) {
-      builder.findConfigs(filename);
+      findConfigs(
+        path.dirname(filename),
+      ).forEach(({ filepath, dirname, options }) => {
+        builder.mergeConfig({
+          type: "options",
+          options,
+          alias: filepath,
+          dirname,
+        });
+      });
     }
   } catch (e) {
     if (e.code !== "BABEL_IGNORED_FILE") throw e;
@@ -54,17 +63,6 @@ class ConfigChainBuilder {
 
   constructor(file: LoadedFile | null) {
     this.file = file;
-  }
-
-  findConfigs(loc: string) {
-    findConfigs(path.dirname(loc)).forEach(({ filepath, dirname, options }) => {
-      this.mergeConfig({
-        type: "options",
-        options,
-        alias: filepath,
-        dirname,
-      });
-    });
   }
 
   mergeConfig({ type, options: rawOpts, alias, dirname }) {

--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -146,12 +146,7 @@ class ConfigChainBuilder {
         return config.alias === extendsConfig.filepath;
       });
       if (!existingConfig) {
-        this.mergeConfig({
-          type: "options",
-          alias: extendsConfig.filepath,
-          options: extendsConfig.options,
-          dirname: extendsConfig.dirname,
-        });
+        this.mergeConfigFile(extendsConfig);
       }
     }
   }

--- a/packages/babel-core/src/config/caching.js
+++ b/packages/babel-core/src/config/caching.js
@@ -31,7 +31,7 @@ export function makeStrongCache<ArgT, ResultT>(
  * configures its caching behavior. Cached values are stored weakly and the function argument must be
  * an object type.
  */
-export function makeWeakCache<ArgT: {}, ResultT>(
+export function makeWeakCache<ArgT: {} | Array<*>, ResultT>(
   handler: (ArgT, CacheConfigurator) => ResultT,
   autoPermacache?: boolean,
 ): ArgT => ResultT {

--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -10,7 +10,7 @@ import { makeStrongCache } from "../../caching";
 
 const debug = buildDebug("babel:config:loading:files:configuration");
 
-type ConfigFile = {
+export type ConfigFile = {
   filepath: string,
   dirname: string,
   options: {},

--- a/packages/babel-core/src/config/loading/files/index-browser.js
+++ b/packages/babel-core/src/config/loading/files/index-browser.js
@@ -1,6 +1,6 @@
 // @flow
 
-type ConfigFile = {
+export type ConfigFile = {
   filepath: string,
   dirname: string,
   options: {},

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/babelignore/.babelignore
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/babelignore/.babelignore
@@ -1,0 +1,1 @@
+fake-file.js

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/babelrc-js/.babelrc.js
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/babelrc-js/.babelrc.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.env();
+
+  return {
+    comments: false,
+  };
+}

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/babelrc/.babelrc
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/babelrc/.babelrc
@@ -1,0 +1,3 @@
+{
+  comments: false,
+}

--- a/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/pkg/package.json
+++ b/packages/babel-core/test/fixtures/config/complex-plugin-config/config-identity/pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "babel": {
+    "comments": false
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | N
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N, I _think_
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

This change does essentially nothing on its own, but it opens up a bunch of options for us in the future. By preserving the object identity of as much of our config as we can, we can better cache processing around those configs.

### In the future

The simplest case for this is that with this we can validate a config file and cache it by just doing

```
const isValid = makeWeakCache(config => {
  return doExpensiveValidation(config);
});
```
and the `doExpensiveValidation` will only be executed once for a given `config` object. Any time Babel runs on the same `.babelrc`, it'll never have to run that validation again.

We'll also be able to apply that caching for plugins and presets, so if you're babelrc is

```
{
    presets: ['es2015']
}
```
currently in Babel 6, the preset function for `es2015` will run _every_ time Babel runs on a file. Not only that, but Babel has to figure out where the `es2015` package is in the filesystem. That's a ton of extra work for absolutely no reason. If we know the config hasn't changed, we can skip calling it again. The only downside is that if a preset uses globals somehow for config, we could cache in a bad state. Given this, we can re-use the same caching API I added for `.babelrc.js` files in presets too.

And we have the opposite problem in plugins currently. Plugins are _always_ cached for performance, but this means we're locked with the plugin API as `function (babelAPI){` while presets get additional data as `function (babelAPI, options, {dirname})`. By allowing caching by object identity, we can remove the permacache restriction from plugins, allowing they to accept options as top-level parameters, just like presets do.

I have this caching all done on a branch, and it improves the time to go from the name of the file to compile, to a fully verified config object and an array of plugins by ~2-3x, while allowing plugins to have access to options up front, which is a huge win in my mind.

### In this PR

The most complex part of this PR is that I've implemented identity preservation rules for arguments passed to Babel too. Babel's top-level options object passed in programmatically is something that is commonly either mutated often, or passed as a fresh object. This means it's essentially impossible for us to do the caching I mentioned above for plugins/presets/whatever.

One approach would be to freeze every options object passed to Babel, so we could know the user hasn't gone and mutated it between calls, but the DX on that would be a pain for everyone.

To try to strike a middle ground, in this PR I've approached the issue by caching individual properties of the programmatic options object by their identity instead. So for `opts.plugins`, we generate a new cacheable config object for just the plugins. The same is true for `.env` and `.presets`, since these are all objects that have a unique identity.

This means that babel won't be able to cache the option validation I mentioned above for the programmatic options, but it _will_ be able to do it for the plugins, presets, and anything nested under the `env` block.

I think it's a solid compromise, but I'm curious for feedback.