### PR TITLE
Add loose mode for nullish coalescing operator

### DIFF
--- a/packages/babel-plugin-transform-nullish-coalescing-operator/README.md
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/README.md
@@ -52,3 +52,33 @@ require("@babel/core").transform("code", {
   plugins: ["transform-nullish-coalescing-operator"]
 });
 ```
+
+## Options
+
+### `loose`
+
+`boolean`, defaults to `false`.
+
+When `true`, this transform will pretend `document.all` does not exist,
+and perform loose equality checks with `null` instead of string equality checks
+against both `null` and `undefined`.
+
+#### Example
+
+**In**
+
+```javascript
+var foo = object.foo ?? "default";
+```
+
+**Out**
+
+```javascript
+var _object$foo;
+
+var foo = (_object$foo = object.foo, _object$foo != null ? _object$foo : "default");
+```
+
+## References
+
+* [Proposal: Nullish Coalescing](https://github.com/tc39-transfer/proposal-nullish-coalescing)

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/README.md
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/README.md
@@ -15,7 +15,7 @@ var foo = object.foo ?? "default";
 ```javascript
 var _object$foo;
 
-var foo = (_object$foo = object.foo, _object$foo !== null && _object$foo !== void 0 ? _object$foo : "default");
+var foo = (_object$foo = object.foo) !== null && _object$foo !== void 0 ? _object$foo : "default";
 ```
 
 > **NOTE:** We cannot use `!= null` here because `document.all == null` and
@@ -76,7 +76,7 @@ var foo = object.foo ?? "default";
 ```javascript
 var _object$foo;
 
-var foo = (_object$foo = object.foo, _object$foo != null ? _object$foo : "default");
+var foo = (_object$foo = object.foo) != null ? _object$foo : "default";
 ```
 
 ## References

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.js
@@ -1,6 +1,6 @@
 import syntaxNullishCoalescingOperator from "@babel/plugin-syntax-nullish-coalescing-operator";
 
-export default function({ types: t }) {
+export default function({ types: t }, { loose = false }) {
   return {
     inherits: syntaxNullishCoalescingOperator,
 
@@ -18,17 +18,19 @@ export default function({ types: t }) {
           t.sequenceExpression([
             t.assignmentExpression("=", ref, node.left),
             t.conditionalExpression(
-              // We cannot use `!= null` here because `document.all == null`
-              // and `document.all` has been deemed not "nullish".
-              t.logicalExpression(
-                "&&",
-                t.binaryExpression("!==", t.clone(ref), t.nullLiteral()),
-                t.binaryExpression(
-                  "!==",
-                  t.clone(ref),
-                  scope.buildUndefinedNode(),
-                ),
-              ),
+              // We cannot use `!= null` in spec mode because
+              // `document.all == null` and `document.all` is not "nullish".
+              loose
+                ? t.binaryExpression("!=", t.clone(ref), t.nullLiteral())
+                : t.logicalExpression(
+                    "&&",
+                    t.binaryExpression("!==", t.clone(ref), t.nullLiteral()),
+                    t.binaryExpression(
+                      "!==",
+                      t.clone(ref),
+                      scope.buildUndefinedNode(),
+                    ),
+                  ),
               t.clone(ref),
               node.right,
             ),

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.js
@@ -14,27 +14,26 @@ export default function({ types: t }, { loose = false }) {
         const ref = scope.generateUidIdentifierBasedOnNode(node.left);
         scope.push({ id: ref });
 
+        const assignment = t.assignmentExpression("=", t.clone(ref), node.left);
+
         path.replaceWith(
-          t.sequenceExpression([
-            t.assignmentExpression("=", ref, node.left),
-            t.conditionalExpression(
-              // We cannot use `!= null` in spec mode because
-              // `document.all == null` and `document.all` is not "nullish".
-              loose
-                ? t.binaryExpression("!=", t.clone(ref), t.nullLiteral())
-                : t.logicalExpression(
-                    "&&",
-                    t.binaryExpression("!==", t.clone(ref), t.nullLiteral()),
-                    t.binaryExpression(
-                      "!==",
-                      t.clone(ref),
-                      scope.buildUndefinedNode(),
-                    ),
+          t.conditionalExpression(
+            // We cannot use `!= null` in spec mode because
+            // `document.all == null` and `document.all` is not "nullish".
+            loose
+              ? t.binaryExpression("!=", assignment, t.nullLiteral())
+              : t.logicalExpression(
+                  "&&",
+                  t.binaryExpression("!==", assignment, t.nullLiteral()),
+                  t.binaryExpression(
+                    "!==",
+                    t.clone(ref),
+                    scope.buildUndefinedNode(),
                   ),
-              t.clone(ref),
-              node.right,
-            ),
-          ]),
+                ),
+            t.clone(ref),
+            node.right,
+          ),
         );
       },
     },

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-in-default/expected.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-in-default/expected.js
@@ -1,3 +1,3 @@
-function foo(foo, bar = (_foo = foo, _foo !== null && _foo !== void 0 ? _foo : "bar")) {
+function foo(foo, bar = (_foo = foo) !== null && _foo !== void 0 ? _foo : "bar") {
   var _foo;
 }

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-in-function/expected.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-in-function/expected.js
@@ -1,5 +1,5 @@
 function foo(opts) {
   var _opts$foo;
 
-  var foo = (_opts$foo = opts.foo, _opts$foo !== null && _opts$foo !== void 0 ? _opts$foo : "default");
+  var foo = (_opts$foo = opts.foo) !== null && _opts$foo !== void 0 ? _opts$foo : "default";
 }

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/actual.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/actual.js
@@ -1,0 +1,3 @@
+function foo(opts) {
+  var foo = opts.foo ?? "default";
+}

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/expected.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/expected.js
@@ -1,5 +1,5 @@
 function foo(opts) {
   var _opts$foo;
 
-  var foo = (_opts$foo = opts.foo, _opts$foo != null ? _opts$foo : "default");
+  var foo = (_opts$foo = opts.foo) != null ? _opts$foo : "default";
 }

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/expected.js
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/expected.js
@@ -1,0 +1,5 @@
+function foo(opts) {
+  var _opts$foo;
+
+  var foo = (_opts$foo = opts.foo, _opts$foo != null ? _opts$foo : "default");
+}

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/options.json
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/fixtures/nullish-coalescing/transform-loose/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-nullish-coalescing-operator", {"loose":true}]]
+}

--- a/packages/babel-plugin-transform-optional-chaining/README.md
+++ b/packages/babel-plugin-transform-optional-chaining/README.md
@@ -81,8 +81,6 @@ new Test?.(); // test instance
 new exists?.(); // undefined
 ```
 
