### PR TITLE
Make all log and debug output use stderr

### DIFF
--- a/experimental/babel-preset-env/src/debug.js
+++ b/experimental/babel-preset-env/src/debug.js
@@ -9,7 +9,7 @@ const wordEnds = size => {
 export const logMessage = (message, context) => {
   const pre = context ? `[${context}] ` : "";
   const logStr = `  ${pre}${message}`;
-  console.log(logStr);
+  console.error(logStr);
 };
 
 export const logPlugin = (plugin, targets, list, context) => {
@@ -36,21 +36,21 @@ export const logEntryPolyfills = (
   onDebug,
 ) => {
   if (!importPolyfillIncluded) {
-    console.log(
+    console.error(
       `
 [${filename}] \`import '@babel/polyfill'\` was not found.`,
     );
     return;
   }
   if (!polyfills.size) {
-    console.log(
+    console.error(
       `
 [${filename}] Based on your targets, none were added.`,
     );
     return;
   }
 
-  console.log(
+  console.error(
     `
 [${filename}] Replaced \`@babel/polyfill\` with the following polyfill${wordEnds(
       polyfills.size,
@@ -61,13 +61,13 @@ export const logEntryPolyfills = (
 
 export const logUsagePolyfills = (polyfills, filename, onDebug) => {
   if (!polyfills.size) {
-    console.log(
+    console.error(
       `
 [${filename}] Based on your code and targets, none were added.`,
     );
     return;
   }
-  console.log(
+  console.error(
     `
 [${filename}] Added following polyfill${wordEnds(polyfills.size)}:`,
   );

--- a/experimental/babel-preset-env/src/index.js
+++ b/experimental/babel-preset-env/src/index.js
@@ -196,10 +196,10 @@ export default function buildPreset(
     hasUglifyTarget = true;
     delete optionsTargets.uglify;
 
-    console.log("");
-    console.log("The uglify target has been deprecated. Set the top level");
-    console.log("option `forceAllTransforms: true` instead.");
-    console.log("");
+    console.error("");
+    console.error("The uglify target has been deprecated. Set the top level");
+    console.error("option `forceAllTransforms: true` instead.");
+    console.error("");
   }
 
   const targets = getTargets(optionsTargets, {
@@ -255,21 +255,21 @@ export default function buildPreset(
 
   if (debug && !hasBeenLogged) {
     hasBeenLogged = true;
-    console.log("@babel/preset-env: `DEBUG` option");
-    console.log("\nUsing targets:");
-    console.log(JSON.stringify(prettifyTargets(targets), null, 2));
-    console.log(`\nUsing modules transform: ${modules.toString()}`);
-    console.log("\nUsing plugins:");
+    console.error("@babel/preset-env: `DEBUG` option");
+    console.error("\nUsing targets:");
+    console.error(JSON.stringify(prettifyTargets(targets), null, 2));
+    console.error(`\nUsing modules transform: ${modules.toString()}`);
+    console.error("\nUsing plugins:");
     transformations.forEach(transform => {
       logPlugin(transform, targets, pluginList);
     });
 
     if (!useBuiltIns) {
-      console.log(
+      console.error(
         "\nUsing polyfills: No polyfills were added, since the `useBuiltIns` option was not set.",
       );
     } else {
-      console.log(
+      console.error(
         `
 Using polyfills with \`${useBuiltIns}\` option:`,
       );

--- a/experimental/babel-preset-env/src/targets-parser.js
+++ b/experimental/babel-preset-env/src/targets-parser.js
@@ -71,17 +71,19 @@ const outputDecimalWarning = (decimalTargets: Array<Object>): void => {
     return;
   }
 
-  console.log("Warning, the following targets are using a decimal version:");
-  console.log("");
+  console.error("Warning, the following targets are using a decimal version:");
+  console.error("");
   decimalTargets.forEach(({ target, value }) =>
-    console.log(`  ${target}: ${value}`),
+    console.error(`  ${target}: ${value}`),
   );
-  console.log("");
-  console.log(
+  console.error("");
+  console.error(
     "We recommend using a string for minor/patch versions to avoid numbers like 6.10",
   );
-  console.log("getting parsed as 6.1, which can lead to unexpected behavior.");
-  console.log("");
+  console.error(
+    "getting parsed as 6.1, which can lead to unexpected behavior.",
+  );
+  console.error("");
 };
 
 const targetParserMap = {

--- a/packages/babel-cli/src/babel-external-helpers.js
+++ b/packages/babel-cli/src/babel-external-helpers.js
@@ -24,4 +24,4 @@ commander.option(
 commander.usage("[options]");
 commander.parse(process.argv);
 
-console.log(buildExternalHelpers(commander.whitelist, commander.outputType));
+console.error(buildExternalHelpers(commander.whitelist, commander.outputType));

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -47,7 +47,7 @@ export function addSourceMappingUrl(code, loc) {
 }
 
 export function log(msg) {
-  if (!commander.quiet) console.log(msg);
+  if (!commander.quiet) console.error(msg);
 }
 
 export function transform(filename, code, opts) {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #6597
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Yes, debug output goes to `stderr` now so scripts might need adjusting
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes (no tests added)
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

The debug/log output for babel-preset-env and babel-cli now goes to `stderr`.
This is how it works in all Unix utilities and prevents mixing log information with real Babel output
