### PR TITLE
Use the peerDep to load types/template/traverse in plugins

### DIFF
--- a/codemods/babel-plugin-codemod-optional-catch-binding/src/index.js
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/src/index.js
@@ -1,7 +1,7 @@
 import syntaxOptionalCatchBinding from "@babel/plugin-syntax-optional-catch-binding";
+import { types as t } from "@babel/core";
 
-export default function(babel) {
-  const { types: t } = babel;
+export default function() {
   return {
     inherits: syntaxOptionalCatchBinding,
 

--- a/experimental/babel-preset-env/src/index.js
+++ b/experimental/babel-preset-env/src/index.js
@@ -146,7 +146,7 @@ const filterItems = (
 };
 
 export default function buildPreset(
-  context: Object,
+  api: Object,
   opts: Object = {},
 ): { plugins: Array<Plugin> } {
   const {

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@babel/helper-get-function-arity": "7.0.0-beta.31",
     "@babel/template": "7.0.0-beta.31",
-    "@babel/traverse": "7.0.0-beta.31",
     "@babel/types": "7.0.0-beta.31"
   }
 }

--- a/packages/babel-plugin-check-constants/src/index.js
+++ b/packages/babel-plugin-check-constants/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   /**
    * Helper function to run a statement before an expression by replacing it with a comma expression
    * and wrapping the statement in an IIFE as the first operand.

--- a/packages/babel-plugin-external-helpers/src/index.js
+++ b/packages/babel-plugin-external-helpers/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     pre(file) {
       file.set("helpersNamespace", t.identifier("babelHelpers"));

--- a/packages/babel-plugin-proposal-async-generator-functions/src/index.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/index.js
@@ -1,7 +1,8 @@
 import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
 import syntaxAsyncGenerators from "@babel/plugin-syntax-async-generators";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   const yieldStarVisitor = {
     Function(path) {
       path.skip();

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -10,8 +10,7 @@
   ],
   "dependencies": {
     "@babel/helper-function-name": "7.0.0-beta.31",
-    "@babel/plugin-syntax-class-properties": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31"
+    "@babel/plugin-syntax-class-properties": "7.0.0-beta.31"
   },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -1,8 +1,8 @@
 import nameFunction from "@babel/helper-function-name";
-import template from "@babel/template";
 import syntaxClassProperties from "@babel/plugin-syntax-class-properties";
+import { template, types as t } from "@babel/core";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { loose } = options;
 
   const findBareSupers = {

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -12,8 +12,7 @@
     "decorators"
   ],
   "dependencies": {
-    "@babel/plugin-syntax-decorators": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31"
+    "@babel/plugin-syntax-decorators": "7.0.0-beta.31"
   },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"

--- a/packages/babel-plugin-proposal-decorators/src/index.js
+++ b/packages/babel-plugin-proposal-decorators/src/index.js
@@ -1,7 +1,7 @@
 // Fork of https://github.com/loganfsmyth/babel-plugin-proposal-decorators-legacy
 
-import template from "@babel/template";
 import syntaxDecorators from "@babel/plugin-syntax-decorators";
+import { template, types as t } from "@babel/core";
 
 const buildClassDecorator = template(`
   DECORATOR(CLASS_REF = INNER) || CLASS_REF;
@@ -82,7 +82,7 @@ const buildApplyDecoratedDescriptor = template(`
     }
 `);
 
-export default function({ types: t }) {
+export default function() {
   /**
    * Add a helper to take an initial descriptor, apply some decorators to it, and optionally
    * define the property.

--- a/packages/babel-plugin-proposal-export-default/src/index.js
+++ b/packages/babel-plugin-proposal-export-default/src/index.js
@@ -1,6 +1,7 @@
 import syntaxExportExtensions from "@babel/plugin-syntax-export-extensions";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     inherits: syntaxExportExtensions,
 

--- a/packages/babel-plugin-proposal-export-namespace/src/index.js
+++ b/packages/babel-plugin-proposal-export-namespace/src/index.js
@@ -1,6 +1,7 @@
 import syntaxExportExtensions from "@babel/plugin-syntax-export-extensions";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     inherits: syntaxExportExtensions,
 

--- a/packages/babel-plugin-proposal-function-bind/src/index.js
+++ b/packages/babel-plugin-proposal-function-bind/src/index.js
@@ -1,6 +1,7 @@
 import syntaxFunctionBind from "@babel/plugin-syntax-function-bind";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function getTempId(scope) {
     let id = scope.path.getData("functionBind");
     if (id) return id;

--- a/packages/babel-plugin-proposal-function-sent/src/index.js
+++ b/packages/babel-plugin-proposal-function-sent/src/index.js
@@ -1,7 +1,8 @@
 import syntaxFunctionSent from "@babel/plugin-syntax-function-sent";
 import wrapFunction from "@babel/helper-wrap-function";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   const isFunctionSent = node =>
     t.isIdentifier(node.meta, { name: "function" }) &&
     t.isIdentifier(node.property, { name: "sent" });

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
@@ -1,6 +1,7 @@
 import syntaxNullishCoalescingOperator from "@babel/plugin-syntax-nullish-coalescing-operator";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }, { loose = false }) {
+export default function(api, { loose = false }) {
   return {
     inherits: syntaxNullishCoalescingOperator,
 

--- a/packages/babel-plugin-proposal-numeric-separator/src/index.js
+++ b/packages/babel-plugin-proposal-numeric-separator/src/index.js
@@ -1,6 +1,7 @@
 import syntaxNumericSeparator from "@babel/plugin-syntax-numeric-separator";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function replaceNumberArg({ node }) {
     if (node.callee.name !== "Number") {
       return;

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -1,6 +1,7 @@
 import syntaxObjectRestSpread from "@babel/plugin-syntax-object-rest-spread";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function hasRestElement(path) {
     let foundRestElement = false;
     path.traverse({

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -1,6 +1,7 @@
 import syntaxOptionalChaining from "@babel/plugin-syntax-optional-chaining";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { loose = false } = options;
 
   function optional(path, replacementPath) {

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -1,6 +1,7 @@
 import syntaxPipelineOperator from "@babel/plugin-syntax-pipeline-operator";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     inherits: syntaxPipelineOperator,
 

--- a/packages/babel-plugin-proposal-throw-expressions/src/index.js
+++ b/packages/babel-plugin-proposal-throw-expressions/src/index.js
@@ -1,6 +1,7 @@
 import syntaxThrowExpressions from "@babel/plugin-syntax-throw-expressions";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     inherits: syntaxThrowExpressions,
 

--- a/packages/babel-plugin-transform-arrow-functions/src/index.js
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.js
@@ -1,6 +1,6 @@
 import type NodePath from "@babel/traverse";
 
-export default function(babel, options) {
+export default function(api, options) {
   const { spec } = options;
   return {
     visitor: {

--- a/packages/babel-plugin-transform-async-to-generator/src/index.js
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.js
@@ -1,7 +1,8 @@
 import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
 import { addNamed } from "@babel/helper-module-imports";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { method, module } = options;
 
   if (method && module) {

--- a/packages/babel-plugin-transform-block-scoped-functions/src/index.js
+++ b/packages/babel-plugin-transform-block-scoped-functions/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   function statementList(key, path) {
     const paths: Array = path.get(key);
 

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -6,9 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/template": "7.0.0-beta.31",
-    "@babel/traverse": "7.0.0-beta.31",
-    "@babel/types": "7.0.0-beta.31",
     "lodash": "^4.2.0"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -1,12 +1,10 @@
 import type NodePath from "@babel/traverse";
 import type Scope from "@babel/traverse";
 import type File from "../../../file";
-import traverse from "@babel/traverse";
 import { visitor as tdzVisitor } from "./tdz";
-import * as t from "@babel/types";
 import values from "lodash/values";
 import extend from "lodash/extend";
-import template from "@babel/template";
+import { traverse, template, types as t } from "@babel/core";
 
 const DONE = new WeakSet();
 

--- a/packages/babel-plugin-transform-block-scoping/src/tdz.js
+++ b/packages/babel-plugin-transform-block-scoping/src/tdz.js
@@ -1,4 +1,4 @@
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 function getTDZStatus(refPath, bindingPath) {
   const executionStatus = bindingPath._guessExecutionStatusRelativeTo(refPath);

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -10,10 +10,7 @@
     "@babel/helper-define-map": "7.0.0-beta.31",
     "@babel/helper-function-name": "7.0.0-beta.31",
     "@babel/helper-optimise-call-expression": "7.0.0-beta.31",
-    "@babel/helper-replace-supers": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31",
-    "@babel/traverse": "7.0.0-beta.31",
-    "@babel/types": "7.0.0-beta.31"
+    "@babel/helper-replace-supers": "7.0.0-beta.31"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-classes/src/index.js
+++ b/packages/babel-plugin-transform-classes/src/index.js
@@ -2,8 +2,9 @@ import LooseTransformer from "./loose";
 import VanillaTransformer from "./vanilla";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import nameFunction from "@babel/helper-function-name";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { loose } = options;
   const Constructor = loose ? LooseTransformer : VanillaTransformer;
 

--- a/packages/babel-plugin-transform-classes/src/lib/memoise-decorators.js
+++ b/packages/babel-plugin-transform-classes/src/lib/memoise-decorators.js
@@ -1,5 +1,5 @@
 import type { Scope } from "@babel/traverse";
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 export default function(
   decorators: Array<Object>,

--- a/packages/babel-plugin-transform-classes/src/loose.js
+++ b/packages/babel-plugin-transform-classes/src/loose.js
@@ -1,6 +1,6 @@
 import nameFunction from "@babel/helper-function-name";
 import VanillaTransformer from "./vanilla";
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 export default class LooseClassTransformer extends VanillaTransformer {
   constructor() {

--- a/packages/babel-plugin-transform-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-classes/src/vanilla.js
@@ -1,10 +1,8 @@
 import type { NodePath } from "@babel/traverse";
-import { visitors } from "@babel/traverse";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import optimiseCall from "@babel/helper-optimise-call-expression";
 import * as defineMap from "@babel/helper-define-map";
-import template from "@babel/template";
-import * as t from "@babel/types";
+import { traverse, template, types as t } from "@babel/core";
 
 const noMethodVisitor = {
   "FunctionExpression|FunctionDeclaration"(path) {
@@ -16,7 +14,7 @@ const noMethodVisitor = {
   },
 };
 
-const verifyConstructorVisitor = visitors.merge([
+const verifyConstructorVisitor = traverse.visitors.merge([
   noMethodVisitor,
   {
     MemberExpression: {
@@ -63,7 +61,7 @@ const verifyConstructorVisitor = visitors.merge([
   },
 ]);
 
-const findThisesVisitor = visitors.merge([
+const findThisesVisitor = traverse.visitors.merge([
   noMethodVisitor,
   {
     ThisExpression(path) {

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "@babel/template": "7.0.0-beta.31"
-  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"
   },

--- a/packages/babel-plugin-transform-computed-properties/src/index.js
+++ b/packages/babel-plugin-transform-computed-properties/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t, template }, options) {
+import { template, types as t } from "@babel/core";
+
+export default function(api, options) {
   const { loose } = options;
   const pushComputedProps = loose
     ? pushComputedPropsLoose

--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   /**
    * Test if a VariableDeclaration's declarations contains any Patterns.
    */

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "@babel/types": "7.0.0-beta.31"
-  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"
   },

--- a/packages/babel-plugin-transform-duplicate-keys/src/index.js
+++ b/packages/babel-plugin-transform-duplicate-keys/src/index.js
@@ -1,4 +1,4 @@
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 function getName(key) {
   if (t.isIdentifier(key)) {

--- a/packages/babel-plugin-transform-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/src/index.js
@@ -1,6 +1,7 @@
 import build from "@babel/helper-builder-binary-assignment-operator-visitor";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     visitor: build({
       operator: "**",

--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -1,6 +1,7 @@
 import syntaxFlow from "@babel/plugin-syntax-flow";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function wrapInFlowComment(path, parent) {
     let attach = path.getPrevSibling();
     let where = "trailing";

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -1,6 +1,7 @@
 import syntaxFlow from "@babel/plugin-syntax-flow";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   const FLOW_DIRECTIVE = "@flow";
 
   let skipStrip = false;

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -1,4 +1,6 @@
-export default function({ template, types: t }, options) {
+import { template, types as t } from "@babel/core";
+
+export default function(api, options) {
   const { loose } = options;
   const pushComputedProps = loose
     ? pushComputedPropsLoose

--- a/packages/babel-plugin-transform-instanceof/src/index.js
+++ b/packages/babel-plugin-transform-instanceof/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     visitor: {
       BinaryExpression(path) {

--- a/packages/babel-plugin-transform-jscript/src/index.js
+++ b/packages/babel-plugin-transform-jscript/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     visitor: {
       FunctionExpression: {

--- a/packages/babel-plugin-transform-member-expression-literals/src/index.js
+++ b/packages/babel-plugin-transform-member-expression-literals/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     visitor: {
       MemberExpression: {

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-module-transforms": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31"
+    "@babel/helper-module-transforms": "7.0.0-beta.31"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -1,4 +1,3 @@
-import template from "@babel/template";
 import {
   isModule,
   rewriteModuleStatementsAndPrepareHeader,
@@ -8,13 +7,14 @@ import {
   ensureStatementsHoisted,
   wrapInterop,
 } from "@babel/helper-module-transforms";
+import { template, types as t } from "@babel/core";
 
 const buildWrapper = template(`
   define(MODULE_NAME, AMD_ARGUMENTS, function(IMPORT_NAMES) {
   })
 `);
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { loose, allowTopLevelThis, strict, strictMode, noInterop } = options;
   return {
     visitor: {

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -7,8 +7,9 @@ import {
   wrapInterop,
 } from "@babel/helper-module-transforms";
 import simplifyAccess from "@babel/helper-simple-access";
+import { template, types as t } from "@babel/core";
 
-export default function({ types: t, template }, options) {
+export default function(api, options) {
   const {
     loose,
     allowTopLevelThis,

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-hoist-variables": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31"
+    "@babel/helper-hoist-variables": "7.0.0-beta.31"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.js
@@ -1,5 +1,5 @@
 import hoistVariables from "@babel/helper-hoist-variables";
-import template from "@babel/template";
+import { template, types as t } from "@babel/core";
 
 const buildTemplate = template(`
   SYSTEM_REGISTER(MODULE_NAME, SOURCES, function (EXPORT_IDENTIFIER, CONTEXT_IDENTIFIER) {
@@ -22,7 +22,7 @@ const buildExportAll = template(`
 
 const TYPE_IMPORT = "Import";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { systemGlobal = "System" } = options;
   const IGNORE_REASSIGNMENT_SYMBOL = Symbol();
 

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-module-transforms": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31"
+    "@babel/helper-module-transforms": "7.0.0-beta.31"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -1,5 +1,4 @@
 import { basename, extname } from "path";
-import template from "@babel/template";
 import {
   isModule,
   rewriteModuleStatementsAndPrepareHeader,
@@ -9,6 +8,7 @@ import {
   ensureStatementsHoisted,
   wrapInterop,
 } from "@babel/helper-module-transforms";
+import { types as t, template } from "@babel/core";
 
 const buildPrerequisiteAssignment = template(`
   GLOBAL_REFERENCE = GLOBAL_REFERENCE || {}
@@ -30,7 +30,7 @@ const buildWrapper = template(`
   })
 `);
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const {
     globals,
     exactGlobals,

--- a/packages/babel-plugin-transform-new-target/src/index.js
+++ b/packages/babel-plugin-transform-new-target/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     name: "transform-new-target",
 

--- a/packages/babel-plugin-transform-object-super/src/index.js
+++ b/packages/babel-plugin-transform-object-super/src/index.js
@@ -1,4 +1,5 @@
 import ReplaceSupers from "@babel/helper-replace-supers";
+import { types as t } from "@babel/core";
 
 function replacePropertySuper(path, node, scope, getObjectRef, file) {
   const replaceSupers = new ReplaceSupers({
@@ -13,7 +14,7 @@ function replacePropertySuper(path, node, scope, getObjectRef, file) {
   replaceSupers.replace();
 }
 
-export default function({ types: t }) {
+export default function() {
   return {
     visitor: {
       ObjectExpression(path, state) {

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -7,10 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-call-delegate": "7.0.0-beta.31",
-    "@babel/helper-get-function-arity": "7.0.0-beta.31",
-    "@babel/template": "7.0.0-beta.31",
-    "@babel/traverse": "7.0.0-beta.31",
-    "@babel/types": "7.0.0-beta.31"
+    "@babel/helper-get-function-arity": "7.0.0-beta.31"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-parameters/src/index.js
+++ b/packages/babel-plugin-transform-parameters/src/index.js
@@ -1,7 +1,7 @@
 import convertFunctionParams from "./params";
 import convertFunctionRest from "./rest";
 
-export default function(babel, options) {
+export default function(api, options) {
   const { loose } = options;
   return {
     visitor: {

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -1,6 +1,5 @@
 import callDelegate from "@babel/helper-call-delegate";
-import template from "@babel/template";
-import * as t from "@babel/types";
+import { template, types as t } from "@babel/core";
 
 const buildDefaultParam = template(`
   let VARIABLE_NAME =

--- a/packages/babel-plugin-transform-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-parameters/src/rest.js
@@ -1,5 +1,4 @@
-import template from "@babel/template";
-import * as t from "@babel/types";
+import { template, types as t } from "@babel/core";
 
 const buildRest = template(`
   for (var LEN = ARGUMENTS.length,

--- a/packages/babel-plugin-transform-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-property-literals/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     visitor: {
       ObjectProperty: {

--- a/packages/babel-plugin-transform-property-mutators/src/index.js
+++ b/packages/babel-plugin-transform-property-mutators/src/index.js
@@ -1,6 +1,7 @@
 import * as defineMap from "@babel/helper-define-map";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     visitor: {
       ObjectExpression(path, file) {

--- a/packages/babel-plugin-transform-proto-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-proto-to-assign/src/index.js
@@ -1,6 +1,7 @@
 import pull from "lodash/pull";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function isProtoKey(node) {
     return t.isLiteral(t.toComputedKey(node, node.key), { value: "__proto__" });
   }

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -1,4 +1,6 @@
-export default function transformReactConstantElement({ types: t }, options) {
+import { types as t } from "@babel/core";
+
+export default function transformReactConstantElement(api, options) {
   const { allowMutablePropsOnTags } = options;
 
   if (

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -1,6 +1,7 @@
 import path from "path";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function addDisplayName(id, call) {
     const props = call.arguments[0].properties;
     let safe = true;

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -1,6 +1,7 @@
 import helper from "@babel/helper-builder-react-jsx";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   function hasRefOrSpread(attrs) {
     for (let i = 0; i < attrs.length; i++) {
       const attr = attrs[i];

--- a/packages/babel-plugin-transform-react-jsx-compat/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-compat/src/index.js
@@ -1,6 +1,7 @@
 import helper from "@babel/helper-builder-react-jsx";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }) {
+export default function() {
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.js
@@ -11,10 +11,11 @@
  *
  * <sometag __self={this} />
  */
+import { types as t } from "@babel/core";
 
 const TRACE_ID = "__self";
 
-export default function({ types: t }) {
+export default function() {
   const visitor = {
     JSXOpeningElement({ node }) {
       const id = t.jSXIdentifier(TRACE_ID);

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -12,11 +12,12 @@
  * var __jsxFileName = 'this/file.js';
  * <sometag __source={{fileName: __jsxFileName, lineNumber: 10}}/>
  */
+import { types as t } from "@babel/core";
 
 const TRACE_ID = "__source";
 const FILE_NAME_VAR = "_jsxFileName";
 
-export default function({ types: t }) {
+export default function() {
   function makeTrace(fileNameIdentifier, lineNumber) {
     const fileLineLiteral =
       lineNumber != null ? t.numericLiteral(lineNumber) : t.nullLiteral();

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -1,7 +1,8 @@
 import jsx from "@babel/plugin-syntax-jsx";
 import helper from "@babel/helper-builder-react-jsx";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const THROW_IF_NAMESPACE =
     options.throwIfNamespace === undefined ? true : !!options.throwIfNamespace;
 

--- a/packages/babel-plugin-transform-reserved-words/src/index.js
+++ b/packages/babel-plugin-transform-reserved-words/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     visitor: {
       "BindingIdentifier|ReferencedIdentifier"(path) {

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -1,8 +1,9 @@
 import { addDefault, isModule } from "@babel/helper-module-imports";
+import { types as t } from "@babel/core";
 
 import definitions from "./definitions";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const {
     helpers,
     moduleName = "@babel/runtime",

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "@babel/types": "7.0.0-beta.31"
-  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"
   },

--- a/packages/babel-plugin-transform-shorthand-properties/src/index.js
+++ b/packages/babel-plugin-transform-shorthand-properties/src/index.js
@@ -1,4 +1,4 @@
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 export default function() {
   return {

--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }, options) {
+import { types as t } from "@babel/core";
+
+export default function(api, options) {
   const { loose } = options;
 
   function getSpreadLiteral(spread, scope) {

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-regex": "7.0.0-beta.31",
-    "@babel/types": "7.0.0-beta.31"
+    "@babel/helper-regex": "7.0.0-beta.31"
   },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"

--- a/packages/babel-plugin-transform-sticky-regex/src/index.js
+++ b/packages/babel-plugin-transform-sticky-regex/src/index.js
@@ -1,5 +1,5 @@
 import * as regex from "@babel/helper-regex";
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 export default function() {
   return {

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -8,9 +8,6 @@
   "keywords": [
     "babel-plugin"
   ],
-  "dependencies": {
-    "@babel/types": "7.0.0-beta.31"
-  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"
   },

--- a/packages/babel-plugin-transform-strict-mode/src/index.js
+++ b/packages/babel-plugin-transform-strict-mode/src/index.js
@@ -1,4 +1,4 @@
-import * as t from "@babel/types";
+import { types as t } from "@babel/core";
 
 export default function() {
   return {

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -1,6 +1,7 @@
 import annotateAsPure from "@babel/helper-annotate-as-pure";
+import { types as t } from "@babel/core";
 
-export default function({ types: t }, options) {
+export default function(api, options) {
   const { loose } = options;
 
   let helperName = "taggedTemplateLiteral";

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.js
@@ -1,4 +1,6 @@
-export default function({ types: t }) {
+import { types as t } from "@babel/core";
+
+export default function() {
   return {
     visitor: {
       Scope({ scope }) {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -1,4 +1,5 @@
 import syntaxTypeScript from "@babel/plugin-syntax-typescript";
+import { types as t } from "@babel/core";
 
 import transpileEnum from "./enum";
 
@@ -18,7 +19,7 @@ interface State {
   programPath: any;
 }
 
-export default function({ types: t }) {
+export default function() {
   return {
     inherits: syntaxTypeScript,
     visitor: {

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -24,7 +24,7 @@ import transformES2015ModulesUMD from "@babel/plugin-transform-modules-umd";
 import transformES2015Instanceof from "@babel/plugin-transform-instanceof";
 import transformRegenerator from "@babel/plugin-transform-regenerator";
 
-export default function(context, opts = {}) {
+export default function(api, opts = {}) {
   const moduleTypes = ["commonjs", "amd", "umd", "systemjs"];
   let loose = false;
   let modules = "commonjs";

--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -4,7 +4,7 @@ import transformReactDisplayName from "@babel/plugin-transform-react-display-nam
 import transformReactJSXSource from "@babel/plugin-transform-react-jsx-source";
 import transformReactJSXSelf from "@babel/plugin-transform-react-jsx-self";
 
-export default function(context, opts = {}) {
+export default function(api, opts = {}) {
   const pragma = opts.pragma || "React.createElement";
   const pragmaFrag = opts.pragmaFrag || "React.Fragment";
   const throwIfNamespace =


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

We've got it, so I'd say we should use it.

I haven't done it in this PR, but one big benefit here is that we can hoist more of our transform utilities into the top-level module scope to make the core of our plugin functions smaller, which should also help make them more readable.

The other reason I'm adding this is that I'd like to use a helper module for caching, and it'll require injecting code into each plugin. I could explicitly add a dependency to every plugin for that helper, but it's just as easy to expose that via babel-core and then not have to add dependencies to the plugins at all.

Thoughts?