-
-
 ## Installation
 
 ```sh

--- a/packages/babel-plugin-transform-optional-chaining/README.md
+++ b/packages/babel-plugin-transform-optional-chaining/README.md
@@ -81,6 +81,8 @@ new Test?.(); // test instance
 new exists?.(); // undefined
 ```
 
+
+
 ## Installation
 
 ```sh
@@ -111,6 +113,36 @@ babel --plugins transform-optional-chaining script.js
 require("@babel/core").transform("code", {
   plugins: ["transform-optional-chaining"]
 });
+```
+
+## Options
+
+### `loose`
+
+`boolean`, defaults to `false`.
+
+When `true`, this transform will pretend `document.all` does not exist,
+and perform loose equality checks with `null` instead of string equality checks
+against both `null` and `undefined`.
+
+#### Example
+
+In
+
+```javascript
+foo?.bar;
+```
+
+Out (`loose === true`)
+
+```javascript
+foo == null ? void 0 : foo.bar;
+```
+
+Out (`loose === false`)
+
+```javascript
+foo === null || foo === void 0 ? void 0 : foo.bar;
 ```
 
 ## References


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | 👍
| Documentation PR         | 
| Any Dependency Changes?  | 

* Adds `loose` mode to the nullish coalescing operator to check `_ref != null` instead of `_ref !== null && _ref !== undefined`.
* In the process realized there was an unneeded sequence expression, so I removed it from the transform.
* Adds documentation of `loose` to both `nullish-coalescing-operator` and `optional-chaining`.

```js
var foo = opts.foo ?? "default";
```

Transforms to

```js
var _opts$foo;

var foo = (_opts$foo = opts.foo) != null ? _opts$foo : "default";
```

Rather than (before this PR)

```js
var _x$y;

var foo = (_opts$foo = opts.foo, _opts$foo !== null && _opts$foo !== void 0 ? _opts$foo : "default");
```