### PR TITLE
Fixed es2015-template-literals dependencies

### DIFF
--- a/packages/babel-plugin-transform-es2015-template-literals/package.json
+++ b/packages/babel-plugin-transform-es2015-template-literals/package.json
@@ -5,11 +5,13 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-template-literals",
   "license": "MIT",
   "main": "lib/index.js",
+  "dependencies": {
+    "babel-helper-annotate-as-pure": "7.0.0-beta.3"
+  },
   "keywords": [
     "babel-plugin"
   ],
   "devDependencies": {
-    "babel-helper-annotate-as-pure": "7.0.0-beta.3",
     "babel-helper-plugin-test-runner": "7.0.0-beta.3"
   }
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | kinda
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | n/a
| Documentation PR         | no
| Any Dependency Changes?  | yes (internal deps)

By accident I have put `babel-helper-annotate-as-pure` in `devDependencies` of `babel-plugin-transform-es2015-template-literals`, where it should be dependency.

This PR fixes it, therefore fixing preset-es2015 usage on npm@2
