### PR TITLE
Add transformations export

### DIFF
--- a/experimental/babel-preset-env/src/index.js
+++ b/experimental/babel-preset-env/src/index.js
@@ -268,5 +268,6 @@ Using polyfills with \`${useBuiltIns}\` option:`,
 
   return {
     plugins,
+    transformations,
   };
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍 
| Tests Added + Pass?      | ---
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Hi all! This tiny PR is more of a question/discussion starter than anything else, because it's possibly following a wrong direction.

I'm experimenting with a service that runs Babel on a per-request basis, transpiling just what's needed. This involves changing a bit the way parameters are sent to the preset, because instead of pre-defining a range of browsers that I wish to support, I'll be specifying exactly the browser and version that I want to transpile for.

I can use something like [browserslist-useragent](https://github.com/pastelsky/browserslist-useragent) to convert the user agent into a browserslist query, which I can pass to babel, but when I get to (the very important subject of) caching the transpilations, I'm left with a sub-optimal solution.

I want to cache bundles so that the second time someone with the exact same browser capabilities requests a bundle, we can deliver straight from cache. But doing so by browser vendor+version, which is what I can extract from the user agent, means that two browsers from different vendors or with different versions that have the exact same capabilities will generate different cache keys, even thought the generated bundle will be exactly the same.

Ideally, I'd like to be able to ask Babel: "given this browser vendor/version, what things will you need to transpile?", which would yield the same results for different browsers with the same capabilities, which I could then use as the cache key.

From what I've seen, the `transformations` variable seems to contain that information:

```js
[ 'check-es2015-constants',
  'transform-es2015-arrow-functions',
  'transform-es2015-block-scoped-functions',
  'transform-es2015-block-scoping',
  'transform-es2015-classes',
  'transform-es2015-computed-properties',
  'transform-es2015-destructuring',
  'transform-es2015-duplicate-keys',
  'transform-es2015-for-of',
  'transform-es2015-function-name',
  'transform-es2015-literals',
  'transform-es2015-object-super',
  'transform-es2015-parameters',
  'transform-es2015-shorthand-properties',
  'transform-es2015-spread',
  'transform-es2015-sticky-regex',
  'transform-es2015-template-literals',
  'transform-es2015-typeof-symbol',
  'transform-es2015-unicode-regex',
  'transform-regenerator',
  'transform-exponentiation-operator',
  'transform-async-to-generator',
  'syntax-trailing-function-commas' ]
```

So, in this PR I simply added that variable to the module exports. I could then require the preset module directly, call its default export with the target corresponding to the browser version of the request and, from there, obtain a list of the features that need to be transpiled. With that information, I could decide whether to serve a cached bundle or to start a new transpilation.

Let me know if any of this doesn't make sense or if there is an easier and more obvious way of doing what I'm after. Please accept my apologies if there is, I blame it on the fact that it's Sunday morning. 😇 

Thanks in advance for listening and for your awesome work on Babel. 💪 
