### PR TITLE
Make SpreadProperty and RestProperty a deprecatedAlias

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -662,6 +662,7 @@ defineType("RestElement", {
   visitor: ["argument", "typeAnnotation"],
   builder: ["argument"],
   aliases: ["LVal", "PatternLike"],
+  deprecatedAlias: "RestProperty",
   fields: {
     ...patternLikeCommon,
     argument: {

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -467,6 +467,7 @@ defineType("ObjectPattern", {
 defineType("SpreadElement", {
   visitor: ["argument"],
   aliases: ["UnaryLike"],
+  deprecatedAlias: "SpreadProperty",
   fields: {
     argument: {
       validate: assertNodeType("Expression"),

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -77,14 +77,6 @@ for (const type in t.VISITOR_KEYS) {
   registerType(type);
 }
 
-// Compat helpers so code for Babel 6.x is more likely to work on Babel 7.x.
-export function isRestProperty(...args) {
-  return t.isRestElement(...args);
-}
-export function isSpreadProperty(...args) {
-  return t.isSpreadElement(...args);
-}
-
 /**
  * Flip `ALIAS_KEYS` for faster access in the reverse direction.
  */


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |
| License                  | MIT


Make `SpreadProperty` and `RestProperty` a `deprecatedAlias` instead of hardcoding backwards compatibility.
This way we get deprecation warnings and also builders + assert will be generated.

related: #5727
