### PR TITLE
Fix unpkg link

### DIFF
--- a/packages/babel-standalone/README.md
+++ b/packages/babel-standalone/README.md
@@ -18,7 +18,7 @@ Installation
 
 There are several ways to get a copy of @babel/standalone. Pick whichever one you like:
 
-- Use it via UNPKG: https://unpkg.com/@babel/standalone@6/babel.min.js. This is a simple way to embed it on a webpage without having to do any other setup.
+- Use it via UNPKG: https://unpkg.com/@babel/standalone/babel.min.js. This is a simple way to embed it on a webpage without having to do any other setup.
 - Install via Bower: `bower install @babel/standalone`
 - Install via NPM: `npm install --save @babel/standalone`
 - Manually grab `babel.js` and/or `babel.min.js` from the [GitHub releases page](https://github.com/Daniel15/babel-standalone/releases). Every release includes these files.


### PR DESCRIPTION
It doesn't look like there are any versions of the `@babel/standalone` package on version 6, so I just removed the version number so it'll pull the latest (currently 7.0.0-beta.4).

Cheers! 😅 