### PR TITLE
Fix validation of WithStatement and enable flow in definitions

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -1,5 +1,4 @@
-/* eslint max-len: "off" */
-
+// @flow
 import * as t from "../index";
 
 import {
@@ -848,7 +847,7 @@ defineType("WithStatement", {
   aliases: ["Statement"],
   fields: {
     object: {
-      object: assertNodeType("Expression"),
+      validate: assertNodeType("Expression"),
     },
     body: {
       validate: assertNodeType("BlockStatement", "Statement"),

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -1,5 +1,4 @@
-/* eslint max-len: "off" */
-
+// @flow
 import defineType, {
   assertNodeType,
   assertValueType,
@@ -396,7 +395,7 @@ export const classMethodOrPropertyCommon = {
       );
       const computed = assertNodeType("Expression");
 
-      return function(node, key, val) {
+      return function(node: Object, key: string, val: any) {
         const validator = node.computed ? computed : normal;
         validator(node, key, val);
       };

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -1,3 +1,4 @@
+// @flow
 import defineType, {
   assertEach,
   assertNodeType,

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -1,3 +1,4 @@
+// @flow
 import defineType, {
   assertEach,
   assertNodeType,

--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -1,3 +1,4 @@
+// @flow
 import defineType, {
   assertNodeType,
   assertValueType,

--- a/packages/babel-types/src/definitions/misc.js
+++ b/packages/babel-types/src/definitions/misc.js
@@ -1,3 +1,4 @@
+// @flow
 import defineType, { assertNodeType } from "./index";
 
 defineType("Noop", {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

This enables flow in the babel-type definitions and makes the types of defineType more strict.
This revealed an invalid definition of `WithStatement` which wasn't validated till now.
