### PR TITLE
Remove extraneous console output when running preset-env tests

### DIFF
--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-config-ignore-with-false/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-config-ignore-with-false/options.json
@@ -3,7 +3,6 @@
     ["../../../../lib", {
       "configPath": "../fixtures/preset-options/browserslist-config-ignore-with-false",
       "modules": false,
-      "debug": true,
       "ignoreBrowserslistConfig": true
     }]
   ]

--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-config/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-config/options.json
@@ -2,8 +2,7 @@
   "presets": [
     ["../../../../lib", {
       "configPath": "../fixtures/preset-options/browserslist-config",
-      "modules": false,
-      "debug": true
+      "modules": false
     }]
   ]
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-package-ignore-with-array/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-package-ignore-with-array/options.json
@@ -6,8 +6,7 @@
         "chrome": 55,
         "browsers": []
       },
-      "modules": false,
-      "debug": true
+      "modules": false
     }]
   ]
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/browserslist-package/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/browserslist-package/options.json
@@ -5,8 +5,7 @@
       "targets": {
         "chrome": 55
       },
-      "modules": false,
-      "debug": true
+      "modules": false
     }]
   ]
 }


### PR DESCRIPTION
Fix #6571
