### PR TITLE
Parse TS type parameters when JSX is enabled.

### DIFF
--- a/packages/babylon/src/plugins/jsx/index.js
+++ b/packages/babylon/src/plugins/jsx/index.js
@@ -69,8 +69,26 @@ function getQualifiedJSXName(
   throw new Error("Node had unexpected type: " + object.type);
 }
 
+function assert(x: boolean): void {
+  if (!x) {
+    throw new Error("Assert fail");
+  }
+}
+
 export default (superClass: Class<Parser>): Class<Parser> =>
   class extends superClass {
+    jsxTagStartToRelational() {
+      assert(this.match(tt.jsxTagStart));
+      this.state.type = tt.relational;
+      this.state.value = "<";
+
+      // Pop the context added by the jsxTagStart.
+      assert(this.curContext() === tc.j_oTag);
+      this.state.context.pop();
+      assert(this.curContext() === tc.j_expr);
+      this.state.context.pop();
+    }
+
     // Reads inline JSX contents token.
 
     jsxReadToken(): void {

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -64,6 +64,8 @@ function keywordTypeFromName(
 
 export default (superClass: Class<Parser>): Class<Parser> =>
   class extends superClass {
+    +jsxTagStartToRelational: () => void;
+
     tsIsIdentifier(): boolean {
       // TODO: actually a bit more complex in TypeScript, but shouldn't matter.
       // See https://github.com/Microsoft/TypeScript/issues/15008
@@ -270,8 +272,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.finishNode(node, "TSTypeParameter");
     }
 
+    tsIsStartOfTypeParameters(): boolean {
+      return this.isRelational("<") || this.match(tt.jsxTagStart);
+    }
+
     tsTryParseTypeParameters(): ?N.TsTypeParameterDeclaration {
-      if (this.isRelational("<")) {
+      if (this.tsIsStartOfTypeParameters()) {
         return this.tsParseTypeParameters();
       }
     }
@@ -279,7 +285,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     tsParseTypeParameters() {
       const node: N.TsTypeParameterDeclaration = this.startNode();
 
-      if (this.isRelational("<") || this.match(tt.jsxTagStart)) {
+      // In case the first token of the type has been parsed as a JSX tag
+      // start, we need to translate it.
+      if (this.match(tt.jsxTagStart)) {
+        this.jsxTagStartToRelational();
+      }
+
+      if (this.isRelational("<")) {
         this.next();
       } else {
         this.unexpected();
@@ -402,7 +414,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsParseTypeMember(): N.TsTypeElement {
-      if (this.match(tt.parenL) || this.isRelational("<")) {
+      if (this.match(tt.parenL) || this.tsIsStartOfTypeParameters()) {
         return this.tsParseSignatureMember("TSCallSignatureDeclaration");
       }
       if (
@@ -425,7 +437,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     tsIsStartOfConstructSignature() {
       this.next();
-      return this.match(tt.parenL) || this.isRelational("<");
+      return this.match(tt.parenL) || this.tsIsStartOfTypeParameters();
     }
 
     tsParseTypeLiteral(): N.TsTypeLiteral {
@@ -669,7 +681,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsIsStartOfFunctionType() {
-      if (this.isRelational("<")) {
+      if (this.tsIsStartOfTypeParameters()) {
         return true;
       }
       return (
@@ -1289,7 +1301,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return this.finishNode(nonNullExpression, "TSNonNullExpression");
       }
 
-      if (!noCalls && this.isRelational("<")) {
+      if (!noCalls && this.tsIsStartOfTypeParameters()) {
         if (this.atPossibleAsync(base)) {
           // Almost certainly this is a generic async function `async <T>() => ...
           // But it might be a call with a type argument `async<T>();`
@@ -1730,11 +1742,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           }
 
           this.state = state;
-          // Pop the context added by the jsxTagStart.
-          assert(this.curContext() === ct.j_oTag);
-          this.state.context.pop();
-          assert(this.curContext() === ct.j_expr);
-          this.state.context.pop();
+          this.jsxTagStartToRelational();
           jsxError = err;
         }
       }
@@ -1743,7 +1751,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return super.parseMaybeAssign(...args);
       }
 
-      // Either way, we're looking at a '<': tt.jsxTagStart or relational.
+      // ASSERT: this.isRelational("<")
 
       let arrowExpression;
       let typeParameters: N.TsTypeParameterDeclaration;
@@ -1899,7 +1907,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     // === === === === === === === === === === === === === === === ===
 
     isClassMethod(): boolean {
-      return this.isRelational("<") || super.isClassMethod();
+      return this.tsIsStartOfTypeParameters() || super.isClassMethod();
     }
 
     isClassProperty(): boolean {

--- a/packages/babylon/test/fixtures/typescript/tsx/type-arguments/actual.js
+++ b/packages/babylon/test/fixtures/typescript/tsx/type-arguments/actual.js
@@ -1,0 +1,3 @@
+f<T>();
+new C<T>();
+type A = T<T>;

--- a/packages/babylon/test/fixtures/typescript/tsx/type-arguments/expected.json
+++ b/packages/babylon/test/fixtures/typescript/tsx/type-arguments/expected.json
@@ -1,0 +1,341 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 14
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 14
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 7,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "expression": {
+          "type": "CallExpression",
+          "start": 0,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            }
+          },
+          "callee": {
+            "type": "Identifier",
+            "start": 0,
+            "end": 1,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 1
+              },
+              "identifierName": "f"
+            },
+            "name": "f"
+          },
+          "arguments": [],
+          "typeParameters": {
+            "type": "TSTypeParameterInstantiation",
+            "start": 1,
+            "end": 4,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            },
+            "params": [
+              {
+                "type": "TSTypeReference",
+                "start": 2,
+                "end": 3,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 3
+                  }
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "start": 2,
+                  "end": 3,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 3
+                    },
+                    "identifierName": "T"
+                  },
+                  "name": "T"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 8,
+        "end": 19,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 11
+          }
+        },
+        "expression": {
+          "type": "NewExpression",
+          "start": 8,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 10
+            }
+          },
+          "callee": {
+            "type": "Identifier",
+            "start": 12,
+            "end": 13,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              },
+              "identifierName": "C"
+            },
+            "name": "C"
+          },
+          "typeParameters": {
+            "type": "TSTypeParameterInstantiation",
+            "start": 13,
+            "end": 16,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 8
+              }
+            },
+            "params": [
+              {
+                "type": "TSTypeReference",
+                "start": 14,
+                "end": 15,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 7
+                  }
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "start": 14,
+                  "end": 15,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 6
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 7
+                    },
+                    "identifierName": "T"
+                  },
+                  "name": "T"
+                }
+              }
+            ]
+          },
+          "arguments": []
+        }
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start": 20,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 14
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 25,
+          "end": 26,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 5
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "typeAnnotation": {
+          "type": "TSTypeReference",
+          "start": 29,
+          "end": 33,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 13
+            }
+          },
+          "typeName": {
+            "type": "Identifier",
+            "start": 29,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 9
+              },
+              "end": {
+                "line": 3,
+                "column": 10
+              },
+              "identifierName": "T"
+            },
+            "name": "T"
+          },
+          "typeParameters": {
+            "type": "TSTypeParameterInstantiation",
+            "start": 30,
+            "end": 33,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 10
+              },
+              "end": {
+                "line": 3,
+                "column": 13
+              }
+            },
+            "params": [
+              {
+                "type": "TSTypeReference",
+                "start": 31,
+                "end": 32,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 12
+                  }
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "start": 31,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 12
+                    },
+                    "identifierName": "T"
+                  },
+                  "name": "T"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/typescript/tsx/type-parameters/actual.js
+++ b/packages/babylon/test/fixtures/typescript/tsx/type-parameters/actual.js
@@ -1,0 +1,18 @@
+type A<T> = {};
+type A = <T>() => {}
+
+var x: <T>() => {} = async <T>() => {};
+
+function f<T>(param: <T>() => {}): <T>() => {} {}
+class C<T> {
+  property: <T>() => {};
+  method<T>() {}
+}
+
+interface I<T> {
+  new <T>(): T,
+  <T>(): T,
+  [name: string]: <T>() => {}
+};
+
+x as <T>() => {};

