### PR TITLE
Add noConflict entry mode to @babel/polyfill

### DIFF
--- a/packages/babel-polyfill/noConflict.js
+++ b/packages/babel-polyfill/noConflict.js
@@ -1,1 +1,1 @@
-import "lib/noConflict";
+require("./lib/noConflict");

--- a/packages/babel-polyfill/noConflict.js
+++ b/packages/babel-polyfill/noConflict.js
@@ -1,0 +1,1 @@
+import "lib/noConflict";

--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -1,11 +1,11 @@
 import "core-js/shim";
 import "regenerator-runtime/runtime";
 
-if (global._babelPolyfill) {
+if (global._babelPolyfill && typeof console !== "undefined" && console.warn) {
   console.warn(
     "@babel/polyfill is loaded more than once on this page. This is probably not desirable/intended " +
       "and may have consequences if different versions of the polyfills are applied sequentially. " +
-      "If you do need to load the polyfill more than once, use @babel/polyfill/lib/noConflict " +
+      "If you do need to load the polyfill more than once, use @babel/polyfill/noConflict " +
       "instead to bypass the warning.",
   );
 }

--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -5,8 +5,8 @@ if (global._babelPolyfill) {
   console.warn(
     "@babel/polyfill is loaded more than once on this page. This is probably not desirable/intended " +
       "and may have consequences if different versions of the polyfills are applied sequentially. " +
-      "If you do need to load the polyfill more than once, use @babel/polyfill/noConflict " +
-      "instead to bypass the error.",
+      "If you do need to load the polyfill more than once, use @babel/polyfill/lib/noConflict " +
+      "instead to bypass the warning.",
   );
 }
 

--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -2,7 +2,7 @@ import "core-js/shim";
 import "regenerator-runtime/runtime";
 
 if (global._babelPolyfill) {
-  throw new Error(
+  console.warn(
     "@babel/polyfill is loaded more than once on this page. This is probably not desirable/intended " +
       "and may have consequences if different versions of the polyfills are applied sequentially. " +
       "If you do need to load the polyfill more than once, use @babel/polyfill/noConflict " +

--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -1,7 +1,13 @@
-if (global._babelPolyfill) {
-  throw new Error("only one instance of @babel/polyfill is allowed");
-}
-global._babelPolyfill = true;
-
 import "core-js/shim";
 import "regenerator-runtime/runtime";
+
+if (global._babelPolyfill) {
+  throw new Error(
+    "@babel/polyfill is loaded more than once on this page. This is probably not desirable/intended " +
+      "and may have consequences if different versions of the polyfills are applied sequentially. " +
+      "If you do need to load the polyfill more than once, use @babel/polyfill/noConflict " +
+      "instead to bypass the error.",
+  );
+}
+
+global._babelPolyfill = true;

--- a/packages/babel-polyfill/src/noConflict.js
+++ b/packages/babel-polyfill/src/noConflict.js
@@ -1,3 +1,2 @@
-import "./index";
-
-global._babelPolyfill = false;
+import "core-js/shim";
+import "regenerator-runtime/runtime";

--- a/packages/babel-polyfill/src/noConflict.js
+++ b/packages/babel-polyfill/src/noConflict.js
@@ -1,0 +1,3 @@
+import "./index";
+
+global._babelPolyfill = false;


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #4019 <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
Currently if babel-polyfill is used twice on the same page, a hard error is emitted. This is unfortunate from a developer experience perspective because we can't always be in control of what is being loaded by library authors or other packages.

Assuming loading polyfill twice doesn't actually break anything, a warning would be much more friendly and avoid breaking build systems that halt on JS errors when the application remains functional.