### PR TITLE
babel-traverse, modification: exit early

### DIFF
--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -138,6 +138,9 @@ export function updateSiblingKeys(fromIndex, incrementBy) {
   if (!this.parent) return;
 
   const paths = pathCache.get(this.parent);
+
+  if (!paths) return;
+
   for (let i = 0; i < paths.length; i++) {
     const path = paths[i];
     if (path.key >= fromIndex) {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None, I make PRs, not issues :P jkjk, this was just easier to make than an issue.
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  | :-1:
| Minor: New Feature?      | :-1:
| Tests Added + Pass?      | We'll see what CI says 😅 
| Documentation PR         | :-1:
| Any Dependency Changes?  | :-1:

<!-- Describe your changes below in as much detail as possible -->

I just updated the deps in `babel-plugin-preval` and this error popped up. I'm not sure what the root cause is, but doing this seems to fix things for me. I checked and this area of the code hasn't changed in ages, so I'm not sure what's going on...

Any ideas?
