### PR TITLE
Make syntax highlighting for `@` and `#` nicer

### DIFF
--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -82,6 +82,13 @@ function getTokenType(match) {
     return "bracket";
   }
 
+  if (
+    token.type === "invalid" &&
+    (token.value === "@" || token.value === "#")
+  ) {
+    return "punctuator";
+  }
+
   return token.type;
 }
 


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | nope
| Patch: Bug Fix?          | kinda
| Major: Breaking Change?  | nah
| Minor: New Feature?      | not really
| Tests Added + Pass?      | no + yes
| Documentation PR         | no
| Any Dependency Changes?  | nein

<!-- Describe your changes below in as much detail as possible -->

Pictures say more than a 1000 words, eh?

Before:
![screenshot from 2017-10-24 21-17-57](https://user-images.githubusercontent.com/2142817/31963622-9e1dfc26-b901-11e7-9692-770dd626400c.png)

After:
![screenshot from 2017-10-24 21-18-20](https://user-images.githubusercontent.com/2142817/31963626-a47f347c-b901-11e7-9945-ae4b70471a6a.png)


([js-tokens](https://github.com/lydell/js-tokens/) considers `@` and `#` to be invalid characters, because it only supports the latest stable specification, but in the Babel world they're not.)
