### PR TITLE
Unify eslint/prettier config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -21,9 +21,4 @@ experimental/babel-preset-env/test/debug-fixtures
 packages/babel-standalone/babel.js
 packages/babel-standalone/babel.min.js
 packages/babylon/build
-packages/babylon/scripts
 packages/babylon/test/expressions
-
-# Prettier tries to insert trailing commas in function calls, which Node.js
-# doesn't natively support. This causes an error when loading the Gulp tasks.
-packages/babel-standalone/src/gulpTasks.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,11 +5,24 @@
   ],
   "rules": {
     "curly": ["error", "multi-line"],
-    "prettier/prettier": ["error", { "trailingComma": "es5" }],
+    "prettier/prettier": "error",
     "no-case-declarations": "error"
   },
   "env": {
-    "node": true,
-    "mocha": true
-  }
+    "node": true
+  },
+  "overrides": [
+    {
+      "files": "packages/*/src/**/*.js",
+      "rules": {
+        "no-undefined-identifier": "error"
+      }
+    },
+    {
+      "files": [ "packages/*/test/**/*.js", "test/**/*.js" ],
+      "env": {
+        "mocha": true
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,11 @@
   },
   "overrides": [
     {
-      "files": "packages/*/src/**/*.js",
+      "files": [
+        "packages/*/src/**/*.js",
+        "experimental/*/src/**/*.js",
+        "codemods/*/src/**/*.js"
+      ],
       "rules": {
         "no-undefined-identifier": "error"
       }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,10 @@
   "trailingComma": "es5",
   "overrides": [{
     "files": [
+      "**/experimental/*/src/**/*.js",
+      "**/experimental/*/test/**/*.js",
+      "**/codemods/*/src/**/*.js",
+      "**/codemods/*/test/**/*.js",
       "**/packages/*/src/**/*.js",
       "**/packages/*/test/**/*.js"
     ],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "trailingComma": "es5",
+  "overrides": [{
+    "files": [
+      "**/packages/*/src/**/*.js",
+      "**/packages/*/test/**/*.js"
+    ],
+    "options": {
+      "trailingComma": "all"
+    }
+  }]
+}

--- a/packages/.eslintrc
+++ b/packages/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undefined-identifier": 2
-  }
-}

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import * as babel from "@babel/core";
 import { buildExternalHelpers } from "@babel/core";
 import getFixtures from "@babel/helper-fixtures";

--- a/packages/babylon/.eslintrc
+++ b/packages/babylon/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "../.eslintrc",
-  "rules": {
-    "curly": "off"
-  }
-}

--- a/packages/babylon/scripts/generate-identifier-regex.js
+++ b/packages/babylon/scripts/generate-identifier-regex.js
@@ -14,12 +14,13 @@ const cont = [0x200c, 0x200d].concat(
     version +
     "/Binary_Property/ID_Continue/code-points.js").filter(function(ch) {
     return ch > 0x7f && search(start, ch, last + 1) == -1;
-  }),
+  })
 );
 
 function search(arr, ch, starting) {
-  for (let i = starting; arr[i] <= ch && i < arr.length; last = i++)
+  for (let i = starting; arr[i] <= ch && i < arr.length; last = i++) {
     if (arr[i] === ch) return i;
+  }
   return -1;
 }
 
@@ -62,10 +63,8 @@ const contData = generate(cont);
 console.log('let nonASCIIidentifierStartChars = "' + startData.nonASCII + '";');
 console.log('let nonASCIIidentifierChars = "' + contData.nonASCII + '";');
 console.log(
-  "const astralIdentifierStartCodes = " +
-    JSON.stringify(startData.astral) +
-    ";",
+  "const astralIdentifierStartCodes = " + JSON.stringify(startData.astral) + ";"
 );
 console.log(
-  "const astralIdentifierCodes = " + JSON.stringify(contData.astral) + ";",
+  "const astralIdentifierCodes = " + JSON.stringify(contData.astral) + ";"
 );

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -61,8 +61,9 @@ export default class ExpressionParser extends LValParser {
     const name = key.type === "Identifier" ? key.name : String(key.value);
 
     if (name === "__proto__") {
-      if (propHash.proto)
+      if (propHash.proto) {
         this.raise(key.start, "Redefinition of __proto__ property");
+      }
       propHash.proto = true;
     }
   }
