### PR TITLE
Hoist more plugin options and default useUnicodeFlag to 'true'.

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -1,7 +1,12 @@
 import syntaxObjectRestSpread from "@babel/plugin-syntax-object-rest-spread";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default function(api, opts) {
+  const { useBuiltIns = false } = opts;
+  if (typeof useBuiltIns !== "boolean") {
+    throw new Error(".useBuiltIns must be a boolean, or undefined");
+  }
+
   function hasRestElement(path) {
     let foundRestElement = false;
     path.traverse({
@@ -346,14 +351,6 @@ export default function() {
       // var a = { ...b, ...c }
       ObjectExpression(path, file) {
         if (!hasSpread(path.node)) return;
-
-        const useBuiltIns = file.opts.useBuiltIns || false;
-        if (typeof useBuiltIns !== "boolean") {
-          throw new Error(
-            "proposal-object-rest-spread currently only accepts a boolean " +
-              "option for useBuiltIns (defaults to false)",
-          );
-        }
 
         const args = [];
         let props = [];

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/useBuiltIns/assignment-invalid-option/options.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/useBuiltIns/assignment-invalid-option/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": [["proposal-object-rest-spread", { "useBuiltIns": "invalidOption" }]],
-  "throws": "proposal-object-rest-spread currently only accepts a boolean option for useBuiltIns (defaults to false)"
+  "throws": ".useBuiltIns must be a boolean, or undefined"
 }

--- a/packages/babel-plugin-proposal-unicode-property-regex/README.md
+++ b/packages/babel-plugin-proposal-unicode-property-regex/README.md
@@ -43,10 +43,17 @@ To transpile to ES6/ES2015:
 ```js
 require("@babel/core").transform(code, {
   "plugins": [
-    ["@babel/proposal-unicode-property-regex", { "useUnicodeFlag": true }]
+    ["@babel/proposal-unicode-property-regex", { "useUnicodeFlag": false }]
   ]
 });
 ```
+
+## Options
+
+* `useUnicodeFlag` (defaults to `true`)
+
+When disabled with `false`, the transform will convert unicode regexes to
+non-unicode regexes, removing the `u` flag. See https://www.npmjs.com/package/regexpu-core#useunicodeflag-default-false- for more information.
 
 ## Author
 

--- a/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
+++ b/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
@@ -1,18 +1,22 @@
 import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
-export default function() {
+export default function(api, options) {
+  const { useUnicodeFlag = false } = options;
+  if (typeof useUnicodeFlag !== "boolean") {
+    throw new Error(".useUnicodeFlag must be a boolean, or undefined");
+  }
+
   return {
     visitor: {
-      RegExpLiteral(path, state) {
+      RegExpLiteral(path) {
         const node = path.node;
         if (!regex.is(node, "u")) {
           return;
         }
-        const useUnicodeFlag = state.opts.useUnicodeFlag || false;
         node.pattern = rewritePattern(node.pattern, node.flags, {
           unicodePropertyEscape: true,
-          useUnicodeFlag: useUnicodeFlag,
+          useUnicodeFlag,
         });
         if (!useUnicodeFlag) {
           regex.pullFlag(node, "u");

--- a/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
+++ b/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
@@ -2,7 +2,7 @@ import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
 export default function(api, options) {
-  const { useUnicodeFlag = false } = options;
+  const { useUnicodeFlag = true } = options;
   if (typeof useUnicodeFlag !== "boolean") {
     throw new Error(".useUnicodeFlag must be a boolean, or undefined");
   }

--- a/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/without-unicode-flag/options.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/without-unicode-flag/options.json
@@ -1,5 +1,7 @@
 {
   "plugins": [
-    ["proposal-unicode-property-regex"]
+    ["proposal-unicode-property-regex", {
+      "useUnicodeFlag": false
+    }]
   ]
 }

--- a/packages/babel-plugin-transform-block-scoping/src/tdz.js
+++ b/packages/babel-plugin-transform-block-scoping/src/tdz.js
@@ -12,8 +12,8 @@ function getTDZStatus(refPath, bindingPath) {
   }
 }
 
-function buildTDZAssert(node, file) {
-  return t.callExpression(file.addHelper("temporalRef"), [
+function buildTDZAssert(node, state) {
+  return t.callExpression(state.addHelper("temporalRef"), [
     node,
     t.stringLiteral(node.name),
   ]);
@@ -29,7 +29,7 @@ function isReference(node, scope, state) {
 
 export const visitor = {
   ReferencedIdentifier(path, state) {
-    if (!this.file.opts.tdz) return;
+    if (!state.tdzEnabled) return;
 
     const { node, parent, scope } = path;
 
@@ -42,7 +42,7 @@ export const visitor = {
     if (status === "inside") return;
 
     if (status === "maybe") {
-      const assert = buildTDZAssert(node, state.file);
+      const assert = buildTDZAssert(node, state);
 
       // add tdzThis to parent variable declarator so it's exploded
       bindingPath.parent._tdzThis = true;
@@ -73,7 +73,7 @@ export const visitor = {
 
   AssignmentExpression: {
     exit(path, state) {
-      if (!this.file.opts.tdz) return;
+      if (!state.tdzEnabled) return;
 
       const { node } = path;
       if (node._ignoreBlockScopingTDZ) return;
@@ -85,7 +85,7 @@ export const visitor = {
         const id = ids[name];
 
         if (isReference(id, path.scope, state)) {
-          nodes.push(buildTDZAssert(id, state.file));
+          nodes.push(buildTDZAssert(id, state));
         }
       }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

A few places that are hard to grep for and got missed in https://github.com/babel/babel/pull/6381.

One other small change is making `unicode-property-regex` default to `useUnicodeFlag: true` instead of `: false`, which makes it leave the `/u` flag on the regex by default, so the transform will focus on transforming property regexes, rather than also transforming other unicode-related stuff.

I was tempted to just remove the flag, but opted to leave it for now.