### PR TITLE
Fix property lookup on booleans in needsWhitespace.

### DIFF
--- a/packages/babel-generator/src/node/index.js
+++ b/packages/babel-generator/src/node/index.js
@@ -75,7 +75,11 @@ export function needsWhitespace(node, parent, type) {
     }
   }
 
-  return (linesInfo && linesInfo[type]) || 0;
+  if (typeof linesInfo === "object" && linesInfo !== null) {
+    return linesInfo[type] || 0;
+  }
+
+  return 0;
 }
 
 export function needsWhitespaceBefore(node, parent) {


### PR DESCRIPTION
The code

```js
linesInfo && linesInfo[type]
```

performs a lot of dynamic lookups on the `Boolean.prototype`, as the
*ToBoolean* operation let's `true` pass for `linesInfo` (which might
itself be concerning that this can be a boolean). Instead of the
coercion, the code should properly check for valid objects via `typeof`
and strict equality with `null` comparison.

This is a non-breaking performance fix.