### PR TITLE
Optimize class properties output

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/output.js
@@ -1,18 +1,9 @@
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 class C {
   // Output should not use `_initialiseProps`
   constructor(T) {
-    Object.defineProperty(this, "x", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: void 0
-    });
-    Object.defineProperty(this, "y", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: 0
-    });
+    _defineProperty(_defineProperty(this, "x", void 0), "y", 0);
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
@@ -24,12 +24,7 @@ function (_Hello) {
 
     let Inner = function Inner() {
       babelHelpers.classCallCheck(this, Inner);
-      Object.defineProperty(this, _this2, {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: "hello"
-      });
+      babelHelpers.defineProperty(this, _this2, "hello");
     };
 
     return babelHelpers.possibleConstructorReturn(_this, new Inner());

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -31,12 +31,7 @@ function (_Hello) {
 
     let Inner = function Inner() {
       babelHelpers.classCallCheck(this, Inner);
-      Object.defineProperty(this, _babelHelpers$get$cal, {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: 'hello'
-      });
+      babelHelpers.defineProperty(this, _babelHelpers$get$cal, 'hello');
     };
 
     return babelHelpers.possibleConstructorReturn(_this, new Inner());

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
@@ -28,60 +28,7 @@ function () {
 
   function MyClass() {
     babelHelpers.classCallCheck(this, MyClass);
-    Object.defineProperty(this, null, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "null"
-    });
-    Object.defineProperty(this, _undefined, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "undefined"
-    });
-    Object.defineProperty(this, void 0, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "void 0"
-    });
-    Object.defineProperty(this, _ref3, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "regex"
-    });
-    Object.defineProperty(this, foo, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "foo"
-    });
-    Object.defineProperty(this, _bar, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "bar"
-    });
-    Object.defineProperty(this, _baz, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "baz"
-    });
-    Object.defineProperty(this, `template`, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "template"
-    });
-    Object.defineProperty(this, _ref4, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "template-with-expression"
-    });
+    babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(this, null, "null"), _undefined, "undefined"), void 0, "void 0"), _ref3, "regex"), foo, "foo"), _bar, "bar"), _baz, "baz"), `template`, "template"), _ref4, "template-with-expression");
   }
 
   babelHelpers.createClass(MyClass, [{
@@ -104,27 +51,4 @@ function () {
   return MyClass;
 }();
 
-Object.defineProperty(MyClass, _one, {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: "test"
-});
-Object.defineProperty(MyClass, 2 * 4 + 7, {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: "247"
-});
-Object.defineProperty(MyClass, 2 * four + 7, {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: "247"
-});
-Object.defineProperty(MyClass, _ref, {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: "247"
-});
+babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(MyClass, _one, "test"), 2 * 4 + 7, "247"), 2 * four + 7, "247"), _ref, "247");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/constructor-collision/output.js
@@ -4,11 +4,6 @@ var Foo = function Foo() {
   "use strict";
 
   babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, "bar", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: foo
-  });
+  babelHelpers.defineProperty(this, "bar", foo);
   var _foo = "foo";
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -9,12 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args)), Object.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "foo"
-    }), _temp));
+    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), _temp));
   }
 
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
@@ -10,13 +10,8 @@ function (_Parent) {
 
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
-    Object.defineProperty(babelHelpers.assertThisInitialized(_this), "scopedFunctionWithThis", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function value() {
-        _this.name = {};
-      }
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "scopedFunctionWithThis", function () {
+      _this.name = {};
     });
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/instance-computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/instance-computed/output.js
@@ -5,12 +5,7 @@ function test(x) {
     "use strict";
 
     babelHelpers.classCallCheck(this, F);
-    Object.defineProperty(this, _x, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: 1
-    });
+    babelHelpers.defineProperty(this, _x, 1);
   };
 
   x = 'deadbeef';

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/instance-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/instance-undefined/output.js
@@ -2,10 +2,5 @@ var Foo = function Foo() {
   "use strict";
 
   babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, "bar", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: void 0
-  });
+  babelHelpers.defineProperty(this, "bar", void 0);
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/instance/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/instance/output.js
@@ -2,10 +2,5 @@ var Foo = function Foo() {
   "use strict";
 
   babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, "bar", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: "foo"
-  });
+  babelHelpers.defineProperty(this, "bar", "foo");
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
@@ -15,13 +15,8 @@ export default (param => {
       }
     }]);
     return App;
-  }(), Object.defineProperty(_class, "props", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: {
-      prop1: 'prop1',
-      prop2: 'prop2'
-    }
+  }(), babelHelpers.defineProperty(_class, "props", {
+    prop1: 'prop1',
+    prop2: 'prop2'
   }), _temp;
 });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T2983/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T2983/output.mjs
@@ -2,22 +2,12 @@ var _class, _temp;
 
 call((_temp = _class = function _class() {
   babelHelpers.classCallCheck(this, _class);
-}, Object.defineProperty(_class, "test", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: true
-}), _temp));
+}, babelHelpers.defineProperty(_class, "test", true), _temp));
 
 var _default = function _default() {
   babelHelpers.classCallCheck(this, _default);
 };
 
