### PR TITLE
 Copy getters and setters correctly in interopWildcard

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -450,7 +450,9 @@ helpers.interopRequireWildcard = defineHelper(`
       if (obj != null) {
         for (var key in obj) {
           if (Object.prototype.hasOwnProperty.call(obj, key)) {
-            var desc = Object.getOwnPropertyDescriptor(obj, key);
+            var desc = Object.defineProperty && Object.getOwnPropertyDescriptor
+              ? Object.getOwnPropertyDescriptor(obj, key)
+              : {};
             if (desc.get || desc.set) {
               Object.defineProperty(newObj, key, desc);
             } else {

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -449,7 +449,14 @@ helpers.interopRequireWildcard = defineHelper(`
       var newObj = {};
       if (obj != null) {
         for (var key in obj) {
-          if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key];
+          if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = Object.getOwnPropertyDescriptor(obj, key);
+            if (desc.get || desc.set) {
+              Object.defineProperty(newObj, key, desc);
+            } else {
+              newObj[key] = obj[key];
+            }
+          }
         }
       }
       newObj.default = obj;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/actual.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/actual.js
@@ -1,0 +1,3 @@
+import * as foo from "./moduleWithGetter";
+
+export { foo };

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/exec.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/exec.js
@@ -1,0 +1,5 @@
+import * as foo from "./moduleWithGetter";
+
+assert.throws(() => foo.boo);
+
+// No exception should be thrown

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/expected.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/expected.js
@@ -9,4 +9,4 @@ var foo = _interopRequireWildcard(require("./moduleWithGetter"));
 
 exports.foo = foo;
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.getOwnPropertyDescriptor(obj, key); if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/expected.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/expected.js
@@ -1,0 +1,12 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.foo = void 0;
+
+var foo = _interopRequireWildcard(require("./moduleWithGetter"));
+
+exports.foo = foo;
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.getOwnPropertyDescriptor(obj, key); if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/moduleWithGetter.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters-star/moduleWithGetter.js
@@ -1,0 +1,6 @@
+var Obj = {
+  baz: 123,
+  get boo() { throw new Error('Should never be triggered'); }
+}
+
+module.exports = Obj;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/actual.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/actual.js
@@ -1,0 +1,3 @@
+import Foo, { baz } from "./moduleWithGetter";
+
+export { Foo, baz };

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.js
@@ -1,3 +1,3 @@
 import Foo, { baz } from "./moduleWithGetter";
 
-// Should not execute the getter in the imported module which would throw
+// No exception should be thrown

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/exec.js
@@ -1,0 +1,3 @@
+import Foo, { baz } from "./moduleWithGetter";
+
+// Should not execute the getter in the imported module which would throw

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/expected.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/expected.js
@@ -18,4 +18,4 @@ Object.defineProperty(exports, "baz", {
 
 var _moduleWithGetter = _interopRequireWildcard(require("./moduleWithGetter"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.getOwnPropertyDescriptor(obj, key); if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/expected.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/expected.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(exports, "Foo", {
+  enumerable: true,
+  get: function () {
+    return _moduleWithGetter.default;
+  }
+});
+Object.defineProperty(exports, "baz", {
+  enumerable: true,
+  get: function () {
+    return _moduleWithGetter.baz;
+  }
+});
+
+var _moduleWithGetter = _interopRequireWildcard(require("./moduleWithGetter"));
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.getOwnPropertyDescriptor(obj, key); if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/moduleWithGetter.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/copy-getters-setters/moduleWithGetter.js
@@ -1,0 +1,6 @@
+var Obj = {
+  baz: 123,
+  get boo() { throw new Error('Should never be triggered'); }
+}
+
+module.exports = Obj;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/expected.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/expected.js
@@ -6,7 +6,7 @@ var Bar = _interopRequireWildcard(require("bar"));
 
 var _baz = require("baz");
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.getOwnPropertyDescriptor(obj, key); if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/expected.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/expected.js
@@ -6,7 +6,7 @@ var Bar = _interopRequireWildcard(require("bar"));
 
 var _baz = require("baz");
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.getOwnPropertyDescriptor(obj, key); if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #4290 Fixes #5790
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n?
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

This ensures that getters and setters are copied correctly in the `interopRequireWildcard` helper.