### PR TITLE
Fix path.popContext() to not try to load "-1" from contexts array.

### DIFF
--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -194,7 +194,11 @@ export function _resyncRemoved() {
 
 export function popContext() {
   this.contexts.pop();
-  this.setContext(this.contexts[this.contexts.length - 1]);
+  if (this.contexts.length) {
+    this.setContext(this.contexts[this.contexts.length - 1]);
+  } else {
+    this.setContext(undefined);
+  }
 }
 
 export function pushContext(context) {

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -194,7 +194,7 @@ export function _resyncRemoved() {
 
 export function popContext() {
   this.contexts.pop();
-  if (this.contexts.length) {
+  if (this.contexts.length > 0) {
     this.setContext(this.contexts[this.contexts.length - 1]);
   } else {
     this.setContext(undefined);


### PR DESCRIPTION
The current implement of popContext does

```js
this.setContext(this.contexts[this.contexts.length - 1]);
```

even if `this.contexts` can be empty, which causes it to lookup the
property `"-1"`, which is not found on the array itself and obviously
also not in the `Object.prototype` and the `Array.prototype`. However
since `"-1"` is not a valid array index, but has a valid integer
representation, this is a very expensive lookup in V8 (and probably
other engines too, but that is probably less relevant, since Babel
most often runs on Node nowadays). In V8 this causes a call to
the `%KeyedGetProperty` runtime function for each of these `"-1"`
property lookups, and in addition sends the whole `KeyedLoadIC`
to `MEGAMORPHIC` state, which also penalizes other accesses
on this line.

This is a small non-breaking performance fix.