### PR TITLE
Allowed hintedNames for namespaced imports, changed some other defaul…

### DIFF
--- a/packages/babel-helper-module-imports/src/import-builder.js
+++ b/packages/babel-helper-module-imports/src/import-builder.js
@@ -43,7 +43,7 @@ export default class ImportBuilder {
     return this;
   }
 
-  namespace(name) {
+  namespace(name = "namespace") {
     name = this._scope.generateUidIdentifier(name);
 
     const statement = this._statements[this._statements.length - 1];

--- a/packages/babel-helper-module-imports/src/import-injector.js
+++ b/packages/babel-helper-module-imports/src/import-injector.js
@@ -197,16 +197,17 @@ export default class ImportInjector {
       importingInterop,
       ensureLiveReference,
       ensureNoContext,
-
-      // Provide a hint for generateUidIdentifier for the local variable name
-      // to use for the import, if the code will generate a simple assignment
-      // to a variable.
-      nameHint = importName,
+      nameHint,
 
       // Not meant for public usage. Allows code that absolutely must control
       // ordering to set a specific hoist value on the import nodes.
       blockHoist,
     } = opts;
+
+    // Provide a hint for generateUidIdentifier for the local variable name
+    // to use for the import, if the code will generate a simple assignment
+    // to a variable.
+    let name = nameHint || importName;
 
     const isMod = isModule(this._programPath, true);
     const isModuleForNode = isMod && importingInterop === "node";
@@ -228,9 +229,9 @@ export default class ImportInjector {
       // import { named } from ''; named
       builder.import();
       if (isNamespace) {
-        builder.namespace("namespace");
+        builder.namespace(nameHint || importedSource);
       } else if (isDefault || isNamed) {
-        builder.named(nameHint, importName);
+        builder.named(name, importName);
       }
     } else if (importedType !== "commonjs") {
       throw new Error(`Unexpected interopType "${importedType}"`);
@@ -239,29 +240,31 @@ export default class ImportInjector {
         // import _tmp from ''; var namespace = interopRequireWildcard(_tmp); namespace
         // import _tmp from ''; var def = interopRequireDefault(_tmp).default; def
         // import _tmp from ''; _tmp.named
+        name = name !== "default" ? name : importedSource;
+        const es6Default = `${importedSource}$es6Default`;
 
         builder.import();
         if (isNamespace) {
           builder
-            .default("es6Default")
-            .var(nameHint || "namespace")
+            .default(es6Default)
+            .var(name || importedSource)
             .wildcardInterop();
         } else if (isDefault) {
           if (ensureLiveReference) {
             builder
-              .default("es6Default")
-              .var("namespace")
+              .default(es6Default)
+              .var(name || importedSource)
               .defaultInterop()
               .read("default");
           } else {
             builder
-              .default("es6Default")
-              .var(nameHint)
+              .default(es6Default)
+              .var(name)
               .defaultInterop()
               .prop(importName);
           }
         } else if (isNamed) {
-          builder.default("es6Default").read(importName);
+          builder.default(es6Default).read(importName);
         }
       } else if (isModuleForBabel) {
         // import * as namespace from ''; namespace
@@ -269,9 +272,9 @@ export default class ImportInjector {
         // import { named } from ''; named
         builder.import();
         if (isNamespace) {
-          builder.namespace("namespace");
+          builder.namespace(name || importedSource);
         } else if (isDefault || isNamed) {
-          builder.named(nameHint, importName);
+          builder.named(name, importName);
         }
       } else {
         // var namespace = interopRequireWildcard(require(''));
@@ -279,18 +282,22 @@ export default class ImportInjector {
         // var named = require('').named; named
         builder.require();
         if (isNamespace) {
-          builder.var("namespace").wildcardInterop();
+          builder.var(name || importedSource).wildcardInterop();
         } else if ((isDefault || isNamed) && ensureLiveReference) {
-          builder.var("namespace").read(importName);
-
-          if (isDefault) builder.defaultInterop();
+          if (isDefault) {
+            name = name !== "default" ? name : importedSource;
+            builder.var(name).read(importName);
+            builder.defaultInterop();
+          } else {
+            builder.var(importedSource).read(importName);
+          }
         } else if (isDefault) {
           builder
-            .var(nameHint)
+            .var(name)
             .defaultInterop()
             .prop(importName);
         } else if (isNamed) {
-          builder.var(nameHint).prop(importName);
+          builder.var(name).prop(importName);
         }
       }
     } else if (importedInterop === "compiled") {
@@ -301,9 +308,9 @@ export default class ImportInjector {
 
         builder.import();
         if (isNamespace) {
-          builder.default("namespace");
+          builder.default(name || importedSource);
         } else if (isDefault || isNamed) {
-          builder.default("namespace").read(importName);
+          builder.default(importedSource).read(name);
         }
       } else if (isModuleForBabel) {
         // import * as namespace from ''; namespace
@@ -314,24 +321,23 @@ export default class ImportInjector {
 
         builder.import();
         if (isNamespace) {
-          builder.namespace("namespace");
+          builder.namespace(name || importedSource);
         } else if (isDefault || isNamed) {
-          builder.named(nameHint, importName);
+          builder.named(name, importName);
         }
       } else {
         // var namespace = require(''); namespace
         // var namespace = require(''); namespace.default
         // var namespace = require(''); namespace.named
         // var named = require('').named;
-
         builder.require();
         if (isNamespace) {
-          builder.var("namespace");
+          builder.var(name || importedSource);
         } else if (isDefault || isNamed) {
           if (ensureLiveReference) {
-            builder.var("namespace").read(importName);
+            builder.var(importedSource).read(name);
           } else {
-            builder.prop(importName).var(nameHint);
+            builder.prop(importName).var(name);
           }
         }
       }
@@ -344,14 +350,13 @@ export default class ImportInjector {
         // import namespace from ''; namespace
         // import def from ''; def;
         // import namespace from ''; namespace.named
-
         builder.import();
         if (isNamespace) {
-          builder.default("namespace");
+          builder.default(name || importedSource);
         } else if (isDefault) {
-          builder.default(nameHint);
+          builder.default(name);
         } else if (isNamed) {
-          builder.default("namespace").read(importName);
+          builder.default(importedSource).read(name);
         }
       } else if (isModuleForBabel) {
         // import namespace from '';
@@ -363,28 +368,27 @@ export default class ImportInjector {
 
         builder.import();
         if (isNamespace) {
-          builder.default("namespace");
+          builder.default(name || importedSource);
         } else if (isDefault) {
-          builder.default(nameHint);
+          builder.default(name);
         } else if (isNamed) {
-          builder.named(nameHint, importName);
+          builder.named(name, importName);
         }
       } else {
         // var namespace = require(''); namespace
         // var def = require(''); def
         // var namespace = require(''); namespace.named
         // var named = require('').named;
-
         builder.require();
         if (isNamespace) {
-          builder.var("namespace");
+          builder.var(name || importedSource);
         } else if (isDefault) {
-          builder.var(nameHint);
+          builder.var(name);
         } else if (isNamed) {
           if (ensureLiveReference) {
-            builder.var("namespace").read(importName);
+            builder.var(importedSource).read(name);
           } else {
-            builder.var(nameHint).prop(importName);
+            builder.var(name).prop(importName);
           }
         }
       }

--- a/packages/babel-helper-module-imports/test/index.js
+++ b/packages/babel-helper-module-imports/test/index.js
@@ -55,8 +55,19 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedType },
             addNamespace(),
             `
-              import * as _namespace from "source";
-              _namespace;
+              import * as _source from "source";
+              _source;
+            `,
+          );
+        });
+
+        it("should import with a name hint", () => {
+          testModule(
+            { importingInterop, importedType },
+            addNamespace({ nameHint: "hintedName" }),
+            `
+              import * as _hintedName from "source";
+              _hintedName;
             `,
           );
         });
@@ -70,8 +81,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedType },
             addNamespace(),
             `
-              import * as _namespace from "source";
-              _namespace;
+              import * as _source from "source";
+              _source;
             `,
           );
         });
