### PR TITLE
Fix shadow variables reassignment for block scoping in loops.

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/for-continuation-outer-reference.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/for-continuation-outer-reference.js
@@ -1,0 +1,13 @@
+let data = [true, false, false, true, false];
+
+for (let index = 0; index < data.length; index++) {
+    let item = data[index];
+    if (!item) {
+        data.splice(index, 1);
+        index--;
+        continue;
+    }
+    let fn = function () {item;};
+}
+
+assert(data.every(item => item));

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/wrap-closure-shadow-variables-reassignment/actual.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/wrap-closure-shadow-variables-reassignment/actual.js
@@ -1,0 +1,7 @@
+for (let index = 0; index < 10; index++) {
+    if (index % 2) {
+        index+=3;
+        continue;
+    }
+    let fn = function () {index;};
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/wrap-closure-shadow-variables-reassignment/expected.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/wrap-closure-shadow-variables-reassignment/expected.js
@@ -1,0 +1,19 @@
+var _loop = function (_index) {
+  if (_index % 2) {
+    _index += 3;
+    index = _index;
+    return "continue";
+  }
+
+  var fn = function () {
+    _index;
+  };
+
+  index = _index;
+};
+
+for (var index = 0; index < 10; index++) {
+  var _ret = _loop(index);
+
+  if (_ret === "continue") continue;
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6809 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         |
| Any Dependency Changes?  |
| License                  | MIT

Fix for `transform-block-scoping` plugin.
Currently, to assign outer reference in the loops, we just wrapping all the content from the loop block to the function block and ejecting it in the loop with arguments its refer. It can return `continue` or `break` strings which will point us whether or not use `continue`/`break` statements. It works good, but in continue/break cases, the execution of the function ends when it stumbles on `return 'continue'`. But in this case, we just ignoring outer reference assign. Because of we use `fn.body.body.push` to add these assignations to **the end of the block**.

```js
_loop = function (_index) {
  if (somethingHappened) {
    // assign was avoided and original index wasn't reassigned.
    _index++;
    return 'continue';
  }
  // function that refers to the index
  var fn = function () { _index; };
  // assign was added just to the end and works fine unless somethingHappened
  index = _index
}

for (var index = 0; index < 10; index++) {
  var _ret = _loop(index);

  if (_ret === "continue") continue;
}
```
