### PR TITLE
No unneeded empty arrays in transform spread

### DIFF
--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/expected.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/expected.js
@@ -21,7 +21,7 @@ var _ref4 = [a[1], a[0]];
 a[0] = _ref4[0];
 a[1] = _ref4[1];
 
-var _ref5 = [].concat(babelHelpers.toConsumableArray(foo), [bar]),
+var _ref5 = babelHelpers.toConsumableArray(foo).concat([bar]),
     a = _ref5[0],
     b = _ref5[1];
 

--- a/packages/babel-plugin-transform-spread/README.md
+++ b/packages/babel-plugin-transform-spread/README.md
@@ -15,7 +15,7 @@ var b = [...a, 'foo'];
 
 ```js
 var a = [ 'a', 'b', 'c' ];
-var b = [].concat(a, [ 'foo' ]);
+var b = a.concat([ 'foo' ]);
 ```
 
 ## Installation

--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -18,28 +18,6 @@ export default function({ types: t }, options) {
     return false;
   }
 
-  function isConsumableArrayHelper(node) {
-    return (
-      t.isCallExpression(node) &&
-      t.isIdentifier(node.callee.object, { name: "babelHelpers" }) &&
-      t.isIdentifier(node.callee.property, { name: "toConsumableArray" })
-    );
-  }
-
-  function isArrayPrototypeSliceCall(node) {
-    return (
-      t.isCallExpression(node) &&
-      t.isIdentifier(node.callee.property, { name: "call" }) &&
-      t.isMemberExpression(node.callee.object) &&
-      node.arguments.length === 1 &&
-      t.isIdentifier(node.arguments[0], { name: "arguments" })
-    );
-  }
-
-  function isNewArray(node) {
-    return isConsumableArrayHelper(node) || isArrayPrototypeSliceCall(node);
-  }
-
   function push(_props, nodes) {
     if (!_props.length) return _props;
     nodes.push(t.arrayExpression(_props));
@@ -74,7 +52,7 @@ export default function({ types: t }, options) {
         const nodes = build(elements, scope, state);
         const first = nodes.shift();
 
-        if (nodes.length === 0 && isNewArray(first)) {
+        if (nodes.length === 0 && first !== elements[0].argument) {
           path.replaceWith(first);
           return;
         }

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/arguments-array/expected.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/arguments-array/expected.js
@@ -1,5 +1,5 @@
 function foo() {
-  return bar([].concat(Array.prototype.slice.call(arguments)));
+  return bar(Array.prototype.slice.call(arguments));
 }
 
 function bar(one, two, three) {

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-first/expected.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/array-literal-first/expected.js
@@ -1,1 +1,1 @@
-var lyrics = [].concat(babelHelpers.toConsumableArray(parts), ["head", "and", "toes"]);
+var lyrics = babelHelpers.toConsumableArray(parts).concat(["head", "and", "toes"]);

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/known-rest/expected.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/known-rest/expected.js
@@ -3,5 +3,5 @@ function foo() {
     bar[_key] = arguments[_key];
   }
 
-  return [].concat(bar);
+  return bar.concat();
 }

--- a/packages/babel-plugin-transform-spread/test/fixtures/spread/single/expected.js
+++ b/packages/babel-plugin-transform-spread/test/fixtures/spread/single/expected.js
@@ -1,1 +1,1 @@
-[].concat(babelHelpers.toConsumableArray(foo));
+babelHelpers.toConsumableArray(foo);


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #6017 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes?
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No<!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


Since `Array.prototype.concat` creates a new array from inputs, there's no need to call it from a new empty array (`[].concat()`).

This also allowed simplification of cases where a single `arguments` or `babelHelpers.toConsumableArray` is used with a spread operator (no need to call `concat` at all since both already return a fresh array).

First time diving into Babel internals so wasn't sure if my ways of testing in `isConsumableArrayHelper` and `isArrayPrototypeSliceCall` were necessarily optimal.