### PR TITLE
WIP test for length [skip ci] (don't merge)

### DIFF
--- a/packages/.eslintrc
+++ b/packages/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
     "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undefined-identifier": 2
+    "no-undefined-identifier": 2,
+    "no-tail-check-without-length-check": 2
   }
 }

--- a/scripts/eslint_rules/no-tail-check-without-length-check.js
+++ b/scripts/eslint_rules/no-tail-check-without-length-check.js
@@ -1,0 +1,91 @@
+"use strict";
+
+function sameNode(firstNode, secondNode) {
+  if (firstNode.type === "Identifier" || secondNode.type === "Identifier") {
+    return firstNode.name === secondNode.name;
+  }
+
+  if (
+    firstNode.type === "MemberExpression" &&
+    secondNode.type === "MemberExpression"
+  ) {
+    const nodes = [];
+
+    let node;
+    for (
+      node = firstNode;
+      node.type === "MemberExpression";
+      node = node.object
+    ) {
+      nodes.push(node.property);
+    }
+    nodes.push(node);
+
+    const second = [];
+
+    let node2;
+    for (
+      node2 = secondNode;
+      node2.type === "MemberExpression";
+      node2 = node2.object
+    ) {
+      second.push(node2.property);
+    }
+    second.push(node2);
+
+    if (nodes.length < second.length) return false;
+
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      let value;
+      if (node.type === "Identifier") {
+        value = node.name;
+      } else if (node.type === "Literal" && typeof node.value === "string") {
+        value = node.value;
+      } else {
+        return false;
+      }
+
+      const node2 = second[i];
+      let value2;
+      if (node2.type === "Identifier") {
+        value2 = node2.name;
+      } else if (node2.type === "Literal" && typeof node2.value === "string") {
+        value2 = node2.value;
+      } else {
+        return false;
+      }
+
+      if (value !== value2) return false;
+    }
+    return true;
+  }
+}
+
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  create: function(context) {
+    return {
+      MemberExpression(node) {
+        if (
+          node.computed === true &&
+          node.property.type === "BinaryExpression" &&
+          node.property.operator == "-" &&
+          node.property.right.type === "Literal" &&
+          node.property.right.value === 1 &&
+          node.property.left.type === "MemberExpression" &&
+          node.property.left.property.type === "Identifier" &&
+          node.property.left.property.name === "length" &&
+          sameNode(node.object, node.property.left.object)
+        ) {
+          context.report(
+            node,
+            'Potential performance penality without fixing access to "-1" property by adding a length check'
+          );
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Ref https://github.com/babel/babel/pull/6582/files, trying to automate finding it a bit @bmeurer? Code sucks but figured it was simple to do, maybe has false positive since I didn't really test much

If these are good, they can all be `good first issue` PRs!

## After running `make lint`

error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-generator/src/buffer.js:119:18:
  117 |
  118 |     this._buf.push(str);
> 119 |     this._last = str[str.length - 1];
      |                  ^
  120 |
  121 |     for (let i = 0; i < str.length; i++) {
  122 |       if (str[i] === "\n") {


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-generator/src/buffer.js:149:16:
  147 |       if (this._queue.length > 0) {
  148 |         const str = this._queue[0][0];
> 149 |         last = str[str.length - 1];
      |                ^
  150 |       } else {
  151 |         last = this._last;
  152 |       }


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-generator/src/generators/statements.js:195:23:
  193 |     indent: true,
  194 |     addNewlines(leading, cas) {
> 195 |       if (!leading && node.cases[node.cases.length - 1] === cas) return -1;
      |                       ^
  196 |     },
  197 |   });
  198 |


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-generator/src/generators/template-literals.js:8:18:
   6 | export function TemplateElement(node: Object, parent: Object) {
   7 |   const isFirst = parent.quasis[0] === node;
>  8 |   const isLast = parent.quasis[parent.quasis.length - 1] === node;
     |                  ^
   9 |
  10 |   const value = (isFirst ? "`" : "}") + node.value.raw + (isLast ? "`" : "${");
  11 |


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-generator/src/node/whitespace.js:94:9:
  92 |       after:
  93 |         !node.consequent.length &&
> 94 |         parent.cases[parent.cases.length - 1] === node,
     |         ^
  95 |     };
  96 |   },
  97 |


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-generator/src/printer.js:141:7:
  139 |       !SCIENTIFIC_NOTATION.test(str) &&
  140 |       !ZERO_DECIMAL_INTEGER.test(str) &&
> 141 |       str[str.length - 1] !== ".";
      |       ^
  142 |   }
  143 |
  144 |   /**


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-node/src/_babel-node.js:176:28:
  174 |
  175 |   try {
> 176 |     if (code[0] === "(" && code[code.length - 1] === ")") {
      |                            ^
  177 |       code = code.slice(1, -1); // remove "(" and ")"
  178 |     }
  179 |


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-plugin-proposal-object-rest-spread/src/index.js:69:18:
  67 |   function createObjectSpread(path, file, objRef) {
  68 |     const props = path.get("properties");
> 69 |     const last = props[props.length - 1];
     |                  ^
  70 |     t.assertRestElement(last.node);
  71 |     const restElement = t.clone(last.node);
  72 |     last.remove();


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-plugin-transform-es2015-destructuring/src/index.js:510:26:
  508 |               // we aren't the last declarator so let's just make the
  509 |               // last transformed node inherit from us
> 510 |               t.inherits(nodes[nodes.length - 1], declar);
      |                          ^
  511 |             }
  512 |           } else {
  513 |             nodes.push(


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-plugin-transform-es2015-destructuring/src/index.js:524:24:
  522 |         const nodesOut = [];
  523 |         for (const node of nodes) {
> 524 |           const tail = nodesOut[nodesOut.length - 1];
      |                        ^
  525 |           if (
  526 |             tail &&
  527 |             t.isVariableDeclaration(tail) &&


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-template/src/parse.js:85:33:
  83 |   ancestors = ancestors.slice();
  84 |
> 85 |   const { node: parent, key } = ancestors[ancestors.length - 1];
     |                                 ^
  86 |
  87 |   let type: PlaceholderType;
  88 |   if (t.isStringLiteral(node)) {


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-template/src/parse.js:124:26:
  122 |   }
  123 |
> 124 |   const { key, index } = ancestors[ancestors.length - 1];
      |                          ^
  125 |
  126 |   return { parent, key, index };
  127 | }


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/src/context.js:107:9:
  105 |       if (
  106 |         path.contexts.length === 0 ||
> 107 |         path.contexts[path.contexts.length - 1] !== this
      |         ^
  108 |       ) {
  109 |         // The context might already have been pushed when this path was inserted and queued.
  110 |         // If we always re-pushed here, we could get duplicates and risk leaving contexts


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/src/path/evaluation.js:80:27:
  78 |   if (path.isSequenceExpression()) {
  79 |     const exprs = path.get("expressions");
> 80 |     return evaluateCached(exprs[exprs.length - 1], state);
     |                           ^
  81 |   }
  82 |
  83 |   if (


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/src/path/replacement.js:51:29:
  49 |   nodes = this._verifyNodeList(nodes);
  50 |   t.inheritLeadingComments(nodes[0], this.node);
> 51 |   t.inheritTrailingComments(nodes[nodes.length - 1], this.node);
     |                             ^
  52 |   this.node = this.container[this.key] = null;
  53 |   const paths = this.insertAfter(nodes);
  54 |

---

assert tests should be fine to leave 

<details>

error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/test/modification.js:101:24:
   99 |       assert.equal(Array.isArray(result), true);
  100 |       assert.equal(result.length, 1);
> 101 |       assert.deepEqual(result[result.length - 1].node, t.identifier("b"));
      |                        ^
  102 |       assert.equal(
  103 |         generateCode(rootPath),
  104 |         "if (x) {\n  b\n\n  for (var i = 0; i < 0; i++) {}\n}",


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/test/modification.js:115:24:
  113 |       assert.equal(Array.isArray(result), true);
  114 |       assert.equal(result.length, 1);
> 115 |       assert.deepEqual(result[result.length - 1].node, t.identifier("b"));
      |                        ^
  116 |       assert.equal(
  117 |         generateCode(rootPath),
  118 |         "if (x) {\n  b\n\n  for (var i = 0; i < 0; i++) {}\n}",


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/test/modification.js:131:24:
  129 |       assert.equal(Array.isArray(result), true);
  130 |       assert.equal(result.length, 1);
> 131 |       assert.deepEqual(result[result.length - 1].node, t.identifier("b"));
      |                        ^
  132 |       assert.equal(generateCode(rootPath), "if (x) {\n  y;\n  b\n}");
  133 |     });
  134 |


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/test/modification.js:142:24:
  140 |       assert.equal(Array.isArray(result), true);
  141 |       assert.equal(result.length, 1);
> 142 |       assert.deepEqual(result[result.length - 1].node, t.identifier("b"));
      |                        ^
  143 |       assert.equal(generateCode(rootPath), "if (x) {\n  y;\n  b\n}");
  144 |     });
  145 |


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/test/modification.js:153:24:
  151 |       assert.equal(Array.isArray(result), true);
  152 |       assert.equal(result.length, 1);
> 153 |       assert.deepEqual(result[result.length - 1].node, t.identifier("b"));
      |                        ^
  154 |       assert.equal(
  155 |         generateCode(rootPath),
  156 |         "if (x) {\n  for (var i = 0; i < 0; i++) {}\n\n  b\n}",


error: Fix access to "-1" property  (no-tail-check-without-length-check) at packages/babel-traverse/test/modification.js:167:24:
  165 |       assert.equal(Array.isArray(result), true);
  166 |       assert.equal(result.length, 1);
> 167 |       assert.deepEqual(result[result.length - 1].node, t.identifier("b"));
      |                        ^
  168 |       assert.equal(
  169 |         generateCode(rootPath),
  170 |         "if (x) {\n  for (var i = 0; i < 0; i++) {}\n\n  b\n}",
</details>