### PR TITLE
Apply option defaults when transforming, not up front.

### DIFF
--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -120,6 +120,7 @@ class OptionManager {
 
     // Tack the passes onto the object itself so that, if this object is passed back to Babel a second time,
     // it will be in the right structure to not change behavior.
+    opts.babelrc = false;
     opts.plugins = this.passes[0];
     opts.presets = this.passes
       .slice(1)

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -2,10 +2,8 @@
 
 import * as context from "../index";
 import Plugin, { validatePluginObject } from "./plugin";
-import defaults from "lodash/defaults";
 import merge from "lodash/merge";
 import buildConfigChain, { type ConfigItem } from "./build-config-chain";
-import path from "path";
 import traverse from "@babel/traverse";
 import clone from "lodash/clone";
 import { makeWeakCache } from "./caching";
@@ -118,7 +116,7 @@ class OptionManager {
       throw e;
     }
 
-    const opts: Object = merge(createInitialOptions(), this.options);
+    const opts: Object = this.options;
 
     // Tack the passes onto the object itself so that, if this object is passed back to Babel a second time,
     // it will be in the right structure to not change behavior.
@@ -128,39 +126,6 @@ class OptionManager {
       .filter(plugins => plugins.length > 0)
       .map(plugins => ({ plugins }));
     opts.passPerPreset = opts.presets.length > 0;
-
-    if (opts.inputSourceMap) {
-      opts.sourceMaps = true;
-    }
-
-    if (opts.moduleId) {
-      opts.moduleIds = true;
-    }
-
-    defaults(opts, {
-      moduleRoot: opts.sourceRoot,
-    });
-
-    defaults(opts, {
-      sourceRoot: opts.moduleRoot,
-    });
-
-    defaults(opts, {
-      filenameRelative: opts.filename,
-    });
-
-    if (typeof opts.filenameRelative === "string") {
-      const basenameRelative = path.basename(opts.filenameRelative);
-
-      if (path.extname(opts.filenameRelative) === ".mjs") {
-        opts.sourceType = "module";
-      }
-
-      defaults(opts, {
-        sourceFileName: basenameRelative,
-        sourceMapTarget: basenameRelative,
-      });
-    }
 
     return {
       options: opts,
@@ -392,17 +357,5 @@ function chain(a, b) {
     for (const fn of fns) {
       fn.apply(this, args);
     }
-  };
-}
-
-function createInitialOptions() {
-  return {
-    sourceType: "module",
-    babelrc: true,
-    code: true,
-    ast: true,
-    comments: true,
-    compact: "auto",
-    highlightCode: true,
   };
 }

--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -61,44 +61,46 @@ export default class File {
   }
 
   getModuleName(): ?string {
-    const opts = this.opts;
-    if (!opts.moduleIds) {
-      return null;
-    }
+    const {
+      filename,
+      filenameRelative = filename,
+
+      moduleId,
+      moduleIds = !!moduleId,
+
+      getModuleId,
+
+      sourceRoot: sourceRootTmp,
+      moduleRoot = sourceRootTmp,
+      sourceRoot = moduleRoot,
+    } = this.opts;
+
+    if (!moduleIds) return null;
 
     // moduleId is n/a if a `getModuleId()` is provided
-    if (opts.moduleId != null && !opts.getModuleId) {
-      return opts.moduleId;
+    if (moduleId != null && !getModuleId) {
+      return moduleId;
     }
 
-    let filenameRelative = opts.filenameRelative;
-    let moduleName = "";
+    let moduleName = moduleRoot != null ? moduleRoot + "/" : "";
 
-    if (opts.moduleRoot != null) {
-      moduleName = opts.moduleRoot + "/";
+    if (filenameRelative) {
+      const sourceRootReplacer =
+        sourceRoot != null ? new RegExp("^" + sourceRoot + "/?") : "";
+
+      moduleName += filenameRelative
+        // remove sourceRoot from filename
+        .replace(sourceRootReplacer, "")
+        // remove extension
+        .replace(/\.(\w*?)$/, "");
     }
-
-    if (!opts.filenameRelative) {
-      return moduleName + opts.filename.replace(/^\//, "");
-    }
-
-    if (opts.sourceRoot != null) {
-      // remove sourceRoot from filename
-      const sourceRootRegEx = new RegExp("^" + opts.sourceRoot + "/?");
-      filenameRelative = filenameRelative.replace(sourceRootRegEx, "");
-    }
-
-    // remove extension
-    filenameRelative = filenameRelative.replace(/\.(\w*?)$/, "");
-
-    moduleName += filenameRelative;
 
     // normalize path separators
     moduleName = moduleName.replace(/\\/g, "/");
 
-    if (opts.getModuleId) {
+    if (getModuleId) {
       // If return is falsy, assume they want us to use our generated default name
-      return opts.getModuleId(moduleName) || moduleName;
+      return getModuleId(moduleName) || moduleName;
     } else {
       return moduleName;
     }
@@ -202,6 +204,8 @@ export default class File {
     }
 
     if (loc) {
+      const { highlightCode = true } = this.opts;
+
       msg +=
         "\n" +
         codeFrameColumns(
@@ -212,9 +216,7 @@ export default class File {
               column: loc.column + 1,
             },
           },
-          {
-            highlightCode: this.opts.highlightCode,
-          },
+          { highlightCode },
         );
     }
 

--- a/packages/babel-core/src/transformation/index.js
+++ b/packages/babel-core/src/transformation/index.js
@@ -58,14 +58,13 @@ export function runSync(
   transformFile(file, config.passes);
 
   const opts = file.opts;
-  const { outputCode, outputMap } = opts.code
-    ? generateCode(config.passes, file)
-    : {};
+  const { outputCode, outputMap } =
+    opts.code !== false ? generateCode(config.passes, file) : {};
 
   return {
     metadata: file.metadata,
     options: opts,
-    ast: opts.ast ? file.ast : null,
+    ast: opts.ast !== false ? file.ast : null,
     code: outputCode === undefined ? null : outputCode,
     map: outputMap === undefined ? null : outputMap,
   };

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -1,15 +1,34 @@
 // @flow
 
+import path from "path";
 import type { ResolvedConfig } from "../config";
 
 export default function normalizeOptions(config: ResolvedConfig): {} {
+  const {
+    filename,
+    filenameRelative = filename || "unknown",
+    sourceType = "module",
+    inputSourceMap,
+    sourceMaps = !!inputSourceMap,
+
+    moduleRoot,
+    sourceRoot = moduleRoot,
+
+    sourceFileName = filenameRelative,
+    sourceMapTarget = filenameRelative,
+
+    comments = true,
+    compact = "auto",
+  } = config.options;
+
   const opts = config.options;
 
   const options = Object.assign({}, opts, {
     parserOpts: Object.assign(
       {
-        sourceType: opts.sourceType,
-        sourceFileName: opts.filename || "unknown",
+        sourceType:
+          path.extname(filenameRelative) === ".mjs" ? "module" : sourceType,
+        sourceFileName: filename,
         plugins: [],
       },
       opts.parserOpts,
@@ -17,20 +36,20 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
     generatorOpts: Object.assign(
       {
         // General generator flags.
-        filename: opts.filename || "unknown",
+        filename,
         auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
         auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
         retainLines: opts.retainLines,
-        comments: opts.comments,
-        compact: opts.compact,
+        comments,
+        compact,
         minified: opts.minified,
         concise: opts.concise,
 
         // Source-map generation flags.
-        sourceMaps: opts.sourceMaps,
-        sourceMapTarget: opts.sourceMapTarget || "unknown",
-        sourceRoot: opts.sourceRoot,
-        sourceFileName: opts.sourceFileName || "unknown",
+        sourceMaps,
+        sourceMapTarget,
+        sourceRoot,
+        sourceFileName,
       },
       opts.generatorOpts,
     ),

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -44,17 +44,6 @@ describe("option-manager", () => {
     });
   });
 
-  describe("source type", function() {
-    it("should set module for .mjs extension", () => {
-      const config = manageOptions({
-        sourceType: "script",
-        filename: "foo.mjs",
-      });
-
-      assert.equal(config.options.sourceType, "module");
-    });
-  });
-
   describe("presets", function() {
     function presetTest(name) {
       it(name, function() {

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -63,16 +63,11 @@ function compile(code, filename) {
     }
   }
 
-  const result = babel.transform(
-    code,
-    Object.assign(opts, {
-      // Do not process config files since has already been done with the OptionManager
-      // calls above and would introduce duplicates.
-      babelrc: false,
-      sourceMaps: opts.sourceMaps === undefined ? "both" : opts.sourceMaps,
-      ast: false,
-    }),
-  );
+  const result = babel.transform(code, {
+    ...opts,
+    sourceMaps: opts.sourceMaps === undefined ? "both" : opts.sourceMaps,
+    ast: false,
+  });
 
   if (cache) {
     cache[cacheKey] = result;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | N, theoretically if someone was loading the config and relying on the defaults being populated, but doesn't seem likely.
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

The up-front application of defaults is going to cause problems with cases like https://github.com/babel/babel/pull/6651/files#diff-75a0292ed78043766c2d5564edd84ad2R72, so this basically makes the config returned from loadConfig _explicitly_ only the options that the user has provided + options that guarantee that if the same config is passed back to Babel, that it will parse the same way the next time, which makes it easier for people to load the config, make a few small tweaks, and call Babel again.
