### PR TITLE
Publish to the latest dist tag [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ publish:
 	make test
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	./node_modules/.bin/lerna publish --force-publish=* --npm-tag=next --exact --skip-temp-tag
+	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag
 	make clean
 
 bootstrap:


### PR DESCRIPTION
- This is because with scoped packages the `latest` package was the first publish we did
- This happens to be beta.4..
- So in this case we should publish whatever version as latest anyway

And I manually have to do `npm dist-tag add @babel/cli@7.0.0-beta.31 latest` now for all pkgs