### PR TITLE
Remove stale emoji tests in plugin-transform-unicode-property-regex

### DIFF
--- a/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/with-unicode-flag/emoji/actual.js
+++ b/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/with-unicode-flag/emoji/actual.js
@@ -1,2 +1,0 @@
-var regexEmojiModifier = /\p{Emoji_Modifier}/u;
-var regexEmojiComponent = /\p{Emoji_Component}/u;

--- a/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/with-unicode-flag/emoji/expected.js
+++ b/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/with-unicode-flag/emoji/expected.js
@@ -1,2 +1,0 @@
-var regexEmojiModifier = /[\u{1F3FB}-\u{1F3FF}]/u;
-var regexEmojiComponent = /[#\*0-9\u200D\u20E3\uFE0F\u{1F1E6}-\u{1F1FF}\u{1F3FB}-\u{1F3FF}\u{E0020}-\u{E007F}]/u;

--- a/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/without-unicode-flag/emoji/actual.js
+++ b/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/without-unicode-flag/emoji/actual.js
@@ -1,2 +1,0 @@
-var regexEmojiModifier = /\p{Emoji_Modifier}/u;
-var regexEmojiComponent = /\p{Emoji_Component}/u;

--- a/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/without-unicode-flag/emoji/expected.js
+++ b/packages/babel-plugin-transform-unicode-property-regex/test/fixtures/without-unicode-flag/emoji/expected.js
@@ -1,2 +1,0 @@
-var regexEmojiModifier = /(?:\uD83C[\uDFFB-\uDFFF])/;
-var regexEmojiComponent = /(?:[#\*0-9\u200D\u20E3\uFE0F]|\uD83C[\uDDE6-\uDDFF\uDFFB-\uDFFF]|\uDB40[\uDC20-\uDC7F])/;


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6537 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
