### PR TITLE
unshiftContainer seems to incorrectly handle function params #6150

### DIFF
--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -20,7 +20,9 @@ export function insertBefore(nodes) {
   ) {
     return this.parentPath.insertBefore(nodes);
   } else if (
-    (this.isNodeType("Expression") && this.listKey !== "params") ||
+    (this.isNodeType("Expression") &&
+      this.listKey !== "params" &&
+      this.listKey !== "arguments") ||
     (this.parentPath.isForStatement() && this.key === "init")
   ) {
     if (this.node) nodes.push(this.node);

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -53,6 +53,19 @@ describe("modification", function() {
 
       assert.equal(generateCode(rootPath), "function test(a) {\n  b;\n}");
     });
+
+    it("properly handles more than one arguments", function() {
+      const code = "foo(a, b);";
+      const ast = parse(code);
+      traverse(ast, {
+        CallExpression: function(path) {
+          path.unshiftContainer("arguments", t.identifier("d"));
+          assert.equal(generateCode(path), "foo(d, a, b);");
+          path.unshiftContainer("arguments", t.stringLiteral("s"));
+          assert.equal(generateCode(path), `foo("s", d, a, b);`);
+        },
+      });
+    });
   });
 
   describe("insertBefore", function() {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6150 <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | Yes
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
The case where listKey is equal to "arguments" should be handled in the same way as when it is "params". In the test we visit CallExpression as only it can have "arguments". Also, there is nothing special with function as argument, as the title of the issue might suggest. Even with normal identifiers, the bug is there.
