### PR TITLE
transform-es2015-template-literals doesn't have spec mode anymore, ch…

### DIFF
--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -92,12 +92,9 @@ describe("babel-standalone", () => {
 
   it("handles plugins with options", () => {
     const output = Babel.transform("`${x}`", {
-      plugins: [["transform-es2015-template-literals", { spec: true }]],
+      plugins: [["transform-es2015-template-literals", { loose: true }]],
     }).code;
-    assert.equal(
-      output,
-      '"".concat(x);', // https://github.com/babel/babel/pull/5791
-    );
+    assert.equal(output, '"" + x;');
   });
 
   it("throws on invalid preset name", () => {


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | n/a
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | yes
| Spec Compliancy?         | n/a
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes?  | no

Just a really small change, align a single test to the supported options of the `transform-es2015-template-literals` plugin.
