### PR TITLE
Properly guard for..in loops with Object#hasOwnProperty.

### DIFF
--- a/packages/babylon/src/parser/node.js
+++ b/packages/babylon/src/parser/node.js
@@ -33,10 +33,12 @@ class Node implements NodeBase {
     // $FlowIgnore
     const node2: any = new Node();
     for (const key in this) {
-      // Do not clone comments that are already attached to the node
-      if (commentKeys.indexOf(key) < 0) {
-        // $FlowIgnore
-        node2[key] = this[key];
+      if (Object.prototype.hasOwnProperty.call(this, key)) {
+        // Do not clone comments that are already attached to the node
+        if (commentKeys.indexOf(key) < 0) {
+          // $FlowIgnore
+          node2[key] = this[key];
+        }
       }
     }
 

--- a/packages/babylon/src/parser/node.js
+++ b/packages/babylon/src/parser/node.js
@@ -32,15 +32,13 @@ class Node implements NodeBase {
   __clone(): this {
     // $FlowIgnore
     const node2: any = new Node();
-    for (const key in this) {
-      if (Object.prototype.hasOwnProperty.call(this, key)) {
-        // Do not clone comments that are already attached to the node
-        if (commentKeys.indexOf(key) < 0) {
-          // $FlowIgnore
-          node2[key] = this[key];
-        }
+    Object.keys(this).forEach(key => {
+      // Do not clone comments that are already attached to the node
+      if (commentKeys.indexOf(key) < 0) {
+        // $FlowIgnore
+        node2[key] = this[key];
       }
-    }
+    });
 
     return node2;
   }

--- a/packages/babylon/src/tokenizer/state.js
+++ b/packages/babylon/src/tokenizer/state.js
@@ -185,19 +185,17 @@ export default class State {
 
   clone(skipArrays?: boolean): State {
     const state = new State();
-    for (const key in this) {
-      if (Object.prototype.hasOwnProperty.call(this, key)) {
-        // $FlowIgnore
-        let val = this[key];
+    Object.keys(this).forEach(key => {
+      // $FlowIgnore
+      let val = this[key];
 
-        if ((!skipArrays || key === "context") && Array.isArray(val)) {
-          val = val.slice();
-        }
-
-        // $FlowIgnore
-        state[key] = val;
+      if ((!skipArrays || key === "context") && Array.isArray(val)) {
+        val = val.slice();
       }
-    }
+
+      // $FlowIgnore
+      state[key] = val;
+    });
     return state;
   }
 }

--- a/packages/babylon/src/tokenizer/state.js
+++ b/packages/babylon/src/tokenizer/state.js
@@ -186,15 +186,17 @@ export default class State {
   clone(skipArrays?: boolean): State {
     const state = new State();
     for (const key in this) {
-      // $FlowIgnore
-      let val = this[key];
+      if (Object.prototype.hasOwnProperty.call(this, key)) {
+        // $FlowIgnore
+        let val = this[key];
 
-      if ((!skipArrays || key === "context") && Array.isArray(val)) {
-        val = val.slice();
+        if ((!skipArrays || key === "context") && Array.isArray(val)) {
+          val = val.slice();
+        }
+
+        // $FlowIgnore
+        state[key] = val;
       }
-
-      // $FlowIgnore
-      state[key] = val;
     }
     return state;
   }


### PR DESCRIPTION
I noticed that babylon spends a lot of time in what we call *slow mode*
`for..in` when running in Node (on V8), and the reason for that is that
the version distributed on npm is build with *loose mode*, which turns
methods on the prototype into enumerable properties. Let's look at a
simplified example of the `State` class from `src/tokenizer/state.js`:

```js
class State {
  constructor() { this.x = 1; }

  clone() {
    var state = new State();
    for (var key in this) {
      var val = this[key];
      state[key] = val;
    }
    return state;
  }
}
```

According to the specification the `State.prototype.clone` method is
non-enumerable. However when transpiling this with loose mode, we get
the following output:

```js
var State = (function() {
  function State() { this.x = 1; }

  State.prototype.clone = function clone() {
    var state = new State();
    for (var key in this) {
      var val = this[key];
      state[key] = val;
    }
    return state;
  }

  return State;
})();
```

So all of a sudden the `State.prototype.clone` method is enumerable.
This means that the `for..in` loop inside of that method enumerates
`x` and `clone` for `key`, whereas originally it was supposed to only
enumerate `x`. This in turn means that the shape of the result of a
call to `clone` will be different than the shape of a state that is
created via the `State` constructor. You can check this in `d8` using
the `--allow-natives-syntax` flag and this simple test driver:

```js
const s = new State;
%DebugPrint(s);
%DebugPrint(s.clone());
```

Using either the class version or the transpiled version we see:

```
$ out/Release/d8 --allow-natives-syntax state-original.js
0x2a9d7970d329 <State map = 0x2a9d40b0c751>
0x2a9d7970d3c1 <State map = 0x2a9d40b0c751>
$ out/Release/d8 --allow-natives-syntax state-loose.js
0x3729ee30d1b9 <State map = 0x3729af90c701>
0x3729ee30d251 <State map = 0x3729af90c7a1>
```

So as you can see, the transpiled version (using *loose mode*) produces
a different shape for the result of `clone`, whereas the original
version is fine. This pollutes all sites which use either a state
created from the `State` constructor or returned from the `clone`
method. The original one has only the `x` property in either case,
whereas in the transpiled version the result of `clone` has properties
`x` and `clone` on the instance.

To mitigate this effect, it's best to replace the `for..in` loops with
a combination of `Object.keys` and `Array.prototype.filter`, so that
the loop body only deals with own properties and not with properties
from the prototype chain. This change does exactly that for the two
affected `clone` functions.

On the babylon test in the web-tooling-benchmark, this improves
the runs/sec by around 5-7% alone.