### PR TITLE
Implement TDZ for ClassFieldDefinitionEvaluation

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -633,12 +633,6 @@ helpers.readOnlyError = defineHelper(`
   }
 `);
 
-helpers.readOnlyError = defineHelper(`
-  export default function _readOnlyError(name) {
-    throw new Error("\\"" + name + "\\" is read-only");
-  }
-`);
-
 helpers.classNameTDZError = defineHelper(`
   export default function _classNameTDZError(name) {
     throw new Error("Class \\"" + name + "\\" cannot be referenced in computed property keys.");

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -633,6 +633,12 @@ helpers.readOnlyError = defineHelper(`
   }
 `);
 
+helpers.readOnlyError = defineHelper(`
+  export default function _readOnlyError(name) {
+    throw new Error("\\"" + name + "\\" is read-only");
+  }
+`);
+
 helpers.classNameTDZError = defineHelper(`
   export default function _classNameTDZError(name) {
     throw new Error("Class \\"" + name + "\\" cannot be referenced in computed property keys.");

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -633,6 +633,12 @@ helpers.readOnlyError = defineHelper(`
   }
 `);
 
+helpers.classNameTDZError = defineHelper(`
+  export default function _classNameTDZError(name) {
+    throw new Error("Class \\"" + name + "\\" cannot be referenced in computed property keys.");
+  }
+`);
+
 helpers.temporalUndefined = defineHelper(`
   export default {};
 `);

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -25,6 +25,26 @@ export default function(api, options) {
     },
   };
 
+  const ClassFieldDefinitionEvaluationTDZVisitor = {
+    Expression(path) {
+      if (path === this.shouldSkip) {
+        path.skip();
+      }
+    },
+
+    ReferencedIdentifier(path) {
+      if (this.classRef === path.scope.getBinding(path.node.name)) {
+        const classNameTDZError = this.file.addHelper("classNameTDZError");
+        const throwNode = t.callExpression(classNameTDZError, [
+          t.stringLiteral(path.node.name),
+        ]);
+
+        path.replaceWith(t.sequenceExpression([throwNode, path.node]));
+        path.skip();
+      }
+    },
+  };
+
   const buildClassPropertySpec = (ref, { key, value, computed }, scope) => {
     return template.statement`
       Object.defineProperty(REF, KEY, {
@@ -55,7 +75,7 @@ export default function(api, options) {
     inherits: syntaxClassProperties,
 
     visitor: {
-      Class(path, state) {
+      Class(path) {
         const isDerived = !!path.node.superClass;
         let constructor;
         const props = [];
@@ -90,37 +110,16 @@ export default function(api, options) {
         const staticNodes = [];
         let instanceBody = [];
 
-        const ClassFieldDefinitionEvaluationTDZ = (classRef, state) => ({
-          Expression(path) {
-            if (path.parentKey === "value") {
-              path.skip();
-            }
-          },
-
-          ReferencedIdentifier(path) {
-            if (classRef === path.scope.getBinding(path.node.name)) {
-              const classNameTDZError = state.addHelper("classNameTDZError");
-              const throwNode = t.callExpression(classNameTDZError, [
-                t.stringLiteral(path.node.name),
-              ]);
-
-              path.replaceWith(t.sequenceExpression([throwNode, path.node]));
-              path.skip();
-            }
-          },
-        });
-
         for (const computedPath of computedPaths) {
           const computedNode = computedPath.node;
           // Make sure computed property names are only evaluated once (upon class definition)
           // and in the right order in combination with static properties
           if (!computedPath.get("key").isConstantExpression()) {
-            computedPath.traverse(
-              ClassFieldDefinitionEvaluationTDZ(
-                path.scope.getBinding(ref.name),
-                state,
-              ),
-            );
+            computedPath.traverse(ClassFieldDefinitionEvaluationTDZVisitor, {
+              classRef: path.scope.getBinding(ref.name),
+              file: this.file,
+              shouldSkip: computedPath.get("value"),
+            });
             const ident = path.scope.generateUidIdentifierBasedOnNode(
               computedNode.key,
             );

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/edgest-case/actual.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/edgest-case/actual.js
@@ -1,0 +1,3 @@
+class A {
+  static [{ x: A || 0 }.x];
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/edgest-case/expected.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/edgest-case/expected.js
@@ -1,0 +1,17 @@
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _classNameTDZError(name) { throw new Error("Class \"" + name + "\" cannot be referenced in computed property keys."); }
+
+let A = function A() {
+  _classCallCheck(this, A);
+};
+
+var _x$x = {
+  x: (_classNameTDZError("A"), A) || 0
+}.x;
+Object.defineProperty(A, _x$x, {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  value: void 0
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/actual.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/actual.js
@@ -1,0 +1,3 @@
+class C {
+  static [C + 3] = 3;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/exec.js
@@ -1,0 +1,3 @@
+class C {
+  static [C + 3] = 3;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/expected.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/expected.js
@@ -1,0 +1,16 @@
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+let C = function C() {
+  _classCallCheck(this, C);
+};
+
+var _ref = (function () {
+  throw new Error("Class cannot be referenced in computed property keys.");
+}(), C) + 3;
+
+Object.defineProperty(C, _ref, {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  value: 3
+});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/expected.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/expected.js
@@ -1,12 +1,12 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _classNameTDZError(name) { throw new Error("Class \"" + name + "\" cannot be referenced in computed property keys."); }
+
 let C = function C() {
   _classCallCheck(this, C);
 };
 
-var _ref = (function () {
-  throw new Error("Class cannot be referenced in computed property keys.");
-}(), C) + 3;
+var _ref = (_classNameTDZError("C"), C) + 3;
 
 Object.defineProperty(C, _ref, {
   configurable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/general/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Class \"C\" cannot be referenced in computed property keys."
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/actual.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/actual.js
@@ -1,0 +1,3 @@
+class C {
+  static [C + 3] = 3;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/exec.js
@@ -1,0 +1,3 @@
+class C {
+  static [C + 3] = 3;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/expected.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/expected.js
@@ -1,0 +1,7 @@
+class C {}
+
+var _ref = (function () {
+  throw new Error("Class cannot be referenced in computed property keys.");
+}(), C) + 3;
+
+C[_ref] = 3;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/expected.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/expected.js
@@ -1,7 +1,7 @@
+function _classNameTDZError(name) { throw new Error("Class \"" + name + "\" cannot be referenced in computed property keys."); }
+
 class C {}
 
-var _ref = (function () {
-  throw new Error("Class cannot be referenced in computed property keys.");
-}(), C) + 3;
+var _ref = (_classNameTDZError("C"), C) + 3;
 
 C[_ref] = 3;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/options.json
@@ -1,3 +1,4 @@
 {
+  "throws": "Class \"C\" cannot be referenced in computed property keys.",
   "plugins": [["proposal-class-properties", {"loose": true}]]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/loose/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["proposal-class-properties", {"loose": true}]]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-class-properties", "transform-classes"]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/options.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["proposal-class-properties", "transform-classes"]
+  "plugins": ["proposal-class-properties", "transform-classes"],
+  "minNodeVersion": "6.0.0"
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6732 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

My approach:
1. Additional subtraversal of property name computation for computed class properties
1. Find all identifiers referencing the class binding
1. Insert runtime errors using the same approach as with `const` checks (https://github.com/babel/babel/pull/5930).

This shares the helper function `statementBeforeExpression` with the mentioned PR and should probably be moved into some place where both plugins can use it.

