### PR TITLE
Arrow functions and methods' params are binding identifiers

### DIFF
--- a/packages/babel-types/src/retrievers.js
+++ b/packages/babel-types/src/retrievers.js
@@ -88,6 +88,9 @@ getBindingIdentifiers.keys = {
 
   FunctionDeclaration: ["id", "params"],
   FunctionExpression: ["id", "params"],
+  ArrowFunctionExpression: ["params"],
+  ObjectMethod: ["params"],
+  ClassMethod: ["params"],
 
   ForInStatement: ["left"],
   ForOfStatement: ["left"],


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

http://astexplorer.net/#/gist/cf16aa767135cda4332131b34f203167/f3e29432ae98e751f280bffccc709ec85880b69c
In the console you can see that the parameter of the normal function is considered as a binding identifier, but the parameter of the arrow function isn't.
The same applies for object and class methods.

I didn't add any test because the object I updated doesn't contain any logic, so there isn't much to test.
Prettier complains a lot about unrelated files on my machine, I hope it passes on travis.