### PR TITLE
Use no-undefined-identifier eslint rule in packages

### DIFF
--- a/codemods/.eslintrc
+++ b/codemods/.eslintrc
@@ -1,6 +1,6 @@
 {
   "rules": {
     "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undef": 2
+    "no-undefined-identifier": 2
   }
 }

--- a/experimental/.eslintrc
+++ b/experimental/.eslintrc
@@ -1,6 +1,6 @@
 {
   "rules": {
     "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undef": 2
+    "no-undefined-identifier": 2
   }
 }

--- a/packages/.eslintrc
+++ b/packages/.eslintrc
@@ -1,6 +1,6 @@
 {
   "rules": {
     "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undef": 2
+    "no-undefined-identifier": 2
   }
 }


### PR DESCRIPTION
When I merged preset-env into the repo, I was running into troubles with `no-undefined-identifier` and stupidly "fixed" it while completely forgetting that we had added a custom rule.

This rights the wrong :)