### PR TITLE
Add "use exports { }" directive in es2015-modules-commonjs. Closes #6449

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2663/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2694/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2775/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2941/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/2941/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/3028/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6750/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming-2/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming-3/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming-es3/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming-es3/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/export-default-arrow-renaming/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-2/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-function-name/test/fixtures/function-name/modules-3/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/auxiliary-comment/overview/expected.js
@@ -1,5 +1,6 @@
 /*before*/
 "use strict";
+"use exports { test, test2 }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-10/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-10/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-11/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-11/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default, Cachier }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-2/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-3/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-4/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-4/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-5/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-6/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-7/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-7/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-8/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-8/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-9/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default-9/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-default/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-destructured/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-destructured/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { x, y, f1, f2, f3, f4 }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-2/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-3/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-4/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-4/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-5/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-6/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default, bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-7/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-7/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-8/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from-8/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo14, foo15, foo16, foo17, foo18, foo19, foo20, foo21, foo22, foo23, foo24, foo25, foo26, foo27, foo28, foo29, foo30, foo31, foo32, foo33, foo34, foo35, foo36, foo37, foo38, foo39, foo40, foo41, foo42, foo43, foo44, foo45, foo46, foo47, foo48, foo49, foo50, foo51, foo52, foo53, foo54, foo55, foo56, foo57, foo58, foo59, foo60, foo61, foo62, foo63, foo64, foo65, foo66, foo67, foo68, foo69, foo70, foo71, foo72, foo73, foo74, foo75, foo76, foo77, foo78, foo79, foo80, foo81, foo82, foo83, foo84, foo85, foo86, foo87, foo88, foo89, foo90, foo91, foo92, foo93, foo94, foo95, foo96, foo97, foo98, foo99, foo100 }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-2/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-3/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-3/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-4/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-4/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-5/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named-5/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default, bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-named/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-variable/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/exports-variable/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, foo2, bar, foo3, foo4, foo5, foo6, foo7, foo8, foo9 }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/hoist-function-exports/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/hoist-function-exports/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { nextOdd, isOdd }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/module-shadow/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/module-shadow/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { module }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/overview/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { test, test2 }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/remap/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/remap/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { test, a, c, e, f }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/noInterop/export-from/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/4462-T7565/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/4462-T7565/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { yy, zz }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7160/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7160/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7272/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7272/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { state }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-class/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-function/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-class/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility-named-function/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/es3-compatibility/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-1/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-1/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 exports.default = void 0;
 var _default = foo;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-2/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-2/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 exports.default = void 0;
 var foo;

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/actual.js
@@ -3,6 +3,7 @@ export * from 'mod';
 export class a {}
 export function b() {}
 export { c } from 'mod';
+export { c as g } from 'bod';
 export let d = 42;
 export let e = 1, f = 2;
 export default function() {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { z, a, b, d, e, f, default, c, g }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -10,7 +11,8 @@ var _exportNames = {
   d: true,
   e: true,
   f: true,
-  c: true
+  c: true,
+  g: true
 };
 exports.b = b;
 exports.default = _default;
@@ -18,6 +20,12 @@ Object.defineProperty(exports, "c", {
   enumerable: true,
   get: function () {
     return _mod.c;
+  }
+});
+Object.defineProperty(exports, "g", {
+  enumerable: true,
+  get: function () {
+    return _bod.c;
   }
 });
 exports.f = exports.e = exports.d = exports.a = exports.z = void 0;
@@ -34,6 +42,9 @@ Object.keys(_mod).forEach(function (key) {
     }
   });
 });
+
+var _bod = require("bod");
+
 var z = 100;
 exports.z = z;
 

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-default-params/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-default-params/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 exports.bar = exports.foo = void 0;
 const [foo, bar = 2] = [];

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-rest/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-array-rest/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar, baz }";
 
 exports.baz = exports.bar = exports.foo = void 0;
 const [foo, bar, ...baz] = [];

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-array/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-array/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 exports.bar = exports.foo = void 0;
 const [foo, bar] = [];

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-deep/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-deep/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { baz, qux }";
 
 exports.qux = exports.baz = void 0;
 const {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-default-params/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-default-params/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 exports.bar = exports.foo = void 0;
 const {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-rest/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-object-rest/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo, bar }";
 
 exports.bar = exports.foo = void 0;
 const {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-object/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-const-destructuring-object/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { bar, baz }";
 
 exports.baz = exports.bar = void 0;
 const {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { foo }";
 
 exports.foo = foo;
 

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/6057-expanded/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/regression/6057-expanded/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/member-expression/expected.js
+++ b/packages/babel-plugin-transform-react-inline-elements/test/fixtures/inline-elements/member-expression/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/6733/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { default }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/empty-options/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/empty-options/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { a }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/loose-false/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/loose-false/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { a }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/loose/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/loose/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { a }";
 
 exports.__esModule = true;
 exports.a = a;

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/modules-commonjs/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/modules-commonjs/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { a }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/no-options/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/no-options/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { a }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-preset-es2015/test/fixtures/preset-options/string-preset/expected.js
+++ b/packages/babel-preset-es2015/test/fixtures/preset-options/string-preset/expected.js
@@ -1,4 +1,5 @@
 "use strict";
+"use exports { a }";
 
 Object.defineProperty(exports, "__esModule", {
   value: true


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6449
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | No + yes
| Documentation PR         | No
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->

Makes the change as described in #6449 to the `transform-es2015-modules-commonjs` plugin.

I do have a 2 follow-up questions for @bmeck, though. 

1. What do you want us to do when `[[ExportName]]` would be `null` (`export * from 'mod'`)? Seems like you still need some hint of the exported names that would be coming from the module request. We're not able to handle that within Babel (operates on a single file at a time, no dep graph). Would it work if we extend the directive to reference which module requests had a `*` export?

2. [You mentioned that](https://github.com/bmeck/node/blob/named-export-core/doc/api/esm.md#use-exports-):
    > The properties in the prologue cannot be redefined to be getters or setters.

   Is this only a concern when _redefining_? Just want to make sure we're ok if they start as getters or setters at the time you read the directive.

**Notes**
- I considered adding a flag to disable this, but I can't think of a good reason to not just have it on all the time. I can't imagine there are tools that choke on unrecognized directives (and that would be reading compiled code). The only thing that is making me hesitate is this line from the spec:

    > If an appropriate notification mechanism exists, an implementation should issue a warning if it encounters in a Directive Prologue an ExpressionStatement that is not a Use Strict Directive and which does not have a meaning defined by the implementation.