### PR TITLE
Add an official 'state.filename' and be more explicit about option passing.

### DIFF
--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -163,16 +163,18 @@ class OptionManager {
       filenameRelative: opts.filename,
     });
 
-    const basenameRelative = path.basename(opts.filenameRelative);
+    if (typeof opts.filenameRelative === "string") {
+      const basenameRelative = path.basename(opts.filenameRelative);
 
-    if (path.extname(opts.filenameRelative) === ".mjs") {
-      opts.sourceType = "module";
+      if (path.extname(opts.filenameRelative) === ".mjs") {
+        opts.sourceType = "module";
+      }
+
+      defaults(opts, {
+        sourceFileName: basenameRelative,
+        sourceMapTarget: basenameRelative,
+      });
     }
-
-    defaults(opts, {
-      sourceFileName: basenameRelative,
-      sourceMapTarget: basenameRelative,
-    });
 
     return {
       options: opts,
@@ -461,7 +463,6 @@ function createInitialOptions() {
   return {
     sourceType: "module",
     babelrc: true,
-    filename: "unknown",
     code: true,
     ast: true,
     comments: true,

--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -212,7 +212,9 @@ export default class File {
               column: loc.column + 1,
             },
           },
-          this.opts,
+          {
+            highlightCode: this.opts.highlightCode,
+          },
         );
     }
 

--- a/packages/babel-core/src/transformation/file/generate.js
+++ b/packages/babel-core/src/transformation/file/generate.js
@@ -24,7 +24,7 @@ export default function generateCode(
     Object.assign(
       {
         // General generator flags.
-        filename: opts.filename,
+        filename: opts.filename || "unknown",
         auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
         auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
         retainLines: opts.retainLines,
@@ -35,9 +35,9 @@ export default function generateCode(
 
         // Source-map generation flags.
         sourceMaps: opts.sourceMaps,
-        sourceMapTarget: opts.sourceMapTarget,
+        sourceMapTarget: opts.sourceMapTarget || "unknown",
         sourceRoot: opts.sourceRoot,
-        sourceFileName: opts.sourceFileName,
+        sourceFileName: opts.sourceFileName || "unknown",
       },
       opts.generatorOpts,
     ),

--- a/packages/babel-core/src/transformation/file/generate.js
+++ b/packages/babel-core/src/transformation/file/generate.js
@@ -19,30 +19,7 @@ export default function generateCode(
     gen = opts.generatorOpts.generator;
   }
 
-  let { code: outputCode, map: outputMap } = gen(
-    ast,
-    Object.assign(
-      {
-        // General generator flags.
-        filename: opts.filename || "unknown",
-        auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
-        auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
-        retainLines: opts.retainLines,
-        comments: opts.comments,
-        compact: opts.compact,
-        minified: opts.minified,
-        concise: opts.concise,
-
-        // Source-map generation flags.
-        sourceMaps: opts.sourceMaps,
-        sourceMapTarget: opts.sourceMapTarget || "unknown",
-        sourceRoot: opts.sourceRoot,
-        sourceFileName: opts.sourceFileName || "unknown",
-      },
-      opts.generatorOpts,
-    ),
-    code,
-  );
+  let { code: outputCode, map: outputMap } = gen(ast, opts.generatorOpts, code);
 
   if (shebang) {
     // add back shebang

--- a/packages/babel-core/src/transformation/file/generate.js
+++ b/packages/babel-core/src/transformation/file/generate.js
@@ -21,7 +21,26 @@ export default function generateCode(
 
   let { code: outputCode, map: outputMap } = gen(
     ast,
-    opts.generatorOpts ? Object.assign(opts, opts.generatorOpts) : opts,
+    Object.assign(
+      {
+        // General generator flags.
+        filename: opts.filename,
+        auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
+        auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
+        retainLines: opts.retainLines,
+        comments: opts.comments,
+        compact: opts.compact,
+        minified: opts.minified,
+        concise: opts.concise,
+
+        // Source-map generation flags.
+        sourceMaps: opts.sourceMaps,
+        sourceMapTarget: opts.sourceMapTarget,
+        sourceRoot: opts.sourceRoot,
+        sourceFileName: opts.sourceFileName,
+      },
+      opts.generatorOpts,
+    ),
     code,
   );
 

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -70,7 +70,7 @@ function parser(options, code) {
     if (loc) {
       err.loc = null;
       err.message =
-        `${options.filename}: ${err.message}\n` +
+        `${options.filename || "unknown"}: ${err.message}\n` +
         codeFrameColumns(
           code,
           {

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -7,7 +7,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
     parserOpts: Object.assign(
       {
         sourceType: config.options.sourceType,
-        sourceFileName: config.options.filename,
+        sourceFileName: config.options.filename || "unknown",
         plugins: [],
       },
       config.options.parserOpts,

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -3,19 +3,41 @@
 import type { ResolvedConfig } from "../config";
 
 export default function normalizeOptions(config: ResolvedConfig): {} {
-  const options = Object.assign({}, config.options, {
+  const opts = config.options;
+
+  const options = Object.assign({}, opts, {
     parserOpts: Object.assign(
       {
-        sourceType: config.options.sourceType,
-        sourceFileName: config.options.filename || "unknown",
+        sourceType: opts.sourceType,
+        sourceFileName: opts.filename || "unknown",
         plugins: [],
       },
-      config.options.parserOpts,
+      opts.parserOpts,
+    ),
+    generatorOpts: Object.assign(
+      {
+        // General generator flags.
+        filename: opts.filename || "unknown",
+        auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
+        auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
+        retainLines: opts.retainLines,
+        comments: opts.comments,
+        compact: opts.compact,
+        minified: opts.minified,
+        concise: opts.concise,
+
+        // Source-map generation flags.
+        sourceMaps: opts.sourceMaps,
+        sourceMapTarget: opts.sourceMapTarget || "unknown",
+        sourceRoot: opts.sourceRoot,
+        sourceFileName: opts.sourceFileName || "unknown",
+      },
+      opts.generatorOpts,
     ),
   });
 
-  for (const pluginPairs of config.passes) {
-    for (const plugin of pluginPairs) {
+  for (const plugins of config.passes) {
+    for (const plugin of plugins) {
       if (plugin.manipulateOptions) {
         plugin.manipulateOptions(options, options.parserOpts);
       }

--- a/packages/babel-core/src/transformation/plugin-pass.js
+++ b/packages/babel-core/src/transformation/plugin-pass.js
@@ -7,11 +7,14 @@ export default class PluginPass {
   key: ?string;
   file: File;
   opts: Object;
+  filename: string | void;
 
   constructor(file: File, key: ?string, options: ?Object) {
     this.key = key;
     this.file = file;
     this.opts = options || {};
+    this.filename =
+      typeof file.opts.filename === "string" ? file.opts.filename : undefined;
   }
 
   set(key: mixed, val: mixed) {

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -44,10 +44,15 @@ export default function({ types: t }, options) {
   /**
    * Build the assignment statements that initialize the UMD global.
    */
-  function buildBrowserInit(browserGlobals, exactGlobals, file, moduleName) {
+  function buildBrowserInit(
+    browserGlobals,
+    exactGlobals,
+    filename,
+    moduleName,
+  ) {
     const moduleNameOrBasename = moduleName
       ? moduleName.value
-      : basename(file.opts.filename, extname(file.opts.filename));
+      : basename(filename, extname(filename));
     let globalToAssign = t.memberExpression(
       t.identifier("global"),
       t.identifier(t.toIdentifier(moduleNameOrBasename)),
@@ -204,7 +209,7 @@ export default function({ types: t }, options) {
               GLOBAL_TO_ASSIGN: buildBrowserInit(
                 browserGlobals,
                 exactGlobals,
-                this.file,
+                this.filename || "unknown",
                 moduleName,
               ),
             }),

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -52,14 +52,13 @@ export default function({ types: t }) {
     visitor: {
       ExportDefaultDeclaration({ node }, state) {
         if (isCreateClass(node.declaration)) {
-          let displayName = path.basename(
-            state.file.opts.filename,
-            path.extname(state.file.opts.filename),
-          );
+          const filename = state.filename || "unknown";
+
+          let displayName = path.basename(filename, path.extname(filename));
 
           // ./{module name}/index.js
           if (displayName === "index") {
-            displayName = path.basename(path.dirname(state.file.opts.filename));
+            displayName = path.basename(path.dirname(filename));
           }
 
           addDisplayName(displayName, node.declaration);

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -50,7 +50,7 @@ export default function({ types: t }) {
       }
 
       if (!state.fileNameIdentifier) {
-        const fileName = state.file.opts.filename || "";
+        const fileName = state.filename || "";
 
         const fileNameIdentifier = path.scope.generateUidIdentifier(
           FILE_NAME_VAR,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y, but only if a plugin relies on `state.file.opts.filename` defaulting to "unknown", and the caller of Babel doesn't pass one in, which most of the main ones do.
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Having to do "state.file.opts.filename" is both ugly and undiscoverable. This adds an official API on the `state` object that plugins can use the access the current filename.

Ideally in the future, especially if we can nail down a good concept of the "root" directory for config loading that we've been talking about, we can expose that too, and we'll have a nice pair.

Otherwise this PR is mostly trying to avoid just passing Babel's core options object off to other modules, which makes it _super_ hard to do a search to figure out where options are used, and also just makes things harder to track.