### PR TITLE
Remove syntax-trailing-function-commas from Babel presets

### DIFF
--- a/experimental/babel-preset-env/data/plugin-features.js
+++ b/experimental/babel-preset-env/data/plugin-features.js
@@ -128,11 +128,6 @@ const es2017 = {
       "async functions",
     ],
   },
-  "syntax-trailing-function-commas": {
-    features: [
-      "trailing commas in function syntax",
-    ],
-  }
 };
 
 const proposals = require("./shipped-proposals").features;

--- a/experimental/babel-preset-env/data/plugins.json
+++ b/experimental/babel-preset-env/data/plugins.json
@@ -228,16 +228,6 @@
     "opera": "42",
     "electron": "1.6"
   },
-  "syntax-trailing-function-commas": {
-    "chrome": "58",
-    "edge": "14",
-    "firefox": "52",
-    "safari": "10",
-    "node": "8",
-    "ios": "10",
-    "opera": "45",
-    "electron": "1.7"
-  },
   "transform-async-generator-functions": {
     "chrome": "63",
     "firefox": "57",

--- a/experimental/babel-preset-env/package.json
+++ b/experimental/babel-preset-env/package.json
@@ -15,7 +15,6 @@
     "@babel/plugin-syntax-async-generators": "7.0.0-beta.3",
     "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.3",
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.3",
-    "babel-plugin-syntax-trailing-function-commas": "7.0.0-beta.0",
     "@babel/plugin-transform-async-generator-functions": "7.0.0-beta.3",
     "@babel/plugin-transform-async-to-generator": "7.0.0-beta.3",
     "@babel/plugin-transform-es2015-arrow-functions": "7.0.0-beta.3",

--- a/experimental/babel-preset-env/src/available-plugins.js
+++ b/experimental/babel-preset-env/src/available-plugins.js
@@ -3,7 +3,6 @@ export default {
   "syntax-async-generators": require("@babel/plugin-syntax-async-generators"),
   "syntax-object-rest-spread": require("@babel/plugin-syntax-object-rest-spread"),
   "syntax-optional-catch-binding": require("@babel/plugin-syntax-optional-catch-binding"),
-  "syntax-trailing-function-commas": require("babel-plugin-syntax-trailing-function-commas"),
   "transform-async-to-generator": require("@babel/plugin-transform-async-to-generator"),
   "transform-async-generator-functions": require("@babel/plugin-transform-async-generator-functions"),
   "transform-es2015-arrow-functions": require("@babel/plugin-transform-es2015-arrow-functions"),

--- a/experimental/babel-preset-env/test/debug-fixtures/android/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/android/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-regenerator { "android":"4" }
   transform-exponentiation-operator { "android":"4" }
   transform-async-to-generator { "android":"4" }
-  syntax-trailing-function-commas { "android":"4" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
@@ -13,7 +13,6 @@ Using plugins:
   transform-es2015-function-name { "node":"6" }
   transform-exponentiation-operator { "node":"6" }
   transform-async-to-generator { "node":"6" }
-  syntax-trailing-function-commas { "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
@@ -34,7 +34,6 @@ Using plugins:
   transform-regenerator {}
   transform-exponentiation-operator {}
   transform-async-to-generator {}
-  syntax-trailing-function-commas { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
@@ -33,7 +33,6 @@ Using plugins:
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6" }
   transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  syntax-trailing-function-commas { "chrome":"54", "ie":"10", "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/electron/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/electron/stdout.txt
@@ -26,7 +26,6 @@ Using plugins:
   transform-regenerator { "electron":"0.36" }
   transform-exponentiation-operator { "electron":"0.36" }
   transform-async-to-generator { "electron":"0.36" }
-  syntax-trailing-function-commas { "electron":"0.36" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-regenerator {}
   transform-exponentiation-operator {}
   transform-async-to-generator {}
-  syntax-trailing-function-commas { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
@@ -20,7 +20,6 @@ Using plugins:
   transform-es2015-for-of { "firefox":"52" }
   transform-es2015-function-name { "firefox":"52" }
   transform-es2015-literals { "firefox":"52" }
-  syntax-trailing-function-commas { "node":"7.4" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
 src/in.js -> lib/in.js

--- a/experimental/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
@@ -29,7 +29,6 @@ Using plugins:
   transform-regenerator {}
   transform-exponentiation-operator {}
   transform-async-to-generator {}
-  syntax-trailing-function-commas {}
   transform-async-generator-functions {}
   transform-object-rest-spread {}
   transform-optional-catch-binding {}

--- a/experimental/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -36,7 +36,6 @@ Using plugins:
   transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  syntax-trailing-function-commas { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  syntax-trailing-function-commas { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
@@ -8,7 +8,6 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
-  syntax-trailing-function-commas { "chrome":"55" }
 
 Using polyfills with `usage` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/usage/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/usage/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  syntax-trailing-function-commas { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
@@ -42,7 +42,6 @@ Using plugins:
   transform-regenerator { "electron":"0.36", "ie":"10" }
   transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  syntax-trailing-function-commas { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 
 Using polyfills with `entry` option:
 

--- a/experimental/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
+++ b/experimental/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
@@ -33,7 +33,6 @@ Using plugins:
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6.10" }
   transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  syntax-trailing-function-commas { "chrome":"54", "ie":"10", "node":"6.10" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-es2017/package.json
+++ b/packages/babel-preset-es2017/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2017",
   "main": "lib/index.js",
   "dependencies": {
-    "babel-plugin-syntax-trailing-function-commas": "7.0.0-beta.0",
     "@babel/plugin-transform-async-to-generator": "7.0.0-beta.3"
   }
 }

--- a/packages/babel-preset-es2017/src/index.js
+++ b/packages/babel-preset-es2017/src/index.js
@@ -1,8 +1,7 @@
-import syntaxTrailingFunctionCommas from "babel-plugin-syntax-trailing-function-commas";
 import transformAsyncToGenerator from "@babel/plugin-transform-async-to-generator";
 
 export default function() {
   return {
-    plugins: [syntaxTrailingFunctionCommas, transformAsyncToGenerator],
+    plugins: [transformAsyncToGenerator],
   };
 }


### PR DESCRIPTION
Partial revert of https://github.com/babel/babel/commit/57584268cdaed12ef1fdc27841207c82c1241745

Edit: 

For historical purposes, the [trailingComma syntax is enabled _by default_ in Babylon](https://github.com/babel/babylon/pull/98), so there's no need for a plugin that enables it.