### PR TITLE
Limit file-based plugins/presets to only exporting functions.

### DIFF
--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -556,6 +556,15 @@ function normalizePair(
     );
   }
 
+  if (filepath !== null && typeof value === "object" && value) {
+    // We allow object values for plugins/presets nested directly within a
+    // config object, because it can be useful to define them in nested
+    // configuration contexts.
+    throw new Error(
+      "Plugin/Preset files are not allowed to export objects, only functions.",
+    );
+  }
+
   if (options != null && typeof options !== "object") {
     throw new Error(
       "Plugin/Preset options must be an object, null, or undefined",

--- a/packages/babel-core/test/fixtures/option-manager/presets/es2015_default_object.js
+++ b/packages/babel-core/test/fixtures/option-manager/presets/es2015_default_object.js
@@ -7,6 +7,8 @@
 'use strict';
 
 exports.__esModule = true;
-exports.default = {
-  plugins: [require('../../../../../babel-plugin-syntax-decorators')]
+module.exports = function() {
+  return {
+    plugins: [require('../../../../../babel-plugin-syntax-decorators')]
+  };
 };

--- a/packages/babel-core/test/fixtures/option-manager/presets/es5_object.js
+++ b/packages/babel-core/test/fixtures/option-manager/presets/es5_object.js
@@ -1,5 +1,7 @@
-module.exports = {
-  plugins: [
-    require('../../../../../babel-plugin-syntax-decorators'),
-  ]
+module.exports = function() {
+  return {
+    plugins: [
+      require('../../../../../babel-plugin-syntax-decorators'),
+    ]
+  };
 };

--- a/packages/babel-core/test/fixtures/resolution/babel-org-paths/node_modules/@babel/plugin-foo/index.js
+++ b/packages/babel-core/test/fixtures/resolution/babel-org-paths/node_modules/@babel/plugin-foo/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/babel-org-paths/node_modules/@babel/preset-foo/index.js
+++ b/packages/babel-core/test/fixtures/resolution/babel-org-paths/node_modules/@babel/preset-foo/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/babel-scoped-nested-module-paths/node_modules/@babel/mod/plugin.js
+++ b/packages/babel-core/test/fixtures/resolution/babel-scoped-nested-module-paths/node_modules/@babel/mod/plugin.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/babel-scoped-nested-module-paths/node_modules/@babel/mod/preset.js
+++ b/packages/babel-core/test/fixtures/resolution/babel-scoped-nested-module-paths/node_modules/@babel/mod/preset.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-plugin-mod/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-plugin-mod/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-preset-mod/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-preset-mod/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/module-paths/node_modules/plugin/index.js
+++ b/packages/babel-core/test/fixtures/resolution/module-paths/node_modules/plugin/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/module-paths/node_modules/preset/index.js
+++ b/packages/babel-core/test/fixtures/resolution/module-paths/node_modules/preset/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/nested-module-paths/node_modules/mod/plugin.js
+++ b/packages/babel-core/test/fixtures/resolution/nested-module-paths/node_modules/mod/plugin.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/nested-module-paths/node_modules/mod/preset.js
+++ b/packages/babel-core/test/fixtures/resolution/nested-module-paths/node_modules/mod/preset.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/relative-paths/dir/plugin.js
+++ b/packages/babel-core/test/fixtures/resolution/relative-paths/dir/plugin.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/relative-paths/dir/preset.js
+++ b/packages/babel-core/test/fixtures/resolution/relative-paths/dir/preset.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/scoped-nested-module-paths/node_modules/@foo/mod/plugin.js
+++ b/packages/babel-core/test/fixtures/resolution/scoped-nested-module-paths/node_modules/@foo/mod/plugin.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/scoped-nested-module-paths/node_modules/@foo/mod/preset.js
+++ b/packages/babel-core/test/fixtures/resolution/scoped-nested-module-paths/node_modules/@foo/mod/preset.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/standard-paths/node_modules/babel-plugin-mod/index.js
+++ b/packages/babel-core/test/fixtures/resolution/standard-paths/node_modules/babel-plugin-mod/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/standard-paths/node_modules/babel-preset-mod/index.js
+++ b/packages/babel-core/test/fixtures/resolution/standard-paths/node_modules/babel-preset-mod/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/throw-babel-paths/node_modules/@babel/plugin-foo/index.js
+++ b/packages/babel-core/test/fixtures/resolution/throw-babel-paths/node_modules/@babel/plugin-foo/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/throw-babel-paths/node_modules/@babel/preset-foo/index.js
+++ b/packages/babel-core/test/fixtures/resolution/throw-babel-paths/node_modules/@babel/preset-foo/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/throw-module-paths/node_modules/foo/index.js
+++ b/packages/babel-core/test/fixtures/resolution/throw-module-paths/node_modules/foo/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/throw-opposite-paths/node_modules/babel-plugin-testplugin/index.js
+++ b/packages/babel-core/test/fixtures/resolution/throw-opposite-paths/node_modules/babel-plugin-testplugin/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/throw-opposite-paths/node_modules/babel-preset-testpreset/index.js
+++ b/packages/babel-core/test/fixtures/resolution/throw-opposite-paths/node_modules/babel-preset-testpreset/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-helpers/test/fixtures/dependencies/basic/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/basic/plugin.js
@@ -12,12 +12,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/deep/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/deep/plugin.js
@@ -17,12 +17,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/missing/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/missing/plugin.js
@@ -8,12 +8,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/multiple/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/multiple/plugin.js
@@ -17,12 +17,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/rename-binding-equal/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/rename-binding-equal/plugin.js
@@ -15,12 +15,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/rename-deep-global/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/rename-deep-global/plugin.js
@@ -14,12 +14,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/reuse-dependency/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/reuse-dependency/plugin.js
@@ -12,16 +12,18 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name === "REPLACE_ME_1") {
-        const mainHelper = this.addHelper(main);
-        path.replaceWith(mainHelper);
-      } else if (path.node.name === "REPLACE_ME_2") {
-        const dependencyHelper = this.addHelper(dependency);
-        path.replaceWith(dependencyHelper);
-      }
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name === "REPLACE_ME_1") {
+          const mainHelper = this.addHelper(main);
+          path.replaceWith(mainHelper);
+        } else if (path.node.name === "REPLACE_ME_2") {
+          const dependencyHelper = this.addHelper(dependency);
+          path.replaceWith(dependencyHelper);
+        }
+      },
     },
