### PR TITLE
Fix regression that leaks JSX pragma config between files.

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -2,8 +2,7 @@ import jsx from "@babel/plugin-syntax-jsx";
 import helper from "@babel/helper-builder-react-jsx";
 
 export default function({ types: t }, options) {
-  const { pragma } = options;
-  let id = pragma || "React.createElement";
+  const pragma = options.pragma || "React.createElement";
 
   const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
 
@@ -26,6 +25,7 @@ export default function({ types: t }, options) {
   visitor.Program = function(path, state) {
     const { file } = state;
 
+    let id = pragma;
     for (const comment of (file.ast.comments: Array<Object>)) {
       const matches = JSX_ANNOTATION_REGEX.exec(comment.value);
       if (matches) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6518
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

Fix a regression from https://github.com/babel/babel/pull/6381/files#diff-18da325252fa9074bd50f8b406413a01L25 that made the top-level `pragma` value mutable across files accidentally.