### PR TITLE
Fix helper dependencies in babel runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,16 @@ package-lock.json
 !/packages/babel-runtime/core-js/map.js
 /packages/babel-runtime/helpers/*.js
 !/packages/babel-runtime/helpers/toArray.js
+!/packages/babel-runtime/helpers/temporalRef.js
 /packages/babel-runtime/helpers/builtin/*.js
 !/packages/babel-runtime/helpers/builtin/toArray.js
+!/packages/babel-runtime/helpers/builtin/temporalRef.js
 /packages/babel-runtime/helpers/builtin/es6/*.js
 !/packages/babel-runtime/helpers/builtin/es6/toArray.js
+!/packages/babel-runtime/helpers/builtin/es6/temporalRef.js
 /packages/babel-runtime/helpers/es6/*.js
 !/packages/babel-runtime/helpers/es6/toArray.js
+!/packages/babel-runtime/helpers/es6/temporalRef.js
 /packages/babel-register/test/.babel
 /packages/babel-cli/test/tmp
 /packages/babel-node/test/tmp

--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -1,6 +1,6 @@
 // @flow
 
-import getHelper from "@babel/helpers";
+import * as helpers from "@babel/helpers";
 import { NodePath, Hub, Scope } from "@babel/traverse";
 import { codeFrameColumns } from "@babel/code-frame";
 import traverse from "@babel/traverse";
@@ -132,11 +132,16 @@ export default class File {
       name,
     ));
 
-    const { nodes, globals } = getHelper(
+    const dependencies = {};
+    for (const dep of helpers.getDependencies(name)) {
+      dependencies[dep] = this.addHelper(dep);
+    }
+
+    const { nodes, globals } = helpers.get(
       name,
-      name => this.addHelper(name),
+      dep => dependencies[dep],
       uid,
-      () => Object.keys(this.scope.getAllBindings()),
+      Object.keys(this.scope.getAllBindings()),
     );
 
     globals.forEach(name => {

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -600,7 +600,9 @@ helpers.taggedTemplateLiteralLoose = defineHelper(`
 `);
 
 helpers.temporalRef = defineHelper(`
-  export default function _temporalRef(val, name, undef) {
+  import undef from "temporalUndefined";
+
+  export default function _temporalRef(val, name) {
     if (val === undef) {
       throw new ReferenceError(name + " is not defined - temporal dead zone");
     } else {

--- a/packages/babel-helpers/src/index.js
+++ b/packages/babel-helpers/src/index.js
@@ -134,8 +134,8 @@ function getHelperMetadata(file) {
 /**
  * Given a helper AST and information about how it will be used, update the AST to match the usage.
  */
