### PR TITLE
Export File from babel-core again

### DIFF
--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+export { default as File } from "./transformation/file/file";
 export {
   default as buildExternalHelpers,
 } from "./tools/build-external-helpers";


### PR DESCRIPTION
If you want to use Babel's traversal tools outside of plugins, you cannot use babel-traverse on it's own because NodePath won't have Hub/File.

In order to create a matching NodePath you need the `File` export of babel-core. As such, a lot of the ecosystem depends on it (including a lot of my own tools).

This was [removed recently](https://github.com/babel/babel/pull/6359) and broke everything that was using it with no reasonable alternative that I've been able to find.

**I'm not looking to debate a better solution for how we can make NodePath/traversal work outside of plugins.** Until a better solution exists this API should not be removed as a lot of tools in the ecosystem need it. I have lots of ideas, but we should discuss that separately

`File` is already an exposed API because we put it on node paths inside plugin transforms, removing it from the exports does not make it private API.