@@ -99,8 +110,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamespace(),
             `
-              import _namespace from "source";
-              _namespace;
+              import _source from "source";
+              _source;
             `,
           );
         });
@@ -114,8 +125,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamespace(),
             `
-              import _namespace from "source";
-              _namespace;
+              import _source from "source";
+              _source;
             `,
           );
         });
@@ -127,8 +138,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop },
             addNamespace(),
             `
-              var _namespace = require("source");
-              _namespace;
+              var _source = require("source");
+              _source;
             `,
           );
         });
@@ -146,8 +157,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamespace(),
             `
-              import _namespace from "source";
-              _namespace;
+              import _source from "source";
+              _source;
             `,
           );
         });
@@ -161,8 +172,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamespace(),
             `
-              import * as _namespace from "source";
-              _namespace;
+              import * as _source from "source";
+              _source;
             `,
           );
         });
@@ -174,8 +185,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop },
             addNamespace(),
             `
-              var _namespace = require("source");
-              _namespace;
+              var _source = require("source");
+              _source;
             `,
           );
         });
@@ -193,9 +204,9 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamespace(),
             `
-            import _es6Default from "source";
-              var _namespace = babelHelpers.interopRequireWildcard(_es6Default);
-              _namespace;
+              import _source$es6Default from "source";
+              var _source = babelHelpers.interopRequireWildcard(_source$es6Default);
+              _source;
             `,
           );
         });