@@ -124,8 +125,9 @@ export default class ExpressionParser extends LValParser {
     const startLoc = this.state.startLoc;
     if (this.match(tt._yield) && this.state.inGenerator) {
       let left = this.parseYield();
-      if (afterLeftParse)
+      if (afterLeftParse) {
         left = afterLeftParse.call(this, left, startPos, startLoc);
+      }
       return left;
     }
 
@@ -146,8 +148,9 @@ export default class ExpressionParser extends LValParser {
       refShorthandDefaultPos,
       refNeedsArrowPos,
     );
-    if (afterLeftParse)
+    if (afterLeftParse) {
       left = afterLeftParse.call(this, left, startPos, startLoc);
+    }
     if (this.state.type.isAssign) {
       const node = this.startNodeAt(startPos, startLoc);
       node.operator = this.state.value;
@@ -1000,8 +1003,9 @@ export default class ExpressionParser extends LValParser {
       (arrowNode = this.parseArrow(arrowNode))
     ) {
       for (const param of exprList) {
-        if (param.extra && param.extra.parenthesized)
+        if (param.extra && param.extra.parenthesized) {
           this.unexpected(param.extra.parenStart);
+        }
       }
 
       this.parseArrowExpression(arrowNode, exprList);
@@ -1016,8 +1020,9 @@ export default class ExpressionParser extends LValParser {
     }
     if (optionalCommaStart) this.unexpected(optionalCommaStart);
     if (spreadStart) this.unexpected(spreadStart);
-    if (refShorthandDefaultPos.start)
+    if (refShorthandDefaultPos.start) {
       this.unexpected(refShorthandDefaultPos.start);
+    }
     if (refNeedsArrowPos.start) this.unexpected(refNeedsArrowPos.start);
 
     if (exprList.length > 1) {

--- a/packages/babylon/src/parser/lval.js
+++ b/packages/babylon/src/parser/lval.js
@@ -159,11 +159,12 @@ export default class LValParser extends NodeUtils {
     }
     for (let i = 0; i < end; i++) {
       const elt = exprList[i];
-      if (elt && elt.type === "SpreadElement")
+      if (elt && elt.type === "SpreadElement") {
         this.raise(
           elt.start,
           "The rest element has to be the last element when destructuring",
         );
+      }
       if (elt) this.toAssignable(elt, isBinding, contextDescription);
     }
     return exprList;
@@ -352,13 +353,14 @@ export default class LValParser extends NodeUtils {
 
       case "ArrayPattern":
         for (const elem of expr.elements) {
-          if (elem)
+          if (elem) {
             this.checkLVal(
               elem,
               isBinding,
               checkClashes,
               "array destructuring pattern",
             );
+          }
         }
         break;
 

--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -133,8 +133,9 @@ export default class StatementParser extends ExpressionParser {
           (this.hasPlugin("dynamicImport") &&
             this.lookahead().type === tt.parenL) ||
           (this.hasPlugin("importMeta") && this.lookahead().type === tt.dot)
-        )
+        ) {
           break;
+        }
 
         if (!this.options.allowImportExportEverywhere && !topLevel) {
           this.raise(
@@ -305,8 +306,9 @@ export default class StatementParser extends ExpressionParser {
         if (node.label && isBreak) break;
       }
     }
-    if (i === this.state.labels.length)
+    if (i === this.state.labels.length) {
       this.raise(node.start, "Unsyntactic " + keyword);
+    }
     return this.finishNode(
       node,
       isBreak ? "BreakStatement" : "ContinueStatement",
@@ -449,8 +451,9 @@ export default class StatementParser extends ExpressionParser {
         if (isCase) {
           cur.test = this.parseExpression();
         } else {
-          if (sawDefault)
+          if (sawDefault) {
             this.raise(this.state.lastTokStart, "Multiple default clauses");
+          }
           sawDefault = true;
           cur.test = null;
         }
@@ -473,8 +476,9 @@ export default class StatementParser extends ExpressionParser {
     this.next();
     if (
       lineBreak.test(this.input.slice(this.state.lastTokEnd, this.state.start))
-    )
+    ) {
       this.raise(this.state.lastTokEnd, "Illegal newline after throw");
+    }
     node.argument = this.parseExpression();
     this.semicolon();
     return this.finishNode(node, "ThrowStatement");
@@ -533,8 +537,9 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseWithStatement(node: N.WithStatement): N.WithStatement {
-    if (this.state.strict)
+    if (this.state.strict) {
       this.raise(this.state.start, "'with' in strict mode");
+    }
     this.next();
     node.object = this.parseParenExpression();
     node.body = this.parseStatement(false);

--- a/packages/babylon/src/plugins/estree.js
+++ b/packages/babylon/src/plugins/estree.js
@@ -121,8 +121,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const name = key.type === "Identifier" ? key.name : String(key.value);
 
       if (name === "__proto__") {
-        if (propHash.proto)
+        if (propHash.proto) {
           this.raise(key.start, "Redefinition of __proto__ property");
+        }
         propHash.proto = true;
       }
     }

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -184,11 +184,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         if (this.lookahead().type === tt.dot) {
           return this.flowParseDeclareModuleExports(node);
         } else {
-          if (insideModule)
+          if (insideModule) {
             this.unexpected(
               null,
               "`declare module` cannot be used inside another `declare module`",
             );
+          }
           return this.flowParseDeclareModule(node);
         }
       } else if (this.isContextual("type")) {
@@ -261,15 +262,17 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         "Found both `declare module.exports` and `declare export` in the same module. Modules can only have 1 since they are either an ES module or they are a CommonJS module";
       body.forEach(bodyElement => {
         if (isEsModuleType(bodyElement)) {
-          if (kind === "CommonJS")
+          if (kind === "CommonJS") {
             this.unexpected(bodyElement.start, errorMessage);
+          }
           kind = "ES";
         } else if (bodyElement.type === "DeclareModuleExports") {
-          if (hasModuleExport)
+          if (hasModuleExport) {
             this.unexpected(
               bodyElement.start,
               "Duplicate `declare module.exports` statement",
             );
+          }
           if (kind === "ES") this.unexpected(bodyElement.start, errorMessage);
           kind = "CommonJS";
           hasModuleExport = true;
@@ -755,8 +758,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           node.value = this.flowParseObjectTypeMethodish(
             this.startNodeAt(node.start, node.loc.start),
           );
-          if (kind === "get" || kind === "set")
+          if (kind === "get" || kind === "set") {
             this.flowCheckGetterSetterParamCount(node);
+          }
         } else {
           if (kind !== "init") this.unexpected();
           if (this.eat(tt.question)) {
@@ -1054,8 +1058,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         case tt.plusMin:
           if (this.state.value === "-") {
             this.next();
-            if (!this.match(tt.num))
+            if (!this.match(tt.num)) {
               this.unexpected(null, "Unexpected token, expected number");
+            }
 
             return this.parseLiteral(
               -this.state.value,

--- a/packages/babylon/src/plugins/jsx/index.js
+++ b/packages/babylon/src/plugins/jsx/index.js
@@ -170,12 +170,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (str[0] === "#") {
             if (str[1] === "x") {
               str = str.substr(2);
-              if (HEX_NUMBER.test(str))
+              if (HEX_NUMBER.test(str)) {
                 entity = String.fromCodePoint(parseInt(str, 16));
+              }
             } else {
               str = str.substr(1);
-              if (DECIMAL_NUMBER.test(str))
+              if (DECIMAL_NUMBER.test(str)) {
                 entity = String.fromCodePoint(parseInt(str, 10));
+              }
             }
           } else {
             entity = XHTMLEntities[str];

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -1009,10 +1009,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node.end = original.end;
       node.loc.end = original.loc.end;
 
-      if (original.leadingComments)
+      if (original.leadingComments) {
         node.leadingComments = original.leadingComments;
-      if (original.trailingComments)
+      }
+      if (original.trailingComments) {
         node.trailingComments = original.trailingComments;
+      }
       if (original.innerComments) node.innerComments = original.innerComments;
 
       return node;

--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -786,8 +786,9 @@ export default class Tokenizer extends LocationParser {
     const start = this.state.pos;
     let escaped, inClass;
     for (;;) {
-      if (this.state.pos >= this.input.length)
+      if (this.state.pos >= this.input.length) {
         this.raise(start, "Unterminated regular expression");
+      }
       const ch = this.input.charAt(this.state.pos);
       if (lineBreak.test(ch)) {
         this.raise(start, "Unterminated regular expression");
@@ -813,8 +814,9 @@ export default class Tokenizer extends LocationParser {
     const mods = this.readWord1();
     if (mods) {
       const validFlags = /^[gmsiyu]*$/;
-      if (!validFlags.test(mods))
+      if (!validFlags.test(mods)) {
         this.raise(start, "Invalid regular expression flag");
+      }
     }
 
     this.finishToken(tt.regexp, {
@@ -886,8 +888,9 @@ export default class Tokenizer extends LocationParser {
     if (
       this.state.pos === start ||
       (len != null && this.state.pos - start !== len)
-    )
+    ) {
       return null;
+    }
 
     return total;
   }
@@ -898,8 +901,9 @@ export default class Tokenizer extends LocationParser {
 
     this.state.pos += 2; // 0x
     const val = this.readInt(radix);
-    if (val == null)
+    if (val == null) {
       this.raise(this.state.start + 2, "Expected number in radix " + radix);
+    }
 
     if (this.hasPlugin("bigInt")) {
       if (this.input.charCodeAt(this.state.pos) === 0x6e) {
@@ -909,8 +913,9 @@ export default class Tokenizer extends LocationParser {
       }
     }
 
-    if (isIdentifierStart(this.fullCharCodeAtPos()))
+    if (isIdentifierStart(this.fullCharCodeAtPos())) {
       this.raise(this.state.pos, "Identifier directly after number");
+    }
 
     if (isBigInt) {
       const str = this.input.slice(start, this.state.pos).replace(/[_n]/g, "");
@@ -929,8 +934,9 @@ export default class Tokenizer extends LocationParser {
     let isFloat = false;
     let isBigInt = false;
 
-    if (!startsWithDot && this.readInt(10) === null)
+    if (!startsWithDot && this.readInt(10) === null) {
       this.raise(start, "Invalid number");
+    }
     if (octal && this.state.pos == start + 1) octal = false; // number === 0
 
     let next = this.input.charCodeAt(this.state.pos);
@@ -961,8 +967,9 @@ export default class Tokenizer extends LocationParser {
       }
     }
 
-    if (isIdentifierStart(this.fullCharCodeAtPos()))
+    if (isIdentifierStart(this.fullCharCodeAtPos())) {
       this.raise(this.state.pos, "Identifier directly after number");
+    }
 
     // remove "_" for numeric literal separator, and "n" for BigInts
     const str = this.input.slice(start, this.state.pos).replace(/[_n]/g, "");
@@ -1022,8 +1029,9 @@ export default class Tokenizer extends LocationParser {
     let out = "",
       chunkStart = ++this.state.pos;
     for (;;) {
-      if (this.state.pos >= this.input.length)
+      if (this.state.pos >= this.input.length) {
         this.raise(this.state.start, "Unterminated string constant");
+      }
       const ch = this.input.charCodeAt(this.state.pos);
       if (ch === quote) break;
       if (ch === 92) {
@@ -1033,8 +1041,9 @@ export default class Tokenizer extends LocationParser {
         out += this.readEscapedChar(false);
         chunkStart = this.state.pos;
       } else {
-        if (isNewLine(ch))
+        if (isNewLine(ch)) {
           this.raise(this.state.start, "Unterminated string constant");
+        }
         ++this.state.pos;
       }
     }
@@ -1049,8 +1058,9 @@ export default class Tokenizer extends LocationParser {
       chunkStart = this.state.pos,
       containsInvalid = false;
     for (;;) {
-      if (this.state.pos >= this.input.length)
+      if (this.state.pos >= this.input.length) {
         this.raise(this.state.start, "Unterminated template");
+      }
       const ch = this.input.charCodeAt(this.state.pos);
       if (
         ch === 96 ||

--- a/packages/babylon/src/util/identifier.js
+++ b/packages/babylon/src/util/identifier.js
@@ -79,10 +79,11 @@ export function isIdentifierStart(code: number): boolean {
   if (code < 91) return true;
   if (code < 97) return code === 95;
   if (code < 123) return true;
-  if (code <= 0xffff)
+  if (code <= 0xffff) {
     return (
       code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code))
     );
+  }
   return isInAstralSet(code, astralIdentifierStartCodes);
 }
 
@@ -95,8 +96,9 @@ export function isIdentifierChar(code: number): boolean {
   if (code < 91) return true;
   if (code < 97) return code === 95;
   if (code < 123) return true;
-  if (code <= 0xffff)
+  if (code <= 0xffff) {
     return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
+  }
   return (
     isInAstralSet(code, astralIdentifierStartCodes) ||
     isInAstralSet(code, astralIdentifierCodes)

--- a/packages/babylon/test/helpers/runFixtureTests.js
+++ b/packages/babylon/test/helpers/runFixtureTests.js
@@ -126,15 +126,17 @@ function misMatch(exp, act) {
     if (left !== right) return left + " !== " + right;
   } else if (Array.isArray(exp)) {
     if (!Array.isArray(act)) return ppJSON(exp) + " != " + ppJSON(act);
-    if (act.length != exp.length)
+    if (act.length != exp.length) {
       return "array length mismatch " + exp.length + " != " + act.length;
+    }
     for (let i = 0; i < act.length; ++i) {
       const mis = misMatch(exp[i], act[i]);
       if (mis) return addPath(mis, i);
     }
   } else if (!exp || !act || typeof exp != "object" || typeof act != "object") {
-    if (exp !== act && typeof exp != "function")
+    if (exp !== act && typeof exp != "function") {
       return ppJSON(exp) + " !== " + ppJSON(act);
+    }
   } else {
     for (const prop in exp) {
       const mis = misMatch(exp[prop], act[prop]);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Use a prettier config file and correctly configure trailing commas. The config file helps with ide integrations for formatting and also correctly formats js files in scripts folder (because trailing function commas not allowed there)

Enable curly in babylon as in all other packages.
