### PR TITLE
Add missing generator argument and remove nonexistent one.

### DIFF
--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -41,9 +41,9 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
         auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
         retainLines: opts.retainLines,
         comments,
+        shouldPrintComment: opts.shouldPrintComment,
         compact,
         minified: opts.minified,
-        concise: opts.concise,
 
         // Source-map generation flags.
         sourceMaps,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6841
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Accidentally introduced a regression in https://github.com/babel/babel/pull/6777. Forgot to pass-through this option, and somehow passed through `concise`, which is a `babel-generator` option, but is not exposed directly via Babel's options.