--- a/packages/babylon/test/fixtures/typescript/tsx/type-parameters/expected.json
+++ b/packages/babylon/test/fixtures/typescript/tsx/type-parameters/expected.json
@@ -1,0 +1,1614 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 283,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 18,
+      "column": 17
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 283,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 17
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start": 0,
+        "end": 15,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 15
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TSTypeParameterDeclaration",
+          "start": 6,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            }
+          },
+          "params": [
+            {
+              "type": "TSTypeParameter",
+              "start": 7,
+              "end": 8,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 7
+                },
+                "end": {
+                  "line": 1,
+                  "column": 8
+                }
+              },
+              "name": "T"
+            }
+          ]
+        },
+        "typeAnnotation": {
+          "type": "TSTypeLiteral",
+          "start": 12,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "members": []
+        }
+      },
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start": 16,
+        "end": 36,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 20
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 21,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "typeAnnotation": {
+          "type": "TSFunctionType",
+          "start": 25,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 9
+            },
+            "end": {
+              "line": 2,
+              "column": 20
+            }
+          },
+          "typeParameters": {
+            "type": "TSTypeParameterDeclaration",
+            "start": 25,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            "params": [
+              {
+                "type": "TSTypeParameter",
+                "start": 26,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                },
+                "name": "T"
+              }
+            ]
+          },
+          "parameters": [],
+          "typeAnnotation": {
+            "type": "TSTypeAnnotation",
+            "start": 31,
+            "end": 36,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 15
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSTypeLiteral",
+              "start": 34,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 18
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "members": []
+            }
+          }
+        }
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 38,
+        "end": 77,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 39
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 42,
+            "end": 76,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 4
+              },
+              "end": {
+                "line": 4,
+                "column": 38
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 42,
+              "end": 56,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 4
+                },
+                "end": {
+                  "line": 4,
+                  "column": 18
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 43,
+                "end": 56,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSFunctionType",
+                  "start": 45,
+                  "end": 56,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 18
+                    }
+                  },
+                  "typeParameters": {
+                    "type": "TSTypeParameterDeclaration",
+                    "start": 45,
+                    "end": 48,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 10
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "TSTypeParameter",
+                        "start": 46,
+                        "end": 47,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 9
+                          }
+                        },
+                        "name": "T"
+                      }
+                    ]
+                  },
+                  "parameters": [],
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start": 51,
+                    "end": 56,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 18
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "TSTypeLiteral",
+                      "start": 54,
+                      "end": 56,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 18
+                        }
+                      },
+                      "members": []
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "ArrowFunctionExpression",
+              "start": 59,
+              "end": 76,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 21
+                },
+                "end": {
+                  "line": 4,
+                  "column": 38
+                }
+              },
+              "typeParameters": {
+                "type": "TSTypeParameterDeclaration",
+                "start": 65,
+                "end": 68,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 30
+                  }
+                },
+                "params": [
+                  {
+                    "type": "TSTypeParameter",
+                    "start": 66,
+                    "end": 67,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 28
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 29
+                      }
+                    },
+                    "name": "T"
+                  }
+                ]
+              },
+              "params": [],
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "async": true,
+              "body": {
+                "type": "BlockStatement",
+                "start": 74,
+                "end": 76,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 36
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 38
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          }
+        ],
+        "kind": "var"
+      },
+      {
+        "type": "FunctionDeclaration",
+        "start": 79,
+        "end": 128,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 49
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 88,
+          "end": 89,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 9
+            },
+            "end": {
+              "line": 6,
+              "column": 10
+            },
+            "identifierName": "f"
+          },
+          "name": "f"
+        },
+        "generator": false,
+        "expression": false,
+        "async": false,
+        "typeParameters": {
+          "type": "TSTypeParameterDeclaration",
+          "start": 89,
+          "end": 92,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 10
+            },
+            "end": {
+              "line": 6,
+              "column": 13
+            }
+          },
+          "params": [
+            {
+              "type": "TSTypeParameter",
+              "start": 90,
+              "end": 91,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 11
+                },
+                "end": {
+                  "line": 6,
+                  "column": 12
+                }
+              },
+              "name": "T"
+            }
+          ]
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "start": 93,
+            "end": 111,
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 14
+              },
+              "end": {
+                "line": 6,
+                "column": 32
+              },
+              "identifierName": "param"
+            },
+            "name": "param",
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 98,
+              "end": 111,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 19
+                },
+                "end": {
+                  "line": 6,
+                  "column": 32
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSFunctionType",
+                "start": 100,
+                "end": 111,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 32
+                  }
+                },
+                "typeParameters": {
+                  "type": "TSTypeParameterDeclaration",
+                  "start": 100,
+                  "end": 103,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 24
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TSTypeParameter",
+                      "start": 101,
+                      "end": 102,
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 22
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 23
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "parameters": [],
+                "typeAnnotation": {
+                  "type": "TSTypeAnnotation",
+                  "start": 106,
+                  "end": 111,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 32
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "TSTypeLiteral",
+                    "start": 109,
+                    "end": 111,
+                    "loc": {
+                      "start": {
+                        "line": 6,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 32
+                      }
+                    },
+                    "members": []
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "returnType": {
+          "type": "TSTypeAnnotation",
+          "start": 112,
+          "end": 125,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 33
+            },
+            "end": {
+              "line": 6,
+              "column": 46
+            }
+          },
+          "typeAnnotation": {
+            "type": "TSFunctionType",
+            "start": 114,
+            "end": 125,
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 35
+              },
+              "end": {
+                "line": 6,
+                "column": 46
+              }
+            },
+            "typeParameters": {
+              "type": "TSTypeParameterDeclaration",
+              "start": 114,
+              "end": 117,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 35
+                },
+                "end": {
+                  "line": 6,
+                  "column": 38
+                }
+              },
+              "params": [
+                {
+                  "type": "TSTypeParameter",
+                  "start": 115,
+                  "end": 116,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 36
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 37
+                    }
+                  },
+                  "name": "T"
+                }
+              ]
+            },
+            "parameters": [],
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 120,
+              "end": 125,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 41
+                },
+                "end": {
+                  "line": 6,
+                  "column": 46
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSTypeLiteral",
+                "start": 123,
+                "end": 125,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 44
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 46
+                  }
+                },
+                "members": []
+              }
+            }
+          }
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 126,
+          "end": 128,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 47
+            },
+            "end": {
+              "line": 6,
+              "column": 49
+            }
+          },
+          "body": [],
+          "directives": []
+        }
+      },
+      {
+        "type": "ClassDeclaration",
+        "start": 129,
+        "end": 185,
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 10,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 135,
+          "end": 136,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 6
+            },
+            "end": {
+              "line": 7,
+              "column": 7
+            },
+            "identifierName": "C"
+          },
+          "name": "C"
+        },
+        "typeParameters": {
+          "type": "TSTypeParameterDeclaration",
+          "start": 136,
+          "end": 139,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 7
+            },
+            "end": {
+              "line": 7,
+              "column": 10
+            }
+          },
+          "params": [
+            {
+              "type": "TSTypeParameter",
+              "start": 137,
+              "end": 138,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 8
+                },
+                "end": {
+                  "line": 7,
+                  "column": 9
+                }
+              },
+              "name": "T"
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 140,
+          "end": 185,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 11
+            },
+            "end": {
+              "line": 10,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 144,
+              "end": 166,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 2
+                },
+                "end": {
+                  "line": 8,
+                  "column": 24
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 144,
+                "end": 152,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 10
+                  },
+                  "identifierName": "property"
+                },
+                "name": "property"
+              },
+              "computed": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 152,
+                "end": 165,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 23
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSFunctionType",
+                  "start": 154,
+                  "end": 165,
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 23
+                    }
+                  },
+                  "typeParameters": {
+                    "type": "TSTypeParameterDeclaration",
+                    "start": 154,
+                    "end": 157,
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 15
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "TSTypeParameter",
+                        "start": 155,
+                        "end": 156,
+                        "loc": {
+                          "start": {
+                            "line": 8,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 8,
+                            "column": 14
+                          }
+                        },
+                        "name": "T"
+                      }
+                    ]
+                  },
+                  "parameters": [],
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start": 160,
+                    "end": 165,
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 18
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 23
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "TSTypeLiteral",
+                      "start": 163,
+                      "end": 165,
+                      "loc": {
+                        "start": {
+                          "line": 8,
+                          "column": 21
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 23
+                        }
+                      },
+                      "members": []
+                    }
+                  }
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassMethod",
+              "start": 169,
+              "end": 183,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 16
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 169,
+                "end": 175,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 8
+                  },
+                  "identifierName": "method"
+                },
+                "name": "method"
+              },
+              "computed": false,
+              "kind": "method",
+              "typeParameters": {
+                "type": "TSTypeParameterDeclaration",
+                "start": 175,
+                "end": 178,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 11
+                  }
+                },
+                "params": [
+                  {
+                    "type": "TSTypeParameter",
+                    "start": 176,
+                    "end": 177,
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 10
+                      }
+                    },
+                    "name": "T"
+                  }
+                ]
+              },
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 181,
+                "end": 183,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 16
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "TSInterfaceDeclaration",
+        "start": 187,
+        "end": 263,
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 0
+          },
+          "end": {
+            "line": 16,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 197,
+          "end": 198,
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 10
+            },
+            "end": {
+              "line": 12,
+              "column": 11
+            },
+            "identifierName": "I"
+          },
+          "name": "I"
+        },
+        "typeParameters": {
+          "type": "TSTypeParameterDeclaration",
+          "start": 198,
+          "end": 201,
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 11
+            },
+            "end": {
+              "line": 12,
+              "column": 14
+            }
+          },
+          "params": [
+            {
+              "type": "TSTypeParameter",
+              "start": 199,
+              "end": 200,
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 12
+                },
+                "end": {
+                  "line": 12,
+                  "column": 13
+                }
+              },
+              "name": "T"
+            }
+          ]
+        },
+        "body": {
+          "type": "TSInterfaceBody",
+          "start": 202,
+          "end": 263,
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 15
+            },
+            "end": {
+              "line": 16,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "TSConstructSignatureDeclaration",
+              "start": 206,
+              "end": 219,
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 2
+                },
+                "end": {
+                  "line": 13,
+                  "column": 15
+                }
+              },
+              "typeParameters": {
+                "type": "TSTypeParameterDeclaration",
+                "start": 210,
+                "end": 213,
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 9
+                  }
+                },
+                "params": [
+                  {
+                    "type": "TSTypeParameter",
+                    "start": 211,
+                    "end": 212,
+                    "loc": {
+                      "start": {
+                        "line": 13,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 13,
+                        "column": 8
+                      }
+                    },
+                    "name": "T"
+                  }
+                ]
+              },
+              "parameters": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 215,
+                "end": 218,
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 14
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "start": 217,
+                  "end": 218,
+                  "loc": {
+                    "start": {
+                      "line": 13,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 13,
+                      "column": 14
+                    }
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 217,
+                    "end": 218,
+                    "loc": {
+                      "start": {
+                        "line": 13,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 13,
+                        "column": 14
+                      },
+                      "identifierName": "T"
+                    },
+                    "name": "T"
+                  }
+                }
+              }
+            },
+            {
+              "type": "TSCallSignatureDeclaration",
+              "start": 222,
+              "end": 231,
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 2
+                },
+                "end": {
+                  "line": 14,
+                  "column": 11
+                }
+              },
+              "typeParameters": {
+                "type": "TSTypeParameterDeclaration",
+                "start": 222,
+                "end": 225,
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 5
+                  }
+                },
+                "params": [
+                  {
+                    "type": "TSTypeParameter",
+                    "start": 223,
+                    "end": 224,
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 4
+                      }
+                    },
+                    "name": "T"
+                  }
+                ]
+              },
+              "parameters": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 227,
+                "end": 230,
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 10
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "start": 229,
+                  "end": 230,
+                  "loc": {
+                    "start": {
+                      "line": 14,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 14,
+                      "column": 10
+                    }
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 229,
+                    "end": 230,
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 10
+                      },
+                      "identifierName": "T"
+                    },
+                    "name": "T"
+                  }
+                }
+              }
+            },
+            {
+              "type": "TSIndexSignature",
+              "start": 234,
+              "end": 261,
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 2
+                },
+                "end": {
+                  "line": 15,
+                  "column": 29
+                }
+              },
+              "parameters": [
+                {
+                  "type": "Identifier",
+                  "start": 235,
+                  "end": 239,
+                  "loc": {
+                    "start": {
+                      "line": 15,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 7
+                    },
+                    "identifierName": "name"
+                  },
+                  "name": "name",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start": 241,
+                    "end": 247,
+                    "loc": {
+                      "start": {
+                        "line": 15,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 15
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "TSStringKeyword",
+                      "start": 241,
+                      "end": 247,
+                      "loc": {
+                        "start": {
+                          "line": 15,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 15,
+                          "column": 15
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 248,
+                "end": 261,
+                "loc": {
+                  "start": {
+                    "line": 15,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 15,
+                    "column": 29
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSFunctionType",
+                  "start": 250,
+                  "end": 261,
+                  "loc": {
+                    "start": {
+                      "line": 15,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 29
+                    }
+                  },
+                  "typeParameters": {
+                    "type": "TSTypeParameterDeclaration",
+                    "start": 250,
+                    "end": 253,
+                    "loc": {
+                      "start": {
+                        "line": 15,
+                        "column": 18
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 21
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "TSTypeParameter",
+                        "start": 251,
+                        "end": 252,
+                        "loc": {
+                          "start": {
+                            "line": 15,
+                            "column": 19
+                          },
+                          "end": {
+                            "line": 15,
+                            "column": 20
+                          }
+                        },
+                        "name": "T"
+                      }
+                    ]
+                  },
+                  "parameters": [],
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "start": 256,
+                    "end": 261,
+                    "loc": {
+                      "start": {
+                        "line": 15,
+                        "column": 24
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 29
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "TSTypeLiteral",
+                      "start": 259,
+                      "end": 261,
+                      "loc": {
+                        "start": {
+                          "line": 15,
+                          "column": 27
+                        },
+                        "end": {
+                          "line": 15,
+                          "column": 29
+                        }
+                      },
+                      "members": []
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "EmptyStatement",
+        "start": 263,
+        "end": 264,
+        "loc": {
+          "start": {
+            "line": 16,
+            "column": 1
+          },
+          "end": {
+            "line": 16,
+            "column": 2
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 266,
+        "end": 283,
+        "loc": {
+          "start": {
+            "line": 18,
+            "column": 0
+          },
+          "end": {
+            "line": 18,
+            "column": 17
+          }
+        },
+        "expression": {
+          "type": "TSAsExpression",
+          "start": 266,
+          "end": 282,
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 0
+            },
+            "end": {
+              "line": 18,
+              "column": 16
+            }
+          },
+          "expression": {
+            "type": "Identifier",
+            "start": 266,
+            "end": 267,
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 0
+              },
+              "end": {
+                "line": 18,
+                "column": 1
+              },
+              "identifierName": "x"
+            },
+            "name": "x"
+          },
+          "typeAnnotation": {
+            "type": "TSFunctionType",
+            "start": 271,
+            "end": 282,
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 5
+              },
+              "end": {
+                "line": 18,
+                "column": 16
+              }
+            },
+            "typeParameters": {
+              "type": "TSTypeParameterDeclaration",
+              "start": 271,
+              "end": 274,
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 5
+                },
+                "end": {
+                  "line": 18,
+                  "column": 8
+                }
+              },
+              "params": [
+                {
+                  "type": "TSTypeParameter",
+                  "start": 272,
+                  "end": 273,
+                  "loc": {
+                    "start": {
+                      "line": 18,
+                      "column": 6
+                    },
+                    "end": {
+                      "line": 18,
+                      "column": 7
+                    }
+                  },
+                  "name": "T"
+                }
+              ]
+            },
+            "parameters": [],
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 277,
+              "end": 282,
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 11
+                },
+                "end": {
+                  "line": 18,
+                  "column": 16
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSTypeLiteral",
+                "start": 280,
+                "end": 282,
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 16
+                  }
+                },
+                "members": []
+              }
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6665 
| Patch: Bug Fix?          | :+1: 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This bug was caused by he JSX plugin, which tokenized "<" as a `jsxTagStart` even when it shouldn't.
I initially tried to fix this bug by setting `this.state.inType = true` before tokenizing `<`, but it is not always possible. For example, in `class C <T> {}` and `class C extends X {}` you don't know if you are parsing a type parameter or not until you tokenize `<` (but then it's too late for setting `this.state.inType`).