### PR TITLE
Optional Chaining: Account for document.all

### DIFF
--- a/packages/babel-plugin-transform-optional-chaining/src/index.js
+++ b/packages/babel-plugin-transform-optional-chaining/src/index.js
@@ -76,7 +76,17 @@ export default function({ types: t }, options) {
 
       replacementPath.replaceWith(
         t.conditionalExpression(
-          t.binaryExpression("==", check, t.nullLiteral()),
+          loose
+            ? t.binaryExpression("==", t.clone(check), t.nullLiteral())
+            : t.logicalExpression(
+                "||",
+                t.binaryExpression("===", t.clone(check), t.nullLiteral()),
+                t.binaryExpression(
+                  "===",
+                  t.clone(ref),
+                  scope.buildUndefinedNode(),
+                ),
+              ),
           nil,
           replacementPath.node,
         ),

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/assignement/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/assignement/expected.js
@@ -1,6 +1,6 @@
 var _a, _a2, _a2$b, _a2$b$c, _a3, _a3$b, _a3$b$c, _a4, _a4$b, _a4$b$c;
 
-(_a = a) == null ? void 0 : _a.b = 42;
-(_a2 = a) == null ? void 0 : (_a2$b = _a2.b) == null ? void 0 : (_a2$b$c = _a2$b.c) == null ? void 0 : _a2$b$c.d = 42;
-(_a3 = a) == null ? void 0 : (_a3$b = _a3.b) == null ? void 0 : (_a3$b$c = _a3$b.c) == null ? void 0 : _a3$b$c.d++;
-(_a4 = a) == null ? void 0 : (_a4$b = _a4.b) == null ? void 0 : (_a4$b$c = _a4$b.c) == null ? void 0 : _a4$b$c.d += 1;
+(_a = a) === null || _a === void 0 ? void 0 : _a.b = 42;
+(_a2 = a) === null || _a2 === void 0 ? void 0 : (_a2$b = _a2.b) === null || _a2$b === void 0 ? void 0 : (_a2$b$c = _a2$b.c) === null || _a2$b$c === void 0 ? void 0 : _a2$b$c.d = 42;
+(_a3 = a) === null || _a3 === void 0 ? void 0 : (_a3$b = _a3.b) === null || _a3$b === void 0 ? void 0 : (_a3$b$c = _a3$b.c) === null || _a3$b$c === void 0 ? void 0 : _a3$b$c.d++;
+(_a4 = a) === null || _a4 === void 0 ? void 0 : (_a4$b = _a4.b) === null || _a4$b === void 0 ? void 0 : (_a4$b$c = _a4$b.c) === null || _a4$b$c === void 0 ? void 0 : _a4$b$c.d += 1;

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/containers/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/containers/expected.js
@@ -1,6 +1,6 @@
 var _user$address, _user$address2, _a, _a2;
 
-var street = (_user$address = user.address) == null ? void 0 : _user$address.street;
-street = (_user$address2 = user.address) == null ? void 0 : _user$address2.street;
-test((_a = a) == null ? void 0 : _a.b, 1);
-1, (_a2 = a) == null ? void 0 : _a2.b, 2;
+var street = (_user$address = user.address) === null || _user$address === void 0 ? void 0 : _user$address.street;
+street = (_user$address2 = user.address) === null || _user$address2 === void 0 ? void 0 : _user$address2.street;
+test((_a = a) === null || _a === void 0 ? void 0 : _a.b, 1);
+1, (_a2 = a) === null || _a2 === void 0 ? void 0 : _a2.b, 2;

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/delete/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/delete/expected.js
@@ -1,4 +1,4 @@
 var _a, _a2, _a2$b, _a2$b$c;
 
-(_a = a) == null ? void 0 : delete _a.b;
-(_a2 = a) == null ? void 0 : (_a2$b = _a2.b) == null ? void 0 : (_a2$b$c = _a2$b.c) == null ? void 0 : delete _a2$b$c.d;
+(_a = a) === null || _a === void 0 ? void 0 : delete _a.b;
+(_a2 = a) === null || _a2 === void 0 ? void 0 : (_a2$b = _a2.b) === null || _a2$b === void 0 ? void 0 : (_a2$b$c = _a2$b.c) === null || _a2$b$c === void 0 ? void 0 : delete _a2$b$c.d;

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/function-call/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/function-call/expected.js
@@ -1,12 +1,12 @@
 var _foo, _foo2, _foo$bar, _foo3, _foo4, _foo4$bar, _foo5, _foo6, _foo7, _foo$bar2, _foo8, _foo$bar3, _foo9, _foo$bar3$call, _foo10, _foo10$bar, _foo11, _foo11$bar, _foo11$bar$call;
 
-(_foo = foo) == null ? void 0 : _foo(foo);
-(_foo2 = foo) == null ? void 0 : _foo2.bar();
-(_foo$bar = (_foo3 = foo).bar) == null ? void 0 : _foo$bar.call(_foo3, foo.bar, false);
-(_foo4 = foo) == null ? void 0 : (_foo4$bar = _foo4.bar) == null ? void 0 : _foo4$bar.call(_foo4, foo.bar, true);
-(_foo5 = foo) == null ? void 0 : _foo5().bar;
-(_foo6 = foo) == null ? void 0 : (_foo7 = _foo6()) == null ? void 0 : _foo7.bar;
-(_foo$bar2 = (_foo8 = foo).bar) == null ? void 0 : _foo$bar2.call(_foo8).baz;
-(_foo$bar3 = (_foo9 = foo).bar) == null ? void 0 : (_foo$bar3$call = _foo$bar3.call(_foo9)) == null ? void 0 : _foo$bar3$call.baz;
-(_foo10 = foo) == null ? void 0 : (_foo10$bar = _foo10.bar) == null ? void 0 : _foo10$bar.call(_foo10).baz;
-(_foo11 = foo) == null ? void 0 : (_foo11$bar = _foo11.bar) == null ? void 0 : (_foo11$bar$call = _foo11$bar.call(_foo11)) == null ? void 0 : _foo11$bar$call.baz;
+(_foo = foo) === null || _foo === void 0 ? void 0 : _foo(foo);
+(_foo2 = foo) === null || _foo2 === void 0 ? void 0 : _foo2.bar();
+(_foo$bar = (_foo3 = foo).bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.call(_foo3, foo.bar, false);
+(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : (_foo4$bar = _foo4.bar) === null || _foo4$bar === void 0 ? void 0 : _foo4$bar.call(_foo4, foo.bar, true);
+(_foo5 = foo) === null || _foo5 === void 0 ? void 0 : _foo5().bar;
+(_foo6 = foo) === null || _foo6 === void 0 ? void 0 : (_foo7 = _foo6()) === null || _foo7 === void 0 ? void 0 : _foo7.bar;
+(_foo$bar2 = (_foo8 = foo).bar) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2.call(_foo8).baz;
+(_foo$bar3 = (_foo9 = foo).bar) === null || _foo$bar3 === void 0 ? void 0 : (_foo$bar3$call = _foo$bar3.call(_foo9)) === null || _foo$bar3$call === void 0 ? void 0 : _foo$bar3$call.baz;
+(_foo10 = foo) === null || _foo10 === void 0 ? void 0 : (_foo10$bar = _foo10.bar) === null || _foo10$bar === void 0 ? void 0 : _foo10$bar.call(_foo10).baz;
+(_foo11 = foo) === null || _foo11 === void 0 ? void 0 : (_foo11$bar = _foo11.bar) === null || _foo11$bar === void 0 ? void 0 : (_foo11$bar$call = _foo11$bar.call(_foo11)) === null || _foo11$bar$call === void 0 ? void 0 : _foo11$bar$call.baz;

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/member-access/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/member-access/expected.js
@@ -1,12 +1,12 @@
 var _foo, _a, _a$b$c, _a$b, _a$b$c$d, _a$b$c2, _a$b$c2$d, _orders, _orders2, _orders2$, _client, _orders$client$key, _a2, _c, _a3;
 
-(_foo = foo) == null ? void 0 : _foo.bar;
-(_a = a) == null ? void 0 : (_a$b$c = _a.b.c) == null ? void 0 : _a$b$c.d.e;
-(_a$b = a.b) == null ? void 0 : (_a$b$c$d = _a$b.c.d) == null ? void 0 : _a$b$c$d.e;
-(_a$b$c2 = a.b.c) == null ? void 0 : (_a$b$c2$d = _a$b$c2.d) == null ? void 0 : _a$b$c2$d.e;
-(_orders = orders) == null ? void 0 : _orders[0].price;
-(_orders2 = orders) == null ? void 0 : (_orders2$ = _orders2[0]) == null ? void 0 : _orders2$.price;
-orders[(_client = client) == null ? void 0 : _client.key].price;
-(_orders$client$key = orders[client.key]) == null ? void 0 : _orders$client$key.price;
-(0, (_a2 = a) == null ? void 0 : _a2.b).c;
-(0, (_c = (0, (_a3 = a) == null ? void 0 : _a3.b).c) == null ? void 0 : _c.d).e;
+(_foo = foo) === null || _foo === void 0 ? void 0 : _foo.bar;
+(_a = a) === null || _a === void 0 ? void 0 : (_a$b$c = _a.b.c) === null || _a$b$c === void 0 ? void 0 : _a$b$c.d.e;
+(_a$b = a.b) === null || _a$b === void 0 ? void 0 : (_a$b$c$d = _a$b.c.d) === null || _a$b$c$d === void 0 ? void 0 : _a$b$c$d.e;
+(_a$b$c2 = a.b.c) === null || _a$b$c2 === void 0 ? void 0 : (_a$b$c2$d = _a$b$c2.d) === null || _a$b$c2$d === void 0 ? void 0 : _a$b$c2$d.e;
+(_orders = orders) === null || _orders === void 0 ? void 0 : _orders[0].price;
+(_orders2 = orders) === null || _orders2 === void 0 ? void 0 : (_orders2$ = _orders2[0]) === null || _orders2$ === void 0 ? void 0 : _orders2$.price;
+orders[(_client = client) === null || _client === void 0 ? void 0 : _client.key].price;
+(_orders$client$key = orders[client.key]) === null || _orders$client$key === void 0 ? void 0 : _orders$client$key.price;
+(0, (_a2 = a) === null || _a2 === void 0 ? void 0 : _a2.b).c;
+(0, (_c = (0, (_a3 = a) === null || _a3 === void 0 ? void 0 : _a3.b).c) === null || _c === void 0 ? void 0 : _c.d).e;

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/memoize/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/memoize/expected.js
@@ -1,14 +1,14 @@
 function test(foo) {
   var _foo$bar, _foo$bar2, _foo$bar3, _foo$bar4, _foo$bar5, _foo$bar6, _foo$bar6$baz, _foo$bar7, _foo$bar7$baz;
 
-  foo == null ? void 0 : foo.bar;
-  foo == null ? void 0 : (_foo$bar = foo.bar) == null ? void 0 : _foo$bar.baz;
-  foo == null ? void 0 : foo(foo);
-  foo == null ? void 0 : foo.bar();
-  (_foo$bar2 = foo.bar) == null ? void 0 : _foo$bar2.call(foo, foo.bar, false);
-  foo == null ? void 0 : (_foo$bar3 = foo.bar) == null ? void 0 : _foo$bar3.call(foo, foo.bar, true);
-  (_foo$bar4 = foo.bar) == null ? void 0 : _foo$bar4.baz(foo.bar, false);
-  foo == null ? void 0 : (_foo$bar5 = foo.bar) == null ? void 0 : _foo$bar5.baz(foo.bar, true);
-  (_foo$bar6 = foo.bar) == null ? void 0 : (_foo$bar6$baz = _foo$bar6.baz) == null ? void 0 : _foo$bar6$baz.call(_foo$bar6, foo.bar, false);
-  foo == null ? void 0 : (_foo$bar7 = foo.bar) == null ? void 0 : (_foo$bar7$baz = _foo$bar7.baz) == null ? void 0 : _foo$bar7$baz.call(_foo$bar7, foo.bar, true);
+  foo === null || foo === void 0 ? void 0 : foo.bar;
+  foo === null || foo === void 0 ? void 0 : (_foo$bar = foo.bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.baz;
+  foo === null || foo === void 0 ? void 0 : foo(foo);
+  foo === null || foo === void 0 ? void 0 : foo.bar();
+  (_foo$bar2 = foo.bar) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2.call(foo, foo.bar, false);
+  foo === null || foo === void 0 ? void 0 : (_foo$bar3 = foo.bar) === null || _foo$bar3 === void 0 ? void 0 : _foo$bar3.call(foo, foo.bar, true);
+  (_foo$bar4 = foo.bar) === null || _foo$bar4 === void 0 ? void 0 : _foo$bar4.baz(foo.bar, false);
+  foo === null || foo === void 0 ? void 0 : (_foo$bar5 = foo.bar) === null || _foo$bar5 === void 0 ? void 0 : _foo$bar5.baz(foo.bar, true);
+  (_foo$bar6 = foo.bar) === null || _foo$bar6 === void 0 ? void 0 : (_foo$bar6$baz = _foo$bar6.baz) === null || _foo$bar6$baz === void 0 ? void 0 : _foo$bar6$baz.call(_foo$bar6, foo.bar, false);
+  foo === null || foo === void 0 ? void 0 : (_foo$bar7 = foo.bar) === null || _foo$bar7 === void 0 ? void 0 : (_foo$bar7$baz = _foo$bar7.baz) === null || _foo$bar7$baz === void 0 ? void 0 : _foo$bar7$baz.call(_foo$bar7, foo.bar, true);
 }

--- a/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/new/expected.js
+++ b/packages/babel-plugin-transform-optional-chaining/test/fixtures/general/new/expected.js
@@ -1,14 +1,14 @@
 var _a, _a2, _a2$b, _a2$b$c, _a3, _a4, _a4$b, _a4$b$c, _b, _a5, _a5$b, _b2, _b3, _ref, _a$b, _a$b2, _ref2, _a6, _a6$b, _a7, _a7$b, _ref3;
 
-(_a = a) == null ? void 0 : new _a.b();
-(_a2 = a) == null ? void 0 : (_a2$b = _a2.b) == null ? void 0 : (_a2$b$c = _a2$b.c) == null ? void 0 : new _a2$b$c.d();
-(_a3 = a) == null ? void 0 : new _a3.b();
-(_a4 = a) == null ? void 0 : (_a4$b = _a4.b) == null ? void 0 : (_a4$b$c = _a4$b.c) == null ? void 0 : new _a4$b$c.d();
-(_b = b) == null ? void 0 : new _b(b);
-(_a5 = a) == null ? void 0 : (_a5$b = _a5.b) == null ? void 0 : new _a5$b(a.b, true);
-(_b2 = b) == null ? void 0 : new _b2().c;
-(_b3 = b) == null ? void 0 : (_ref = new _b3()) == null ? void 0 : _ref.c;
-(_a$b = a.b) == null ? void 0 : new _a$b().c;
-(_a$b2 = a.b) == null ? void 0 : (_ref2 = new _a$b2()) == null ? void 0 : _ref2.c;
-(_a6 = a) == null ? void 0 : (_a6$b = _a6.b) == null ? void 0 : new _a6$b().c;
-(_a7 = a) == null ? void 0 : (_a7$b = _a7.b) == null ? void 0 : (_ref3 = new _a7$b()) == null ? void 0 : _ref3.c;
+(_a = a) === null || _a === void 0 ? void 0 : new _a.b();
+(_a2 = a) === null || _a2 === void 0 ? void 0 : (_a2$b = _a2.b) === null || _a2$b === void 0 ? void 0 : (_a2$b$c = _a2$b.c) === null || _a2$b$c === void 0 ? void 0 : new _a2$b$c.d();
+(_a3 = a) === null || _a3 === void 0 ? void 0 : new _a3.b();
+(_a4 = a) === null || _a4 === void 0 ? void 0 : (_a4$b = _a4.b) === null || _a4$b === void 0 ? void 0 : (_a4$b$c = _a4$b.c) === null || _a4$b$c === void 0 ? void 0 : new _a4$b$c.d();
+(_b = b) === null || _b === void 0 ? void 0 : new _b(b);
+(_a5 = a) === null || _a5 === void 0 ? void 0 : (_a5$b = _a5.b) === null || _a5$b === void 0 ? void 0 : new _a5$b(a.b, true);
+(_b2 = b) === null || _b2 === void 0 ? void 0 : new _b2().c;
+(_b3 = b) === null || _b3 === void 0 ? void 0 : (_ref = new _b3()) === null || _ref === void 0 ? void 0 : _ref.c;
+(_a$b = a.b) === null || _a$b === void 0 ? void 0 : new _a$b().c;
+(_a$b2 = a.b) === null || _a$b2 === void 0 ? void 0 : (_ref2 = new _a$b2()) === null || _ref2 === void 0 ? void 0 : _ref2.c;
+(_a6 = a) === null || _a6 === void 0 ? void 0 : (_a6$b = _a6.b) === null || _a6$b === void 0 ? void 0 : new _a6$b().c;
+(_a7 = a) === null || _a7 === void 0 ? void 0 : (_a7$b = _a7.b) === null || _a7$b === void 0 ? void 0 : (_ref3 = new _a7$b()) === null || _ref3 === void 0 ? void 0 : _ref3.c;


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR         |
| Any Dependency Changes?  | 

Account for `document.all` with the optional-chaining operator.

**Input**:

```js
foo?.bar;
```

**Output - Before**:

```js
var _foo;

(_foo = foo) == null ? void 0 : _foo.bar;
```

**Output - After**:

```js
var _foo;

(_foo = foo) === null || _foo === void 0 ? void 0 : _foo.bar;
```

This is spec-compliant as per [3.8.1 Runtime Semantics: Evaluation
](https://tc39.github.io/proposal-optional-chaining/#sec-optional-chaining-evaluation)

> 4. If _baseValue_ is **undefined** or **null**, then
> Return **undefined**.

As this can generate a fair amount of code, and due to the rarity of `document.all` in practice, I've only made the change in spec mode.

_NB: This will likely have merge conflicts with the files to be deleted in #6345 @jridgewell_