### PR TITLE
Fixed async generator named declarations with inline helpers

### DIFF
--- a/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/expected.js
@@ -1,5 +1,5 @@
 var agf = function () {
-  var _ref = _asyncGenerator.wrap(
+  var _ref = _wrapAsyncGenerator(
   /*#__PURE__*/
   regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
@@ -7,7 +7,7 @@ var agf = function () {
         switch (_context.prev = _context.next) {
           case 0:
             _context.next = 2;
-            return _asyncGenerator.await(1);
+            return _awaitAsyncGenerator(1);
 
           case 2:
             _context.next = 4;
@@ -26,19 +26,21 @@ var agf = function () {
   };
 }();
 
-function AwaitValue(value) { this.value = value; }
+function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
-function AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-if (typeof Symbol === "function" && Symbol.asyncIterator) { AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
-AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
+if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
-AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
+_AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
 
-AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+_AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
 
-var _asyncGenerator = { wrap: function wrap(fn) { return function () { return new AsyncGenerator(fn.apply(this, arguments)); }; }, await: function _await(value) { return new AwaitValue(value); } };
+_AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+
+function _AwaitValue(value) { this.value = value; }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 

--- a/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/expected.js
@@ -9,7 +9,7 @@ require("babel-polyfill/lib/regenerator-runtime/runtime");
 require("babel-polyfill/lib/core-js/modules/es6.object.assign");
 
 var agf = function () {
-  var _ref = _asyncGenerator.wrap(
+  var _ref = _wrapAsyncGenerator(
   /*#__PURE__*/
   regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
@@ -17,7 +17,7 @@ var agf = function () {
         switch (_context.prev = _context.next) {
           case 0:
             _context.next = 2;
-            return _asyncGenerator.await(1);
+            return _awaitAsyncGenerator(1);
 
           case 2:
             _context.next = 4;
@@ -36,19 +36,21 @@ var agf = function () {
   };
 }();
 
-function AwaitValue(value) { this.value = value; }
+function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
-function AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-if (typeof Symbol === "function" && Symbol.asyncIterator) { AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
-AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
+if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
-AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
+_AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
 
-AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+_AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
 
-var _asyncGenerator = { wrap: function wrap(fn) { return function () { return new AsyncGenerator(fn.apply(this, arguments)); }; }, await: function _await(value) { return new AwaitValue(value); } };
+_AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+
+function _AwaitValue(value) { this.value = value; }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 

--- a/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/shippedProposals/expected.js
@@ -1,5 +1,5 @@
 var agf = function () {
-  var _ref = _asyncGenerator.wrap(
+  var _ref = _wrapAsyncGenerator(
   /*#__PURE__*/
   regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
@@ -7,7 +7,7 @@ var agf = function () {
         switch (_context.prev = _context.next) {
           case 0:
             _context.next = 2;
-            return _asyncGenerator.await(1);
+            return _awaitAsyncGenerator(1);
 
           case 2:
             _context.next = 4;
@@ -26,19 +26,21 @@ var agf = function () {
   };
 }();
 
-function AwaitValue(value) { this.value = value; }
+function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
-function AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-if (typeof Symbol === "function" && Symbol.asyncIterator) { AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
-AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
+if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
-AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
+_AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
 
-AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+_AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
 
-var _asyncGenerator = { wrap: function wrap(fn) { return function () { return new AsyncGenerator(fn.apply(this, arguments)); }; }, await: function _await(value) { return new AwaitValue(value); } };
+_AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+
+function _AwaitValue(value) { this.value = value; }
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -87,12 +87,16 @@ helpers.asyncIterator = defineHelper(`
   }
 `);
 
-helpers.asyncGenerator = defineHelper(`
-  function AwaitValue(value) {
+helpers.AwaitValue = defineHelper(`
+  export default function _AwaitValue(value) {
     this.value = value;
   }
+`);
 
-  function AsyncGenerator(gen) {
+helpers.AsyncGenerator = defineHelper(`
+  import AwaitValue from "AwaitValue";
+
+  export default function AsyncGenerator(gen) {
     var front, back;
 
     function send(key, arg) {
@@ -166,17 +170,24 @@ helpers.asyncGenerator = defineHelper(`
   AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
   AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
   AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+`);
 
-  export default {
-    wrap: function (fn) {
-      return function () {
-        return new AsyncGenerator(fn.apply(this, arguments));
-      };
-    },
-    await: function (value) {
-      return new AwaitValue(value);
-    }
-  };
+helpers.wrapAsyncGenerator = defineHelper(`
+  import AsyncGenerator from "AsyncGenerator";
+
+  export default function _wrapAsyncGenerator(fn) {
+    return function () {
+      return new AsyncGenerator(fn.apply(this, arguments));
+    };
+  }
+`);
+
+helpers.awaitAsyncGenerator = defineHelper(`
+  import AwaitValue from "AwaitValue";
+
+  export default function _awaitAsyncGenerator(value) {
+    return new AwaitValue(value);
+  }
 `);
 
 helpers.asyncGeneratorDelegate = defineHelper(`

--- a/packages/babel-plugin-transform-async-generator-functions/src/index.js
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.js
@@ -12,10 +12,7 @@ export default function({ types: t }) {
       const callee = state.addHelper("asyncGeneratorDelegate");
       node.argument = t.callExpression(callee, [
         t.callExpression(state.addHelper("asyncIterator"), [node.argument]),
-        t.memberExpression(
-          state.addHelper("asyncGenerator"),
-          t.identifier("await"),
-        ),
+        state.addHelper("awaitAsyncGenerator"),
       ]);
     },
   };
@@ -29,14 +26,8 @@ export default function({ types: t }) {
         path.traverse(yieldStarVisitor, state);
 
         remapAsyncToGenerator(path, state.file, {
-          wrapAsync: t.memberExpression(
-            state.addHelper("asyncGenerator"),
-            t.identifier("wrap"),
-          ),
-          wrapAwait: t.memberExpression(
-            state.addHelper("asyncGenerator"),
-            t.identifier("await"),
-          ),
+          wrapAsync: state.addHelper("wrapAsyncGenerator"),
+          wrapAwait: state.addHelper("awaitAsyncGenerator"),
         });
       },
     },

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/class-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/class-method/expected.js
@@ -2,9 +2,9 @@ class C {
   g() {
     var _this = this;
 
-    return babelHelpers.asyncGenerator.wrap(function* () {
+    return babelHelpers.wrapAsyncGenerator(function* () {
       _this;
-      yield babelHelpers.asyncGenerator.await(1);
+      yield babelHelpers.awaitAsyncGenerator(1);
       yield 2;
       return 3;
     })();

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/declaration-exec/exec.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/declaration-exec/exec.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const actual = [];
+const expected = ["foo_0", "bar_1", "baz_2"];
+
+async function* test() {
+  actual.push(yield await Promise.resolve("foo"));
+  actual.push(yield await Promise.resolve("bar"));
+  actual.push(yield await Promise.resolve("baz"));
+}
+
+async function main() {
+  const g = test();
+  let i = 0;
+  await g
+    .next()
+    .then(({ value }) => g.next(`${value}_${i++}`))
+    .then(({ value }) => g.next(`${value}_${i++}`))
+    .then(({ value }) => g.next(`${value}_${i++}`));
+}
+
+return main().then(() => {
+  assert.deepEqual(actual, expected);
+});

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/declaration-exec/options.json
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/declaration-exec/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "transform-async-to-generator",
+    "transform-async-generator-functions"
+  ],
+  "presets": ["es2015"],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/declaration/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/declaration/expected.js
@@ -1,7 +1,7 @@
 let agf = (() => {
-  var _ref = babelHelpers.asyncGenerator.wrap(function* () {
+  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
     this;
-    yield babelHelpers.asyncGenerator.await(1);
+    yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/expression/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/expression/expected.js
@@ -1,7 +1,7 @@
 (() => {
-  var _ref = babelHelpers.asyncGenerator.wrap(function* () {
+  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
     this;
-    yield babelHelpers.asyncGenerator.await(1);
+    yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/object-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/object-method/expected.js
@@ -2,9 +2,9 @@
   g() {
     var _this = this;
 
-    return babelHelpers.asyncGenerator.wrap(function* () {
+    return babelHelpers.wrapAsyncGenerator(function* () {
       _this;
-      yield babelHelpers.asyncGenerator.await(1);
+      yield babelHelpers.awaitAsyncGenerator(1);
       yield 2;
       return 3;
     })();

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/static-method/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/static-method/expected.js
@@ -2,9 +2,9 @@ class C {
   static g() {
     var _this = this;
 
-    return babelHelpers.asyncGenerator.wrap(function* () {
+    return babelHelpers.wrapAsyncGenerator(function* () {
       _this;
-      yield babelHelpers.asyncGenerator.await(1);
+      yield babelHelpers.awaitAsyncGenerator(1);
       yield 2;
       return 3;
     })();

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/yield-star/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/async-generators/yield-star/expected.js
@@ -1,7 +1,7 @@
 let g = (() => {
-  var _ref = babelHelpers.asyncGenerator.wrap(function* () {
-    yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator([1, 2, 3]), babelHelpers.asyncGenerator.await);
-    yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator(iterable), babelHelpers.asyncGenerator.await);
+  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
+    yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator([1, 2, 3]), babelHelpers.awaitAsyncGenerator);
+    yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator(iterable), babelHelpers.awaitAsyncGenerator);
   });
 
   return function g() {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-generator/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/async-generator/expected.js
@@ -1,11 +1,11 @@
 let g = (() => {
-  var _ref = babelHelpers.asyncGenerator.wrap(function* () {
+  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
 
     try {
-      for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield babelHelpers.asyncGenerator.await(_iterator.next()), _iteratorNormalCompletion = _step.done, _value = yield babelHelpers.asyncGenerator.await(_step.value), !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
+      for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield babelHelpers.awaitAsyncGenerator(_iterator.next()), _iteratorNormalCompletion = _step.done, _value = yield babelHelpers.awaitAsyncGenerator(_step.value), !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
         let x = _value;
         f(x);
       }
@@ -15,7 +15,7 @@ let g = (() => {
     } finally {
       try {
         if (!_iteratorNormalCompletion && _iterator.return != null) {
-          yield babelHelpers.asyncGenerator.await(_iterator.return());
+          yield babelHelpers.awaitAsyncGenerator(_iterator.return());
         }
       } finally {
         if (_didIteratorError) {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/arrows-in-declaration/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/arrows-in-declaration/expected.js
@@ -1,5 +1,5 @@
 let g = (() => {
-  var _ref = babelHelpers.asyncGenerator.wrap(function* () {
+  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
     var _this = this;
 
     () => this;
@@ -12,7 +12,7 @@ let g = (() => {
       _this;
       yield 1;
     });
-    yield babelHelpers.asyncGenerator.await(1);
+    yield babelHelpers.awaitAsyncGenerator(1);
   });
 
   return function g() {

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/async-in-params/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/async-in-params/expected.js
@@ -1,8 +1,8 @@
 let g = (() => {
-  var _ref = babelHelpers.asyncGenerator.wrap(function* (x = babelHelpers.asyncToGenerator(function* () {
+  var _ref = babelHelpers.wrapAsyncGenerator(function* (x = babelHelpers.asyncToGenerator(function* () {
     yield 1;
   })) {
-    yield babelHelpers.asyncGenerator.await(2);
+    yield babelHelpers.awaitAsyncGenerator(2);
     yield 3;
   });
 

--- a/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/generator-in-async/expected.js
+++ b/packages/babel-plugin-transform-async-generator-functions/test/fixtures/nested/generator-in-async/expected.js
@@ -1,8 +1,8 @@
 let f = (() => {
   var _ref = babelHelpers.asyncToGenerator(function* () {
     let g = (() => {
-      var _ref2 = babelHelpers.asyncGenerator.wrap(function* () {
-        yield babelHelpers.asyncGenerator.await(2);
+      var _ref2 = babelHelpers.wrapAsyncGenerator(function* () {
+        yield babelHelpers.awaitAsyncGenerator(2);
         yield 3;
       });
 

--- a/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/async-generator/expected.js
+++ b/packages/babel-plugin-transform-function-sent/test/fixtures/generator-kinds/async-generator/expected.js
@@ -1,8 +1,8 @@
 let foo = (() => {
-  var _ref = _asyncGenerator.wrap(_skipFirstGeneratorNext(function* () {
+  var _ref = _wrapAsyncGenerator(_skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
-    _functionSent = yield _asyncGenerator.await(_functionSent);
+    _functionSent = yield _awaitAsyncGenerator(_functionSent);
   }));
 
   return function foo() {
@@ -12,16 +12,18 @@ let foo = (() => {
 
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function AwaitValue(value) { this.value = value; }
+function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
-function AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
+function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
 
-if (typeof Symbol === "function" && Symbol.asyncIterator) { AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
+function _AsyncGenerator(gen) { var front, back; function send(key, arg) { return new Promise(function (resolve, reject) { var request = { key: key, arg: arg, resolve: resolve, reject: reject, next: null }; if (back) { back = back.next = request; } else { front = back = request; resume(key, arg); } }); } function resume(key, arg) { try { var result = gen[key](arg); var value = result.value; if (value instanceof _AwaitValue) { Promise.resolve(value.value).then(function (arg) { resume("next", arg); }, function (arg) { resume("throw", arg); }); } else { settle(result.done ? "return" : "normal", result.value); } } catch (err) { settle("throw", err); } } function settle(type, value) { switch (type) { case "return": front.resolve({ value: value, done: true }); break; case "throw": front.reject(value); break; default: front.resolve({ value: value, done: false }); break; } front = front.next; if (front) { resume(front.key, front.arg); } else { back = null; } } this._invoke = send; if (typeof gen.return !== "function") { this.return = undefined; } }
 
-AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
+if (typeof Symbol === "function" && Symbol.asyncIterator) { _AsyncGenerator.prototype[Symbol.asyncIterator] = function () { return this; }; }
 
-AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
+_AsyncGenerator.prototype.next = function (arg) { return this._invoke("next", arg); };
 
-AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+_AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", arg); };
 
-var _asyncGenerator = { wrap: function (fn) { return function () { return new AsyncGenerator(fn.apply(this, arguments)); }; }, await: function (value) { return new AwaitValue(value); } };
+_AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
+
+function _AwaitValue(value) { this.value = value; }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no

Async generators are getting transpiled to IIFEs, if the original async generator is named function declaraction the IIFE gets hoisted to preserve function declaration hoisting behaviour. However helpers were injected into the file before the hoisting has happened, so when IIFE got executed they were not yet available declared properly.

With the change `asyncGenerator.wrap` and `asyncGenerator.await` become named declarations (respectively `wrapAsyncGenerator` and `awaitAsyncGenererator`), so they get hoisted and are available for the transpiled IIFE right away.
