### PR TITLE
Drop old compatibility if statement targeting babel@6.15 and earlier

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -52,11 +52,6 @@ const awaitVisitor = {
 };
 
 export default function(path: NodePath, file: Object, helpers: Object) {
-  if (!helpers) {
-    // bc for 6.15 and earlier
-    helpers = { wrapAsync: file };
-    file = null;
-  }
   path.traverse(awaitVisitor, {
     file,
     wrapAwait: helpers.wrapAwait,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | no
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | yes
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no

Just dropping old if targeting compatibility with older versions of babel.
