### PR TITLE
Babel messages inline

### DIFF
--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -2,7 +2,6 @@
 
 import * as context from "../index";
 import Plugin from "./plugin";
-import * as messages from "babel-messages";
 import defaults from "lodash/defaults";
 import merge from "lodash/merge";
 import removed from "./removed";
@@ -334,7 +333,7 @@ function instantiatePlugin({ value: pluginObj, descriptor }) {
   Object.keys(pluginObj).forEach(key => {
     if (!ALLOWED_PLUGIN_KEYS.has(key)) {
       throw new Error(
-        messages.get("pluginInvalidProperty", descriptor.alias, key),
+        `Plugin ${descriptor.alias} provided an invalid property of ${key}`,
       );
     }
   });

--- a/packages/babel-core/src/tools/build-external-helpers.js
+++ b/packages/babel-core/src/tools/build-external-helpers.js
@@ -1,6 +1,5 @@
 import * as helpers from "babel-helpers";
 import generator from "babel-generator";
-import * as messages from "babel-messages";
 import template from "babel-template";
 import * as t from "babel-types";
 
@@ -178,7 +177,7 @@ export default function(
   if (build) {
     tree = build(namespace, builder);
   } else {
-    throw new Error(messages.get("unsupportedOutputType", outputType));
+    throw new Error(`Unsupported output type ${outputType}`);
   }
 
   return generator(tree).code;

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -1,5 +1,4 @@
 import SourceMap from "./source-map";
-import * as messages from "babel-messages";
 import Printer, { type Format } from "./printer";
 
 /**
@@ -74,7 +73,8 @@ function normalizeOptions(code, opts): Format {
 
     if (format.compact) {
       console.error(
-        "[BABEL] " + messages.get("codeGeneratorDeopt", opts.filename, "500KB"),
+        `[BABEL] Note: The code generator has deoptimised the styling of ${opts.filename},
+        it exceeds the max of 500KB.`,
       );
     }
   }


### PR DESCRIPTION

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | WIP:  #6347 
| Tests Added/Pass?        | Pass   2406 passing (60s) //  7 pending
| Spec Compliancy?         | Yes
| License                  | MIT

File(plus path) messages brought inline && import removed
- [x] [option-manager.js... `/babel-core/src/config/`](/babel-core/src/config/option-manager.js)
- [x] [build-external-helpers.js... `/packages/babel-core/src/tools/`](/packages/babel-core/src/tools/build-external-helpers.js)
- [x] [index.js... `/packages/babel-generator/src/`](/packages/babel-generator/src/index.js)
- [ ] [index.js... `/packages/babel-helper-replace-supers/src/`](/packages/babel-helper-replace-supers/src/index.js)
- [ ] [README.md... `/packages/babel-messages/`](/packages/babel-messages/README.md)
- [ ] [index.js... `/packages/babel-plugin-check-es2015-constants/lib/`](/packages/babel-plugin-check-es2015-constants/lib/index.js)
- [ ] [index.js... `/packages/babel-plugin-check-es2015-constants/src/`](/packages/babel-plugin-check-es2015-constants/src/index.js)
- [ ] [index.js... `/packages/babel-plugin-transform-es2015-for-of/lib/`](/packages/babel-plugin-transform-es2015-for-of/lib/index.js)
- [ ] [index.js... `/packages/babel-plugin-transform-es2015-for-of/src/`](/packages/babel-plugin-transform-es2015-for-of/src/index.js)
- [ ] [babel.js... `/packages/babel-standalone/`](/packages/babel-standalone/babel.js)
- [ ] [index.js... `/packages/babel-traverse/lib/`](/packages/babel-traverse/lib/index.js)
- [ ] [visitors.js... `/packages/babel-traverse/lib/`](/packages/babel-traverse/lib/visitors.js)
- [ ] [index.js... `/packages/babel-traverse/src/`](/packages/babel-traverse/src/index.js)
- [ ] [visitors.js... `/packages/babel-traverse/src/`](/packages/babel-traverse/src/visitors.js)
- [ ] [index.js... `/packages/babel-traverse/lib/scope`](/packages/babel-traverse/lib/scope/index.js)
- [ ] [index.js... `/packages/babel-traverse/src/scope/`](/packages/babel-traverse/src/scope/index.js)