-Object.defineProperty(_default, "test", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: true
-});
+babelHelpers.defineProperty(_default, "test", true);
 export { _default as default };
 ;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
@@ -14,16 +14,11 @@ function withContext(ComposedComponent) {
     }
 
     return WithContext;
-  }(Component), Object.defineProperty(_class, "propTypes", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: {
-      context: PropTypes.shape({
-        addCss: PropTypes.func,
-        setTitle: PropTypes.func,
-        setMeta: PropTypes.func
-      })
-    }
+  }(Component), babelHelpers.defineProperty(_class, "propTypes", {
+    context: PropTypes.shape({
+      addCss: PropTypes.func,
+      setTitle: PropTypes.func,
+      setMeta: PropTypes.func
+    })
   }), _temp;
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T7364/output.mjs
@@ -2,20 +2,11 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    Object.defineProperty(this, "myAsyncMethod", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function () {
-        var _ref = babelHelpers.asyncToGenerator(function* () {
-          console.log(_this);
-        });
-
-        return function value() {
-          return _ref.apply(this, arguments);
-        };
-      }()
-    });
+    babelHelpers.defineProperty(this, "myAsyncMethod",
+    /*#__PURE__*/
+    babelHelpers.asyncToGenerator(function* () {
+      console.log(_this);
+    }));
   }
 
 }
@@ -24,20 +15,11 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    Object.defineProperty(this, "myAsyncMethod", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function () {
-        var _ref2 = babelHelpers.asyncToGenerator(function* () {
-          console.log(_this2);
-        });
-
-        return function value() {
-          return _ref2.apply(this, arguments);
-        };
-      }()
-    });
+    babelHelpers.defineProperty(this, "myAsyncMethod",
+    /*#__PURE__*/
+    babelHelpers.asyncToGenerator(function* () {
+      console.log(_this2);
+    }));
   }
 
 });
@@ -46,20 +28,11 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    Object.defineProperty(this, "myAsyncMethod", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function () {
-        var _ref3 = babelHelpers.asyncToGenerator(function* () {
-          console.log(_this3);
-        });
-
-        return function value() {
-          return _ref3.apply(this, arguments);
-        };
-      }()
-    });
+    babelHelpers.defineProperty(this, "myAsyncMethod",
+    /*#__PURE__*/
+    babelHelpers.asyncToGenerator(function* () {
+      console.log(_this3);
+    }));
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-export/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-export/output.mjs
@@ -1,21 +1,11 @@
 export var MyClass = function MyClass() {
   babelHelpers.classCallCheck(this, MyClass);
 };
-Object.defineProperty(MyClass, "property", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: value
-});
+babelHelpers.defineProperty(MyClass, "property", value);
 
 var MyClass2 = function MyClass2() {
   babelHelpers.classCallCheck(this, MyClass2);
 };
 
-Object.defineProperty(MyClass2, "property", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: value
-});
+babelHelpers.defineProperty(MyClass2, "property", value);
 export { MyClass2 as default };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-infer-name/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-infer-name/output.js
@@ -4,9 +4,4 @@ var Foo = (_temp = _class = function Foo() {
   "use strict";
 
   babelHelpers.classCallCheck(this, Foo);
-}, Object.defineProperty(_class, "num", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: 0
-}), _temp);
+}, babelHelpers.defineProperty(_class, "num", 0), _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-undefined/output.js
@@ -4,9 +4,4 @@ var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
 };
 
-Object.defineProperty(Foo, "bar", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: void 0
-});
+babelHelpers.defineProperty(Foo, "bar", void 0);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static/output.js
@@ -4,9 +4,4 @@ var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
 };
 
-Object.defineProperty(Foo, "bar", {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  value: "foo"
-});
+babelHelpers.defineProperty(Foo, "bar", "foo");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -27,12 +27,7 @@ function (_A) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), Object.defineProperty(babelHelpers.assertThisInitialized(_this), "foo", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(_this)
-    }), _temp));
+    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(_this)), _temp));
   }
 
   return B;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
@@ -9,12 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), Object.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "foo"
-    }), _temp));
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
@@ -10,12 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-    Object.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: "foo"
-    });
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-with-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-with-collision/output.js
@@ -2,16 +2,5 @@ var A = function A(_force) {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
-  Object.defineProperty(this, "force", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: force
-  });
-  Object.defineProperty(this, "foo", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", babelHelpers.assertThisInitialized(this)).call(this)
-  });
+  babelHelpers.defineProperty(babelHelpers.defineProperty(this, "force", force), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", babelHelpers.assertThisInitialized(this)).call(this));
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
@@ -5,25 +5,15 @@ var _this = this;
     constructor() {
       var _this2 = this;
 
-      Object.defineProperty(this, "fn", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: function () {
-          return console.log(_this2);
-        }
+      babelHelpers.defineProperty(this, "fn", function () {
+        return console.log(_this2);
       });
     }
 
   }
 
-  Object.defineProperty(Foo, "fn", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: function () {
-      return console.log(_this);
-    }
+  babelHelpers.defineProperty(Foo, "fn", function () {
+    return console.log(_this);
   });
 });
 
