### PR TITLE
Remove support for flow bindings

### DIFF
--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -2,8 +2,8 @@ import traverse from "../lib";
 import assert from "assert";
 import { parse } from "babylon";
 
-function getPath(code) {
-  const ast = parse(code);
+function getPath(code, options) {
+  const ast = parse(code, options);
   let path;
   traverse(ast, {
     Program: function(_path) {
@@ -70,6 +70,24 @@ describe("scope", function() {
       assert.ok(
         getPath("var { bar: [ foo ] } = null;").scope.getBinding("foo").path
           .type === "VariableDeclarator",
+      );
+    });
+
+    it("declare var", function() {
+      assert.equal(
+        getPath("declare var foo;", { plugins: ["flow"] }).scope.getBinding(
+          "foo",
+        ),
+        null,
+      );
+    });
+
+    it("declare function", function() {
+      assert.equal(
+        getPath("declare function foo(): void;", {
+          plugins: ["flow"],
+        }).scope.getBinding("foo"),
+        null,
       );
     });
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #5395 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 👍
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

> Flow bindings have been deprecated for a while.
The reason behind this change is that `declare var foo`
doesn't introduce a new local binding, but it represents
a global one.