### PR TITLE
Expose `envName` as a top-level Babel option to avoid using environmental variables

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -49,6 +49,11 @@ commander.option(
   collect,
 );
 commander.option("--config-file [path]", "Path a to .babelrc file to use");
+commander.option(
+  "--env-name [name]",
+  "The name of the 'env' to use when loading configs and plugins. " +
+    "Defaults to the value of BABEL_ENV, or else NODE_ENV, or else 'development'.",
+);
 
 // Basic file input configuration.
 commander.option("--source-type [script|module]", "");

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -144,10 +144,11 @@ Following is a table of the options you can use:
 | `auxiliaryCommentAfter`  | `null`               | Attach a comment after all non-user injected code |
 | `auxiliaryCommentBefore` | `null`               | Attach a comment before all non-user injected code |
 | `babelrc`                | `true`               | Specify whether or not to use .babelrc and .babelignore files. Not available when using the CLI, [use `--no-babelrc` instead](https://babeljs.io/docs/usage/cli/#babel-ignoring-babelrc) |
+| `envName`                | env vars             | Defaults to environment variable `BABEL_ENV` if set, or else `NODE_ENV` if set, or else it defaults to `"development"` |
 | `code`                   | `true`               | Enable code generation |
 | `comments`               | `true`               | Output comments in generated output |
 | `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >500KB |
-| `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the environment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
+| `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the `envName` is `production` |
 | `extends`                | `null`               | A path to a `.babelrc` file to extend |
 | `filename`               | `"unknown"`          | Filename for use in errors etc |
 | `filenameRelative`       | `(filename)`         | Filename relative to `sourceRoot` |

--- a/packages/babel-core/src/config/caching.js
+++ b/packages/babel-core/src/config/caching.js
@@ -1,12 +1,13 @@
 // @flow
 
-type CacheConfigurator = CacheConfiguratorFn & CacheConfiguratorObj;
+type SimpleCacheConfigurator = SimpleCacheConfiguratorFn &
+  SimpleCacheConfiguratorObj;
 
-type CacheConfiguratorFn = {
+type SimpleCacheConfiguratorFn = {
   (boolean): void,
   <T>(handler: () => T): T,
 };
-type CacheConfiguratorObj = {
+type SimpleCacheConfiguratorObj = {
   forever: () => void,
   never: () => void,
   using: <T>(handler: () => T) => T,
@@ -56,165 +57,187 @@ function makeCachedFunction<ArgT, ResultT, Cache: CacheMap<ArgT, ResultT>>(
       }
     }
 
-    const { cache, result, deactivate } = makeCacheConfig();
+    const cache = new CacheConfigurator();
 
     const value = handler(arg, cache);
 
-    if (autoPermacache && !result.configured) cache.forever();
+    if (autoPermacache && !cache.configured()) cache.forever();
 
-    deactivate();
+    cache.deactivate();
 
-    if (!result.configured) {
-      // eslint-disable-next-line max-len
-      throw new Error(
-        [
-          "Caching was left unconfigured. Babel's plugins, presets, and .babelrc.js files can be configured",
-          "for various types of caching, using the first param of their handler functions:",
-          "",
-          "module.exports = function(api) {",
-          "  // The API exposes the following:",
-          "",
-          "  // Cache the returned value forever and don't call this function again.",
-          "  api.cache(true);",
-          "",
-          "  // Don't cache at all. Not recommended because it will be very slow.",
-          "  api.cache(false);",
-          "",
-          "  // Cached based on the value of some function. If this function returns a value different from",
-          "  // a previously-encountered value, the plugins will re-evaluate.",
-          "  var env = api.cache(() => process.env.NODE_ENV);",
-          "",
-          "  // If testing for a specific env, we recommend specifics to avoid instantiating a plugin for",
-          "  // any possible NODE_ENV value that might come up during plugin execution.",
-          '  var isProd = api.cache(() => process.env.NODE_ENV === "production");',
-          "",
-          "  // .cache(fn) will perform a linear search though instances to find the matching plugin based",
-          "  // based on previous instantiated plugins. If you want to recreate the plugin and discard the",
-          "  // previous instance whenever something changes, you may use:",
-          '  var isProd = api.cache.invalidate(() => process.env.NODE_ENV === "production");',
-          "",
-          "  // Note, we also expose the following more-verbose versions of the above examples:",
-          "  api.cache.forever(); // api.cache(true)",
-          "  api.cache.never();   // api.cache(false)",
-          "  api.cache.using(fn); // api.cache(fn)",
-          "",
-          "  // Return the value that will be cached.",
-          "  return { };",
-          "};",
-        ].join("\n"),
-      );
-    }
+    cache.assertConfigured();
 
-    if (!result.never) {
-      if (result.forever) {
+    switch (cache.mode()) {
+      case "forever":
         cachedValue = [[value, () => true]];
-      } else if (result.invalidate) {
-        cachedValue = [[value, result.valid]];
-      } else {
-        cachedValue = cachedValue || [];
-        cachedValue.push([value, result.valid]);
-      }
-      callCache.set(arg, cachedValue);
+        callCache.set(arg, cachedValue);
+        break;
+      case "invalidate":
+        cachedValue = [[value, cache.validator()]];
+        callCache.set(arg, cachedValue);
+        break;
+      case "valid":
+        if (cachedValue) {
+          cachedValue.push([value, cache.validator()]);
+        } else {
+          cachedValue = [[value, cache.validator()]];
+          callCache.set(arg, cachedValue);
+        }
     }
 
     return value;
   };
 }
 
-function makeCacheConfig(): {
+class CacheConfigurator {
+  _active: boolean = true;
+  _never: boolean = false;
+  _forever: boolean = false;
+  _invalidate: boolean = false;
+
+  _configured: boolean = false;
+
+  _pairs: Array<[mixed, () => mixed]> = [];
+
+  simple() {
+    return makeSimpleConfigurator(this);
+  }
+
+  mode() {
+    if (this._never) return "never";
+    if (this._forever) return "forever";
+    if (this._invalidate) return "invalidate";
+    return "valid";
+  }
+
+  forever() {
+    if (!this._active) {
+      throw new Error("Cannot change caching after evaluation has completed.");
+    }
+    if (this._never) {
+      throw new Error("Caching has already been configured with .never()");
+    }
+    this._forever = true;
+    this._configured = true;
+  }
+
+  never() {
+    if (!this._active) {
+      throw new Error("Cannot change caching after evaluation has completed.");
+    }
+    if (this._forever) {
+      throw new Error("Caching has already been configured with .forever()");
+    }
+    this._never = true;
+    this._configured = true;
+  }
+
+  using<T>(handler: () => T): T {
+    if (!this._active) {
+      throw new Error("Cannot change caching after evaluation has completed.");
+    }
+    if (this._never || this._forever) {
+      throw new Error(
+        "Caching has already been configured with .never or .forever()",
+      );
+    }
+    this._configured = true;
+
+    const key = handler();
+    this._pairs.push([key, handler]);
+    return key;
+  }
+
+  invalidate<T>(handler: () => T): T {
+    if (!this._active) {
+      throw new Error("Cannot change caching after evaluation has completed.");
+    }
+    if (this._never || this._forever) {
+      throw new Error(
+        "Caching has already been configured with .never or .forever()",
+      );
+    }
+    this._invalidate = true;
+    this._configured = true;
+
+    const key = handler();
+    this._pairs.push([key, handler]);
+    return key;
+  }
+
+  validator(): () => boolean {
+    const pairs = this._pairs;
+    return () => pairs.every(([key, fn]) => key === fn());
+  }
+
+  deactivate() {
+    this._active = false;
+  }
+
+  configured() {
+    return this._configured;
+  }
+
+  assertConfigured() {
+    if (this.configured()) return;
+
+    // eslint-disable-next-line max-len
+    throw new Error(
+      [
+        "Caching was left unconfigured. Babel's plugins, presets, and .babelrc.js files can be configured",
+        "for various types of caching, using the first param of their handler functions:",
+        "",
+        "module.exports = function(api) {",
+        "  // The API exposes the following:",
+        "",
+        "  // Cache the returned value forever and don't call this function again.",
+        "  api.cache(true);",
+        "",
+        "  // Don't cache at all. Not recommended because it will be very slow.",
+        "  api.cache(false);",
+        "",
+        "  // Cached based on the value of some function. If this function returns a value different from",
+        "  // a previously-encountered value, the plugins will re-evaluate.",
+        "  var env = api.cache(() => process.env.NODE_ENV);",
+        "",
+        "  // If testing for a specific env, we recommend specifics to avoid instantiating a plugin for",
+        "  // any possible NODE_ENV value that might come up during plugin execution.",
+        '  var isProd = api.cache(() => process.env.NODE_ENV === "production");',
+        "",
+        "  // .cache(fn) will perform a linear search though instances to find the matching plugin based",
+        "  // based on previous instantiated plugins. If you want to recreate the plugin and discard the",
+        "  // previous instance whenever something changes, you may use:",
+        '  var isProd = api.cache.invalidate(() => process.env.NODE_ENV === "production");',
+        "",
+        "  // Note, we also expose the following more-verbose versions of the above examples:",
+        "  api.cache.forever(); // api.cache(true)",
+        "  api.cache.never();   // api.cache(false)",
+        "  api.cache.using(fn); // api.cache(fn)",
+        "",
+        "  // Return the value that will be cached.",
+        "  return { };",
+        "};",
+      ].join("\n"),
+    );
+  }
+}
+
+function makeSimpleConfigurator(
   cache: CacheConfigurator,
-  result: *,
-  deactivate: () => void,
-} {
-  const pairs = [];
+): SimpleCacheConfigurator {
+  function cacheFn(val) {
+    if (typeof val === "boolean") {
+      if (val) cache.forever();
+      else cache.never();
+      return;
+    }
 
-  const result = {
-    configured: false,
-    never: false,
-    forever: false,
-    invalidate: false,
-    valid: () => pairs.every(([key, fn]) => key === fn()),
-  };
+    return cache.using(val);
+  }
+  cacheFn.forever = () => cache.forever();
+  cacheFn.never = () => cache.never();
+  cacheFn.using = cb => cache.using(cb);
+  cacheFn.invalidate = cb => cache.invalidate(cb);
 
-  let active = true;
-  const deactivate = () => {
-    active = false;
-  };
-
-  const cache: CacheConfigurator = Object.assign(
-    (function cacheFn(val) {
-      if (typeof val === "boolean") {
-        if (val) cache.forever();
-        else cache.never();
-        return;
-      }
-
-      return cache.using(val);
-    }: any),
-    ({
-      forever() {
-        if (!active) {
-          throw new Error(
-            "Cannot change caching after evaluation has completed.",
-          );
-        }
-        if (result.never) {
-          throw new Error("Caching has already been configured with .never()");
-        }
-        result.forever = true;
-        result.configured = true;
-      },
-      never() {
-        if (!active) {
-          throw new Error(
-            "Cannot change caching after evaluation has completed.",
-          );
-        }
-        if (result.forever) {
-          throw new Error(
-            "Caching has already been configured with .forever()",
-          );
-        }
-        result.never = true;
-        result.configured = true;
-      },
-      using<T>(handler: () => T): T {
-        if (!active) {
-          throw new Error(
-            "Cannot change caching after evaluation has completed.",
-          );
-        }
-        if (result.never || result.forever) {
-          throw new Error(
-            "Caching has already been configured with .never or .forever()",
-          );
-        }
-        result.configured = true;
-
-        const key = handler();
-        pairs.push([key, handler]);
-        return key;
-      },
-      invalidate<T>(handler: () => T): T {
-        if (!active) {
-          throw new Error(
-            "Cannot change caching after evaluation has completed.",
-          );
-        }
-        if (result.never || result.forever) {
-          throw new Error(
-            "Caching has already been configured with .never or .forever()",
-          );
-        }
-        result.invalidate = true;
-        result.configured = true;
-
-        const key = handler();
-        pairs.push([key, handler]);
-        return key;
-      },
-    }: CacheConfiguratorObj),
-  );
-
-  return { cache, result, deactivate };
+  return (cacheFn: any);
 }

--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -144,8 +144,8 @@ const readConfigJS = makeStrongCache((filepath, cache) => {
       env: () => cache.using(() => getEnv()),
       async: () => false,
     });
-  } else {
-    cache.forever();
+
+    if (!cache.configured()) throwConfigError();
   }
 
   if (!options || typeof options !== "object" || Array.isArray(options)) {
@@ -169,7 +169,7 @@ const readConfigJS = makeStrongCache((filepath, cache) => {
     dirname: path.dirname(filepath),
     options,
   };
-}, false /* autoPermacache */);
+});
 
 const readConfigFile = makeStaticFileCache((filepath, content) => {
   let options;
@@ -238,4 +238,41 @@ function fileMtime(filepath: string): number | null {
   }
 
   return null;
+}
+
+function throwConfigError() {
+  throw new Error(`\
+Caching was left unconfigured. Babel's plugins, presets, and .babelrc.js files can be configured
+for various types of caching, using the first param of their handler functions:
+
+module.exports = function(api) {
+  // The API exposes the following:
+
+  // Cache the returned value forever and don't call this function again.
+  api.cache(true);
+
+  // Don't cache at all. Not recommended because it will be very slow.
+  api.cache(false);
+
+  // Cached based on the value of some function. If this function returns a value different from
+  // a previously-encountered value, the plugins will re-evaluate.
+  var env = api.cache(() => process.env.NODE_ENV);
+
+  // If testing for a specific env, we recommend specifics to avoid instantiating a plugin for
+  // any possible NODE_ENV value that might come up during plugin execution.
+  var isProd = api.cache(() => process.env.NODE_ENV === "production");
+
+  // .cache(fn) will perform a linear search though instances to find the matching plugin based
+  // based on previous instantiated plugins. If you want to recreate the plugin and discard the
+  // previous instance whenever something changes, you may use:
+  var isProd = api.cache.invalidate(() => process.env.NODE_ENV === "production");
+
+  // Note, we also expose the following more-verbose versions of the above examples:
+  api.cache.forever(); // api.cache(true)
+  api.cache.never();   // api.cache(false)
+  api.cache.using(fn); // api.cache(fn)
+
+  // Return the value that will be cached.
+  return { };
+};`);
 }

--- a/packages/babel-core/src/config/loading/files/configuration.js
+++ b/packages/babel-core/src/config/loading/files/configuration.js
@@ -139,7 +139,7 @@ const readConfigJS = makeStrongCache((filepath, cache) => {
 
   if (typeof options === "function") {
     options = options({
-      cache,
+      cache: cache.simple(),
       // Expose ".env()" so people can easily get the same env that we expose using the "env" key.
       env: () => cache.using(() => getEnv()),
       async: () => false,

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -6,7 +6,7 @@ import merge from "lodash/merge";
 import buildConfigChain, { type ConfigItem } from "./build-config-chain";
 import traverse from "@babel/traverse";
 import clone from "lodash/clone";
-import { makeWeakCache } from "./caching";
+import { makeWeakCache, type CacheConfigurator } from "./caching";
 import { getEnv } from "./helpers/environment";
 import { validate, type ValidatedOptions, type PluginItem } from "./options";
 
@@ -46,14 +46,14 @@ class OptionManager {
    *  - `dirname` is used to resolve plugins relative to it.
    */
 
-  mergeOptions(config: MergeOptions, pass?: Array<Plugin>) {
+  mergeOptions(config: MergeOptions, pass?: Array<Plugin>, envName: string) {
     const result = loadConfig(config);
 
     const plugins = result.plugins.map(descriptor =>
-      loadPluginDescriptor(descriptor),
+      loadPluginDescriptor(descriptor, envName),
     );
     const presets = result.presets.map(descriptor =>
-      loadPresetDescriptor(descriptor),
+      loadPresetDescriptor(descriptor, envName),
     );
 
     const passPerPreset = config.options.passPerPreset;
@@ -70,7 +70,11 @@ class OptionManager {
       }
 
       presets.forEach((presetConfig, i) => {
-        this.mergeOptions(presetConfig, presetPasses ? presetPasses[i] : pass);
+        this.mergeOptions(
+          presetConfig,
+          presetPasses ? presetPasses[i] : pass,
+          envName,
+        );
       });
     }
 
@@ -99,12 +103,14 @@ class OptionManager {
   init(inputOpts: {}) {
     const args = validate("arguments", inputOpts);
 
-    const configChain = buildConfigChain(args);
+    const envName = getEnv();
+
+    const configChain = buildConfigChain(args, envName);
     if (!configChain) return null;
 
     try {
       for (const config of configChain) {
-        this.mergeOptions(config);
+        this.mergeOptions(config, undefined, envName);
       }
     } catch (e) {
       // There are a few case where thrown errors will try to annotate themselves multiple times, so
@@ -182,13 +188,13 @@ const loadConfig = makeWeakCache((config: MergeOptions): {
 const loadDescriptor = makeWeakCache(
   (
     { value, options = {}, dirname, alias }: BasicDescriptor,
-    cache,
+    cache: CacheConfigurator<{ envName: string }>,
   ): LoadedDescriptor => {
     let item = value;
     if (typeof value === "function") {
       const api = Object.assign(Object.create(context), {
         cache: cache.simple(),
-        env: () => cache.using(() => getEnv()),
+        env: () => cache.using(data => data.envName),
         async: () => false,
       });
 
@@ -222,7 +228,10 @@ const loadDescriptor = makeWeakCache(
 /**
  * Instantiate a plugin for the given descriptor, returning the plugin/options pair.
  */
-function loadPluginDescriptor(descriptor: BasicDescriptor): Plugin {
+function loadPluginDescriptor(
+  descriptor: BasicDescriptor,
+  envName: string,
+): Plugin {
   if (descriptor.value instanceof Plugin) {
     if (descriptor.options) {
       throw new Error(
@@ -233,11 +242,16 @@ function loadPluginDescriptor(descriptor: BasicDescriptor): Plugin {
     return descriptor.value;
   }
 
-  return instantiatePlugin(loadDescriptor(descriptor));
+  return instantiatePlugin(loadDescriptor(descriptor, { envName }), {
+    envName,
+  });
 }
 
 const instantiatePlugin = makeWeakCache(
-  ({ value, options, dirname, alias }: LoadedDescriptor, cache): Plugin => {
+  (
+    { value, options, dirname, alias }: LoadedDescriptor,
+    cache: CacheConfigurator<{ envName: string }>,
+  ): Plugin => {
     const pluginObj = validatePluginObject(value);
 
     const plugin = Object.assign({}, pluginObj);
@@ -254,8 +268,8 @@ const instantiatePlugin = makeWeakCache(
       };
 
       // If the inherited plugin changes, reinstantiate this plugin.
-      const inherits = cache.invalidate(() =>
-        loadPluginDescriptor(inheritsDescriptor),
+      const inherits = cache.invalidate(data =>
+        loadPluginDescriptor(inheritsDescriptor, data.envName),
       );
 
       plugin.pre = chain(inherits.pre, plugin.pre);
@@ -277,8 +291,11 @@ const instantiatePlugin = makeWeakCache(
 /**
  * Generate a config object that will act as the root of a new nested config.
  */
-const loadPresetDescriptor = (descriptor: BasicDescriptor): MergeOptions => {
-  return instantiatePreset(loadDescriptor(descriptor));
+const loadPresetDescriptor = (
+  descriptor: BasicDescriptor,
+  envName: string,
+): MergeOptions => {
+  return instantiatePreset(loadDescriptor(descriptor, { envName }));
 };
 
 const instantiatePreset = makeWeakCache(

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -187,7 +187,7 @@ const loadDescriptor = makeWeakCache(
     let item = value;
     if (typeof value === "function") {
       const api = Object.assign(Object.create(context), {
-        cache,
+        cache: cache.simple(),
         env: () => cache.using(() => getEnv()),
         async: () => false,
       });

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -103,7 +103,7 @@ class OptionManager {
   init(inputOpts: {}) {
     const args = validate("arguments", inputOpts);
 
-    const envName = getEnv();
+    const { envName = getEnv() } = args;
 
     const configChain = buildConfigChain(args, envName);
     if (!configChain) return null;
@@ -133,6 +133,7 @@ class OptionManager {
       .filter(plugins => plugins.length > 0)
       .map(plugins => ({ plugins }));
     opts.passPerPreset = opts.presets.length > 0;
+    opts.envName = envName;
 
     return {
       options: opts,

--- a/packages/babel-core/src/config/options.js
+++ b/packages/babel-core/src/config/options.js
@@ -28,6 +28,10 @@ const ROOT_VALIDATORS: ValidatorSet = {
   >),
   code: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "code">>),
   ast: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "ast">>),
+
+  envName: (assertString: Validator<
+    $PropertyType<ValidatedOptions, "envName">,
+  >),
 };
 
 const NONPRESET_VALIDATORS: ValidatorSet = {
@@ -130,6 +134,7 @@ export type ValidatedOptions = {
   code?: boolean,
   ast?: boolean,
   inputSourceMap?: RootInputSourceMapOption,
+  envName?: string,
 
   extends?: string,
   env?: EnvSet<ValidatedOptions>,

--- a/packages/babel-core/test/caching-api.js
+++ b/packages/babel-core/test/caching-api.js
@@ -19,47 +19,11 @@ describe("caching API", () => {
     assert.notEqual(fn("one"), fn("two"));
   });
 
-  it("should allow permacaching with cache(true)", () => {
-    let count = 0;
-
-    const fn = makeStrongCache((arg, cache) => {
-      cache(true);
-      return { arg, count: count++ };
-    });
-
-    assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-    assert.equal(fn("one"), fn("one"));
-
-    assert.deepEqual(fn("two"), { arg: "two", count: 1 });
-    assert.equal(fn("two"), fn("two"));
-
-    assert.notEqual(fn("one"), fn("two"));
-  });
-
   it("should allow disabling caching with .never()", () => {
     let count = 0;
 
     const fn = makeStrongCache((arg, cache) => {
       cache.never();
-      return { arg, count: count++ };
-    });
-
-    assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-    assert.deepEqual(fn("one"), { arg: "one", count: 1 });
-    assert.notEqual(fn("one"), fn("one"));
-
-    assert.deepEqual(fn("two"), { arg: "two", count: 4 });
-    assert.deepEqual(fn("two"), { arg: "two", count: 5 });
-    assert.notEqual(fn("two"), fn("two"));
-
-    assert.notEqual(fn("one"), fn("two"));
-  });
-
-  it("should allow disabling caching with cache(false)", () => {
-    let count = 0;
-
-    const fn = makeStrongCache((arg, cache) => {
-      cache(false);
       return { arg, count: count++ };
     });
 
@@ -80,47 +44,6 @@ describe("caching API", () => {
 
     const fn = makeStrongCache((arg, cache) => {
       const val = cache.using(() => other);
-
-      return { arg, val, count: count++ };
-    });
-
-    assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-    assert.equal(fn("one"), fn("one"));
-
-    assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-    assert.equal(fn("two"), fn("two"));
-
-    other = "new";
-
-    assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-    assert.equal(fn("one"), fn("one"));
-
-    assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-    assert.equal(fn("two"), fn("two"));
-
-    other = "default";
-
-    assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-    assert.equal(fn("one"), fn("one"));
-
-    assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-    assert.equal(fn("two"), fn("two"));
-
-    other = "new";
-
-    assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-    assert.equal(fn("one"), fn("one"));
-
-    assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-    assert.equal(fn("two"), fn("two"));
-  });
-
-  it("should allow caching based on a value with cache(fn)", () => {
-    let count = 0;
-    let other = "default";
-
-    const fn = makeStrongCache((arg, cache) => {
-      const val = cache(() => other);
 
       return { arg, val, count: count++ };
     });
@@ -409,5 +332,90 @@ describe("caching API", () => {
       () => fn().invalidate(() => null),
       /Cannot change caching after evaluation/,
     );
+  });
+
+  describe("simple", () => {
+    it("should allow permacaching with cache(true)", () => {
+      let count = 0;
+
+      const fn = makeStrongCache((arg, cache) => {
+        cache = cache.simple();
+
+        cache(true);
+        return { arg, count: count++ };
+      });
+
+      assert.deepEqual(fn("one"), { arg: "one", count: 0 });
+      assert.equal(fn("one"), fn("one"));
+
+      assert.deepEqual(fn("two"), { arg: "two", count: 1 });
+      assert.equal(fn("two"), fn("two"));
+
+      assert.notEqual(fn("one"), fn("two"));
+    });
+
+    it("should allow disabling caching with cache(false)", () => {
+      let count = 0;
+
+      const fn = makeStrongCache((arg, cache) => {
+        cache = cache.simple();
+
+        cache(false);
+        return { arg, count: count++ };
+      });
+
+      assert.deepEqual(fn("one"), { arg: "one", count: 0 });
+      assert.deepEqual(fn("one"), { arg: "one", count: 1 });
+      assert.notEqual(fn("one"), fn("one"));
+
+      assert.deepEqual(fn("two"), { arg: "two", count: 4 });
+      assert.deepEqual(fn("two"), { arg: "two", count: 5 });
+      assert.notEqual(fn("two"), fn("two"));
+
+      assert.notEqual(fn("one"), fn("two"));
+    });
+
+    it("should allow caching based on a value with cache(fn)", () => {
+      let count = 0;
+      let other = "default";
+
+      const fn = makeStrongCache((arg, cache) => {
+        cache = cache.simple();
+
+        const val = cache(() => other);
+
+        return { arg, val, count: count++ };
+      });
+
+      assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
+      assert.equal(fn("one"), fn("one"));
+
+      assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
+      assert.equal(fn("two"), fn("two"));
+
+      other = "new";
+
+      assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
+      assert.equal(fn("one"), fn("one"));
+
+      assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
+      assert.equal(fn("two"), fn("two"));
+
+      other = "default";
+
+      assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
+      assert.equal(fn("one"), fn("one"));
+
+      assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
+      assert.equal(fn("two"), fn("two"));
+
+      other = "new";
+
+      assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
+      assert.equal(fn("one"), fn("one"));
+
+      assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
+      assert.equal(fn("two"), fn("two"));
+    });
   });
 });

--- a/packages/babel-core/test/caching-api.js
+++ b/packages/babel-core/test/caching-api.js
@@ -221,12 +221,6 @@ describe("caching API", () => {
     assert.equal(fn("two"), fn("two"));
   });
 
-  it("should throw if caching is never configured and not defaulting", () => {
-    const fn = makeStrongCache(() => {}, false /* autoPermacache */);
-
-    assert.throws(() => fn(), /Error: Caching was left unconfigured./);
-  });
-
   it("should auto-permacache by default", () => {
     let count = 0;
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Been wanting to do this for a while anyway, but figured this was something we should do. Given that https://github.com/babel/babel/pull/6780 now allows for the potential that config loading won't run synchronously when Babel is executed, it wouldn't necessarily be safe for users to do explicitly assign `process.env.BABEL_ENV` because now in theory two separate Babel transforms could have been started in parallel. We do this in our own codebases with `babel-loader`'s `forceEnv` option.

Centralizing the `getEnv` call to the top level of config loading also ensures that in the future if we make thing more async, we won't run into cases where two plugins in the same loading pass get two different values for the `env`.

This code got complicated because of the way we do caching, sorry about that. I think the way the code ended up is pretty readable though 😬 .

The quick summary of why it got complicated is that `envName` is almost like a separate flag that works alongside the cache. I didn't want to have to have a separate instance of every single plugin for every single `envName`, and that is all the existing caching API allowed. Ideally only the plugins that actually _query_ the envName should get new instantiations, so that is what this code allows.