### PR TITLE
Adhering to async generator yield behavior change

### DIFF
--- a/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/expected.js
@@ -30,7 +30,7 @@ function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
 function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume("next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
 if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
@@ -40,7 +40,7 @@ _AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", 
 
 _AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
 
-function _AwaitValue(value) { this.value = value; }
+function _AwaitValue(value) { this.wrapped = value; }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 

--- a/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/expected.js
@@ -40,7 +40,7 @@ function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
 function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume("next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
 if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
@@ -50,7 +50,7 @@ _AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", 
 
 _AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
 
-function _AwaitValue(value) { this.value = value; }
+function _AwaitValue(value) { this.wrapped = value; }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 

--- a/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals/expected.js
@@ -30,7 +30,7 @@ function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
 function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume("next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
 if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
@@ -40,7 +40,7 @@ _AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", 
 
 _AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
 
-function _AwaitValue(value) { this.value = value; }
+function _AwaitValue(value) { this.wrapped = value; }
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 

--- a/packages/babel-helper-remap-async-to-generator/src/for-await.js
+++ b/packages/babel-helper-remap-async-to-generator/src/for-await.js
@@ -5,7 +5,7 @@ const awaitTemplate = `
   function* wrapper() {
     var ITERATOR_COMPLETION = true;
     var ITERATOR_HAD_ERROR_KEY = false;
-    var ITERATOR_ERROR_KEY = undefined;
+    var ITERATOR_ERROR_KEY;
     try {
       for (
         var ITERATOR_KEY = GET_ITERATOR(OBJECT), STEP_KEY, STEP_VALUE;
@@ -38,7 +38,7 @@ const buildForAwaitWithoutWrapping = template(
   awaitTemplate.replace(/\bAWAIT\b/g, ""),
 );
 
-export default function(path, helpers) {
+export default function(path, { getAsyncIterator, wrapAwait }) {
   const { node, scope, parent } = path;
 
   const stepKey = scope.generateUidIdentifier("step");
@@ -58,9 +58,7 @@ export default function(path, helpers) {
     ]);
   }
 
-  const build = helpers.wrapAwait
-    ? buildForAwait
-    : buildForAwaitWithoutWrapping;
+  const build = wrapAwait ? buildForAwait : buildForAwaitWithoutWrapping;
   let template = build({
     ITERATOR_HAD_ERROR_KEY: scope.generateUidIdentifier("didIteratorError"),
     ITERATOR_COMPLETION: scope.generateUidIdentifier(
@@ -68,11 +66,11 @@ export default function(path, helpers) {
     ),
     ITERATOR_ERROR_KEY: scope.generateUidIdentifier("iteratorError"),
     ITERATOR_KEY: scope.generateUidIdentifier("iterator"),
-    GET_ITERATOR: helpers.getAsyncIterator,
+    GET_ITERATOR: getAsyncIterator,
     OBJECT: node.right,
     STEP_VALUE: stepValue,
     STEP_KEY: stepKey,
-    ...(helpers.wrapAwait ? { AWAIT: helpers.wrapAwait } : {}),
+    ...(wrapAwait ? { AWAIT: wrapAwait } : {}),
   });
 
   // remove generator function wrapper

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -10,11 +10,21 @@ const awaitVisitor = {
     path.skip();
   },
 
-  AwaitExpression({ node }, { wrapAwait }) {
-    node.type = "YieldExpression";
-    if (wrapAwait) {
-      node.argument = t.callExpression(wrapAwait, [node.argument]);
+  AwaitExpression(path, { wrapAwait }) {
+    const argument = path.get("argument");
+
+    if (path.parentPath.isYieldExpression()) {
+      path.replaceWith(argument.node);
+      return;
     }
+
+    path.replaceWith(
+      t.yieldExpression(
+        wrapAwait
+          ? t.callExpression(wrapAwait, [argument.node])
+          : argument.node,
+      ),
+    );
   },
 
   ForOfStatement(path, { file, wrapAwait }) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/yield-exec/exec.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/yield-exec/exec.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const actual = [];
+const expected = ["foo", "bar", "baz", "xyz"];
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function* test() {
+  yield await delay(0).then(() => actual.push("foo"));
+  await delay(0).then(() => actual.push("bar"));
+  yield delay(0).then(() => actual.push("baz"));
+  actual.push("xyz");
+}
+
+async function main() {
+  const g = test();
+  g.next();
+  g.next();
+  await g.next();
+}
+
+return main().then(() => {
+  assert.deepEqual(actual, expected);
+});

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/yield-exec/options.json
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/yield-exec/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "transform-async-generator-functions"
+  ],
+  "presets": ["es2015"],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-arrow/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-arrow/expected.js
@@ -1,7 +1,8 @@
 babelHelpers.asyncToGenerator(function* () {
   var _iteratorNormalCompletion = true;
   var _didIteratorError = false;
-  var _iteratorError = undefined;
+
+  var _iteratorError;
 
   try {
     for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-function/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-function/expected.js
@@ -2,7 +2,8 @@ let f = (() => {
   var _ref = babelHelpers.asyncToGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
-    var _iteratorError = undefined;
+
+    var _iteratorError;
 
     try {
       for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-generator/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-generator/expected.js
@@ -2,7 +2,8 @@ let g = (() => {
   var _ref = babelHelpers.wrapAsyncGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
-    var _iteratorError = undefined;
+
+    var _iteratorError;
 
     try {
       for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield babelHelpers.awaitAsyncGenerator(_iterator.next()), _iteratorNormalCompletion = _step.done, _value = yield babelHelpers.awaitAsyncGenerator(_step.value), !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/destructuring/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/destructuring/expected.js
@@ -2,7 +2,8 @@ let f = (() => {
   var _ref = babelHelpers.asyncToGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
-    var _iteratorError = undefined;
+
+    var _iteratorError;
 
     try {
       for (var _iterator = babelHelpers.asyncIterator(a), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
@@ -1,7 +1,8 @@
 babelHelpers.asyncToGenerator(function* () {
   var _iteratorNormalCompletion = true;
   var _didIteratorError = false;
-  var _iteratorError = undefined;
+
+  var _iteratorError;
 
   try {
     for (var _iterator = babelHelpers.asyncIterator(iterable), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/async-generator/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/async-generator/expected.js
@@ -16,7 +16,7 @@ function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
 function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; var wrappedAwait = value instanceof _AwaitValue; Promise.resolve(wrappedAwait ? value.wrapped : value).then(function (arg) { if (wrappedAwait) { resume("next", arg); return; } settle(result.done ? "return" : "normal", arg); }, function (err) { resume("throw", err); }); } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
 if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
@@ -26,4 +26,4 @@ _AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", 
 
 _AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
 
-function _AwaitValue(value) { this.value = value; }
+function _AwaitValue(value) { this.wrapped = value; }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6448
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | yes
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no

According to [changes in the spec](https://github.com/tc39/tc39-notes/blob/master/es8/2017-05/may-25.md#15iva-revisiting-async-generator-yield-behavior) - `yield` in async generators should behave just the same as `yield await`.

**NOTE**: It may be (not sure yet) possible to change [`asyncGenerator`](https://github.com/babel/babel/blob/fcdfc61bdbf8898c9cf872fa4f615bddd4cd3548/packages/babel-helpers/src/helpers.js#L90) helper instead of doing my change, but I need to study how it works to see if there is such a possibility