### PR TITLE
Simplify dirname option in plugins/presets?

### DIFF
--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -303,7 +303,7 @@ const loadDescriptor = makeWeakCache(
       });
 
       try {
-        item = value(api, options, { dirname });
+        item = value(api, options, dirname);
       } catch (e) {
         if (alias) {
           e.message += ` (While processing: ${JSON.stringify(alias)})`;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

Thoughts? I think originally the concern was that there might be other things we want to pass in, but especially with the new caching logic, we don't really want to expose a ton more stuff via this API because it'll be more stuff that we have to track alongside the value as cacheable.