### PR TITLE
use pr instead of tag for changelog/prs [skip ci]

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,13 +4,13 @@
   "changelog": {
     "repo": "babel/babel",
     "labels": {
-      "Tag: Spec Compliancy": ":eyeglasses: Spec Compliancy",
-      "Tag: Breaking Change": ":boom: Breaking Change",
-      "Tag: New Feature": ":rocket: New Feature",
-      "Tag: Bug Fix": ":bug: Bug Fix",
-      "Tag: Polish": ":nail_care: Polish",
-      "Tag: Docs": ":memo: Documentation",
-      "Tag: Internal": ":house: Internal"
+      "PR: Spec Compliancy": ":eyeglasses: Spec Compliancy",
+      "PR: Breaking Change": ":boom: Breaking Change",
+      "PR: New Feature": ":rocket: New Feature",
+      "PR: Bug Fix": ":bug: Bug Fix",
+      "PR: Polish": ":nail_care: Polish",
+      "PR: Docs": ":memo: Documentation",
+      "PR: Internal": ":house: Internal"
     }
   },
   "cacheDir": ".changelog",


### PR DESCRIPTION
If we merge this, just need to rename the labels