-function permuteHelperAST(file, metadata, id, getLocalBindings, getDependency) {
-  if (getLocalBindings && !id) {
+function permuteHelperAST(file, metadata, id, localBindings, getDependency) {
+  if (localBindings && !id) {
     throw new Error("Unexpected local bindings for module-based helpers.");
   }
 
@@ -154,11 +154,11 @@ function permuteHelperAST(file, metadata, id, getLocalBindings, getDependency) {
   const dependenciesRefs = {};
   dependencies.forEach((name, id) => {
     dependenciesRefs[id.name] =
-      typeof getDependency === "function" ? getDependency(name) : id;
+      (typeof getDependency === "function" && getDependency(name)) || id;
   });
 
   const toRename = {};
-  const bindings = new Set((getLocalBindings && getLocalBindings()) || []);
+  const bindings = new Set(localBindings || []);
   localBindingNames.forEach(name => {
     let newName = name;
     while (bindings.has(newName)) newName = "_" + newName;
@@ -237,17 +237,17 @@ function loadHelper(name) {
 
     const metadata = getHelperMetadata(fn());
 
-    // Preload dependencies
-    metadata.dependencies.forEach(loadHelper);
+    helperData[name] = {
+      build(getDependency, id, localBindings) {
+        const file = fn();
+        permuteHelperAST(file, metadata, id, localBindings, getDependency);
 
-    helperData[name] = function(getDependency, id, getLocalBindings) {
-      const file = fn();
-      permuteHelperAST(file, metadata, id, getLocalBindings, getDependency);
-
-      return {
-        nodes: file.program.body,
-        globals: metadata.globals,
-      };
+        return {
+          nodes: file.program.body,
+          globals: metadata.globals,
+        };
+      },
+      dependencies: metadata.dependencies,
     };
   }
 
@@ -256,12 +256,15 @@ function loadHelper(name) {
 
 export function get(
   name,
-  getDependency?: string => t.Expression,
+  getDependency?: string => ?t.Expression,
   id?,
-  getLocalBindings?: () => string[],
+  localBindings?: string[],
 ) {
-  const helper = loadHelper(name);
-  return helper(getDependency, id, getLocalBindings);
+  return loadHelper(name).build(getDependency, id, localBindings);
+}
+
+export function getDependencies(name: string): $ReadOnlyArray<string> {
+  return Array.from(loadHelper(name).dependencies.values());
 }
 
 export const list = Object.keys(helpers)

--- a/packages/babel-plugin-transform-es2015-block-scoping/src/tdz.js
+++ b/packages/babel-plugin-transform-es2015-block-scoping/src/tdz.js
@@ -16,7 +16,6 @@ function buildTDZAssert(node, file) {
   return t.callExpression(file.addHelper("temporalRef"), [
     node,
     t.stringLiteral(node.name),
-    file.addHelper("temporalUndefined"),
   ]);
 }
 

--- a/packages/babel-runtime/helpers/builtin/es6/temporalRef.js
+++ b/packages/babel-runtime/helpers/builtin/es6/temporalRef.js
@@ -1,0 +1,8 @@
+import undef from "./temporalUndefined";
+export default function _temporalRef(val, name) {
+  if (val === undef) {
+    throw new ReferenceError(name + " is not defined - temporal dead zone");
+  } else {
+    return val;
+  }
+}

--- a/packages/babel-runtime/helpers/builtin/temporalRef.js
+++ b/packages/babel-runtime/helpers/builtin/temporalRef.js
@@ -1,0 +1,11 @@
+var temporalUndefined = require("./temporalUndefined");
+
+function _temporalRef(val, name) {
+  if (val === temporalUndefined) {
+    throw new ReferenceError(name + " is not defined - temporal dead zone");
+  } else {
+    return val;
+  }
+}
+
+module.exports = _temporalRef;

--- a/packages/babel-runtime/helpers/es6/temporalRef.js
+++ b/packages/babel-runtime/helpers/es6/temporalRef.js
@@ -1,0 +1,8 @@
+import undef from "./temporalUndefined";
+export default function _temporalRef(val, name) {
+  if (val === undef) {
+    throw new ReferenceError(name + " is not defined - temporal dead zone");
+  } else {
+    return val;
+  }
+}

--- a/packages/babel-runtime/helpers/temporalRef.js
+++ b/packages/babel-runtime/helpers/temporalRef.js
@@ -1,0 +1,11 @@
+var temporalUndefined = require("./temporalUndefined");
+
+function _temporalRef(val, name) {
+  if (val === temporalUndefined) {
+    throw new ReferenceError(name + " is not defined - temporal dead zone");
+  } else {
+    return val;
+  }
+}
+
+module.exports = _temporalRef;


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

I promise this will be the last iteration of helper dependencies 😆 

~Commit message:~

> ~Replace imports in helpers with the dependency.~

> ~This commit updates the `getDependency` callback passed
to `helpers.get()`. That callback only used to return an
Identifier or MemberExpression which represents the helper;
now it can return both the reference and the code of the
dependency.
Now babel-runtime/scripts/build-dist.js can easily replace
`import foo from "foo"` with `var foo = require("foo")`.~

> ~As a side effect of this change, helpers dependencies are
directly added to the helper ast instead of the file's, making
the call to `getHelper` inside `File#addHelper` actually
pure, as requested in the review of the original helper dependencies PR [1]~

> ~[1]: #6254 (comment)~

This PR extracts the handling of dependencies out of `babel-helpers/src/index.js`. That file now exports a `getDependencies` function which returns a list containing the name of the dependencies used by an helper. It's up to the consumer to ensure that they are already available when the helper is included.

This PR fixes a bug regarding the transpilation of imports inside babel-runtime.

Ref: https://github.com/babel/babel/pull/6366#discussion_r142262947