### PR TITLE
@babel/cli: removed babel-node mention in README.md [skip ci]

### DIFF
--- a/packages/babel-cli/README.md
+++ b/packages/babel-cli/README.md
@@ -4,7 +4,7 @@
 
 In addition, various entry point scripts live in the top-level package at `@babel/cli/bin`.
 
-There are some shell-executable utility scripts, `babel-external-helpers.js` and `babel-node.js`, and the main Babel cli script, `babel.js`.
+There are some shell-executable utility scripts, `babel-external-helpers.js`, and the main Babel cli script, `babel.js`.
 
 ## Install
 

--- a/packages/babel-cli/README.md
+++ b/packages/babel-cli/README.md
@@ -4,7 +4,7 @@
 
 In addition, various entry point scripts live in the top-level package at `@babel/cli/bin`.
 
-There are some shell-executable utility scripts, `babel-external-helpers.js`, and the main Babel cli script, `babel.js`.
+There is a shell-executable utility script, `babel-external-helpers.js`, and the main Babel cli script, `babel.js`.
 
 ## Install
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes @babel/cli's README.md
| Patch: Bug Fix?          |No
| Major: Breaking Change?  |No
| Minor: New Feature?      |No
| Tests Added + Pass?      | Yes
| Documentation PR         | Yes
| Any Dependency Changes?  |No
| License                  | MIT

As babel-node is no longer a part of @babel/cli, there's no reason to mention that in README.md.

<!-- Describe your changes below in as much detail as possible -->
