### PR TITLE
Add cache.clear() to clear the `data` reference when cache option is `false`

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -62,3 +62,11 @@ export function load() {
 export function get(): Object {
   return data;
 }
+
+/**
+ * Clear the cache object.
+ */
+
+export function clear() {
+  data = {};
+}

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -30,8 +30,7 @@ function installSourceMapSupport() {
   });
 }
 
-registerCache.load();
-let cache = registerCache.get();
+let cache;
 
 function mtime(filename) {
   return +fs.statSync(filename).mtime;
@@ -108,7 +107,13 @@ export default function register(opts?: Object = {}) {
   opts = Object.assign({}, opts);
   if (opts.extensions) hookExtensions(opts.extensions);
 
-  if (opts.cache === false) cache = null;
+  if (opts.cache === false && cache) {
+    registerCache.clear();
+    cache = null;
+  } else if (opts.cache !== false && !cache) {
+    registerCache.load();
+    cache = registerCache.get();
+  }
 
   delete opts.extensions;
   delete opts.cache;


### PR DESCRIPTION
I noticed that even though caching can be disabled, on start it will load the cache json since its cache reference is never cleared. This patch clears the cache reference of `data` when caching is disabled.