-  },
+  };
 };

--- a/packages/babel-helpers/test/fixtures/dependencies/variable-same-name-dependency/plugin.js
+++ b/packages/babel-helpers/test/fixtures/dependencies/variable-same-name-dependency/plugin.js
@@ -15,12 +15,14 @@ const main = defineHelper(__dirname, "main", `
   }
 `);
 
-module.exports = {
-  visitor: {
-    Identifier(path) {
-      if (path.node.name !== "REPLACE_ME") return;
-      const helper = this.addHelper(main);
-      path.replaceWith(helper);
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name !== "REPLACE_ME") return;
+        const helper = this.addHelper(main);
+        path.replaceWith(helper);
+      },
     },
-  },
+  };
 };


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

Figured I'd see what people think about this. We've talked in the past about limiting plugins and presets to be functions, and I think decided there wasn't anything to gain, but as I've been thinking more about it, it has some implications for caching. If a file exports a plugin object directly, there's no way for us to expose an API to manage caching, so it encourages people to write plugins that don't take that into account.

I've been thinking about this more because I'm trying to piece together a system for creating a hash of Babel's input arguments so that we can skip compiling if we've compiled the code previously with the same settings. Ideally to do this, each item that is conceptually a standalone item should have a way to tell Babel what version it is, what name it has, and ideally anything that it might depend on. If file-based plugins and presets export an object, that's a no-go.

This PR allows
```
module.exports = function(){
  return {
    presets: [{
      // Object allowed here, since it's not a string-based preset pointing at another file.
    }],
  };
};
```

What this PR does is try to move us toward a world where essentially, a given plugin or preset will always have an "owner" that is clear. So file-based plugins and presets export functions, which means it is that function's responsibility to define some caching rules. That means that plugins and presets that are objects must be nested either inside a config file (thus caching is determined by the config file's caching logic), or inside the programmatic args for Babel, in which case I'm planning to introduce some logic for passing a cache invalidation value there somehow.