@@ -34,23 +24,13 @@ var _this = this;
     constructor() {
       var _this3 = this;
 
-      Object.defineProperty(this, "fn", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: function () {
-          return console.log(_this3);
-        }
+      babelHelpers.defineProperty(this, "fn", function () {
+        return console.log(_this3);
       });
     }
 
-  }, Object.defineProperty(_class, "fn", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: function () {
-      return console.log(_this);
-    }
+  }, babelHelpers.defineProperty(_class, "fn", function () {
+    return console.log(_this);
   }), _temp;
 });
 
@@ -59,31 +39,15 @@ var _this = this;
     constructor(_force) {
       var _this4 = this;
 
-      Object.defineProperty(this, "fn", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: function () {
-          return console.log(_this4);
-        }
-      });
-      Object.defineProperty(this, "force", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: force
-      });
+      babelHelpers.defineProperty(babelHelpers.defineProperty(this, "fn", function () {
+        return console.log(_this4);
+      }), "force", force);
     }
 
   }
 
-  Object.defineProperty(Baz, "fn", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: function () {
-      return console.log(_this);
-    }
+  babelHelpers.defineProperty(Baz, "fn", function () {
+    return console.log(_this);
   });
 });
 
@@ -94,24 +58,14 @@ var qux = function () {
     constructor() {
       var _this5 = this;
 
-      Object.defineProperty(this, "fn", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: function () {
-          return console.log(_this5);
-        }
+      babelHelpers.defineProperty(this, "fn", function () {
+        return console.log(_this5);
       });
     }
 
   }
 
-  Object.defineProperty(Qux, "fn", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: function () {
-      return console.log(_this6);
-    }
+  babelHelpers.defineProperty(Qux, "fn", function () {
+    return console.log(_this6);
   });
 }.bind(this);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -8,6 +8,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
@@ -41,25 +43,15 @@ var Test = function Test() {
         args[_key] = arguments[_key];
       }
 
-      return _possibleConstructorReturn(_this, (_temp = _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args))), Object.defineProperty(_assertThisInitialized(_this), "a", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: function value() {
-          return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));
-        }
+      return _possibleConstructorReturn(_this, (_temp = _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args))), _defineProperty(_assertThisInitialized(_this), "a", function () {
+        return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));
       }), _temp));
     }
 
     return Other;
   }(Test);
 
-  Object.defineProperty(Other, "a", {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: function value() {
-      return _get(_getPrototypeOf(Test.prototype), "test", _assertThisInitialized(_this2));
-    }
+  _defineProperty(Other, "a", function () {
+    return _get(_getPrototypeOf(Test.prototype), "test", _assertThisInitialized(_this2));
   });
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7371/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7371/output.js
@@ -5,12 +5,7 @@ class C {}
 class A extends C {
   constructor() {
     super();
-    Object.defineProperty(this, "field", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: 1
-    });
+    babelHelpers.defineProperty(this, "field", 1);
 
     class B extends C {
       constructor() {
@@ -40,12 +35,7 @@ class SuperClass extends Obj {
   constructor() {
     var _temp;
 
-    class B extends ((_temp = super(), Object.defineProperty(this, "field", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: 1
-    }), _temp), Obj) {
+    class B extends ((_temp = super(), babelHelpers.defineProperty(this, "field", 1), _temp), Obj) {
       constructor() {
         super();
         expect(this.field).toBeUndefined();
@@ -71,12 +61,7 @@ class ComputedMethod extends Obj {
         expect(this.field).toBeUndefined();
       }
 
-      [(_temp2 = super(), Object.defineProperty(this, "field", {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: 1
-      }), _temp2)]() {}
+      [(_temp2 = super(), babelHelpers.defineProperty(this, "field", 1), _temp2)]() {}
 
     }
 
@@ -92,22 +77,12 @@ class ComputedField extends Obj {
   constructor() {
     var _temp3;
 
-    var _ref = (_temp3 = super(), Object.defineProperty(this, "field", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: 1
-    }), _temp3);
+    var _ref = (_temp3 = super(), babelHelpers.defineProperty(this, "field", 1), _temp3);
 
     class B extends Obj {
       constructor() {
         super();
-        Object.defineProperty(this, _ref, {
-          configurable: true,
-          enumerable: true,
-          writable: true,
-          value: 1
-        });
+        babelHelpers.defineProperty(this, _ref, 1);
         expect(this.field).toBeUndefined();
       }
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -29,6 +29,8 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 var App =
 /*#__PURE__*/
 function (_Component) {
@@ -45,12 +47,7 @@ function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _possibleConstructorReturn(_this, (_temp = _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args))), Object.defineProperty(_assertThisInitialized(_this), "exportType", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: ''
-    }), _temp));
+    return _possibleConstructorReturn(_this, (_temp = _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args))), _defineProperty(_assertThisInitialized(_this), "exportType", ''), _temp));
   }
 
   _createClass(App, [{


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no

Similar to change in https://github.com/babel/babel/pull/6652 . Additionally I switch to using `defineProperty` helper instead of using bare `Object.defineProperty` call - which should have benefit of not having to hit slow `Object.defineProperty` path in most cases.