### PR TITLE
simplify register test

### DIFF
--- a/packages/babel-register/test/__data__/es2015.js
+++ b/packages/babel-register/test/__data__/es2015.js
@@ -1,1 +1,1 @@
-import a from "assert";
+import "assert";

--- a/packages/babel-register/test/__data__/es2015.js
+++ b/packages/babel-register/test/__data__/es2015.js
@@ -1,6 +1,2 @@
 import a from "assert";
-
-export default () => {
-  a.foo();
-  return "b";
-};
+a;

--- a/packages/babel-register/test/__data__/es2015.js
+++ b/packages/babel-register/test/__data__/es2015.js
@@ -1,2 +1,1 @@
 import a from "assert";
-a;

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -1,5 +1,4 @@
 import chai from "chai";
-import path from "path";
 
 const DATA_ES2015 = require.resolve("./__data__/es2015");
 
@@ -12,7 +11,15 @@ describe("babel-register", function() {
     babelRegister.default(
       Object.assign(
         {
-          presets: [path.join(__dirname, "../../babel-preset-es2015")],
+          plugins: [
+            {
+              visitor: {
+                ImportDeclaration(path) {
+                  path.remove();
+                },
+              },
+            },
+          ],
           babelrc: false,
         },
         config,


### PR DESCRIPTION
`TEST_ONLY=babel-register make test-only` was failing with 

1) babel-register registers correctly:
     Error: [BABEL] /Users/hzhu/dev/babel-7.0/packages/babel-preset-es2015/lib/index.js: Reentrant preset detected trying to load "/Users/hzhu/dev/babel-7.0/packages/babel-preset-es2015/lib/index.js". This module is not ignored and is trying to load itself while compiling itself, leading to a dependency cycle. We recommend adding it to your "ignore" list in your babelrc, or to a .babelignore.
      at requireModule (node_modules/babel-core/lib/config/loading/files/plugins.js:191:11)
      at loadPreset (node_modules/babel-core/lib/config/loading/files/plugins.js:64:15)
      at normalizePair (node_modules/babel-core/lib/config/option-manager.js:427:21)
      at node_modules/babel-core/lib/config/option-manager.js:212:27
      at Array.map (native)
      at loadConfig (node_modules/babel-core/lib/config/option-manager.js:211:48)
      at OptionManager.mergeOptions (node_modules/babel-core/lib/config/option-manager.js:71:18)

Can just do this instead