### PR TITLE
Standardize on Sync suffix for sync APIs (with backward-compat)

### DIFF
--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -3,6 +3,8 @@
 import type Plugin from "./plugin";
 import manageOptions from "./option-manager";
 
+export type { InputOptions } from "./options";
+
 export type ResolvedConfig = {
   options: Object,
   passes: PluginPasses,

--- a/packages/babel-core/src/config/options.js
+++ b/packages/babel-core/src/config/options.js
@@ -125,6 +125,8 @@ const COMMON_VALIDATORS: ValidatorSet = {
     $PropertyType<ValidatedOptions, "generatorOpts">,
   >),
 };
+export type InputOptions = ValidatedOptions;
+
 export type ValidatedOptions = {
   filename?: string,
   filenameRelative?: string,

--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -35,9 +35,13 @@ export function Plugin(alias: string) {
 }
 
 export { default as transform } from "./transform";
-export { default as transformFromAst } from "./transform-ast";
+export { default as transformSync } from "./transform-sync";
+
 export { default as transformFile } from "./transform-file";
 export { default as transformFileSync } from "./transform-file-sync";
+
+export { default as transformFromAst } from "./transform-ast";
+export { default as transformFromAstSync } from "./transform-ast-sync";
 
 /**
  * Recommended set of compilable extensions. Not used in @babel/core directly, but meant as

--- a/packages/babel-core/src/transform-ast-sync.js
+++ b/packages/babel-core/src/transform-ast-sync.js
@@ -1,0 +1,18 @@
+// @flow
+import loadConfig, { type InputOptions } from "./config";
+import { runSync, type FileResult } from "./transformation";
+
+type AstRoot = BabelNodeFile | BabelNodeProgram;
+
+export default function transformFromAstSync(
+  ast: AstRoot,
+  code: string,
+  opts: ?InputOptions,
+): FileResult | null {
+  const config = loadConfig(opts);
+  if (config === null) return null;
+
+  if (!ast) throw new Error("No AST given");
+
+  return runSync(config, code, ast);
+}

--- a/packages/babel-core/src/transform-ast.js
+++ b/packages/babel-core/src/transform-ast.js
@@ -1,21 +1,56 @@
 // @flow
-import * as t from "@babel/types";
-import loadConfig from "./config";
-import runTransform, { type FileResult } from "./transformation";
 
-export default function transformFromAst(
-  ast: Object,
-  code: string,
-  opts: Object,
-): FileResult | null {
-  const config = loadConfig(opts);
-  if (config === null) return null;
+import loadConfig, { type InputOptions } from "./config";
+import {
+  runAsync,
+  type FileResult,
+  type FileResultCallback,
+} from "./transformation";
 
-  if (ast && ast.type === "Program") {
-    ast = t.file(ast, [], []);
-  } else if (!ast || ast.type !== "File") {
-    throw new Error("Not a valid ast?");
+import transformAstSync from "./transform-ast-sync";
+
+type AstRoot = BabelNodeFile | BabelNodeProgram;
+
+type TransformAst = {
+  (ast: AstRoot, code: string, callback: FileResultCallback): void,
+  (
+    ast: AstRoot,
+    code: string,
+    opts: ?InputOptions,
+    callback: FileResultCallback,
+  ): void,
+
+  // Here for backward-compatibility. Ideally use ".transformSync" if you want
+  // a synchronous API.
+  (ast: AstRoot, code: string, opts: ?InputOptions): FileResult | null,
+};
+
+export default ((function transformFromAst(ast, code, opts, callback) {
+  if (typeof opts === "function") {
+    opts = undefined;
+    callback = opts;
   }
 
-  return runTransform(config, code, ast);
-}
+  // For backward-compat with Babel 6, we allow sync transformation when
+  // no callback is given. Will be dropped in some future Babel major version.
+  if (callback === undefined) return transformAstSync(ast, code, opts);
+
+  // Reassign to keep Flowtype happy.
+  const cb = callback;
+
+  // Just delaying the transform one tick for now to simulate async behavior
+  // but more async logic may land here eventually.
+  process.nextTick(() => {
+    let cfg;
+    try {
+      cfg = loadConfig(opts);
+      if (cfg === null) return cb(null, null);
+    } catch (err) {
+      return cb(err);
+    }
+
+    if (!ast) return cb(new Error("No AST given"));
+
+    runAsync(cfg, code, ast, cb);
+  });
+}: Function): TransformAst);

--- a/packages/babel-core/src/transform-file-sync.js
+++ b/packages/babel-core/src/transform-file-sync.js
@@ -1,16 +1,21 @@
 // @flow
 import fs from "fs";
 
-import loadConfig from "./config";
-import runTransform, { type FileResult } from "./transformation";
+import loadConfig, { type InputOptions } from "./config";
+import { runSync, type FileResult } from "./transformation";
 
 export default function transformFileSync(
   filename: string,
-  opts?: Object = {},
+  opts: ?InputOptions,
 ): FileResult | null {
-  opts.filename = filename;
+  if (opts == null) {
+    opts = { filename };
+  } else if (opts && typeof opts === "object") {
+    opts = Object.assign(opts, { filename });
+  }
+
   const config = loadConfig(opts);
   if (config === null) return null;
 
-  return runTransform(config, fs.readFileSync(filename, "utf8"));
+  return runSync(config, fs.readFileSync(filename, "utf8"));
 }

--- a/packages/babel-core/src/transform-file.js
+++ b/packages/babel-core/src/transform-file.js
@@ -1,32 +1,42 @@
 // @flow
 import fs from "fs";
 
-import loadConfig from "./config";
-import runTransform, { type FileResult } from "./transformation";
+import loadConfig, { type InputOptions } from "./config";
+import { runAsync, type FileResultCallback } from "./transformation";
 
-export default function transformFile(
-  filename: string,
-  opts?: Object = {},
-  callback: (?Error, FileResult | null) => void,
-) {
+type TransformFile = {
+  (filename: string, callback: FileResultCallback): void,
+  (filename: string, opts: ?InputOptions, callback: FileResultCallback): void,
+};
+
+export default ((function transformFile(filename, opts, callback) {
   if (typeof opts === "function") {
     callback = opts;
-    opts = {};
+    opts = undefined;
   }
 
-  opts.filename = filename;
-  const config = loadConfig(opts);
-  if (config === null) return callback(null, null);
+  if (opts == null) {
+    opts = { filename };
+  } else if (opts && typeof opts === "object") {
+    opts = Object.assign(opts, { filename });
+  }
 
-  fs.readFile(filename, "utf8", function(err, code: string) {
-    if (err) return callback(err, null);
-
-    let result;
+  process.nextTick(() => {
+    let cfg;
     try {
-      result = runTransform(config, code);
-    } catch (_err) {
-      return callback(_err, null);
+      cfg = loadConfig(opts);
+      if (cfg === null) return callback(null, null);
+    } catch (err) {
+      return callback(err);
     }
-    callback(null, result);
+
+    // Reassignment to keep Flow happy.
+    const config = cfg;
+
+    fs.readFile(filename, "utf8", function(err, code: string) {
+      if (err) return callback(err, null);
+
+      runAsync(config, code, null, callback);
+    });
   });
-}
+}: Function): TransformFile);

--- a/packages/babel-core/src/transform-sync.js
+++ b/packages/babel-core/src/transform-sync.js
@@ -1,0 +1,13 @@
+// @flow
+import loadConfig, { type InputOptions } from "./config";
+import { runSync, type FileResult } from "./transformation";
+
+export default function transformSync(
+  code: string,
+  opts: ?InputOptions,
+): FileResult | null {
+  const config = loadConfig(opts);
+  if (config === null) return null;
+
+  return runSync(config, code);
+}

--- a/packages/babel-core/src/transform.js
+++ b/packages/babel-core/src/transform.js
@@ -1,13 +1,46 @@
 // @flow
-import loadConfig from "./config";
-import runTransform, { type FileResult } from "./transformation";
+import loadConfig, { type InputOptions } from "./config";
+import {
+  runAsync,
+  type FileResult,
+  type FileResultCallback,
+} from "./transformation";
 
-export default function transform(
-  code: string,
-  opts?: Object,
-): FileResult | null {
-  const config = loadConfig(opts);
-  if (config === null) return null;
+import transformSync from "./transform-sync";
 
-  return runTransform(config, code);
-}
+type Transform = {
+  (code: string, callback: FileResultCallback): void,
+  (code: string, opts: ?InputOptions, callback: FileResultCallback): void,
+
+  // Here for backward-compatibility. Ideally use ".transformSync" if you want
+  // a synchronous API.
+  (code: string, opts: ?InputOptions): FileResult | null,
+};
+
+export default ((function transform(code, opts, callback) {
+  if (typeof opts === "function") {
+    opts = undefined;
+    callback = opts;
+  }
+
+  // For backward-compat with Babel 6, we allow sync transformation when
+  // no callback is given. Will be dropped in some future Babel major version.
+  if (callback === undefined) return transformSync(code, opts);
+
+  // Reassign to keep Flowtype happy.
+  const cb = callback;
+
+  // Just delaying the transform one tick for now to simulate async behavior
+  // but more async logic may land here eventually.
+  process.nextTick(() => {
+    let cfg;
+    try {
+      cfg = loadConfig(opts);
+      if (cfg === null) return cb(null, null);
+    } catch (err) {
+      return cb(err);
+    }
+
+    runAsync(cfg, code, null, cb);
+  });
+}: Function): Transform);

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -1,5 +1,6 @@
 // @flow
 
+import * as t from "@babel/types";
 import convertSourceMap, { typeof Converter } from "convert-source-map";
 import { parse } from "babylon";
 import { codeFrameColumns } from "@babel/code-frame";
@@ -16,7 +17,7 @@ export type NormalizedFile = {
 export default function normalizeFile(
   options: Object,
   code: string,
-  ast?: {},
+  ast: ?(BabelNodeFile | BabelNodeProgram),
 ): NormalizedFile {
   code = `${code || ""}`;
 
@@ -37,7 +38,15 @@ export default function normalizeFile(
     code = code.replace(shebangRegex, "");
   }
 
-  if (!ast) ast = parser(options, code);
+  if (ast) {
+    if (ast.type === "Program") {
+      ast = t.file(ast, [], []);
+    } else if (ast.type !== "File") {
+      throw new Error("AST root must be a Program or File node");
+    }
+  } else {
+    ast = parser(options, code);
+  }
 
   return {
     code,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  | N, unless someone was accidentally passing a callback to this synchronous API
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

In 6.x we have
```
transform // sync
transformFromAst // sync
transformFile // async
transformFileSync // sync
```
which is pretty confusing, so this PR standardizes it to
```
transform // async, but sync if no callback given, for back compat
transformSync // sync
transformFromAst // async, but sync if no callback given, for back compat
transformFromAstSync // sync
transformFile // async
transformFileSync // sync
```

This PR doesn't _use_ the async ability for anything yet, but it gives us a base to build upon. I'm figuring I'll file a beginner-friendly bug for converting babel-cli to use the async version. We can also update babel-loader and babelify and such, so that when we _do_ start adding things that only work for async usecases, the existing integrations will work. We'll also probably want to run through our tests and update them to use `transformSync`.

As an example of usage here, I'm tossing around the idea of letting caching plugins be async if they want to me, so they'd just log a warning or silently skip cache processing if used with `babel.transformSync` and such. We could also let plugins have async init logic, which could throw if used in a sync context call.