### PR TITLE
Don't run regexpu twice

### DIFF
--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@babel/helper-regex",
   "version": "7.0.0-beta.31",
-  "description": "Helper function to check for literal RegEx",
+  "description": "Helper visitor to transform regular expressions using regexpu",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.2.0"
+    "regexpu-core": "^4.1.3"
   }
 }

--- a/packages/babel-helper-regex/src/index.js
+++ b/packages/babel-helper-regex/src/index.js
@@ -1,12 +1,50 @@
-import pull from "lodash/pull";
+// @flow
+
+import type { NodePath } from "@babel/traverse";
+import rewritePattern from "regexpu-core";
+
+const options: WeakMap<Object, RegexpuOptions> = new WeakMap();
+const flags: WeakMap<Object, Flags> = new WeakMap();
+
+export type RegexpuOptions = {};
+export type Flags = Set<string>;
+
+export type Filter = (node: Object) => boolean;
+export type ManipulateOptions = (options: RegexpuOptions) => ?RegexpuOptions;
+export type ManipulateFlags = (flags: Flags) => ?Flags;
+
+export function buildRegexpVisitor({
+  filter = () => true,
+  manipulateOptions = options => options,
+  manipulateFlags = flags => flags,
+}: {
+  filter: Filter,
+  manipulateOptions: ManipulateOptions,
+  manipulateFlags: ManipulateFlags,
+}) {
+  return {
+    RegExpLiteral: {
+      enter({ node }: NodePath) {
+        if (!filter(node)) return;
+        const opts = options.get(node) || {};
+        const fls = flags.get(node) || new Set(node.flags.split(""));
+        options.set(node, manipulateOptions(opts) || opts);
+        flags.set(node, manipulateFlags(fls) || fls);
+      },
+      exit({ node }: NodePath) {
+        const opts = options.get(node);
+        const fls = flags.get(node);
+        if (!opts || !fls) return;
+        options.delete(node);
+        flags.delete(node);
+
+        node.pattern = rewritePattern(node.pattern, node.flags, opts);
+        node.flags = Array.from(fls).join("");
+      },
+    },
+  };
+}
 
 export function is(node: Object, flag: string): boolean {
   return node.type === "RegExpLiteral" && node.flags.indexOf(flag) >= 0;
-}
-
-export function pullFlag(node: Object, flag: string) {
-  const flags = node.flags.split("");
-  if (node.flags.indexOf(flag) < 0) return;
-  pull(flags, flag);
-  node.flags = flags.join("");
 }

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -18,8 +18,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex",
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
-    "@babel/helper-regex": "7.0.0-beta.31",
-    "regexpu-core": "^4.1.3"
+    "@babel/helper-regex": "7.0.0-beta.31"
   },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"

--- a/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
+++ b/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
@@ -1,4 +1,3 @@
-import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
 export default function(api, options) {
@@ -8,20 +7,14 @@ export default function(api, options) {
   }
 
   return {
-    visitor: {
-      RegExpLiteral(path) {
-        const node = path.node;
-        if (!regex.is(node, "u")) {
-          return;
-        }
-        node.pattern = rewritePattern(node.pattern, node.flags, {
-          unicodePropertyEscape: true,
-          useUnicodeFlag,
-        });
-        if (!useUnicodeFlag) {
-          regex.pullFlag(node, "u");
-        }
-      },
-    },
+    visitor: regex.buildRegexpVisitor({
+      filter: node => regex.is(node, "u"),
+      manipulateFlags: useUnicodeFlag ? undefined : flags => flags.delete("u"),
+      manipulateOptions: options => ({
+        ...options,
+        unicodePropertyEscape: true,
+        useUnicodeFlag,
+      }),
+    }),
   };
 }

--- a/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/with-unicode-flag/plugin-transform-unicode-regex/actual.js
+++ b/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/with-unicode-flag/plugin-transform-unicode-regex/actual.js
@@ -1,0 +1,1 @@
+var regex = /\p{Regional_Indicator}/u;

--- a/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/with-unicode-flag/plugin-transform-unicode-regex/expected.js
+++ b/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/with-unicode-flag/plugin-transform-unicode-regex/expected.js
@@ -1,0 +1,1 @@
+var regex = /(?:\uD83C[\uDDE6-\uDDFF])/;

--- a/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/with-unicode-flag/plugin-transform-unicode-regex/options.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/test/fixtures/with-unicode-flag/plugin-transform-unicode-regex/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["proposal-unicode-property-regex", {
+      "useUnicodeFlag": true
+    }],
+    "transform-unicode-regex"
+  ]
+}

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -9,8 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-regex": "7.0.0-beta.31",
-    "regexpu-core": "^4.1.3"
+    "@babel/helper-regex": "7.0.0-beta.31"
   },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.31"

--- a/packages/babel-plugin-transform-unicode-regex/src/index.js
+++ b/packages/babel-plugin-transform-unicode-regex/src/index.js
@@ -1,14 +1,14 @@
-import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
 export default function() {
   return {
-    visitor: {
-      RegExpLiteral({ node }) {
-        if (!regex.is(node, "u")) return;
-        node.pattern = rewritePattern(node.pattern, node.flags);
-        regex.pullFlag(node, "u");
-      },
-    },
+    visitor: regex.buildRegexpVisitor({
+      filter: node => regex.is(node, "u"),
+      manipulateFlags: flags => flags.delete("u"),
+      manipulateOptions: options => ({
+        ...options,
+        useUnicodeFlag: false,
+      }),
+    }),
   };
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

After https://github.com/babel/babel/pull/6776, the default behavior of `@babel/plugin-proposal-unicode-property-regex` changed and now it keeps the `u` flags (as it should, imo).
This PR avoids running regexpu twice (as noted in https://github.com/babel/babel/pull/6776#issuecomment-343255504) when transpiling to es2015 (`@babel/plugin-proposal-unicode-property-regex` + `@babel/plugin-transform-unicode-regex`) by delaying it when exiting the RegExp node.

Other than making the default behavior faster, this PR would allow us to drop the `useUnicodeFlag` option in the future and keep the "one plugin - one syntax" principle.

---
Benchmarks:

Without this commit: 1.45s
With this commit: 1.20s
<details>
<summary>Code</summary>

```js
const code = `
var regex = /\\p{Regional_Indicator}/u;
`.repeat(100);

const plugins = [
  loadPlugin("proposal-unicode-property-regex"),
  loadPlugin("transform-unicode-regex"),
];

const start = process.hrtime();
for (let i = 0; i < 100; i++) babel.transform(code, { plugins });
console.log(process.hrtime(start));
```

</details>

---
cc @mathiasbynens @loganfsmyth