### PR TITLE
Upgrade source-map to version 0.6.1

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.2.0",
     "output-file-sync": "^2.0.0",
     "slash": "^1.0.0",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   },
   "optionalDependencies": {
     "chokidar": "^1.6.1"

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.2.0",
     "micromatch": "^2.3.11",
     "resolve": "^1.3.2",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "7.0.0-beta.31",

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -14,7 +14,7 @@
     "@babel/types": "7.0.0-beta.31",
     "jsesc": "^2.5.1",
     "lodash": "^4.2.0",
-    "source-map": "^0.5.0",
+    "source-map": "^0.6.1",
     "trim-right": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -15,6 +15,6 @@
     "chai": "^4.1.0",
     "lodash": "^4.2.0",
     "resolve": "^1.3.2",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   }
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  | y
| License                  | MIT

Upgrades source-map to 0.6.1