### PR TITLE
Fix peerDep to ^ for now

### DIFF
--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/experimental/babel-preset-env/package.json
+++ b/experimental/babel-preset-env/package.json
@@ -50,7 +50,7 @@
     "semver": "^5.3.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.4",

--- a/experimental/babel-preset-env/package.json
+++ b/experimental/babel-preset-env/package.json
@@ -50,7 +50,7 @@
     "semver": "^5.3.0"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.4",

--- a/packages/babel-plugin-check-constants/package.json
+++ b/packages/babel-plugin-check-constants/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-check-constants/package.json
+++ b/packages/babel-plugin-check-constants/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-async-generators": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-async-generators": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -14,7 +14,7 @@
     "@babel/template": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -14,7 +14,7 @@
     "@babel/template": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -16,7 +16,7 @@
     "@babel/template": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -16,7 +16,7 @@
     "@babel/template": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-do-expressions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-do-expressions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-export-default/package.json
+++ b/packages/babel-plugin-proposal-export-default/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-export-extensions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-export-default/package.json
+++ b/packages/babel-plugin-proposal-export-default/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-export-extensions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-export-namespace/package.json
+++ b/packages/babel-plugin-proposal-export-namespace/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-export-extensions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-export-namespace/package.json
+++ b/packages/babel-plugin-proposal-export-namespace/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-export-extensions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-function-bind": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-function-bind": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-function-sent": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-function-sent": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-nullish-coalescing-operator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-nullish-coalescing-operator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-optional-chaining": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-optional-chaining": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-pipeline-operator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-pipeline-operator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -22,7 +22,7 @@
     "regexpu-core": "^4.1.3"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -22,7 +22,7 @@
     "regexpu-core": "^4.1.3"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -13,7 +13,7 @@
     "@babel/helper-remap-async-to-generator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -13,7 +13,7 @@
     "@babel/helper-remap-async-to-generator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -15,7 +15,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -15,7 +15,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -19,7 +19,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -19,7 +19,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -12,7 +12,7 @@
     "@babel/template": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -12,7 +12,7 @@
     "@babel/template": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -12,7 +12,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -12,7 +12,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-eval/package.json
+++ b/packages/babel-plugin-transform-eval/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-eval/package.json
+++ b/packages/babel-plugin-transform-eval/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-flow": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-flow": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-flow": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-flow": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -13,7 +13,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -13,7 +13,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -13,7 +13,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -13,7 +13,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -13,7 +13,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -13,7 +13,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -13,7 +13,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -13,7 +13,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -10,7 +10,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -10,7 +10,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-replace-supers": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-replace-supers": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-define-map": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-define-map": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -12,7 +12,7 @@
     "lodash": "^4.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -12,7 +12,7 @@
     "lodash": "^4.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-builder-react-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-builder-react-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-builder-react-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-builder-react-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -12,7 +12,7 @@
     "@babel/plugin-syntax-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-jsx": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-module-imports": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -12,7 +12,7 @@
     "@babel/helper-module-imports": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -12,7 +12,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -12,7 +12,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -13,7 +13,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -13,7 +13,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -12,7 +12,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -12,7 +12,7 @@
     "@babel/types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -12,7 +12,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -12,7 +12,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-typescript": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-syntax-typescript": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -13,7 +13,7 @@
     "regexpu-core": "^4.1.3"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -13,7 +13,7 @@
     "regexpu-core": "^4.1.3"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-preset-es2015/package.json
+++ b/packages/babel-preset-es2015/package.json
@@ -35,7 +35,7 @@
     "@babel/plugin-transform-unicode-regex": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-preset-es2015/package.json
+++ b/packages/babel-preset-es2015/package.json
@@ -35,7 +35,7 @@
     "@babel/plugin-transform-unicode-regex": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-preset-es2016/package.json
+++ b/packages/babel-preset-es2016/package.json
@@ -11,6 +11,6 @@
     "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-es2016/package.json
+++ b/packages/babel-preset-es2016/package.json
@@ -11,6 +11,6 @@
     "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }

--- a/packages/babel-preset-es2017/package.json
+++ b/packages/babel-preset-es2017/package.json
@@ -11,6 +11,6 @@
     "@babel/plugin-transform-async-to-generator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }

--- a/packages/babel-preset-es2017/package.json
+++ b/packages/babel-preset-es2017/package.json
@@ -11,6 +11,6 @@
     "@babel/plugin-transform-async-to-generator": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4"

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.4",

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -13,6 +13,6 @@
     "@babel/preset-stage-1": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -13,6 +13,6 @@
     "@babel/preset-stage-1": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -16,6 +16,6 @@
     "@babel/preset-stage-2": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -16,6 +16,6 @@
     "@babel/preset-stage-2": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -15,6 +15,6 @@
     "@babel/preset-stage-3": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -15,6 +15,6 @@
     "@babel/preset-stage-3": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -16,6 +16,6 @@
     "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -16,6 +16,6 @@
     "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -13,6 +13,6 @@
     "@babel/plugin-transform-typescript": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "7.0.0-beta.3"
+    "@babel/core": "^7.0.0-beta.4"
   }
 }

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -13,6 +13,6 @@
     "@babel/plugin-transform-typescript": "7.0.0-beta.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.4"
+    "@babel/core": ">=7.0.0-beta.4 <7.0.0-rc.0"
   }
 }


### PR DESCRIPTION
lerna didn't update peerDeps so going to use ^? (I guess it's a good thing it doesn't right @evocateur)

looks like angular has a version placeholder https://github.com/angular/angular/blob/master/packages/animations/package.json