### PR TITLE
babel-core: Pass the right err to callback in transformFile()

### DIFF
--- a/packages/babel-core/src/transform-file.js
+++ b/packages/babel-core/src/transform-file.js
@@ -25,7 +25,7 @@ export default function transformFile(
     try {
       result = runTransform(config, code);
     } catch (_err) {
-      return callback(err, null);
+      return callback(_err, null);
     }
     callback(null, result);
   });


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |  👍
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | 👎 
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

When the file being transformed contains invalid JavaScript (ie. contains syntax errors), those errors would be swallowed due to the callback receiving the incorrect `err` object. This PR fixes that.