### PR TITLE
Maintain plugin order with items in the `include` option

### DIFF
--- a/experimental/babel-preset-env/README.md
+++ b/experimental/babel-preset-env/README.md
@@ -235,7 +235,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js) - names without a prefix like `transform-spread` instead of `plugin-transform-spread` are supported.
+- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js), names without a prefix like `transform-spread` instead of `plugin-transform-spread` are supported. Note, that none of the module transforms (`transform-module-*`) are supported here, use the [`modules` option](https://github.com/babel/babel/tree/master/experimental/babel-preset-env#modules) instead.
 
 - [Built-ins](https://github.com/babel/babel-preset-env/blob/master/data/built-in-features.js), such as `map`, `set`, or `object.assign`.
 

--- a/experimental/babel-preset-env/src/index.js
+++ b/experimental/babel-preset-env/src/index.js
@@ -121,17 +121,16 @@ const filterItems = (
   const result = new Set();
 
   for (const item in list) {
-    const excluded = excludes.has(item);
+    if (
+      !excludes.has(item) &&
+      (isPluginRequired(targets, list[item]) || includes.has(item))
+    ) {
+      result.add(item);
+    } else {
+      const shippedProposalsSyntax = pluginSyntaxMap.get(item);
 
-    if (!excluded) {
-      if (isPluginRequired(targets, list[item])) {
-        result.add(item);
-      } else {
-        const shippedProposalsSyntax = pluginSyntaxMap.get(item);
-
-        if (shippedProposalsSyntax) {
-          result.add(shippedProposalsSyntax);
-        }
+      if (shippedProposalsSyntax) {
+        result.add(shippedProposalsSyntax);
       }
     }
   }
@@ -139,8 +138,6 @@ const filterItems = (
   if (defaultItems) {
     defaultItems.forEach(item => !excludes.has(item) && result.add(item));
   }
-
-  includes.forEach(item => result.add(item));
 
   return result;
 };

--- a/experimental/babel-preset-env/test/fixtures/preset-options/exclude-include/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/exclude-include/expected.js
@@ -1,8 +1,8 @@
+import "core-js/modules/es6.map";
 import "core-js/modules/es7.string.pad-end";
 import "core-js/modules/web.timers";
 import "core-js/modules/web.immediate";
 import "core-js/modules/web.dom.iterable";
-import "core-js/modules/es6.map";
 
 async function a() {
   await 1;

--- a/experimental/babel-preset-env/test/fixtures/preset-options/include-built-ins/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/include-built-ins/expected.js
@@ -1,7 +1,7 @@
+import "core-js/modules/es6.map";
+import "core-js/modules/es6.set";
 import "core-js/modules/es7.string.pad-start";
 import "core-js/modules/es7.string.pad-end";
 import "core-js/modules/web.timers";
 import "core-js/modules/web.immediate";
 import "core-js/modules/web.dom.iterable";
-import "core-js/modules/es6.map";
-import "core-js/modules/es6.set";

--- a/experimental/babel-preset-env/test/fixtures/preset-options/include/actual.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/include/actual.js
@@ -1,1 +1,1 @@
-import a from "a";
+class Foo {}

--- a/experimental/babel-preset-env/test/fixtures/preset-options/include/expected.js
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/include/expected.js
@@ -1,5 +1,5 @@
-"use strict";
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var _a = _interopRequireDefault(require("a"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+let Foo = function Foo() {
+  _classCallCheck(this, Foo);
+};

--- a/experimental/babel-preset-env/test/fixtures/preset-options/include/options.json
+++ b/experimental/babel-preset-env/test/fixtures/preset-options/include/options.json
@@ -1,8 +1,10 @@
 {
   "presets": [
     ["../../../../lib", {
-      "targets": {},
-      "include": ["transform-modules-commonjs"],
+      "targets": {
+        "chrome": 61
+      },
+      "include": ["transform-classes"],
       "modules": false
     }]
   ]


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6648
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | y
| Minor: New Feature?      | n
| Tests Added + Pass?      | y/y
| Documentation PR         | 
| Any Dependency Changes?  | 

This tweaks behavior in preset-env so that it checks both whether a plugin/builtin is required _or_ the user has it in their `includes` option as it loops through the (for better or worse) ordered lists.

Plugin ordering can't come soon enough :)

Worth discussing, but this does have the (breaking) side effect that the following is no longer possible:

```
{
  "modules": false,
  "includes": ["transform-modules-commonjs"]
}
```

^ seemed sort of weird anyway?