@@ -209,8 +220,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamespace(),
             `
-              import * as _namespace from "source";
-              _namespace;
+              import * as _source from "source";
+              _source;
             `,
           );
         });
@@ -222,8 +233,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop },
             addNamespace(),
             `
-              var _namespace = babelHelpers.interopRequireWildcard(require("source"));
-              _namespace;
+              var _source = babelHelpers.interopRequireWildcard(require("source"));
+              _source;
             `,
           );
         });
@@ -402,8 +413,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addDefault(),
             `
-              import _namespace from "source";
-              _namespace.default;
+              import _source from "source";
+              _source.default;
             `,
           );
         });
@@ -413,8 +424,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop, ensureNoContext: true },
             addDefault(),
             `
-              import _namespace from "source";
-              0, _namespace.default;
+              import _source from "source";
+              0, _source.default;
             `,
           );
         });
@@ -474,8 +485,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop, ensureLiveReference: true },
             addDefault(),
             `
-              var _namespace = require("source");
-              _namespace.default;
+              var _source = require("source");
+              _source.default;
             `,
           );
         });
@@ -493,9 +504,9 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addDefault(),
             `
-              import _es6Default from "source";
-              var _default = babelHelpers.interopRequireDefault(_es6Default).default;
-              _default;
+              import _source$es6Default from "source";
+              var _source = babelHelpers.interopRequireDefault(_source$es6Default).default;
+              _source;
             `,
           );
         });
@@ -505,8 +516,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addDefault({ nameHint: "hintedName" }),
             `
-              import _es6Default from "source";
-              var _hintedName = babelHelpers.interopRequireDefault(_es6Default).default;
+              import _source$es6Default from "source";
+              var _hintedName = babelHelpers.interopRequireDefault(_source$es6Default).default;
               _hintedName;
             `,
           );
@@ -517,9 +528,9 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop, ensureLiveReference: true },
             addDefault(),
             `
-              import _es6Default from "source";
-              var _namespace = babelHelpers.interopRequireDefault(_es6Default);
-              _namespace.default;
+              import _source$es6Default from "source";
+              var _source = babelHelpers.interopRequireDefault(_source$es6Default);
+              _source.default;
             `,
           );
         });
@@ -579,8 +590,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop, ensureLiveReference: true },
             addDefault(),
             `
-              var _namespace = babelHelpers.interopRequireDefault(require("source"));
-              _namespace.default;
+              var _source = babelHelpers.interopRequireDefault(require("source"));
+              _source.default;
             `,
           );
         });
@@ -668,8 +679,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamed(),
             `
-              import _namespace from "source";
-              _namespace.read;
+              import _source from "source";
+              _source.read;
             `,
           );
         });
@@ -679,8 +690,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop, ensureNoContext: true },
             addNamed(),
             `
-              import _namespace from "source";
-              0, _namespace.read;
+              import _source from "source";
+              0, _source.read;
             `,
           );
         });
@@ -740,8 +751,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop, ensureLiveReference: true },
             addNamed(),
             `
-              var _namespace = require("source");
-              _namespace.read;
+              var _source = require("source");
+              _source.read;
             `,
           );
         });
@@ -759,8 +770,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamed(),
             `
-              import _namespace from "source";
-              _namespace.read;
+              import _source from "source";
+              _source.read;
             `,
           );
         });
@@ -770,8 +781,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop, ensureNoContext: true },
             addNamed(),
             `
-              import _namespace from "source";
-              0, _namespace.read;
+              import _source from "source";
+              0, _source.read;
             `,
           );
         });
@@ -831,8 +842,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop, ensureLiveReference: true },
             addNamed(),
             `
-              var _namespace = require("source");
-              _namespace.read;
+              var _source = require("source");
+              _source.read;
             `,
           );
         });
@@ -850,8 +861,8 @@ describe("@babel/helper-module-imports", () => {
             { importingInterop, importedInterop },
             addNamed(),
             `
-              import _es6Default from "source";
-              _es6Default.read;
+              import _source$es6Default from "source";
+              _source$es6Default.read;
             `,
           );
         });
@@ -911,8 +922,8 @@ describe("@babel/helper-module-imports", () => {
             { importedInterop, ensureLiveReference: true },
             addNamed(),
             `
-              var _namespace = require("source");
-              _namespace.read;
+              var _source = require("source");
+              _source.read;
             `,
           );
         });


### PR DESCRIPTION
…ts for more readable ones

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

Ive just wanted `addNamespace` to accepts `hintedName` option, but in the process I've noticed some auto-determined names make (imho) less sense that they could have, so I've tweaked those helpers a little bit.
