### PR TITLE
Fix `isIdentifer` check for result.deopt in @babel/preset-env

### DIFF
--- a/experimental/babel-preset-env/src/use-built-ins-plugin.js
+++ b/experimental/babel-preset-env/src/use-built-ins-plugin.js
@@ -198,7 +198,7 @@ export default function({ types: t }: { types: Object }): Plugin {
           const result = path.get("object").evaluate();
           if (result.value) {
             instanceType = getType(result.value);
-          } else if (result.deopt && result.deopt.isIdentifier()) {
+          } else if (result.deopt && t.isIdentifier(result.deopt)) {
             evaluatedPropType = result.deopt.node.name;
           }
         }


### PR DESCRIPTION
When using 7.0.0-beta-31, I consistently run into the following error within several babel plugins:

```
node_modules/@babel/preset-env/lib/use-built-ins-plugin.js:180
          } else if (result.deopt && result.deopt.isIdentifier()) {
                                             ^
TypeError: result.deopt.isIdentifier is not a function
```

It's the result.deopt.isIdentifer part that consistently breaks my builds, if the line is changed to use `t.isIdentifer(result.deopt)` everything works perfectly as expected.

I noticed that other places in the same file also use `t.isIdentifer`, so this actually seems to fall more in line with the consistency of the rest of the file.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Bug fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
