### PR TITLE
Strictly validate Babel's options to centralize Flow refinement of datatype

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -242,6 +242,7 @@ delete opts.quiet;
 delete opts.configFile;
 delete opts.deleteDirOnStart;
 delete opts.keepFileExtension;
+delete opts.relative;
 
 // Commander will default the "--no-" arguments to true, but we want to leave them undefined so that
 // @babel/core can handle the default-assignment logic on its own.

--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -16,7 +16,6 @@ type ConfigItem = {
   options: {},
   dirname: string,
   alias: string,
-  loc: string,
 };
 
 type ConfigRaw = {
@@ -351,7 +350,6 @@ function flattenOptionsParts(
       type,
       options,
       alias,
-      loc: alias,
       dirname,
     },
     ignore,

--- a/packages/babel-core/src/config/caching.js
+++ b/packages/babel-core/src/config/caching.js
@@ -31,7 +31,7 @@ export function makeStrongCache<ArgT, ResultT>(
  * configures its caching behavior. Cached values are stored weakly and the function argument must be
  * an object type.
  */
-export function makeWeakCache<ArgT: {} | Array<*>, ResultT>(
+export function makeWeakCache<ArgT: {} | Array<*> | $ReadOnlyArray<*>, ResultT>(
   handler: (ArgT, CacheConfigurator) => ResultT,
   autoPermacache?: boolean,
 ): ArgT => ResultT {

--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -16,7 +16,7 @@ export type PluginPasses = Array<PluginPassList>;
  * Standard API for loading Babel configuration data. Not for public consumption.
  */
 export default function loadConfig(opts: mixed): ResolvedConfig | null {
-  if (opts != null && typeof opts !== "object") {
+  if (opts != null && (typeof opts !== "object" || Array.isArray(opts))) {
     throw new Error("Babel options must be an object, null, or undefined");
   }
 

--- a/packages/babel-core/src/config/option-assertions.js
+++ b/packages/babel-core/src/config/option-assertions.js
@@ -12,30 +12,36 @@ import type {
   RootInputSourceMapOption,
 } from "./options";
 
-export function assertSourceMaps(key: string, value: mixed): ?SourceMapsOption {
+export function assertSourceMaps(
+  key: string,
+  value: mixed,
+): SourceMapsOption | void {
   if (
-    value != null &&
+    value !== undefined &&
     typeof value !== "boolean" &&
     value !== "inline" &&
     value !== "both"
   ) {
     throw new Error(
-      `.${key} must be a boolean, "inline", "both", null, or undefined`,
+      `.${key} must be a boolean, "inline", "both", or undefined`,
     );
   }
   return value;
 }
 
-export function assertCompact(key: string, value: mixed): ?CompactOption {
-  if (value != null && typeof value !== "boolean" && value !== "auto") {
-    throw new Error(`.${key} must be a boolean, "auto", null, or undefined`);
+export function assertCompact(key: string, value: mixed): CompactOption | void {
+  if (value !== undefined && typeof value !== "boolean" && value !== "auto") {
+    throw new Error(`.${key} must be a boolean, "auto", or undefined`);
   }
   return value;
 }
 
-export function assertSourceType(key: string, value: mixed): ?SourceTypeOption {
-  if (value != null && value !== "module" && value !== "script") {
-    throw new Error(`.${key} must be "module", "script", null, or undefined`);
+export function assertSourceType(
+  key: string,
+  value: mixed,
+): SourceTypeOption | void {
+  if (value !== undefined && value !== "module" && value !== "script") {
+    throw new Error(`.${key} must be "module", "script", or undefined`);
   }
   return value;
 }
@@ -43,48 +49,49 @@ export function assertSourceType(key: string, value: mixed): ?SourceTypeOption {
 export function assertInputSourceMap(
   key: string,
   value: mixed,
-): ?RootInputSourceMapOption {
+): RootInputSourceMapOption | void {
   if (
-    value != null &&
+    value !== undefined &&
     typeof value !== "boolean" &&
-    typeof value !== "object"
+    (typeof value !== "object" || !value)
   ) {
-    throw new Error(
-      ".inputSourceMap must be a boolean, object, null, or undefined",
-    );
+    throw new Error(".inputSourceMap must be a boolean, object, or undefined");
   }
   return value;
 }
 
-export function assertString(key: string, value: mixed): ?string {
-  if (value != null && typeof value !== "string") {
-    throw new Error(`.${key} must be a string, null, or undefined`);
+export function assertString(key: string, value: mixed): string | void {
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`.${key} must be a string, or undefined`);
   }
   return value;
 }
 
-export function assertFunction(key: string, value: mixed): ?Function {
-  if (value != null && typeof value !== "function") {
-    throw new Error(`.${key} must be a function, null, or undefined`);
+export function assertFunction(key: string, value: mixed): Function | void {
+  if (value !== undefined && typeof value !== "function") {
+    throw new Error(`.${key} must be a function, or undefined`);
   }
   return value;
 }
 
-export function assertBoolean(key: string, value: mixed): ?boolean {
-  if (value != null && typeof value !== "boolean") {
-    throw new Error(`.${key} must be a boolean, null, or undefined`);
+export function assertBoolean(key: string, value: mixed): boolean | void {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`.${key} must be a boolean, or undefined`);
   }
   return value;
 }
 
-export function assertObject(key: string, value: mixed): ?{} {
-  if (value != null && (typeof value !== "object" || Array.isArray(value))) {
-    throw new Error(`.${key} must be an object, null, or undefined`);
+export function assertObject(key: string, value: mixed): {} | void {
+  if (
+    value !== undefined &&
+    (typeof value !== "object" || Array.isArray(value) || !value)
+  ) {
+    throw new Error(`.${key} must be an object, or undefined`);
   }
   return value;
 }
 
-export function assertIgnoreList(key: string, value: mixed): ?IgnoreList {
+export function assertIgnoreList(key: string, value: mixed): IgnoreList | void {
   const arr = assertArray(key, value);
   if (arr) {
     arr.forEach((item, i) => assertIgnoreItem(key, i, item));
@@ -102,13 +109,13 @@ function assertIgnoreItem(
     !(value instanceof RegExp)
   ) {
     throw new Error(
-      `.${key}[${index}] must be an array of string/Funtion/RegExp values, or null, or undefined`,
+      `.${key}[${index}] must be an array of string/Funtion/RegExp values, or or undefined`,
     );
   }
   return value;
 }
 
-export function assertPluginList(key: string, value: mixed): ?PluginList {
+export function assertPluginList(key: string, value: mixed): PluginList | void {
   const arr = assertArray(key, value);
   if (arr) {
     // Loop instead of using `.map` in order to preserve object identity
@@ -135,9 +142,7 @@ function assertPluginItem(
     if (value.length === 2) {
       const opts = value[1];
       if (opts != null && (typeof opts !== "object" || Array.isArray(opts))) {
-        throw new Error(
-          `.${key}[${index}][1] must be an object, null, or undefined`,
-        );
+        throw new Error(`.${key}[${index}][1] must be an object, or undefined`);
       }
     }
   } else {
@@ -168,7 +173,7 @@ function assertPluginTarget(
 
 function assertArray(key: string, value: mixed): ?$ReadOnlyArray<mixed> {
   if (value != null && !Array.isArray(value)) {
-    throw new Error(`.${key} must be an array, null, or undefined`);
+    throw new Error(`.${key} must be an array, or undefined`);
   }
   return value;
 }

--- a/packages/babel-core/src/config/option-assertions.js
+++ b/packages/babel-core/src/config/option-assertions.js
@@ -1,0 +1,174 @@
+// @flow
+
+import type {
+  IgnoreList,
+  IgnoreItem,
+  PluginList,
+  PluginItem,
+  PluginTarget,
+  SourceMapsOption,
+  SourceTypeOption,
+  CompactOption,
+  RootInputSourceMapOption,
+} from "./options";
+
+export function assertSourceMaps(key: string, value: mixed): ?SourceMapsOption {
+  if (
+    value != null &&
+    typeof value !== "boolean" &&
+    value !== "inline" &&
+    value !== "both"
+  ) {
+    throw new Error(
+      `.${key} must be a boolean, "inline", "both", null, or undefined`,
+    );
+  }
+  return value;
+}
+
+export function assertCompact(key: string, value: mixed): ?CompactOption {
+  if (value != null && typeof value !== "boolean" && value !== "auto") {
+    throw new Error(`.${key} must be a boolean, "auto", null, or undefined`);
+  }
+  return value;
+}
+
+export function assertSourceType(key: string, value: mixed): ?SourceTypeOption {
+  if (value != null && value !== "module" && value !== "script") {
+    throw new Error(`.${key} must be "module", "script", null, or undefined`);
+  }
+  return value;
+}
+
+export function assertInputSourceMap(
+  key: string,
+  value: mixed,
+): ?RootInputSourceMapOption {
+  if (
+    value != null &&
+    typeof value !== "boolean" &&
+    typeof value !== "object"
+  ) {
+    throw new Error(
+      ".inputSourceMap must be a boolean, object, null, or undefined",
+    );
+  }
+  return value;
+}
+
+export function assertString(key: string, value: mixed): ?string {
+  if (value != null && typeof value !== "string") {
+    throw new Error(`.${key} must be a string, null, or undefined`);
+  }
+  return value;
+}
+
+export function assertFunction(key: string, value: mixed): ?Function {
+  if (value != null && typeof value !== "function") {
+    throw new Error(`.${key} must be a function, null, or undefined`);
+  }
+  return value;
+}
+
+export function assertBoolean(key: string, value: mixed): ?boolean {
+  if (value != null && typeof value !== "boolean") {
+    throw new Error(`.${key} must be a boolean, null, or undefined`);
+  }
+  return value;
+}
+
+export function assertObject(key: string, value: mixed): ?{} {
+  if (value != null && (typeof value !== "object" || Array.isArray(value))) {
+    throw new Error(`.${key} must be an object, null, or undefined`);
+  }
+  return value;
+}
+
+export function assertIgnoreList(key: string, value: mixed): ?IgnoreList {
+  const arr = assertArray(key, value);
+  if (arr) {
+    arr.forEach((item, i) => assertIgnoreItem(key, i, item));
+  }
+  return (arr: any);
+}
+function assertIgnoreItem(
+  key: string,
+  index: number,
+  value: mixed,
+): IgnoreItem {
+  if (
+    typeof value !== "string" &&
+    typeof value !== "function" &&
+    !(value instanceof RegExp)
+  ) {
+    throw new Error(
+      `.${key}[${index}] must be an array of string/Funtion/RegExp values, or null, or undefined`,
+    );
+  }
+  return value;
+}
+
+export function assertPluginList(key: string, value: mixed): ?PluginList {
+  const arr = assertArray(key, value);
+  if (arr) {
+    // Loop instead of using `.map` in order to preserve object identity
+    // for plugin array for use during config chain processing.
+    arr.forEach((item, i) => assertPluginItem(key, i, item));
+  }
+  return (arr: any);
+}
+function assertPluginItem(
+  key: string,
+  index: number,
+  value: mixed,
+): PluginItem {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      throw new Error(`.${key}[${index}] must include an object`);
+    }
+    if (value.length > 2) {
+      throw new Error(`.${key}[${index}] may only be a two-tuple`);
+    }
+
+    assertPluginTarget(key, index, true, value[0]);
+
+    if (value.length === 2) {
+      const opts = value[1];
+      if (opts != null && (typeof opts !== "object" || Array.isArray(opts))) {
+        throw new Error(
+          `.${key}[${index}][1] must be an object, null, or undefined`,
+        );
+      }
+    }
+  } else {
+    assertPluginTarget(key, index, false, value);
+  }
+
+  return (value: any);
+}
+function assertPluginTarget(
+  key: string,
+  index: number,
+  inArray: boolean,
+  value: mixed,
+): PluginTarget {
+  if (
+    (typeof value !== "object" || !value) &&
+    typeof value !== "string" &&
+    typeof value !== "function"
+  ) {
+    throw new Error(
+      `.${key}[${index}]${inArray
+        ? `[0]`
+        : ""} must be a string, object, function`,
+    );
+  }
+  return value;
+}
+
+function assertArray(key: string, value: mixed): ?$ReadOnlyArray<mixed> {
+  if (value != null && !Array.isArray(value)) {
+    throw new Error(`.${key} must be an array, null, or undefined`);
+  }
+  return value;
+}

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -137,7 +137,13 @@ class OptionManager {
       pass.unshift(...plugins);
     }
 
-    merge(this.options, result.options);
+    const options = Object.assign({}, result.options);
+    delete options.extends;
+    delete options.env;
+    delete options.plugins;
+    delete options.presets;
+
+    merge(this.options, options);
   }
 
   init(opts: {}) {

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -34,7 +34,6 @@ const optionNames = new Set([
   "env",
   "retainLines",
   "highlightCode",
-  "suppressDeprecationMessages",
   "presets",
   "plugins",
   "ignore",

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -23,7 +23,6 @@ type MergeOptions = {
   +type: "arguments" | "options" | "preset",
   options: {},
   alias: string,
-  loc: string,
   dirname: string,
 };
 
@@ -214,7 +213,6 @@ type BasicDescriptor = {
   options: {} | void,
   dirname: string,
   alias: string,
-  loc: string,
 };
 
 type LoadedDescriptor = {
@@ -222,7 +220,6 @@ type LoadedDescriptor = {
   options: {},
   dirname: string,
   alias: string,
-  loc: string,
 };
 
 /**
@@ -250,8 +247,7 @@ const loadConfig = makeWeakCache((config): {
     );
 
     return {
-      alias: filepath || `${config.loc}$${index}`,
-      loc: filepath || config.loc,
+      alias: filepath || `${config.alias}$${index}`,
       value,
       options,
       dirname: config.dirname,
@@ -273,8 +269,7 @@ const loadConfig = makeWeakCache((config): {
     );
 
     return {
-      alias: filepath || `${config.loc}$${index}`,
-      loc: filepath || config.loc,
+      alias: filepath || `${config.alias}$${index}`,
       value,
       options,
       dirname: config.dirname,
@@ -289,7 +284,7 @@ const loadConfig = makeWeakCache((config): {
  */
 const loadDescriptor = makeWeakCache(
   (
-    { value, options = {}, dirname, alias, loc }: BasicDescriptor,
+    { value, options = {}, dirname, alias }: BasicDescriptor,
     cache,
   ): LoadedDescriptor => {
     let item = value;
@@ -313,7 +308,7 @@ const loadDescriptor = makeWeakCache(
       throw new Error("Plugin/Preset did not return an object.");
     }
 
-    return { value: item, options, dirname, alias, loc };
+    return { value: item, options, dirname, alias };
   },
 );
 
@@ -336,7 +331,7 @@ function loadPluginDescriptor(descriptor: BasicDescriptor): Plugin {
 
 const instantiatePlugin = makeWeakCache(
   (
-    { value: pluginObj, options, dirname, alias, loc }: LoadedDescriptor,
+    { value: pluginObj, options, dirname, alias }: LoadedDescriptor,
     cache,
   ): Plugin => {
     Object.keys(pluginObj).forEach(key => {
@@ -366,8 +361,7 @@ const instantiatePlugin = makeWeakCache(
     let inherits;
     if (plugin.inherits) {
       inheritsDescriptor = {
-        alias: `${loc}$inherits`,
-        loc,
+        alias: `${alias}$inherits`,
         value: plugin.inherits,
         options,
         dirname,
@@ -402,12 +396,11 @@ const loadPresetDescriptor = (descriptor: BasicDescriptor): MergeOptions => {
 };
 
 const instantiatePreset = makeWeakCache(
-  ({ value, dirname, alias, loc }: LoadedDescriptor): MergeOptions => {
+  ({ value, dirname, alias }: LoadedDescriptor): MergeOptions => {
     return {
       type: "preset",
       options: value,
       alias,
-      loc,
       dirname,
     };
   },

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -28,7 +28,6 @@ type MergeOptions = {
 };
 
 const optionNames = new Set([
-  "relative",
   "filename",
   "filenameRelative",
   "inputSourceMap",

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -4,13 +4,13 @@ import * as context from "../index";
 import Plugin from "./plugin";
 import defaults from "lodash/defaults";
 import merge from "lodash/merge";
-import removed from "./removed";
-import buildConfigChain from "./build-config-chain";
+import buildConfigChain, { type ConfigItem } from "./build-config-chain";
 import path from "path";
 import traverse from "@babel/traverse";
 import clone from "lodash/clone";
 import { makeWeakCache } from "./caching";
 import { getEnv } from "./helpers/environment";
+import { validate, type ValidatedOptions, type PluginItem } from "./options";
 
 import {
   loadPlugin,
@@ -19,50 +19,14 @@ import {
   loadGenerator,
 } from "./loading/files";
 
-type MergeOptions = {
-  +type: "arguments" | "options" | "preset",
-  options: {},
-  alias: string,
-  dirname: string,
-};
-
-const optionNames = new Set([
-  "filename",
-  "filenameRelative",
-  "inputSourceMap",
-  "env",
-  "retainLines",
-  "highlightCode",
-  "presets",
-  "plugins",
-  "ignore",
-  "only",
-  "code",
-  "ast",
-  "extends",
-  "comments",
-  "shouldPrintComment",
-  "wrapPluginVisitorMethod",
-  "compact",
-  "minified",
-  "sourceMaps",
-  "sourceMapTarget",
-  "sourceFileName",
-  "sourceRoot",
-  "babelrc",
-  "sourceType",
-  "auxiliaryCommentBefore",
-  "auxiliaryCommentAfter",
-  "getModuleId",
-  "moduleRoot",
-  "moduleIds",
-  "moduleId",
-  "passPerPreset",
-  // Deprecate top level parserOpts
-  "parserOpts",
-  // Deprecate top level generatorOpts
-  "generatorOpts",
-]);
+type MergeOptions =
+  | ConfigItem
+  | {
+      type: "preset",
+      options: ValidatedOptions,
+      alias: string,
+      dirname: string,
+    };
 
 const ALLOWED_PLUGIN_KEYS = new Set([
   "name",
@@ -82,11 +46,11 @@ export default function manageOptions(opts: {}): {
 
 class OptionManager {
   constructor() {
-    this.options = createInitialOptions();
+    this.options = {};
     this.passes = [[]];
   }
 
-  options: Object;
+  options: ValidatedOptions;
   passes: Array<Array<Plugin>>;
 
   /**
@@ -108,12 +72,6 @@ class OptionManager {
       loadPresetDescriptor(descriptor),
     );
 
-    if (
-      config.options.passPerPreset != null &&
-      typeof config.options.passPerPreset !== "boolean"
-    ) {
-      throw new Error(".passPerPreset must be a boolean or undefined");
-    }
     const passPerPreset = config.options.passPerPreset;
     pass = pass || this.passes[0];
 
@@ -142,12 +100,22 @@ class OptionManager {
     delete options.env;
     delete options.plugins;
     delete options.presets;
+    delete options.passPerPreset;
+
+    // "sourceMap" is just aliased to sourceMap, so copy it over as
+    // we merge the options together.
+    if (options.sourceMap) {
+      options.sourceMaps = options.sourceMap;
+      delete options.sourceMap;
+    }
 
     merge(this.options, options);
   }
 
-  init(opts: {}) {
-    const configChain = buildConfigChain(opts);
+  init(inputOpts: {}) {
+    const args = validate("arguments", inputOpts);
+
+    const configChain = buildConfigChain(args);
     if (!configChain) return null;
 
     try {
@@ -158,15 +126,13 @@ class OptionManager {
       // There are a few case where thrown errors will try to annotate themselves multiple times, so
       // to keep things simple we just bail out if re-wrapping the message.
       if (!/^\[BABEL\]/.test(e.message)) {
-        const filename =
-          typeof opts.filename === "string" ? opts.filename : null;
-        e.message = `[BABEL] ${filename || "unknown"}: ${e.message}`;
+        e.message = `[BABEL] ${args.filename || "unknown"}: ${e.message}`;
       }
 
       throw e;
     }
 
-    opts = this.options;
+    const opts: Object = merge(createInitialOptions(), this.options);
 
     // Tack the passes onto the object itself so that, if this object is passed back to Babel a second time,
     // it will be in the right structure to not change behavior.
@@ -175,6 +141,7 @@ class OptionManager {
       .slice(1)
       .filter(plugins => plugins.length > 0)
       .map(plugins => ({ plugins }));
+    opts.passPerPreset = opts.presets.length > 0;
 
     if (opts.inputSourceMap) {
       opts.sourceMaps = true;
@@ -231,19 +198,12 @@ type LoadedDescriptor = {
 /**
  * Load and validate the given config into a set of options, plugins, and presets.
  */
-const loadConfig = makeWeakCache((config): {
+const loadConfig = makeWeakCache((config: MergeOptions): {
   options: {},
   plugins: Array<BasicDescriptor>,
   presets: Array<BasicDescriptor>,
 } => {
   const options = normalizeOptions(config);
-
-  if (
-    config.options.plugins != null &&
-    !Array.isArray(config.options.plugins)
-  ) {
-    throw new Error(".plugins should be an array, null, or undefined");
-  }
 
   const plugins = (config.options.plugins || []).map((plugin, index) => {
     const { filepath, value, options } = normalizePair(
@@ -259,13 +219,6 @@ const loadConfig = makeWeakCache((config): {
       dirname: config.dirname,
     };
   });
-
-  if (
-    config.options.presets != null &&
-    !Array.isArray(config.options.presets)
-  ) {
-    throw new Error(".presets should be an array, null, or undefined");
-  }
 
   const presets = (config.options.presets || []).map((preset, index) => {
     const { filepath, value, options } = normalizePair(
@@ -405,7 +358,7 @@ const instantiatePreset = makeWeakCache(
   ({ value, dirname, alias }: LoadedDescriptor): MergeOptions => {
     return {
       type: "preset",
-      options: value,
+      options: validate("preset", value),
       alias,
       dirname,
     };
@@ -416,72 +369,12 @@ const instantiatePreset = makeWeakCache(
  * Validate and return the options object for the config.
  */
 function normalizeOptions(config) {
-  const alias = config.alias || "foreign";
-  const type = config.type;
-
-  //
-  if (typeof config.options !== "object" || Array.isArray(config.options)) {
-    throw new TypeError(`Invalid options type for ${alias}`);
-  }
-
   //
   const options = Object.assign({}, config.options);
 
-  if (type !== "arguments") {
-    if (options.filename !== undefined) {
-      throw new Error(`${alias}.filename is only allowed as a root argument`);
-    }
-
-    if (options.babelrc !== undefined) {
-      throw new Error(`${alias}.babelrc is only allowed as a root argument`);
-    }
-  }
-
-  if (type === "preset") {
-    if (options.only !== undefined) {
-      throw new Error(`${alias}.only is not supported in a preset`);
-    }
-    if (options.ignore !== undefined) {
-      throw new Error(`${alias}.ignore is not supported in a preset`);
-    }
-    if (options.extends !== undefined) {
-      throw new Error(`${alias}.extends is not supported in a preset`);
-    }
-    if (options.env !== undefined) {
-      throw new Error(`${alias}.env is not supported in a preset`);
-    }
-  }
-
-  if (options.sourceMap !== undefined) {
-    if (options.sourceMaps !== undefined) {
-      throw new Error(`Both ${alias}.sourceMap and .sourceMaps have been set`);
-    }
-
-    options.sourceMaps = options.sourceMap;
-    delete options.sourceMap;
-  }
-
-  for (const key in options) {
-    // check for an unknown option
-    if (!optionNames.has(key)) {
-      if (removed[key]) {
-        const { message, version = 5 } = removed[key];
-
-        throw new ReferenceError(
-          `Using removed Babel ${version} option: ${alias}.${key} - ${message}`,
-        );
-      } else {
-        // eslint-disable-next-line max-len
-        const unknownOptErr = `Unknown option: ${alias}.${key}. Check out http://babeljs.io/docs/usage/options/ for more information about options.`;
-
-        throw new ReferenceError(unknownOptErr);
-      }
-    }
-  }
-
   if (options.parserOpts && typeof options.parserOpts.parser === "string") {
     options.parserOpts = Object.assign({}, options.parserOpts);
-    options.parserOpts.parser = loadParser(
+    (options.parserOpts: any).parser = loadParser(
       options.parserOpts.parser,
       config.dirname,
     ).value;
@@ -492,15 +385,11 @@ function normalizeOptions(config) {
     typeof options.generatorOpts.generator === "string"
   ) {
     options.generatorOpts = Object.assign({}, options.generatorOpts);
-    options.generatorOpts.generator = loadGenerator(
+    (options.generatorOpts: any).generator = loadGenerator(
       options.generatorOpts.generator,
       config.dirname,
     ).value;
   }
-
-  delete options.passPerPreset;
-  delete options.plugins;
-  delete options.presets;
 
   return options;
 }
@@ -509,7 +398,7 @@ function normalizeOptions(config) {
  * Given a plugin/preset item, resolve it into a standard format.
  */
 function normalizePair(
-  pair: mixed,
+  pair: PluginItem,
   resolver,
   dirname,
 ): {
@@ -519,14 +408,8 @@ function normalizePair(
 } {
   let options;
   let value = pair;
-  if (Array.isArray(pair)) {
-    if (pair.length > 2) {
-      throw new Error(
-        `Unexpected extra options ${JSON.stringify(pair.slice(2))}.`,
-      );
-    }
-
-    [value, options] = pair;
+  if (Array.isArray(value)) {
+    [value, options] = value;
   }
 
   let filepath = null;

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -205,35 +205,19 @@ const loadConfig = makeWeakCache((config: MergeOptions): {
 } => {
   const options = normalizeOptions(config);
 
-  const plugins = (config.options.plugins || []).map((plugin, index) => {
-    const { filepath, value, options } = normalizePair(
-      plugin,
-      loadPlugin,
-      config.dirname,
-    );
+  const plugins = (config.options.plugins || []).map((plugin, index) =>
+    createDescriptor(plugin, loadPlugin, config.dirname, {
+      index,
+      alias: config.alias,
+    }),
+  );
 
-    return {
-      alias: filepath || `${config.alias}$${index}`,
-      value,
-      options,
-      dirname: config.dirname,
-    };
-  });
-
-  const presets = (config.options.presets || []).map((preset, index) => {
-    const { filepath, value, options } = normalizePair(
-      preset,
-      loadPreset,
-      config.dirname,
-    );
-
-    return {
-      alias: filepath || `${config.alias}$${index}`,
-      value,
-      options,
-      dirname: config.dirname,
-    };
-  });
+  const presets = (config.options.presets || []).map((preset, index) =>
+    createDescriptor(preset, loadPreset, config.dirname, {
+      index,
+      alias: config.alias,
+    }),
+  );
 
   return { options, plugins, presets };
 });
@@ -397,15 +381,18 @@ function normalizeOptions(config) {
 /**
  * Given a plugin/preset item, resolve it into a standard format.
  */
-function normalizePair(
+function createDescriptor(
   pair: PluginItem,
   resolver,
   dirname,
-): {
-  filepath: string | null,
-  value: {} | Function,
-  options: {} | void,
-} {
+  {
+    index,
+    alias,
+  }: {
+    index: number,
+    alias: string,
+  },
+): BasicDescriptor {
   let options;
   let value = pair;
   if (Array.isArray(value)) {
@@ -451,7 +438,12 @@ function normalizePair(
   }
   options = options || undefined;
 
-  return { filepath, value, options };
+  return {
+    alias: filepath || `${alias}$${index}`,
+    value,
+    options,
+    dirname,
+  };
 }
 
 function chain(a, b) {

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -32,7 +32,6 @@ const optionNames = new Set([
   "filenameRelative",
   "inputSourceMap",
   "env",
-  "mode",
   "retainLines",
   "highlightCode",
   "suppressDeprecationMessages",

--- a/packages/babel-core/src/config/options.js
+++ b/packages/babel-core/src/config/options.js
@@ -126,54 +126,54 @@ const COMMON_VALIDATORS: ValidatorSet = {
   >),
 };
 export type ValidatedOptions = {
-  filename?: ?string,
-  filenameRelative?: ?string,
-  babelrc?: ?boolean,
-  code?: ?boolean,
-  ast?: ?boolean,
-  inputSourceMap?: ?RootInputSourceMapOption,
+  filename?: string,
+  filenameRelative?: string,
+  babelrc?: boolean,
+  code?: boolean,
+  ast?: boolean,
+  inputSourceMap?: RootInputSourceMapOption,
 
-  extends?: ?string,
-  env?: ?EnvSet<ValidatedOptions>,
-  ignore?: ?IgnoreList,
-  only?: ?IgnoreList,
+  extends?: string,
+  env?: EnvSet<ValidatedOptions>,
+  ignore?: IgnoreList,
+  only?: IgnoreList,
 
-  presets?: ?PluginList,
-  plugins?: ?PluginList,
-  passPerPreset?: ?boolean,
+  presets?: PluginList,
+  plugins?: PluginList,
+  passPerPreset?: boolean,
 
   // Options for @babel/generator
-  retainLines?: ?boolean,
-  comments?: ?boolean,
-  shouldPrintComment?: ?Function,
-  compact?: ?CompactOption,
-  minified?: ?boolean,
-  auxiliaryCommentBefore?: ?string,
-  auxiliaryCommentAfter?: ?string,
+  retainLines?: boolean,
+  comments?: boolean,
+  shouldPrintComment?: Function,
+  compact?: CompactOption,
+  minified?: boolean,
+  auxiliaryCommentBefore?: string,
+  auxiliaryCommentAfter?: string,
 
   // Parser
-  sourceType?: ?SourceTypeOption,
+  sourceType?: SourceTypeOption,
 
-  wrapPluginVisitorMethod?: ?Function,
-  highlightCode?: ?boolean,
+  wrapPluginVisitorMethod?: Function,
+  highlightCode?: boolean,
 
   // Sourcemap generation options.
-  sourceMaps?: ?SourceMapsOption,
-  sourceMap?: ?SourceMapsOption,
-  sourceMapTarget?: ?string,
-  sourceFileName?: ?string,
-  sourceRoot?: ?string,
+  sourceMaps?: SourceMapsOption,
+  sourceMap?: SourceMapsOption,
+  sourceMapTarget?: string,
+  sourceFileName?: string,
+  sourceRoot?: string,
 
   // AMD/UMD/SystemJS module naming options.
-  getModuleId?: ?Function,
-  moduleRoot?: ?string,
-  moduleIds?: ?boolean,
-  moduleId?: ?string,
+  getModuleId?: Function,
+  moduleRoot?: string,
+  moduleIds?: boolean,
+  moduleId?: string,
 
   // Deprecate top level parserOpts
-  parserOpts?: ?{},
+  parserOpts?: {},
   // Deprecate top level generatorOpts
-  generatorOpts?: ?{},
+  generatorOpts?: {},
 };
 
 export type EnvSet<T> = {
@@ -241,7 +241,7 @@ function assertNoDuplicateSourcemap(opts: {}): void {
   }
 }
 
-function assertEnvSet(key: string, value: mixed): ?EnvSet<ValidatedOptions> {
+function assertEnvSet(key: string, value: mixed): EnvSet<ValidatedOptions> {
   const obj = assertObject(key, value);
   if (obj) {
     // Validate but don't copy the .env object in order to preserve

--- a/packages/babel-core/src/config/options.js
+++ b/packages/babel-core/src/config/options.js
@@ -1,0 +1,255 @@
+// @flow
+
+import removed from "./removed";
+import {
+  assertString,
+  assertBoolean,
+  assertObject,
+  assertInputSourceMap,
+  assertIgnoreList,
+  assertPluginList,
+  assertFunction,
+  assertSourceMaps,
+  assertCompact,
+  assertSourceType,
+} from "./option-assertions";
+
+type ValidatorSet = {
+  [string]: Validator<any>,
+};
+
+type Validator<T> = (string, mixed) => T;
+
+const ROOT_VALIDATORS: ValidatorSet = {
+  filename: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "filename">,
+  >),
+  filenameRelative: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "filenameRelative">,
+  >),
+  babelrc: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "babelrc">,
+  >),
+  code: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "code">>),
+  ast: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "ast">>),
+};
+
+const NONPRESET_VALIDATORS: ValidatorSet = {
+  extends: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "extends">,
+  >),
+  env: (assertEnvSet: Validator<$PropertyType<ValidatedOptions, "env">>),
+  ignore: (assertIgnoreList: Validator<
+    $PropertyType<ValidatedOptions, "ignore">,
+  >),
+  only: (assertIgnoreList: Validator<$PropertyType<ValidatedOptions, "only">>),
+};
+
+const COMMON_VALIDATORS: ValidatorSet = {
+  // TODO: Should 'inputSourceMap' be moved to be a root-only option?
+  // We may want a boolean-only version to be a common option, with the
+  // object only allowed as a root config argument.
+  inputSourceMap: (assertInputSourceMap: Validator<
+    $PropertyType<ValidatedOptions, "inputSourceMap">,
+  >),
+  presets: (assertPluginList: Validator<
+    $PropertyType<ValidatedOptions, "presets">,
+  >),
+  plugins: (assertPluginList: Validator<
+    $PropertyType<ValidatedOptions, "plugins">,
+  >),
+  passPerPreset: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "passPerPreset">,
+  >),
+  retainLines: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "retainLines">,
+  >),
+  comments: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "comments">,
+  >),
+  shouldPrintComment: (assertFunction: Validator<
+    $PropertyType<ValidatedOptions, "shouldPrintComment">,
+  >),
+  compact: (assertCompact: Validator<
+    $PropertyType<ValidatedOptions, "compact">,
+  >),
+  minified: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "minified">,
+  >),
+  auxiliaryCommentBefore: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "auxiliaryCommentBefore">,
+  >),
+  auxiliaryCommentAfter: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "auxiliaryCommentAfter">,
+  >),
+  sourceType: (assertSourceType: Validator<
+    $PropertyType<ValidatedOptions, "sourceType">,
+  >),
+  wrapPluginVisitorMethod: (assertFunction: Validator<
+    $PropertyType<ValidatedOptions, "wrapPluginVisitorMethod">,
+  >),
+  highlightCode: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "highlightCode">,
+  >),
+  sourceMaps: (assertSourceMaps: Validator<
+    $PropertyType<ValidatedOptions, "sourceMaps">,
+  >),
+  sourceMap: (assertSourceMaps: Validator<
+    $PropertyType<ValidatedOptions, "sourceMap">,
+  >),
+  sourceMapTarget: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "sourceMapTarget">,
+  >),
+  sourceFileName: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "sourceFileName">,
+  >),
+  sourceRoot: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "sourceRoot">,
+  >),
+  getModuleId: (assertFunction: Validator<
+    $PropertyType<ValidatedOptions, "getModuleId">,
+  >),
+  moduleRoot: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "moduleRoot">,
+  >),
+  moduleIds: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "moduleIds">,
+  >),
+  moduleId: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "moduleId">,
+  >),
+  parserOpts: (assertObject: Validator<
+    $PropertyType<ValidatedOptions, "parserOpts">,
+  >),
+  generatorOpts: (assertObject: Validator<
+    $PropertyType<ValidatedOptions, "generatorOpts">,
+  >),
+};
+export type ValidatedOptions = {
+  filename?: ?string,
+  filenameRelative?: ?string,
+  babelrc?: ?boolean,
+  code?: ?boolean,
+  ast?: ?boolean,
+  inputSourceMap?: ?RootInputSourceMapOption,
+
+  extends?: ?string,
+  env?: ?EnvSet<ValidatedOptions>,
+  ignore?: ?IgnoreList,
+  only?: ?IgnoreList,
+
+  presets?: ?PluginList,
+  plugins?: ?PluginList,
+  passPerPreset?: ?boolean,
+
+  // Options for @babel/generator
+  retainLines?: ?boolean,
+  comments?: ?boolean,
+  shouldPrintComment?: ?Function,
+  compact?: ?CompactOption,
+  minified?: ?boolean,
+  auxiliaryCommentBefore?: ?string,
+  auxiliaryCommentAfter?: ?string,
+
+  // Parser
+  sourceType?: ?SourceTypeOption,
+
+  wrapPluginVisitorMethod?: ?Function,
+  highlightCode?: ?boolean,
+
+  // Sourcemap generation options.
+  sourceMaps?: ?SourceMapsOption,
+  sourceMap?: ?SourceMapsOption,
+  sourceMapTarget?: ?string,
+  sourceFileName?: ?string,
+  sourceRoot?: ?string,
+
+  // AMD/UMD/SystemJS module naming options.
+  getModuleId?: ?Function,
+  moduleRoot?: ?string,
+  moduleIds?: ?boolean,
+  moduleId?: ?string,
+
+  // Deprecate top level parserOpts
+  parserOpts?: ?{},
+  // Deprecate top level generatorOpts
+  generatorOpts?: ?{},
+};
+
+export type EnvSet<T> = {
+  [string]: ?T,
+};
+export type IgnoreItem = string | Function | RegExp;
+export type IgnoreList = $ReadOnlyArray<IgnoreItem>;
+
+export type PluginTarget = string | {} | Function;
+export type PluginItem = PluginTarget | [PluginTarget, {} | void];
+export type PluginList = $ReadOnlyArray<PluginItem>;
+
+export type SourceMapsOption = boolean | "inline" | "both";
+export type SourceTypeOption = "module" | "script";
+export type CompactOption = boolean | "auto";
+export type RootInputSourceMapOption = {} | boolean;
+
+export type OptionsType = "arguments" | "file" | "env" | "preset";
+
+export function validate(type: OptionsType, opts: {}): ValidatedOptions {
+  assertNoDuplicateSourcemap(opts);
+
+  Object.keys(opts).forEach(key => {
+    if (type === "preset" && NONPRESET_VALIDATORS[key]) {
+      throw new Error(`.${key} is not allowed in preset options`);
+    }
+    if (type !== "arguments" && ROOT_VALIDATORS[key]) {
+      throw new Error(`.${key} is only allowed in root programmatic options`);
+    }
+
+    const validator =
+      COMMON_VALIDATORS[key] ||
+      NONPRESET_VALIDATORS[key] ||
+      ROOT_VALIDATORS[key];
+
+    if (validator) validator(key, opts[key]);
+    else throw buildUnknownError(key);
+  });
+
+  return (opts: any);
+}
+
+function buildUnknownError(key: string) {
+  if (removed[key]) {
+    const { message, version = 5 } = removed[key];
+
+    throw new ReferenceError(
+      `Using removed Babel ${version} option: .${key} - ${message}`,
+    );
+  } else {
+    // eslint-disable-next-line max-len
+    const unknownOptErr = `Unknown option: .${key}. Check out http://babeljs.io/docs/usage/options/ for more information about options.`;
+
+    throw new ReferenceError(unknownOptErr);
+  }
+}
+
+function has(obj: {}, key: string) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function assertNoDuplicateSourcemap(opts: {}): void {
+  if (has(opts, "sourceMap") && has(opts, "sourceMaps")) {
+    throw new Error(".sourceMap is an alias for .sourceMaps, cannot use both");
+  }
+}
+
+function assertEnvSet(key: string, value: mixed): ?EnvSet<ValidatedOptions> {
+  const obj = assertObject(key, value);
+  if (obj) {
+    // Validate but don't copy the .env object in order to preserve
+    // object identity for use during config chain processing.
+    for (const key of Object.keys(obj)) {
+      const env = assertObject(key, obj[key]);
+      if (env) validate("env", env);
+    }
+  }
+  return (obj: any);
+}

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -145,7 +145,7 @@ describe("api", function() {
       babel.transform("", {
         plugins: [__dirname + "/../../babel-plugin-syntax-jsx", false],
       });
-    }, /Error: \[BABEL\] unknown: Unexpected falsy value: false/);
+    }, /.plugins\[1\] must be a string, object, function/);
   });
 
   it("options merge backwards", function() {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -530,31 +530,31 @@ describe("api", function() {
     it("default", function() {
       const result = babel.transform("foo;", {
         env: {
-          development: { code: false },
+          development: { comments: false },
         },
       });
 
-      assert.equal(result.code, undefined);
+      assert.equal(result.options.comments, false);
     });
 
     it("BABEL_ENV", function() {
       process.env.BABEL_ENV = "foo";
       const result = babel.transform("foo;", {
         env: {
-          foo: { code: false },
+          foo: { comments: false },
         },
       });
-      assert.equal(result.code, undefined);
+      assert.equal(result.options.comments, false);
     });
 
     it("NODE_ENV", function() {
       process.env.NODE_ENV = "foo";
       const result = babel.transform("foo;", {
         env: {
-          foo: { code: false },
+          foo: { comments: false },
         },
       });
-      assert.equal(result.code, undefined);
+      assert.equal(result.options.comments, false);
     });
   });
 

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -372,7 +372,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["extended"],
         },
@@ -380,7 +380,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           extends: "./extended.babelrc.json",
           plugins: ["root"],
@@ -389,7 +389,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -416,7 +416,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -424,7 +424,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["dir2"],
         },
@@ -451,7 +451,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["extended"],
         },
@@ -459,7 +459,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           extends: "./extended.babelrc.json",
           plugins: ["root"],
@@ -468,7 +468,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -495,7 +495,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -503,7 +503,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           env: {
             bar: {
@@ -540,7 +540,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -548,7 +548,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           env: {
             bar: {
@@ -564,7 +564,7 @@ describe("buildConfigChain", function() {
         dirname: fixture("env"),
       },
       {
-        type: "options",
+        type: "env",
         options: {
           plugins: ["env-foo"],
         },
@@ -594,7 +594,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -602,7 +602,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           env: {
             bar: {
@@ -618,7 +618,7 @@ describe("buildConfigChain", function() {
         dirname: fixture("env"),
       },
       {
-        type: "options",
+        type: "env",
         options: {
           plugins: ["env-bar"],
         },
@@ -647,7 +647,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["pkg-plugin"],
         },
@@ -655,7 +655,7 @@ describe("buildConfigChain", function() {
         dirname: fixture("pkg"),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["pkg-ignore"],
         },
@@ -682,7 +682,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -690,7 +690,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["foo", "bar"],
         },
@@ -717,7 +717,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -725,7 +725,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           compact: true,
         },
@@ -752,7 +752,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -760,7 +760,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["foo", "bar"],
         },
@@ -786,7 +786,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -794,7 +794,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           plugins: ["extended"],
         },
@@ -802,7 +802,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           extends: "../extended.babelrc.json",
           plugins: ["foo", "bar"],
@@ -833,7 +833,7 @@ describe("buildConfigChain", function() {
 
       const expected = [
         {
-          type: "options",
+          type: "file",
           options: {
             ignore: ["root-ignore"],
           },
@@ -841,7 +841,7 @@ describe("buildConfigChain", function() {
           dirname: fixture(),
         },
         {
-          type: "options",
+          type: "file",
           options: {
             plugins: ["json"],
           },
@@ -869,7 +869,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -877,7 +877,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["*", "!src.js"],
         },
@@ -910,7 +910,7 @@ describe("buildConfigChain", function() {
 
     const expected = [
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["root-ignore"],
         },
@@ -918,7 +918,7 @@ describe("buildConfigChain", function() {
         dirname: fixture(),
       },
       {
-        type: "options",
+        type: "file",
         options: {
           ignore: ["*", "!folder"],
         },

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -72,7 +72,6 @@ describe("buildConfigChain", function() {
             ],
           },
           alias: "base",
-          loc: "base",
           dirname: base(),
         },
       ];
@@ -117,7 +116,6 @@ describe("buildConfigChain", function() {
             ],
           },
           alias: "base",
-          loc: "base",
           dirname: base(),
         },
       ];
@@ -379,16 +377,15 @@ describe("buildConfigChain", function() {
           plugins: ["extended"],
         },
         alias: fixture("extended.babelrc.json"),
-        loc: fixture("extended.babelrc.json"),
         dirname: fixture(),
       },
       {
         type: "options",
         options: {
+          extends: "./extended.babelrc.json",
           plugins: ["root"],
         },
         alias: fixture(".babelrc"),
-        loc: fixture(".babelrc"),
         dirname: fixture(),
       },
       {
@@ -397,7 +394,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -406,7 +402,6 @@ describe("buildConfigChain", function() {
           filename: fixture("dir1", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -426,7 +421,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -435,7 +429,6 @@ describe("buildConfigChain", function() {
           plugins: ["dir2"],
         },
         alias: fixture("dir2", ".babelrc"),
-        loc: fixture("dir2", ".babelrc"),
         dirname: fixture("dir2"),
       },
       {
@@ -444,7 +437,6 @@ describe("buildConfigChain", function() {
           filename: fixture("dir2", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -464,16 +456,15 @@ describe("buildConfigChain", function() {
           plugins: ["extended"],
         },
         alias: fixture("extended.babelrc.json"),
-        loc: fixture("extended.babelrc.json"),
         dirname: fixture(),
       },
       {
         type: "options",
         options: {
+          extends: "./extended.babelrc.json",
           plugins: ["root"],
         },
         alias: fixture(".babelrc"),
-        loc: fixture(".babelrc"),
         dirname: fixture(),
       },
       {
@@ -482,7 +473,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -491,7 +481,6 @@ describe("buildConfigChain", function() {
           filename: fixture("dir3", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -511,16 +500,22 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
         type: "options",
         options: {
+          env: {
+            bar: {
+              plugins: ["env-bar"],
+            },
+            foo: {
+              plugins: ["env-foo"],
+            },
+          },
           plugins: ["env-base"],
         },
         alias: fixture("env", ".babelrc"),
-        loc: fixture("env", ".babelrc"),
         dirname: fixture("env"),
       },
       {
@@ -529,7 +524,6 @@ describe("buildConfigChain", function() {
           filename: fixture("env", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -551,16 +545,22 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
         type: "options",
         options: {
+          env: {
+            bar: {
+              plugins: ["env-bar"],
+            },
+            foo: {
+              plugins: ["env-foo"],
+            },
+          },
           plugins: ["env-base"],
         },
         alias: fixture("env", ".babelrc"),
-        loc: fixture("env", ".babelrc"),
         dirname: fixture("env"),
       },
       {
@@ -569,7 +569,6 @@ describe("buildConfigChain", function() {
           plugins: ["env-foo"],
         },
         alias: fixture("env", ".babelrc.env.foo"),
-        loc: fixture("env", ".babelrc.env.foo"),
         dirname: fixture("env"),
       },
       {
@@ -578,7 +577,6 @@ describe("buildConfigChain", function() {
           filename: fixture("env", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -601,16 +599,22 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
         type: "options",
         options: {
+          env: {
+            bar: {
+              plugins: ["env-bar"],
+            },
+            foo: {
+              plugins: ["env-foo"],
+            },
+          },
           plugins: ["env-base"],
         },
         alias: fixture("env", ".babelrc"),
-        loc: fixture("env", ".babelrc"),
         dirname: fixture("env"),
       },
       {
@@ -619,7 +623,6 @@ describe("buildConfigChain", function() {
           plugins: ["env-bar"],
         },
         alias: fixture("env", ".babelrc.env.bar"),
-        loc: fixture("env", ".babelrc.env.bar"),
         dirname: fixture("env"),
       },
       {
@@ -628,7 +631,6 @@ describe("buildConfigChain", function() {
           filename: fixture("env", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -650,7 +652,6 @@ describe("buildConfigChain", function() {
           plugins: ["pkg-plugin"],
         },
         alias: fixture("pkg", "package.json"),
-        loc: fixture("pkg", "package.json"),
         dirname: fixture("pkg"),
       },
       {
@@ -659,7 +660,6 @@ describe("buildConfigChain", function() {
           ignore: ["pkg-ignore"],
         },
         alias: fixture("pkg", ".babelignore"),
-        loc: fixture("pkg", ".babelignore"),
         dirname: fixture("pkg"),
       },
       {
@@ -668,7 +668,6 @@ describe("buildConfigChain", function() {
           filename: fixture("pkg", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -688,7 +687,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -697,7 +695,6 @@ describe("buildConfigChain", function() {
           plugins: ["foo", "bar"],
         },
         alias: fixture("js-config", ".babelrc.js"),
-        loc: fixture("js-config", ".babelrc.js"),
         dirname: fixture("js-config"),
       },
       {
@@ -706,7 +703,6 @@ describe("buildConfigChain", function() {
           filename: fixture("js-config", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -726,7 +722,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -735,7 +730,6 @@ describe("buildConfigChain", function() {
           compact: true,
         },
         alias: fixture("js-config-function", ".babelrc.js"),
-        loc: fixture("js-config-function", ".babelrc.js"),
         dirname: fixture("js-config-function"),
       },
       {
@@ -744,7 +738,6 @@ describe("buildConfigChain", function() {
           filename: fixture("js-config-function", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -764,7 +757,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -773,7 +765,6 @@ describe("buildConfigChain", function() {
           plugins: ["foo", "bar"],
         },
         alias: fixture("js-config-default", ".babelrc.js"),
-        loc: fixture("js-config-default", ".babelrc.js"),
         dirname: fixture("js-config-default"),
       },
       {
@@ -782,7 +773,6 @@ describe("buildConfigChain", function() {
           filename: fixture("js-config-default", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -801,7 +791,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -810,16 +799,15 @@ describe("buildConfigChain", function() {
           plugins: ["extended"],
         },
         alias: fixture("extended.babelrc.json"),
-        loc: fixture("extended.babelrc.json"),
         dirname: fixture(),
       },
       {
         type: "options",
         options: {
+          extends: "../extended.babelrc.json",
           plugins: ["foo", "bar"],
         },
         alias: fixture("js-config-extended", ".babelrc.js"),
-        loc: fixture("js-config-extended", ".babelrc.js"),
         dirname: fixture("js-config-extended"),
       },
       {
@@ -828,7 +816,6 @@ describe("buildConfigChain", function() {
           filename: fixture("js-config-extended", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -851,7 +838,6 @@ describe("buildConfigChain", function() {
             ignore: ["root-ignore"],
           },
           alias: fixture(".babelignore"),
-          loc: fixture(".babelignore"),
           dirname: fixture(),
         },
         {
@@ -860,7 +846,6 @@ describe("buildConfigChain", function() {
             plugins: ["json"],
           },
           alias: fixture("json-pkg-config-no-babel", ".babelrc"),
-          loc: fixture("json-pkg-config-no-babel", ".babelrc"),
           dirname: fixture("json-pkg-config-no-babel"),
         },
         {
@@ -869,7 +854,6 @@ describe("buildConfigChain", function() {
             filename: fixture("json-pkg-config-no-babel", "src.js"),
           },
           alias: "base",
-          loc: "base",
           dirname: base(),
         },
       ];
@@ -890,7 +874,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -899,7 +882,6 @@ describe("buildConfigChain", function() {
           ignore: ["*", "!src.js"],
         },
         alias: fixture("ignore-negate", ".babelrc"),
-        loc: fixture("ignore-negate", ".babelrc"),
         dirname: fixture("ignore-negate"),
       },
       {
@@ -908,7 +890,6 @@ describe("buildConfigChain", function() {
           filename: fixture("ignore-negate", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];
@@ -934,7 +915,6 @@ describe("buildConfigChain", function() {
           ignore: ["root-ignore"],
         },
         alias: fixture(".babelignore"),
-        loc: fixture(".babelignore"),
         dirname: fixture(),
       },
       {
@@ -943,7 +923,6 @@ describe("buildConfigChain", function() {
           ignore: ["*", "!folder"],
         },
         alias: fixture("ignore-negate-folder", ".babelrc"),
-        loc: fixture("ignore-negate-folder", ".babelrc"),
         dirname: fixture("ignore-negate-folder"),
       },
       {
@@ -952,7 +931,6 @@ describe("buildConfigChain", function() {
           filename: fixture("ignore-negate-folder", "folder", "src.js"),
         },
         alias: "base",
-        loc: "base",
         dirname: base(),
       },
     ];

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -17,7 +17,7 @@ describe("option-manager", () => {
         manageOptions({
           randomOption: true,
         });
-      }, /Unknown option: base.randomOption/);
+      }, /Unknown option: .randomOption/);
     });
 
     it("throws for removed babel 5 options", () => {
@@ -29,7 +29,7 @@ describe("option-manager", () => {
           });
         },
         // eslint-disable-next-line max-len
-        /Using removed Babel 5 option: base.auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`/,
+        /Using removed Babel 5 option: .auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`/,
       );
     });
 
@@ -47,7 +47,7 @@ describe("option-manager", () => {
   describe("source type", function() {
     it("should set module for .mjs extension", () => {
       const config = manageOptions({
-        sourceType: "program",
+        sourceType: "script",
         filename: "foo.mjs",
       });
 

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -259,7 +259,6 @@ export default function(
                 filenameRelative: task.expect.filename,
                 sourceFileName: task.actual.filename,
                 sourceMapTarget: task.expect.filename,
-                suppressDeprecationMessages: true,
                 babelrc: false,
                 sourceMap: !!(task.sourceMappings || task.sourceMap),
               });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | Only for users passing incorrect or `null` values for options
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

Right now the validation for options is spread all throughout `option-manager` and `build-config-chain` because there's no datatype for our options. This centralizes all of the validation so that when processing the options we can rely on Flow to have already checked the options.

Might be easiest to review one commit at a time.

The big thing with this PR is that we actually _have_ options validation, so if users have been a little handwavy with their options, they'll get errors where they didn't before. I think on the whole that is probably a good thing though?