### PR TITLE
Do not access out of bounds arguments

### DIFF
--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/default-parameters/expected.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/default-parameters/expected.js
@@ -5,6 +5,6 @@ var some = function () {
 
 var collect = function () {
   let since = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
-  let userid = arguments[1];
+  let userid = arguments.length > 1 ? arguments[1] : undefined;
   console.log(userid);
 };

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -19,8 +19,8 @@ const buildLooseDestructuredDefaultParam = template(`
   let ASSIGNMENT_IDENTIFIER = PARAMETER_NAME === UNDEFINED ? DEFAULT_VALUE : PARAMETER_NAME ;
 `);
 
-const buildArgumentsAccess = template(`
-  let $0 = arguments[$1];
+const buildSafeArgumentsAccess = template(`
+  let $0 = arguments.length > $1 ? arguments[$1] : undefined;
 `);
 
 function isSafeBinding(scope, node) {
@@ -110,7 +110,10 @@ export default function convertFunctionParams(path, loose) {
       });
       body.push(defNode);
     } else if (firstOptionalIndex !== null) {
-      const defNode = buildArgumentsAccess([param.node, t.numericLiteral(i)]);
+      const defNode = buildSafeArgumentsAccess([
+        param.node,
+        t.numericLiteral(i),
+      ]);
       body.push(defNode);
     } else if (param.isObjectPattern() || param.isArrayPattern()) {
       const uid = path.scope.generateUidIdentifier("ref");

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-before-last/expected.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-before-last/expected.js
@@ -1,4 +1,4 @@
 function foo() {
   var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "foo";
-  var b = arguments[1];
+  var b = arguments.length > 1 ? arguments[1] : undefined;
 }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-rest-mix/expected.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-rest-mix/expected.js
@@ -1,11 +1,13 @@
 function fn(a1) {
   var a2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 4;
-  var _arguments$ = arguments[2],
-      a3 = _arguments$.a3,
-      a4 = _arguments$.a4;
-  var a5 = arguments[3];
 
-  var _ref = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {},
-      a6 = _ref.a6,
-      a7 = _ref.a7;
+  var _ref = arguments.length > 2 ? arguments[2] : undefined,
+      a3 = _ref.a3,
+      a4 = _ref.a4;
+
+  var a5 = arguments.length > 3 ? arguments[3] : undefined;
+
+  var _ref2 = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {},
+      a6 = _ref2.a6,
+      a7 = _ref2.a7;
 }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/destructuring-rest/expected.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/destructuring-rest/expected.js
@@ -1,9 +1,10 @@
 // #3861
 function t() {
   var x = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "default";
-  var _arguments$ = arguments[1],
-      a = _arguments$.a,
-      b = _arguments$.b;
+
+  var _ref = arguments.length > 1 ? arguments[1] : undefined,
+      a = _ref.a,
+      b = _ref.b;
 
   for (var _len = arguments.length, args = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
     args[_key - 2] = arguments[_key];


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes?
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In `babel-plugin-transform-parameters`, potentially out of bounds arguments should not just be directly accessed, instead use a ternary operator to check length. Accessing out of bounds is expensive ~~and means that engines are unable to optimize the function~~.

(A plain benchmark on accessing out of bounds arguments shows about 5x slower execution for a basic function that literally just accesses a single argument.)