### PR TITLE
Add some nice warnings if plugins happen to return promises instead of sync values.

### DIFF
--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -153,6 +153,16 @@ const readConfigJS = makeStrongCache((filepath, cache) => {
     );
   }
 
+  if (typeof options.then === "function") {
+    throw new Error(
+      `You appear to be using an async configuration, ` +
+        `which your current version of Babel does not support. ` +
+        `We may add support for this in the future, ` +
+        `but if you're on the most recent version of @babel/core and still ` +
+        `seeing this error, then you'll need to synchronously return your config.`,
+    );
+  }
+
   return {
     filepath,
     dirname: path.dirname(filepath),

--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -142,6 +142,7 @@ const readConfigJS = makeStrongCache((filepath, cache) => {
       cache,
       // Expose ".env()" so people can easily get the same env that we expose using the "env" key.
       env: () => cache.using(() => getEnv()),
+      async: () => false,
     });
   } else {
     cache.forever();

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -205,6 +205,15 @@ const loadDescriptor = makeWeakCache(
       throw new Error("Plugin/Preset did not return an object.");
     }
 
+    if (typeof item.then === "function") {
+      throw new Error(
+        `You appear to be using an async plugin, ` +
+          `which your current version of Babel does not support.` +
+          `If you're using a published plugin, ` +
+          `you may need to upgrade your @babel/core version.`,
+      );
+    }
+
     return { value: item, options, dirname, alias };
   },
 );

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -189,6 +189,7 @@ const loadDescriptor = makeWeakCache(
       const api = Object.assign(Object.create(context), {
         cache,
         env: () => cache.using(() => getEnv()),
+        async: () => false,
       });
 
       try {

--- a/packages/babel-core/src/transformation/file/generate.js
+++ b/packages/babel-core/src/transformation/file/generate.js
@@ -38,6 +38,15 @@ export default function generateCode(
     result = generate(ast, opts.generatorOpts, code);
   } else if (results.length === 1) {
     result = results[0];
+
+    if (typeof result.then === "function") {
+      throw new Error(
+        `You appear to be using an async parser plugin, ` +
+          `which your current version of Babel does not support. ` +
+          `If you're using a published plugin, ` +
+          `you may need to upgrade your @babel/core version.`,
+      );
+    }
   } else {
     throw new Error("More than one plugin attempted to override codegen.");
   }

--- a/packages/babel-core/src/transformation/index.js
+++ b/packages/babel-core/src/transformation/index.js
@@ -86,7 +86,18 @@ function transformFile(file: File, pluginPasses: PluginPasses): void {
 
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.pre;
-      if (fn) fn.call(pass, file);
+      if (fn) {
+        const result = fn.call(pass, file);
+
+        if (isThenable(result)) {
+          throw new Error(
+            `You appear to be using an plugin with an async .pre, ` +
+              `which your current version of Babel does not support.` +
+              `If you're using a published plugin, you may need to upgrade ` +
+              `your @babel/core version.`,
+          );
+        }
+      }
     }
 
     // merge all plugin visitors into a single visitor
@@ -99,7 +110,26 @@ function transformFile(file: File, pluginPasses: PluginPasses): void {
 
     for (const [plugin, pass] of passPairs) {
       const fn = plugin.post;
-      if (fn) fn.call(pass, file);
+      if (fn) {
+        const result = fn.call(pass, file);
+
+        if (isThenable(result)) {
+          throw new Error(
+            `You appear to be using an plugin with an async .post, ` +
+              `which your current version of Babel does not support.` +
+              `If you're using a published plugin, you may need to upgrade ` +
+              `your @babel/core version.`,
+          );
+        }
+      }
     }
   }
+}
+
+function isThenable(val: mixed): boolean {
+  return (
+    !!val &&
+    (typeof val === "object" || typeof val === "function") &&
+    typeof val.then === "function"
+  );
 }

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -76,6 +76,14 @@ function parser(pluginPasses, options, code) {
     if (results.length === 0) {
       return parse(code, options.parserOpts);
     } else if (results.length === 1) {
+      if (typeof results[0].then === "function") {
+        throw new Error(
+          `You appear to be using an async codegen plugin, ` +
+            `which your current version of Babel does not support. ` +
+            `If you're using a published plugin, you may need to upgrade ` +
+            `your @babel/core version.`,
+        );
+      }
       return results[0];
     }
     throw new Error("More than one plugin attempted to override parsing.");

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -28,6 +28,14 @@ export function _call(fns?: Array<Function>): boolean {
     if (!node) return true;
 
     const ret = fn.call(this.state, this, this.state);
+    if (ret && typeof ret === "object" && typeof ret.then === "function") {
+      throw new Error(
+        `You appear to be using an plugin with an async traversay visitors, ` +
+          `which your current version of Babel does not support.` +
+          `If you're using a published plugin, you may need to upgrade ` +
+          `your @babel/core version.`,
+      );
+    }
     if (ret) {
       throw new Error(`Unexpected return value from visitor method ${fn}`);
     }


### PR DESCRIPTION
This does nothing for current users. The intention with this is just a bit of future-proofing. I think at some point we'll want to add support for plugins that are async, either as a top-level promise-returning function like an `async function(){}`, or with async handler functions of like `pre`, `post`, `parserOverride`, or `generatorOverride`.

This PR does 2 things:

* Add clear error messages to each of those call sites, so if they do return a promise, the user will have at least some hint of what to do. That way if we allow this eventually in 7.x and someone writes a plugin using it, and then a user runs it on an older 7.x release, they'll get some kind of feedback.
* This adds an `api.async()` function that would allow a plugin to check if async logic is allowed in plugins. Where in the future it might return `true` if used via a Babel transform that allows async logic, like `transform("", () => {})`.

I'm imagining that in the future we might for instance have users doing
```
import asyncPlugin from "./async";
import syncPlugin from "./sync";
export default function(api, ...args) {
  return api.async() ? asyncPlugin(api, ...args) : syncPlugin(api, ...args);
}
```
which is certainly just a guess, but at least if we do go that route, plugins could rely on it being there in early 7.x versions too.