### PR TITLE
babel-register: Add BABEL_DISABLE_SOURCEMAPS

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -12,7 +12,7 @@ const maps = {};
 const transformOpts = {};
 let piratesRevert = null;
 
-sourceMapSupport.install({
+const sourceMapSupportOptions = {
   handleUncaughtExceptions: false,
   environment: "node",
   retrieveSourceMap(source) {
@@ -26,7 +26,11 @@ sourceMapSupport.install({
       return null;
     }
   },
-});
+};
+
+if (!process.env.BABEL_DISABLE_SOURCEMAPS) {
+  sourceMapSupport.install(sourceMapSupportOptions);
+}
 
 registerCache.load();
 let cache = registerCache.get();


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji ) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5890
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | No
| Documentation PR         | No
| Any Dependency Changes?  | No

Add an environment variable to disable `sourceMapSupport.install()` in babel register globally. I am unsure how to test environment variables in the test suite.
