### PR TITLE
Requeueing sometimes has wrong scope

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/4209/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/4209/actual.js
@@ -1,0 +1,10 @@
+import { copy } from './copyPaste';
+
+class Thing {
+  handleCopySomething() {
+    copy();
+  }
+
+  completelyUnrelated(copy = 123) {
+  }
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/4209/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/4209/expected.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var _copyPaste = require("./copyPaste");
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+var Thing =
+/*#__PURE__*/
+function () {
+  function Thing() {
+    _classCallCheck(this, Thing);
+  }
+
+  _createClass(Thing, [{
+    key: "handleCopySomething",
+    value: function handleCopySomething() {
+      (0, _copyPaste.copy)();
+    }
+  }, {
+    key: "completelyUnrelated",
+    value: function completelyUnrelated() {
+      var copy = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 123;
+    }
+  }]);
+
+  return Thing;
+}();

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/4209/options.json
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/4209/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-parameters", "transform-es2015-classes", "transform-es2015-modules-commonjs", "transform-es2015-block-scoping"]
+}

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -95,16 +95,13 @@ export function stop() {
 export function setScope() {
   if (this.opts && this.opts.noScope) return;
 
-  let target = this.context && this.context.scope;
+  let path = this.parentPath;
+  let target;
+  while (path && !target) {
+    if (path.opts && path.opts.noScope) return;
 
-  if (!target) {
-    let path = this.parentPath;
-    while (path && !target) {
-      if (path.opts && path.opts.noScope) return;
-
-      target = path.scope;
-      path = path.parentPath;
-    }
+    target = path.scope;
+    path = path.parentPath;
   }
 
   this.scope = this.getScope(target);


### PR DESCRIPTION
This prevents a requeued path from inheriting a totally wrong scope later on. I can't find exactly where this is happening, but either way a path should only inherit scope from it's ancestors.

Fixes #4209.