### PR TITLE
Lerna: Add publishConfig access public [skip ci]

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -29,6 +29,9 @@
     "codemods/*",
     "experimental/*"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "npmClient": "yarn",
   "npmClientArgs": [
     "--no-lockfile"


### PR DESCRIPTION
Necessary so that the command to publish will be `npm publish --access=public` like in https://docs.npmjs.com/misc/scope#publishing-public-scoped-packages-to-the-primary-npm-registry