### PR TITLE
Cache plugins and presets based on their identity

### DIFF
--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -9,7 +9,7 @@ export type ResolvedConfig = {
 };
 
 export type { Plugin };
-export type PluginPassList = Array<[Plugin, ?{}]>;
+export type PluginPassList = Array<Plugin>;
 export type PluginPasses = Array<PluginPassList>;
 
 /**

--- a/packages/babel-core/src/config/plugin.js
+++ b/packages/babel-core/src/config/plugin.js
@@ -7,7 +7,9 @@ export default class Plugin {
   pre: ?Function;
   visitor: ?{};
 
-  constructor(plugin: {}, key?: string) {
+  options: {} | void;
+
+  constructor(plugin: {}, options: ?{}, key?: string) {
     if (plugin.name != null && typeof plugin.name !== "string") {
       throw new Error("Plugin .name must be a string, null, or undefined");
     }
@@ -35,5 +37,6 @@ export default class Plugin {
     this.post = plugin.post;
     this.pre = plugin.pre;
     this.visitor = plugin.visitor;
+    this.options = options || undefined;
   }
 }

--- a/packages/babel-core/src/transformation/block-hoist-plugin.js
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.js
@@ -6,7 +6,7 @@ import loadConfig, { type Plugin } from "../config";
 
 let LOADED_PLUGIN: Plugin | void;
 
-export default function loadBlockHoistPlugin(): [Plugin, void] {
+export default function loadBlockHoistPlugin(): Plugin {
   if (!LOADED_PLUGIN) {
     // Lazy-init the internal plugin to remove the init-time circular
     // dependency between plugins being passed babel-core's export object,
@@ -15,11 +15,11 @@ export default function loadBlockHoistPlugin(): [Plugin, void] {
       babelrc: false,
       plugins: [blockHoistPlugin],
     });
-    LOADED_PLUGIN = config ? config.passes[0][0][0] : undefined;
+    LOADED_PLUGIN = config ? config.passes[0][0] : undefined;
     if (!LOADED_PLUGIN) throw new Error("Assertion failure");
   }
 
-  return [LOADED_PLUGIN, undefined];
+  return LOADED_PLUGIN;
 }
 
 const blockHoistPlugin = {

--- a/packages/babel-core/src/transformation/index.js
+++ b/packages/babel-core/src/transformation/index.js
@@ -49,10 +49,8 @@ function transformFile(file: File, pluginPasses: PluginPasses): void {
     const passes = [];
     const visitors = [];
 
-    for (const [plugin, pluginOpts] of pluginPairs.concat([
-      loadBlockHoistPlugin(),
-    ])) {
-      const pass = new PluginPass(file, plugin.key, pluginOpts);
+    for (const plugin of pluginPairs.concat([loadBlockHoistPlugin()])) {
+      const pass = new PluginPass(file, plugin.key, plugin.options);
 
       passPairs.push([plugin, pass]);
       passes.push(pass);

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -15,7 +15,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
   });
 
   for (const pluginPairs of config.passes) {
-    for (const [plugin] of pluginPairs) {
+    for (const plugin of pluginPairs) {
       if (plugin.manipulateOptions) {
         plugin.manipulateOptions(options, options.parserOpts);
       }

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -154,9 +154,8 @@ describe("api", function() {
       plugins: [__dirname + "/../../babel-plugin-syntax-jsx"],
     }).then(function(result) {
       assert.ok(
-        result.options.plugins[0][0].manipulateOptions
-          .toString()
-          .indexOf("jsx") >= 0,
+        result.options.plugins[0].manipulateOptions.toString().indexOf("jsx") >=
+          0,
       );
     });
   });

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,0 +1,254 @@
+import loadConfig from "../lib/config";
+import path from "path";
+import { expect } from "chai";
+
+describe("babel-core config loading", () => {
+  const FILEPATH = path.join(
+    __dirname,
+    "fixtures",
+    "config-loading",
+    "folder",
+    "example.js",
+  );
+
+  afterEach(() => {
+    delete process.env.INVALIDATE_BABELRC;
+    delete process.env.INVALIDATE_PRESET1;
+    delete process.env.INVALIDATE_PRESET2;
+    delete process.env.INVALIDATE_PRESET3;
+    delete process.env.INVALIDATE_PLUGIN1;
+    delete process.env.INVALIDATE_PLUGIN2;
+    delete process.env.INVALIDATE_PLUGIN3;
+    delete process.env.INVALIDATE_PLUGIN4;
+    delete process.env.INVALIDATE_PLUGIN5;
+    delete process.env.INVALIDATE_PLUGIN6;
+  });
+
+  function makeOpts(skipProgrammatic = false) {
+    return {
+      filename: FILEPATH,
+      presets: skipProgrammatic
+        ? null
+        : [require("./fixtures/config-loading/preset3")],
+      plugins: skipProgrammatic
+        ? null
+        : [require("./fixtures/config-loading/plugin6")],
+    };
+  }
+
+  describe("config file", () => {
+    it("should load and cache the config with plugins and presets", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+      expect(options1.plugins.map(p => p.key)).to.eql([
+        "plugin6",
+        "plugin5",
+        "plugin1",
+        "plugin2",
+        "plugin4",
+        "plugin3",
+      ]);
+
+      const options2 = loadConfig(opts).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+      }
+    });
+
+    it("should load and cache the config for unique opts objects", () => {
+      const options1 = loadConfig(makeOpts(true)).options;
+      expect(options1.plugins.map(p => p.key)).to.eql([
+        "plugin1",
+        "plugin2",
+        "plugin4",
+        "plugin3",
+      ]);
+
+      const options2 = loadConfig(makeOpts(true)).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+      }
+    });
+
+    it("should invalidate config file plugins", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      process.env.INVALIDATE_PLUGIN1 = true;
+
+      const options2 = loadConfig(opts).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 2) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+
+      process.env.INVALIDATE_PLUGIN3 = true;
+
+      const options3 = loadConfig(opts).options;
+      expect(options3.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 2 || i === 5) {
+          expect(options3.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options3.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+
+    it("should invalidate config file presets and their children", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      process.env.INVALIDATE_PRESET1 = true;
+
+      const options2 = loadConfig(opts).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 5) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+
+      process.env.INVALIDATE_PRESET2 = true;
+
+      const options3 = loadConfig(opts).options;
+      expect(options3.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 4 || i === 5) {
+          expect(options3.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options3.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+
+    it("should invalidate the config file and its plugins/presets", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      process.env.INVALIDATE_BABELRC = true;
+
+      const options2 = loadConfig(opts).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 2 || i === 3 || i === 4 || i === 5 || i === 6) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+  });
+
+  describe("programmatic plugins/presets", () => {
+    it("should not invalidate the plugins when given a fresh object", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      const options2 = loadConfig(Object.assign({}, opts)).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+      }
+    });
+
+    it("should invalidate the plugins when given a fresh arrays", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      const options2 = loadConfig({
+        ...opts,
+        plugins: opts.plugins.slice(),
+      }).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        if (i === 0) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+
+    it("should invalidate the presets when given a fresh arrays", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      const options2 = loadConfig({
+        ...opts,
+        presets: opts.presets.slice(),
+      }).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        if (i === 1) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+
+    it("should invalidate the programmatic plugins", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      process.env.INVALIDATE_PLUGIN6 = true;
+
+      const options2 = loadConfig(opts).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 0) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+
+    it("should invalidate the programmatic presets and their children", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      process.env.INVALIDATE_PRESET3 = true;
+
+      const options2 = loadConfig(opts).options;
+      expect(options2.plugins.length).to.equal(options1.plugins.length);
+
+      for (let i = 0; i < options1.plugins.length; i++) {
+        if (i === 1) {
+          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+        } else {
+          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        }
+      }
+    });
+  });
+});

--- a/packages/babel-core/test/fixtures/config-loading/.babelrc.js
+++ b/packages/babel-core/test/fixtures/config-loading/.babelrc.js
@@ -1,0 +1,14 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_BABELRC);
+
+  return {
+    plugins: [
+      "./plugin1",
+      "./plugin2",
+    ],
+    presets: [
+      "./preset1",
+      "./preset2",
+    ],
+  }
+};

--- a/packages/babel-core/test/fixtures/config-loading/folder/.babelignore
+++ b/packages/babel-core/test/fixtures/config-loading/folder/.babelignore
@@ -1,0 +1,2 @@
+# No-op .babelignore to stop babel from skipping these, which the root
+# .babelignore tells it to do.

--- a/packages/babel-core/test/fixtures/config-loading/plugin1.js
+++ b/packages/babel-core/test/fixtures/config-loading/plugin1.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_PLUGIN1);
+
+  return {
+    name: "plugin1",
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/plugin2.js
+++ b/packages/babel-core/test/fixtures/config-loading/plugin2.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_PLUGIN2);
+
+  return {
+    name: "plugin2",
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/plugin3.js
+++ b/packages/babel-core/test/fixtures/config-loading/plugin3.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_PLUGIN3);
+
+  return {
+    name: "plugin3",
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/plugin4.js
+++ b/packages/babel-core/test/fixtures/config-loading/plugin4.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_PLUGIN4);
+
+  return {
+    name: "plugin4",
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/plugin5.js
+++ b/packages/babel-core/test/fixtures/config-loading/plugin5.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_PLUGIN5);
+
+  return {
+    name: "plugin5",
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/plugin6.js
+++ b/packages/babel-core/test/fixtures/config-loading/plugin6.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache.using(() => process.env.INVALIDATE_PLUGIN6);
+
+  return {
+    name: "plugin6",
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/preset1.js
+++ b/packages/babel-core/test/fixtures/config-loading/preset1.js
@@ -1,0 +1,9 @@
+module.exports = function(api, options) {
+  api.cache.using(() => process.env.INVALIDATE_PRESET1);
+
+  return {
+    plugins: [
+      [require('./plugin3.js'), options],
+    ],
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/preset2.js
+++ b/packages/babel-core/test/fixtures/config-loading/preset2.js
@@ -1,0 +1,9 @@
+module.exports = function(api, options) {
+  api.cache.using(() => process.env.INVALIDATE_PRESET2);
+
+  return {
+    plugins: [
+      [require('./plugin4.js'), options],
+    ],
+  };
+};

--- a/packages/babel-core/test/fixtures/config-loading/preset3.js
+++ b/packages/babel-core/test/fixtures/config-loading/preset3.js
@@ -1,0 +1,9 @@
+module.exports = function(api, options) {
+  api.cache.using(() => process.env.INVALIDATE_PRESET3);
+
+  return {
+    plugins: [
+      [require('./plugin5.js'), options],
+    ],
+  };
+};


### PR DESCRIPTION
| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             |
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | Y
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

This changes how Babel approaches caching and execution of plugins and presets.

### In Babel 6

#### Plugins

The plugin functions in Babel 6 where only ever executed a single time. This was done for performance reasons because plugins do a bunch of work up front, like calling `template` and other stuff. The downside of this is that plugin options when used like:

```
plugins: [
  ['transform-thing', {someFlag: true}],
]
```
where only available during execution of the plugin itself in its handler functions. e.g.

```
visitor: {
   Identifier() {
     console.log(this.opts);
   },
}
```

#### Presets

The preset functions in Babel 6 run _every_ time a file is compiled by Babel. This slows down the process of loading Babel's configuration.

### With this PR

With this, up-front API of both plugins and presets is standardized as

```
function(api, options, { dirname }) { ... }
```

so plugins may access their options up front during initialization time.

Another big benefit of this is that now plugin options can toggle plugin behavior more aggressively. If the options don't require a feature, you could for instance entirely omit the visitor functions for those nodes to potentially avoid extra work.

Plugins can also now toggle `inherits` blocks based on options, so if you had a syntax plugin that you only wanted to enable _some_ of the time, it can now be easily toggled.

#### What has changed to allow this

To achieve this, Babel needs to know how to cache a plugin or preset's execution result, and most importantly, when to consider a plugin or preset invalidated. With this, Babel's config loading has several layers of caching.

A give plugin/preset is tied to its location in the configuration. If you have a config like
```
{
  plugins: [
    ['my-plugin', {option: true}],
    ['my-plugin', {option: false}],
  ],
}
```
the plugin construction function will be called twice, with each set of options.

If the `.babelrc` containing this config changes its mtime, each plugin will be re-executed. For `.babelrc.js` files, this invalidation behavior will depend on the programmatic API defined for those in https://github.com/babel/babel/pull/5608/files#diff-2f4602ba055eb6ec98d6bac3161d43ffR67.

Importantly, plugins and presets _also_ have access to this programmatic API, the same way `.babelrc.js` files do, do if a preset depends on some kind of global state like an environmental variable, it can do
```
api.cache.using(() => process.env.SOME_VAR === "value")
```
to essentially say that the preset has two possible states, one with and one without a global `value` flag.

Finally, in https://github.com/babel/babel/pull/6326 I talked briefly about caching for programmatic options, so that also comes into play here. Take a call like

```
babel.transform("", { presets: ['es2015'] })
babel.transform("", { presets: ['es2015'] })
```
the question is, how often does the initialization function for `es2015` get executed? In this case, the function will be executed twice, and because the plugins used in this preset depend on it as a parent configuration, all of those plugins have to be re-executed too.

To address this in a way that should be workable for the 99% case, this PR makes it so that doing this will only execute the preset once. 

```
const presets = ['es2015'];
babel.transform("", { preset })
babel.transform("", { preset })
```
because Babel can see that it was passed exactly the same object for `presets` both times, it will re-use all of the plugin and preset initialization that happened in the previous call to Babel.

The only downside to this approach, I've called out in https://github.com/babel/babel/pull/6326#issuecomment-333254188, but I think realistically, it is an edge case that, if it _is_ hit, is easily fixable by cloning the array instead of mutating it.