### PR TITLE
Adding parserOptions to babel-core transform result

### DIFF
--- a/packages/babel-core/src/transformation/file/index.js
+++ b/packages/babel-core/src/transformation/file/index.js
@@ -471,6 +471,7 @@ export default class File extends Store {
     const result = {
       metadata: null,
       options: this.opts,
+      parserOptions: this.parserOpts,
       ignored: !!ignored,
       code: null,
       ast: null,


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added/Pass?        | Not yet
| Spec Compliancy?         | N/A
| License                  | MIT
| Doc PR                   | No
| Any Dependency Changes?  | No


This adds `parserOptions` to the transform result from `babel-core`. The intent here is to be able to run a no-op through `babel.transform()` and get the resulting babylon options. These could then be used in something like `babel-eslint` to automatically have it configured based on the result of your babel plugins.