### PR TITLE
Fix transform-arrow-functions in { spec: true } shadowing

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -130,7 +130,7 @@ function visit(node, name, scope) {
  * @param {NodePath} param0
  * @param {Boolean} localBinding whether a name could shadow a self-reference (e.g. converting arrow function)
  */
-export default function({ node, parent, scope, id }) {
+export default function({ node, parent, scope, id }, localBinding = false) {
   // has an `id` so we don't need to infer one
   if (node.id) return;
 
@@ -145,7 +145,8 @@ export default function({ node, parent, scope, id }) {
     // let foo = function () {};
     id = parent.id;
 
-    if (t.isIdentifier(id)) {
+    // but not "let foo = () => {};" being converted to function expression
+    if (t.isIdentifier(id) && !localBinding) {
       const binding = scope.parent.getBinding(id.name);
       if (
         binding &&

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/actual.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/actual.js
@@ -1,0 +1,7 @@
+var fooCalls = []
+var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
+Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+jumpTable('foo', 'bar')
+
+assert.isArray(fooCalls[0])
+assert.strictEqual(fooCalls[0][0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/actual.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/actual.js
@@ -1,7 +1,6 @@
 var fooCalls = []
-var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
-Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+var jumpTable = (name, arg) => { if (jumpTable[name]) { jumpTable[name](arg) } }
+Object.assign(jumpTable, { foo (arg) { fooCalls.push(arg) } });
 jumpTable('foo', 'bar')
 
-assert.isArray(fooCalls[0])
-assert.strictEqual(fooCalls[0][0], 'bar')
+assert.strictEqual(fooCalls[0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/exec.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/exec.js
@@ -1,0 +1,7 @@
+var fooCalls = []
+var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
+Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+jumpTable('foo', 'bar')
+
+assert.isArray(fooCalls[0])
+assert.strictEqual(fooCalls[0][0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/exec.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/exec.js
@@ -1,7 +1,6 @@
 var fooCalls = []
-var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
-Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+var jumpTable = (name, arg) => { if (jumpTable[name]) { jumpTable[name](arg) } }
+Object.assign(jumpTable, { foo (arg) { fooCalls.push(arg) } });
 jumpTable('foo', 'bar')
 
-assert.isArray(fooCalls[0])
-assert.strictEqual(fooCalls[0][0], 'bar')
+assert.strictEqual(fooCalls[0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/expected.js
@@ -1,0 +1,17 @@
+var fooCalls = [];
+
+var jumpTable = function (name, ...args) {
+  if (jumpTable[name]) {
+    jumpTable[name](...args);
+  }
+};
+
+Object.assign(jumpTable, {
+  foo(...args) {
+    fooCalls.push(args);
+  }
+
+});
+jumpTable('foo', 'bar');
+assert.isArray(fooCalls[0]);
+assert.strictEqual(fooCalls[0][0], 'bar');

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/expected.js
@@ -1,6 +1,6 @@
 var fooCalls = [];
 
-var jumpTable = function (name, ...args) {
+var jumpTable = function jumpTable(name, ...args) {
   if (jumpTable[name]) {
     jumpTable[name](...args);
   }

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/expected.js
@@ -1,17 +1,16 @@
 var fooCalls = [];
 
-var jumpTable = function jumpTable(name, ...args) {
+var jumpTable = function jumpTable(name, arg) {
   if (jumpTable[name]) {
-    jumpTable[name](...args);
+    jumpTable[name](arg);
   }
 };
 
 Object.assign(jumpTable, {
-  foo(...args) {
-    fooCalls.push(args);
+  foo(arg) {
+    fooCalls.push(arg);
   }
 
 });
 jumpTable('foo', 'bar');
-assert.isArray(fooCalls[0]);
-assert.strictEqual(fooCalls[0][0], 'bar');
+assert.strictEqual(fooCalls[0], 'bar');

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/options.json
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["external-helpers", ["transform-arrow-functions", { "spec": false }]]
+  "plugins": ["external-helpers", ["transform-arrow-functions", { "spec": false }], "transform-function-name"]
 }

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/options.json
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", ["transform-arrow-functions", { "spec": false }]]
+}

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/actual.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/actual.js
@@ -1,0 +1,7 @@
+var fooCalls = []
+var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
+Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+jumpTable('foo', 'bar')
+
+assert.isArray(fooCalls[0])
+assert.strictEqual(fooCalls[0][0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/actual.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/actual.js
@@ -1,7 +1,6 @@
 var fooCalls = []
-var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
-Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+var jumpTable = (name, arg) => { if (jumpTable[name]) { jumpTable[name](arg) } }
+Object.assign(jumpTable, { foo (arg) { fooCalls.push(arg) } });
 jumpTable('foo', 'bar')
 
-assert.isArray(fooCalls[0])
-assert.strictEqual(fooCalls[0][0], 'bar')
+assert.strictEqual(fooCalls[0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/exec.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/exec.js
@@ -1,8 +1,6 @@
 var fooCalls = []
-var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
-Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+var jumpTable = (name, arg) => { if (jumpTable[name]) { jumpTable[name](arg) } }
+Object.assign(jumpTable, { foo (arg) { fooCalls.push(arg) } });
 jumpTable('foo', 'bar')
 
-assert.isArray(fooCalls[0])
-assert.strictEqual(fooCalls[0][0], 'bar')
-assert.match(jumpTable.name, /jumpTable/)
+assert.strictEqual(fooCalls[0], 'bar')

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/exec.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/exec.js
@@ -1,0 +1,8 @@
+var fooCalls = []
+var jumpTable = (name, ...args) => { if (jumpTable[name]) { jumpTable[name](...args) } }
+Object.assign(jumpTable, { foo (...args) { fooCalls.push(args) } });
+jumpTable('foo', 'bar')
+
+assert.isArray(fooCalls[0])
+assert.strictEqual(fooCalls[0][0], 'bar')
+assert.match(jumpTable.name, /jumpTable/)

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/expected.js
@@ -2,22 +2,21 @@ var _this = this;
 
 var fooCalls = [];
 
-var _jumpTable = function jumpTable(name, ...args) {
+var _jumpTable = function jumpTable(name, arg) {
   babelHelpers.newArrowCheck(this, _this);
 
   if (_jumpTable[name]) {
-    _jumpTable[name](...args);
+    _jumpTable[name](arg);
   }
 }.bind(this);
 
 Object.assign(_jumpTable, {
-  foo(...args) {
-    fooCalls.push(args);
+  foo(arg) {
+    fooCalls.push(arg);
   }
 
 });
 
 _jumpTable('foo', 'bar');
 
-assert.isArray(fooCalls[0]);
-assert.strictEqual(fooCalls[0][0], 'bar');
+assert.strictEqual(fooCalls[0], 'bar');

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/expected.js
@@ -2,20 +2,22 @@ var _this = this;
 
 var fooCalls = [];
 
-var jumpTable = function _jumpTable(name, ...args) {
+var _jumpTable = function jumpTable(name, ...args) {
   babelHelpers.newArrowCheck(this, _this);
 
-  if (jumpTable[name]) {
-    jumpTable[name](...args);
+  if (_jumpTable[name]) {
+    _jumpTable[name](...args);
   }
 }.bind(this);
 
-Object.assign(jumpTable, {
+Object.assign(_jumpTable, {
   foo(...args) {
     fooCalls.push(args);
   }
 
 });
-jumpTable('foo', 'bar');
+
+_jumpTable('foo', 'bar');
+
 assert.isArray(fooCalls[0]);
 assert.strictEqual(fooCalls[0][0], 'bar');

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/expected.js
@@ -1,0 +1,21 @@
+var _this = this;
+
+var fooCalls = [];
+
+var jumpTable = function _jumpTable(name, ...args) {
+  babelHelpers.newArrowCheck(this, _this);
+
+  if (jumpTable[name]) {
+    jumpTable[name](...args);
+  }
+}.bind(this);
+
+Object.assign(jumpTable, {
+  foo(...args) {
+    fooCalls.push(args);
+  }
+
+});
+jumpTable('foo', 'bar');
+assert.isArray(fooCalls[0]);
+assert.strictEqual(fooCalls[0][0], 'bar');

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/options.json
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", ["transform-arrow-functions", { "spec": true }]]
+}

--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/options.json
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/spec-self-referential/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["external-helpers", ["transform-arrow-functions", { "spec": true }]]
+  "plugins": ["external-helpers", ["transform-arrow-functions", { "spec": true }], "transform-function-name"]
 }

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/actual.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/actual.js
@@ -1,5 +1,4 @@
 // These are actually handled by transform-arrow-functions
-// x's name does not match exactly to avoid shadowing the const x
 const x = () => x;
 const y = x => x();
 const z = { z: () => y(x) }.z;

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/actual.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/actual.js
@@ -1,4 +1,5 @@
 // These are actually handled by transform-arrow-functions
+// x's name does not match exactly to avoid shadowing the const x
 const x = () => x;
 const y = x => x();
 const z = { z: () => y(x) }.z;

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/expected.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/expected.js
@@ -1,10 +1,9 @@
 var _this = this;
 
 // These are actually handled by transform-arrow-functions
-// x's name does not match exactly to avoid shadowing the const x
-const x = function _x() {
+const _x = function x() {
   babelHelpers.newArrowCheck(this, _this);
-  return x;
+  return _x;
 }.bind(this);
 
 const y = function y(x) {
@@ -15,6 +14,6 @@ const y = function y(x) {
 const z = {
   z: function z() {
     babelHelpers.newArrowCheck(this, _this);
-    return y(x);
+    return y(_x);
   }.bind(this)
 }.z;

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/expected.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform-spec/expected.js
@@ -1,7 +1,8 @@
 var _this = this;
 
 // These are actually handled by transform-arrow-functions
-const x = function x() {
+// x's name does not match exactly to avoid shadowing the const x
+const x = function _x() {
   babelHelpers.newArrowCheck(this, _this);
   return x;
 }.bind(this);

--- a/packages/babel-traverse/src/path/conversion.js
+++ b/packages/babel-traverse/src/path/conversion.js
@@ -144,7 +144,7 @@ export function arrowFunctionToExpression(
     this.replaceWith(
       t.callExpression(
         t.memberExpression(
-          nameFunction(this) || this.node,
+          nameFunction(this, true) || this.node,
           t.identifier("bind"),
         ),
         [checkBinding ? t.identifier(checkBinding.name) : t.thisExpression()],


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 🙆‍♀️
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

A few months ago I made the arrow function transform name functions when in spec mode. This is all well and good, but things break when there is a self-reference to the function object -- as, in `spec` mode, the function is fed to `.bind(true)`, the reference held in the binding that received the function is _not_ the same as the named function expression's `name`.

Avoid this problem by generating a UidIdentifier based on the binding's name if it happens to be referenced inside the function. It's still safe to shadow it if no references happen inside the function's scope, so a simple `hasReference` check is not sufficient.