### PR TITLE
fix(babel-core): add missing extension to package.json dependency

### DIFF
--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -6,7 +6,7 @@ export {
 } from "./tools/build-external-helpers";
 export { resolvePlugin, resolvePreset } from "./config/loading/files";
 
-export { version } from "../package";
+export { version } from "../package.json";
 export { getEnv } from "./config/helpers/environment";
 
 export * as types from "@babel/types";


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?         | 👍 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | 
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->

Not having the `.json` extension makes TypeScript to fail when requiring this file. That's by [definition in TypeScript](https://www.typescriptlang.org/docs/handbook/module-resolution.html).

That's reproducible easily using [this repo](https://github.com/pyramation/typescript-starter-example). If you follow the steps you'll see this error:

```
Cannot find module '../../package' from 'node.js'
      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
      at Object.<anonymous> (node_modules/babel-core/lib/api/node.js:60:16)
```

This PR fixes the issue by adding the extension.
