### PR TITLE
Enforce Prettier defaults + also format .babelrc and .json

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,7 +9,7 @@ function istanbulHacks() {
     visitor: {
       Program: {
         exit: function(path) {
-          if (!this.__dv__) return
+          if (!this.__dv__) return;
 
           const node = path.node.body[0];
           if (
@@ -30,23 +30,20 @@ function istanbulHacks() {
   };
 }
 
-let envOpts = {
+const envOpts = {
   loose: true,
   exclude: ["transform-typeof-symbol"],
 };
 
 const config = {
   comments: false,
-  presets: [
-    ["@babel/env", envOpts],
-    "@babel/flow"
-  ],
+  presets: [["@babel/env", envOpts], "@babel/flow"],
   plugins: [
     ["@babel/proposal-class-properties", { loose: true }],
     "@babel/proposal-export-namespace",
     "@babel/proposal-numeric-separator",
-    ["@babel/proposal-object-rest-spread", { useBuiltIns: true}],
-  ]
+    ["@babel/proposal-object-rest-spread", { useBuiltIns: true }],
+  ],
 };
 
 if (process.env.BABEL_ENV === "cov") {
@@ -56,7 +53,7 @@ if (process.env.BABEL_ENV === "cov") {
 
 if (process.env.BABEL_ENV === "development") {
   envOpts.targets = {
-    node: "current"
+    node: "current",
   };
   envOpts.debug = true;
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,11 @@
 {
   "trailingComma": "es5",
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "bracketSpacing": true,
+  "tabWidth": 2,
+  "printWidth": 80,
   "overrides": [{
     "files": [
       "**/experimental/*/src/**/*.js",

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ lint:
 	./node_modules/.bin/eslint scripts $(SOURCES) '*.js' '**/.*.js' --format=codeframe --rulesdir="./scripts/eslint_rules"
 
 fix:
+	./node_modules/.bin/prettier --write --ignore-path .eslintignore '**/*.json'
 	./node_modules/.bin/eslint scripts $(SOURCES) '*.js' '**/.*.js' --format=codeframe --fix --rulesdir="./scripts/eslint_rules"
 
 clean: test-clean

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ flow:
 	./node_modules/.bin/flow check --strip-root
 
 lint:
-	./node_modules/.bin/eslint scripts $(SOURCES) *.js --format=codeframe --rulesdir="./scripts/eslint_rules"
+	./node_modules/.bin/eslint scripts $(SOURCES) '*.js' '**/.*.js' --format=codeframe --rulesdir="./scripts/eslint_rules"
 
 fix:
-	./node_modules/.bin/eslint scripts $(SOURCES) *.js --format=codeframe --fix --rulesdir="./scripts/eslint_rules"
+	./node_modules/.bin/eslint scripts $(SOURCES) '*.js' '**/.*.js' --format=codeframe --fix --rulesdir="./scripts/eslint_rules"
 
 clean: test-clean
 	rm -rf packages/babel-polyfill/browser*

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-codemod-optional-catch-binding",
   "version": "7.0.0-beta.32",
   "description": "Remove unused catch bindings",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-remove-unused-catch-binding",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-remove-unused-catch-binding",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "@babel/plugin"
-  ],
+  "keywords": ["@babel/plugin"],
   "dependencies": {
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.32"
   },

--- a/experimental/babel-preset-env-standalone/package.json
+++ b/experimental/babel-preset-env-standalone/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@babel/preset-env-standalone",
   "version": "7.0.0-beta.32",
-  "description": "Standalone build of babel-prest-env for use in non-Node.js environments.",
+  "description":
+    "Standalone build of babel-prest-env for use in non-Node.js environments.",
   "main": "babel-preset-env.js",
-  "files": [
-    "babel-preset-env.js",
-    "babel-preset-env.min.js",
-    "src"
-  ],
+  "files": ["babel-preset-env.js", "babel-preset-env.min.js", "src"],
   "devDependencies": {
     "@babel/plugin-transform-new-target": "7.0.0-beta.32",
     "@babel/preset-env": "7.0.0-beta.32",
@@ -28,11 +25,9 @@
   "bugs": {
     "url": "https://github.com/babel/babel/issues"
   },
-  "homepage": "https://github.com/babel/babel/packages/babel-preset-env-standalone#readme",
+  "homepage":
+    "https://github.com/babel/babel/packages/babel-preset-env-standalone#readme",
   "jest": {
-    "transformIgnorePatterns": [
-      "/node_modules/",
-      "babel-preset-env.js"
-    ]
+    "transformIgnorePatterns": ["/node_modules/", "babel-preset-env.js"]
   }
 }

--- a/experimental/babel-preset-env/package.json
+++ b/experimental/babel-preset-env/package.json
@@ -5,7 +5,8 @@
   "author": "Henry Zhu <hi@henryzoo.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/experimental/babel-preset-env",
+  "repository":
+    "https://github.com/babel/babel/tree/master/experimental/babel-preset-env",
   "main": "lib/index.js",
   "scripts": {
     "build-data": "node ./scripts/build-data.js"
@@ -57,7 +58,8 @@
     "@babel/core": "7.0.0-beta.32",
     "@babel/helper-fixtures": "7.0.0-beta.32",
     "@babel/helper-plugin-test-runner": "7.0.0-beta.32",
-    "compat-table": "kangax/compat-table#957f1ff15972e8fb2892a172f985e9af27bf1c75",
+    "compat-table":
+      "kangax/compat-table#957f1ff15972e8fb2892a172f985e9af27bf1c75",
     "electron-to-chromium": "^1.3.27"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -16,21 +16,10 @@
   "cacheDir": ".changelog",
   "commands": {
     "publish": {
-      "ignore": [
-        "*.md",
-        "test/**",
-        "codemods/**",
-        "experimental/**"
-      ]
+      "ignore": ["*.md", "test/**", "codemods/**", "experimental/**"]
     }
   },
-  "packages": [
-    "packages/*",
-    "codemods/*",
-    "experimental/*"
-  ],
+  "packages": ["packages/*", "codemods/*", "experimental/*"],
   "npmClient": "yarn",
-  "npmClientArgs": [
-    "--no-lockfile"
-  ]
+  "npmClientArgs": ["--no-lockfile"]
 }

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@babel/code-frame",
   "version": "7.0.0-beta.32",
-  "description": "Generate errors that contain a code frame that point to source locations.",
+  "description":
+    "Generate errors that contain a code frame that point to source locations.",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
   "main": "lib/index.js",
   "dependencies": {
     "chalk": "^2.0.0",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -6,7 +6,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-core",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-core",
   "keywords": [
     "6to5",
     "babel",
@@ -23,7 +24,8 @@
     "compiler"
   ],
   "browser": {
-    "./lib/config/loading/files/index.js": "./lib/config/loading/files/index-browser.js",
+    "./lib/config/loading/files/index.js":
+      "./lib/config/loading/files/index-browser.js",
     "./lib/transform-file.js": "./lib/transform-file-browser.js",
     "./lib/transform-file-sync.js": "./lib/transform-file-sync-browser.js"
   },

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -5,11 +5,10 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-generator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-generator",
   "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "dependencies": {
     "@babel/types": "7.0.0-beta.32",
     "jsesc": "^2.5.1",

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@babel/helper-annotate-as-pure",
   "version": "7.0.0-beta.32",
-  "description": "Helper function to annotate paths and nodes with #__PURE__ comment",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure",
+  "description":
+    "Helper function to annotate paths and nodes with #__PURE__ comment",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-bindify-decorators",
   "version": "7.0.0-beta.32",
   "description": "Helper function to bindify decorators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-builder-binary-assignment-operator-visitor",
   "version": "7.0.0-beta.32",
   "description": "Helper function to build binary assignment operator visitors",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-builder-react-jsx",
   "version": "7.0.0-beta.32",
   "description": "Helper function to build react jsx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-call-delegate",
   "version": "7.0.0-beta.32",
   "description": "Helper function to call delegate",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-define-map",
   "version": "7.0.0-beta.32",
   "description": "Helper function to define a map",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-explode-assignable-expression",
   "version": "7.0.0-beta.32",
   "description": "Helper function to explode an assignable expression",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-explode-class",
   "version": "7.0.0-beta.32",
   "description": "Helper function to explode class",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -4,7 +4,8 @@
   "description": "Helper function to support fixtures",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {
     "lodash": "^4.2.0",

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@babel/helper-function-name",
   "version": "7.0.0-beta.32",
-  "description": "Helper function to change the property 'name' of every function",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
+  "description":
+    "Helper function to change the property 'name' of every function",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-get-function-arity",
   "version": "7.0.0-beta.32",
   "description": "Helper function to get function arity",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-hoist-variables",
   "version": "7.0.0-beta.32",
   "description": "Helper function to hoist variables",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -5,7 +5,8 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "7.0.0-beta.32",

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@babel/helper-module-transforms",
   "version": "7.0.0-beta.32",
-  "description": "Babel helper functions for implementing ES6 module transformations",
+  "description":
+    "Babel helper functions for implementing ES6 module transformations",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-imports": "7.0.0-beta.32",

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-optimise-call-expression",
   "version": "7.0.0-beta.32",
   "description": "Helper function to optimise call expression",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-plugin-test-runner",
   "version": "7.0.0-beta.32",
   "description": "Helper function to support test runner",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-regex",
   "version": "7.0.0-beta.32",
   "description": "Helper function to check for literal RegEx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-remap-async-to-generator",
   "version": "7.0.0-beta.32",
   "description": "Helper function to remap async functions to generators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-replace-supers",
   "version": "7.0.0-beta.32",
   "description": "Helper function to replace supers",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@babel/helper-simple-access",
   "version": "7.0.0-beta.32",
-  "description": "Babel helper for ensuring that access to a given value is performed through simple accesses",
+  "description":
+    "Babel helper for ensuring that access to a given value is performed through simple accesses",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/template": "7.0.0-beta.32",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.32",

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/helper-wrap-function",
   "version": "7.0.0-beta.32",
   "description": "Helper to wrap functions inside a function call.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helpers",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-helpers",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/template": "7.0.0-beta.32",

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-node",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-node",
   "keywords": [
     "6to5",
     "babel",

--- a/packages/babel-plugin-check-constants/package.json
+++ b/packages/babel-plugin-check-constants/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-check-constants",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 constants to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-check-constants",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-check-constants",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-external-helpers",
   "version": "7.0.0-beta.32",
-  "description": "This plugin contains helper functions that’ll be placed at the top of the generated code",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
+  "description":
+    "This plugin contains helper functions that’ll be placed at the top of the generated code",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-async-generator-functions",
   "version": "7.0.0-beta.32",
   "description": "Turn async generator functions into ES2015 generators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-remap-async-to-generator": "7.0.0-beta.32",
     "@babel/plugin-syntax-async-generators": "7.0.0-beta.32"

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-proposal-class-properties",
   "version": "7.0.0-beta.32",
-  "description": "This plugin transforms static class properties as well as properties declared with the property initializer syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
+  "description":
+    "This plugin transforms static class properties as well as properties declared with the property initializer syntax",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-function-name": "7.0.0-beta.32",
     "@babel/plugin-syntax-class-properties": "7.0.0-beta.32"

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -4,13 +4,10 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "license": "MIT",
   "description": "Compile class and object decorators to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-decorators",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-decorators",
   "main": "lib/index.js",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "decorators"
-  ],
+  "keywords": ["babel", "babel-plugin", "decorators"],
   "dependencies": {
     "@babel/plugin-syntax-decorators": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-do-expressions",
   "version": "7.0.0-beta.32",
   "description": "Compile do expressions to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-do-expressions": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-export-default/package.json
+++ b/packages/babel-plugin-proposal-export-default/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-export-default",
   "version": "7.0.0-beta.32",
   "description": "Compile export default to ES2015",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-export-extensions": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-export-namespace/package.json
+++ b/packages/babel-plugin-proposal-export-namespace/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-export-namespace",
   "version": "7.0.0-beta.32",
   "description": "Compile export namespace to ES2015",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-export-extensions": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-function-bind",
   "version": "7.0.0-beta.32",
   "description": "Compile function bind operator to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-function-bind": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-function-sent",
   "version": "7.0.0-beta.32",
   "description": "Compile the function.sent meta propety to valid ES2015 code",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-wrap-function": "7.0.0-beta.32",
     "@babel/plugin-syntax-function-sent": "7.0.0-beta.32"

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-nullish-coalescing-operator",
   "version": "7.0.0-beta.32",
   "description": "Remove nullish coalescing operator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-nullish-coalescing-opearator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-nullish-coalescing-opearator",
   "license": "MIT",
   "main": "lib",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-nullish-coalescing-operator": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-proposal-numeric-separator",
   "version": "7.0.0-beta.32",
-  "description": "Remove numeric separators from Decimal, Binary, Hex and Octal literals",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
+  "description":
+    "Remove numeric separators from Decimal, Binary, Hex and Octal literals",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-object-rest-spread",
   "version": "7.0.0-beta.32",
   "description": "Compile object rest and spread to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-optional-catch-binding",
   "version": "7.0.0-beta.32",
   "description": "Compile optional catch bindings",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-proposal-optional-chaining",
   "version": "7.0.0-beta.32",
-  "description": "Transform optional chaining operators into a series of nil checks",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
+  "description":
+    "Transform optional chaining operators into a series of nil checks",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-optional-chaining": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-pipeline-operator",
   "version": "7.0.0-beta.32",
   "description": "Transform pipeline operator into call expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-pipeline-operator": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-proposal-throw-expressions",
   "version": "7.0.0-beta.32",
   "description": "Wraps Throw Expressions in an IIFE",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@babel/plugin-proposal-unicode-property-regex",
   "version": "7.0.0-beta.32",
-  "description": "Compile Unicode property escapes in Unicode regular expressions to ES5.",
+  "description":
+    "Compile Unicode property escapes in Unicode regular expressions to ES5.",
   "homepage": "https://babeljs.io/",
   "main": "lib/index.js",
   "engines": {
@@ -15,7 +16,8 @@
     "unicode properties",
     "unicode"
   ],
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex",
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
     "@babel/helper-regex": "7.0.0-beta.32",

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-async-generators",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of async generator functions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-class-properties",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of class properties",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-decorators",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of decorators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-do-expressions",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of do expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-dynamic-import/package.json
+++ b/packages/babel-plugin-syntax-dynamic-import/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-dynamic-import",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of import()",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-export-extensions/package.json
+++ b/packages/babel-plugin-syntax-export-extensions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-export-extensions",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of export extensions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-extensions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-extensions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-flow",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of the flow syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-function-bind",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of function bind",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-function-sent",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of the function.sent meta property",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-jsx",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of jsx",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-nullish-coalescing-operator",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of the nullish-coalescing operator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
   "license": "MIT",
   "main": "lib",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-syntax-numeric-separator",
   "version": "7.0.0-beta.32",
-  "description": "Allow parsing of Decimal, Binary, Hex and Octal literals that contain a Numeric Literal Separator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
+  "description":
+    "Allow parsing of Decimal, Binary, Hex and Octal literals that contain a Numeric Literal Separator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-object-rest-spread",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of object rest/spread",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-optional-catch-binding/package.json
+++ b/packages/babel-plugin-syntax-optional-catch-binding/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-optional-catch-binding",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of optional catch bindings",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-optional-chaining/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-optional-chaining",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of optional properties",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-pipeline-operator",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of the pipeline operator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-syntax-throw-expressions",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of Throw Expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -2,13 +2,11 @@
   "name": "@babel/plugin-syntax-typescript",
   "version": "7.0.0-beta.32",
   "description": "Allow parsing of TypeScript syntax",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin",
-    "typescript"
-  ],
+  "keywords": ["babel-plugin", "typescript"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-arrow-functions",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 arrow functions to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-async-to-generator",
   "version": "7.0.0-beta.32",
   "description": "Turn async functions into ES2015 generators",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-module-imports": "7.0.0-beta.32",
     "@babel/helper-remap-async-to-generator": "7.0.0-beta.32"

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-block-scoped-functions",
   "version": "7.0.0-beta.32",
-  "description": "Babel plugin to ensure function declarations at the block level are block scoped",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions",
+  "description":
+    "Babel plugin to ensure function declarations at the block level are block scoped",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -2,15 +2,14 @@
   "name": "@babel/plugin-transform-block-scoping",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 block scoping (const and let) to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "lodash": "^4.2.0"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -2,7 +2,8 @@
   "name": "@babel/plugin-transform-classes",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 classes to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
@@ -12,9 +13,7 @@
     "@babel/helper-optimise-call-expression": "7.0.0-beta.32",
     "@babel/helper-replace-supers": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-computed-properties",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 computed properties to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-destructuring",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 destructuring to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-duplicate-keys",
   "version": "7.0.0-beta.32",
   "description": "Compile objects with duplicate keys to valid strict ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-eval/package.json
+++ b/packages/babel-plugin-transform-eval/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-eval",
   "version": "7.0.0-beta.32",
   "description": "Compile eval calls with string literals",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-eval",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-eval",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-exponentiation-operator",
   "version": "7.0.0-beta.32",
   "description": "Compile exponentiation operator to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-flow-comments",
   "version": "7.0.0-beta.32",
   "description": "Turn flow type annotations into comments",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-flow": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-flow-strip-types",
   "version": "7.0.0-beta.32",
   "description": "Strip flow type annotations from your output code.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-flow": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-for-of",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 for...of to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-function-name",
   "version": "7.0.0-beta.32",
   "description": "Apply ES2015 function.name semantics to all functions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-function-name": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-instanceof",
   "version": "7.0.0-beta.32",
   "description": "This plugin transforms all the ES2015 'instanceof' methods",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-instanceof",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-instanceof",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-jscript",
   "version": "7.0.0-beta.32",
   "description": "Babel plugin to fix buggy JScript named function expressions",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jscript",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jscript",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-literals",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 unicode string and number literals to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-member-expression-literals",
   "version": "7.0.0-beta.32",
   "description": "Ensure that reserved words are quoted in property accesses",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -2,15 +2,14 @@
   "name": "@babel/plugin-transform-modules-amd",
   "version": "7.0.0-beta.32",
   "description": "This plugin transforms ES2015 modules to AMD",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -2,16 +2,15 @@
   "name": "@babel/plugin-transform-modules-commonjs",
   "version": "7.0.0-beta.32",
   "description": "This plugin transforms ES2015 modules to CommonJS",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "7.0.0-beta.32",
     "@babel/helper-simple-access": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -2,15 +2,14 @@
   "name": "@babel/plugin-transform-modules-systemjs",
   "version": "7.0.0-beta.32",
   "description": "This plugin transforms ES2015 modules to SystemJS",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-hoist-variables": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -2,15 +2,14 @@
   "name": "@babel/plugin-transform-modules-umd",
   "version": "7.0.0-beta.32",
   "description": "This plugin transforms ES2015 modules to UMD",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-new-target",
   "version": "7.0.0-beta.32",
   "description": "Transforms new.target meta property",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -2,13 +2,12 @@
   "name": "@babel/plugin-transform-object-assign",
   "version": "7.0.0-beta.32",
   "description": "Replace Object.assign with an inline helper",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-assign",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-assign",
   "author": "Jed Watson",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-object-set-prototype-of-to-assign",
   "version": "7.0.0-beta.32",
   "description": "Turn Object.setPrototypeOf to assignments",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-set-prototype-of-to-assign",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-set-prototype-of-to-assign",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-object-super",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 object super to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-replace-supers": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -2,16 +2,15 @@
   "name": "@babel/plugin-transform-parameters",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 default and rest parameters to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-call-delegate": "7.0.0-beta.32",
     "@babel/helper-get-function-arity": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-property-literals",
   "version": "7.0.0-beta.32",
-  "description": "Ensure that reserved words are quoted in object property keys",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals",
+  "description":
+    "Ensure that reserved words are quoted in object property keys",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-property-mutators",
   "version": "7.0.0-beta.32",
-  "description": "Compile ES5 property mutator shorthand syntax to Object.defineProperty",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-mutators",
+  "description":
+    "Compile ES5 property mutator shorthand syntax to Object.defineProperty",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-mutators",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-define-map": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-proto-to-assign",
   "version": "7.0.0-beta.32",
-  "description": "Babel plugin for turning __proto__ into a shallow property clone",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
+  "description":
+    "Babel plugin for turning __proto__ into a shallow property clone",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "lodash": "^4.2.0"
   },

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-react-constant-elements",
   "version": "7.0.0-beta.32",
-  "description": "Treat React JSX elements as value types and hoist them to the highest scope",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-constant-elements",
+  "description":
+    "Treat React JSX elements as value types and hoist them to the highest scope",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-constant-elements",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-react-display-name",
   "version": "7.0.0-beta.32",
   "description": "Add displayName to React.createClass calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-react-inline-elements",
   "version": "7.0.0-beta.32",
   "description": "Turn JSX elements into exploded React objects",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-inline-elements",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-inline-elements",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-builder-react-jsx": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-compat",
   "version": "7.0.0-beta.32",
   "description": "Turn JSX into React Pre-0.12 function calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-compat",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-compat",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-builder-react-jsx": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-self",
   "version": "7.0.0-beta.32",
   "description": "Add a __self prop to all JSX Elements",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-jsx": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx-source",
   "version": "7.0.0-beta.32",
   "description": "Add a __source prop to all JSX Elements",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/plugin-syntax-jsx": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-react-jsx",
   "version": "7.0.0-beta.32",
   "description": "Turn JSX into React function calls",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-builder-react-jsx": "7.0.0-beta.32",
     "@babel/plugin-syntax-jsx": "7.0.0-beta.32"

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -3,8 +3,10 @@
   "author": "Ben Newman <bn@cs.stanford.edu>",
   "description": "Explode async and generator functions into a state machine.",
   "version": "7.0.0-beta.32",
-  "homepage": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
+  "homepage":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator",
   "main": "lib/index.js",
   "dependencies": {
     "regenerator-transform": "^0.11.0"

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-reserved-words",
   "version": "7.0.0-beta.32",
   "description": "Ensure that no reserved words are used.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-runtime",
   "version": "7.0.0-beta.32",
-  "description": "Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime",
+  "description":
+    "Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-module-imports": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-shorthand-properties",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 shorthand properties to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-spread",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 spread to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-sticky-regex",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 sticky regex to an ES5 RegExp constructor",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-regex": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-strict-mode",
   "version": "7.0.0-beta.32",
-  "description": "This plugin places a 'use strict'; directive at the top of all files to enable strict mode",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
+  "description":
+    "This plugin places a 'use strict'; directive at the top of all files to enable strict mode",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -2,15 +2,14 @@
   "name": "@babel/plugin-transform-template-literals",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 template literals to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-annotate-as-pure": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@babel/plugin-transform-typeof-symbol",
   "version": "7.0.0-beta.32",
-  "description": "This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol",
+  "description":
+    "This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -2,13 +2,11 @@
   "name": "@babel/plugin-transform-typescript",
   "version": "7.0.0-beta.32",
   "description": "Transform TypeScript into ES.next",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin",
-    "typescript"
-  ],
+  "keywords": ["babel-plugin", "typescript"],
   "dependencies": {
     "@babel/plugin-syntax-typescript": "7.0.0-beta.32"
   },

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -2,12 +2,11 @@
   "name": "@babel/plugin-transform-unicode-regex",
   "version": "7.0.0-beta.32",
   "description": "Compile ES2015 Unicode regex to ES5",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-plugin"
-  ],
+  "keywords": ["babel-plugin"],
   "dependencies": {
     "@babel/helper-regex": "7.0.0-beta.32",
     "regexpu-core": "^4.1.3"

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-polyfill",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-polyfill",
   "main": "lib/index.js",
   "dependencies": {
     "core-js": "^2.4.0",

--- a/packages/babel-preset-es2015/package.json
+++ b/packages/babel-preset-es2015/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2015",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-es2015",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-check-constants": "7.0.0-beta.32",

--- a/packages/babel-preset-es2016/package.json
+++ b/packages/babel-preset-es2016/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2016",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-es2016",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.32"

--- a/packages/babel-preset-es2017/package.json
+++ b/packages/babel-preset-es2017/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2017",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-es2017",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-transform-async-to-generator": "7.0.0-beta.32"

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -3,15 +3,11 @@
   "version": "7.0.0-beta.32",
   "description": "Babel preset for all Flow plugins.",
   "author": "James Kyle <me@thejameskyle.com>",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-preset",
-    "flowtype",
-    "flow",
-    "types"
-  ],
+  "keywords": ["babel-preset", "flowtype", "flow", "types"],
   "dependencies": {
     "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.32"
   },

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-syntax-jsx": "7.0.0-beta.32",

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-0",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-0",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-proposal-do-expressions": "7.0.0-beta.32",

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-proposal-decorators": "7.0.0-beta.32",

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-proposal-export-namespace": "7.0.0-beta.32",

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-3",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-3",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.32",

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -2,13 +2,11 @@
   "name": "@babel/preset-typescript",
   "version": "7.0.0-beta.32",
   "description": "Babel preset for TypeScript.",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
   "license": "MIT",
   "main": "lib/index.js",
-  "keywords": [
-    "babel-preset",
-    "typescript"
-  ],
+  "keywords": ["babel-preset", "typescript"],
   "dependencies": {
     "@babel/plugin-transform-typescript": "7.0.0-beta.32"
   },

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -3,7 +3,8 @@
   "version": "7.0.0-beta.32",
   "description": "babel require hook",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-register",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-register",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "main": "lib/index.js",
   "browser": {

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@babel/standalone",
   "version": "7.0.0-beta.32",
-  "description": "Standalone build of Babel for use in non-Node.js environments.",
+  "description":
+    "Standalone build of Babel for use in non-Node.js environments.",
   "main": "babel.js",
-  "files": [
-    "babel.js",
-    "babel.min.js",
-    "src"
-  ],
+  "files": ["babel.js", "babel.min.js", "src"],
   "devDependencies": {
     "@babel/core": "7.0.0-beta.32",
     "@babel/plugin-check-constants": "7.0.0-beta.32",
@@ -56,7 +53,8 @@
     "@babel/plugin-transform-modules-umd": "7.0.0-beta.32",
     "@babel/plugin-transform-new-target": "7.0.0-beta.32",
     "@babel/plugin-transform-object-assign": "7.0.0-beta.32",
-    "@babel/plugin-transform-object-set-prototype-of-to-assign": "7.0.0-beta.32",
+    "@babel/plugin-transform-object-set-prototype-of-to-assign":
+      "7.0.0-beta.32",
     "@babel/plugin-transform-object-super": "7.0.0-beta.32",
     "@babel/plugin-transform-parameters": "7.0.0-beta.32",
     "@babel/plugin-transform-property-literals": "7.0.0-beta.32",
@@ -89,13 +87,7 @@
     "@babel/preset-stage-3": "7.0.0-beta.32",
     "@babel/preset-typescript": "7.0.0-beta.32"
   },
-  "keywords": [
-    "babel",
-    "babeljs",
-    "6to5",
-    "transpile",
-    "transpiler"
-  ],
+  "keywords": ["babel", "babeljs", "6to5", "transpile", "transpiler"],
   "author": "Daniel Lo Nigro <daniel@dan.cx> (http://dan.cx/)",
   "license": "MIT",
   "bugs": {

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-template",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-template",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.32",

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@babel/traverse",
   "version": "7.0.0-beta.32",
-  "description": "The Babel Traverse module maintains the overall tree state, and is responsible for replacing, removing, and adding nodes",
+  "description":
+    "The Babel Traverse module maintains the overall tree state, and is responsible for replacing, removing, and adding nodes",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-traverse",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-traverse",
   "main": "lib/index.js",
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.32",

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -5,7 +5,8 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
-  "repository": "https://github.com/babel/babel/tree/master/packages/babel-types",
+  "repository":
+    "https://github.com/babel/babel/tree/master/packages/babel-types",
   "main": "lib/index.js",
   "dependencies": {
     "esutils": "^2.0.2",

--- a/packages/babylon/package.json
+++ b/packages/babylon/package.json
@@ -15,10 +15,7 @@
   ],
   "repository": "https://github.com/babel/babel/tree/master/packages/babylon",
   "main": "lib/index.js",
-  "files": [
-    "bin",
-    "lib"
-  ],
+  "files": ["bin", "lib"],
   "engines": {
     "node": ">=4.2.0"
   },


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes (no tests added, all pass)
| Documentation PR         |
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is basically a dev-only change.

If you use prettier-on-save and you have different settings from the Babel settings, they will be used instead of the defaults. This PR adds the default values for all Prettier settings so this no longer happens.

I also noticed that the `.babelrc.js` file was being ignored, so I added that to the globs.

Finally, prettier supports formatting `.json` files, so I added that to the `Makefile`.