### PR TITLE
Removed index.js stub from packages/babel-core

### DIFF
--- a/packages/babel-core/index.js
+++ b/packages/babel-core/index.js
@@ -1,1 +1,0 @@
-module.exports = require("./lib/index.js");

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -2,7 +2,7 @@
   "name": "babel-core",
   "version": "7.0.0-beta.2",
   "description": "Babel compiler core.",
-  "main":"./lib/index.js",
+  "main": "./lib/index.js",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -2,6 +2,7 @@
   "name": "babel-core",
   "version": "7.0.0-beta.2",
   "description": "Babel compiler core.",
+  "main":"./lib/index.js",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",


### PR DESCRIPTION
Added "main":"./lib/index.js" entry to package.json to replace index.js in packages/babel-core

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | Changes the way the entry point for babel-core is accessed, but otherwise no

<!-- Describe your changes below in as much detail as possible -->

Removes the `packages/babel-core/index.js` file which serves as a stub and simply exports the export of `./lib/index.js`. By adding `"main":"./lib/index.js"` to `packages/babel-core/package.json`, we can achieve still specify the entry point for the babel-core module while maintaining one less file.