### PR TITLE
Remove unneeded .eslintrc files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,12 @@
       }
     },
     {
-      "files": [ "packages/*/test/**/*.js", "test/**/*.js" ],
+      "files": [
+        "packages/*/test/**/*.js",
+        "experimental/*/test/**/*.js",
+        "codemods/*/test/**/*.js",
+        "test/**/*.js"
+      ],
       "env": {
         "mocha": true
       }

--- a/codemods/.eslintrc
+++ b/codemods/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undefined-identifier": 2
-  }
-}

--- a/experimental/.eslintrc
+++ b/experimental/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "prettier/prettier": ["error", { "trailingComma": "all" }],
-    "no-undefined-identifier": 2
-  }
-}

--- a/experimental/babel-preset-env/.eslintignore
+++ b/experimental/babel-preset-env/.eslintignore
@@ -1,6 +1,0 @@
-/lib
-debug-fixtures
-fixtures
-/data
-/flow-typed
-test/tmp

--- a/experimental/babel-preset-env/scripts/.eslintrc
+++ b/experimental/babel-preset-env/scripts/.eslintrc
@@ -1,5 +1,0 @@
-{
-    "rules": {
-      "prettier/prettier": ["error", { "trailingComma": "es5" }]
-    }
-  }

--- a/experimental/babel-preset-env/test/.eslintrc
+++ b/experimental/babel-preset-env/test/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "mocha": true
-  },
-  "rules": {
-    "max-len": 0
-  }
-}

--- a/packages/babel-polyfill/scripts/.eslintrc
+++ b/packages/babel-polyfill/scripts/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "prettier/prettier": ["error", { "trailingComma": "es5" }]
-  }
-}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | n/y
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Removes a couple leftover (and unneeded) .eslintrc files now that we have [everything unified](https://github.com/babel/babel/pull/6747)