### PR TITLE
Fix generator missing parens on Flow union types

### DIFF
--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -93,6 +93,17 @@ export function Binary(node: Object, parent: Object): boolean {
   return false;
 }
 
+export function UnionTypeAnnotation(node: Object, parent: Object): boolean {
+  return (
+    t.isArrayTypeAnnotation(parent) ||
+    t.isNullableTypeAnnotation(parent) ||
+    t.isIntersectionTypeAnnotation(parent) ||
+    t.isUnionTypeAnnotation(parent)
+  );
+}
+
+export { UnionTypeAnnotation as IntersectionTypeAnnotation };
+
 export function TSAsExpression() {
   return true;
 }

--- a/packages/babel-generator/test/fixtures/flow/type-union-intersection/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-union-intersection/actual.js
@@ -1,0 +1,10 @@
+type foo = ?(a | b);
+type foo2 = ?(a & b);
+type foo3 = (a | b)[];
+type foo4 = (a & b)[];
+type foo5 = a | b | c;
+type foo6 = a & b & c;
+type foo7 = a & b | c;
+type foo8 = a | b & c;
+type foo9 = a & (b | c);
+type foo10 = (a | b) & c;

--- a/packages/babel-generator/test/fixtures/flow/type-union-intersection/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-union-intersection/expected.js
@@ -1,0 +1,10 @@
+type foo = ?(a | b);
+type foo2 = ?(a & b);
+type foo3 = (a | b)[];
+type foo4 = (a & b)[];
+type foo5 = a | b | c;
+type foo6 = a & b & c;
+type foo7 = (a & b) | c;
+type foo8 = a | (b & c);
+type foo9 = a & (b | c);
+type foo10 = (a | b) & c;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,9 +1017,9 @@ babylon@7.0.0-beta.18:
   version "7.0.0-beta.18"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.18.tgz#5c23ee3fdb66358aabf3789779319c5b78a233c7"
 
-babylon@7.0.0-beta.25:
-  version "7.0.0-beta.25"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.25.tgz#5fff5062b7082203b1bc5cab488e154cfee0202a"
+babylon@7.0.0-beta.26:
+  version "7.0.0-beta.26"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.26.tgz#afc2c6b86113d000cc9476fd6f73e2a9223de8f7"
 
 babylon@^6.17.4, babylon@^6.18.0:
   version "6.18.0"


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6333
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
