### PR TITLE
Fixed reusing node in destructuring plugin, which caused caching issu…

### DIFF
--- a/packages/babel-plugin-transform-es2015-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/src/index.js
@@ -211,7 +211,7 @@ export default function({ types: t }) {
         if (t.isRestElement(prop)) {
           this.pushObjectRest(pattern, objRef, prop, i);
         } else {
-          this.pushObjectProperty(prop, objRef);
+          this.pushObjectProperty(prop, t.clone(objRef));
         }
       }
     }

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-6373/actual.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-6373/actual.js
@@ -1,0 +1,3 @@
+import { NestedObjects } from "./some-module"
+
+const { Foo, Bar } = NestedObjects

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-6373/expected.js
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-6373/expected.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var _someModule = require("./some-module");
+
+const Foo = _someModule.NestedObjects.Foo,
+      Bar = _someModule.NestedObjects.Bar;

--- a/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-6373/options.json
+++ b/packages/babel-plugin-transform-es2015-destructuring/test/fixtures/destructuring/issue-6373/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-destructuring", "transform-es2015-modules-commonjs"]
+}


### PR DESCRIPTION
…e in helper-module-transforms

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | Fixes #6373 
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added/Pass?        | yes
| Spec Compliancy?         | n/a
| License                  | MIT
| Doc PR                   | no
| Any Dependency Changes?  | no

I thought about lifting this cloning into a function which would be called in each `push*` method to obtain a cloned node, but I couldn't reproduce issue in any other scenario (but there are just so many I could have not thought of, so...). So i've chosen not to be too aggressive about this cloning for now, however it could potentially save us from other headaches in the future. 

Please try to break my build (or master) with any other, similar, code 😄 
