### PR TITLE
Define readOnlyError helper and use in check-constants plugin

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -627,6 +627,12 @@ helpers.temporalRef = defineHelper(`
   }
 `);
 
+helpers.readOnlyError = defineHelper(`
+  export default function _readOnlyError(name) {
+    throw new Error("\\"" + name + "\\" is read-only");
+  }
+`);
+
 helpers.temporalUndefined = defineHelper(`
   export default {};
 `);

--- a/packages/babel-plugin-check-constants/test/fixtures/general/deadcode-violation/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/deadcode-violation/expected.js
@@ -1,7 +1,7 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 (function () {
   var a = "foo";
-  if (false) a = (function () {
-    throw new Error("\"a\" is read-only");
-  }(), "false");
+  if (false) a = (_readOnlyError("a"), "false");
   return a;
 })();

--- a/packages/babel-plugin-check-constants/test/fixtures/general/destructuring-assignment/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/destructuring-assignment/expected.js
@@ -1,5 +1,5 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var a = 1,
     b = 2;
-a = (function () {
-  throw new Error("\"a\" is read-only");
-}(), 3);
+a = (_readOnlyError("a"), 3);

--- a/packages/babel-plugin-check-constants/test/fixtures/general/loop/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/loop/expected.js
@@ -1,5 +1,5 @@
-for (var i = 0; i < 3; i = (function () {
-  throw new Error("\"i\" is read-only");
-}(), i + 1)) {
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
+for (var i = 0; i < 3; i = (_readOnlyError("i"), i + 1)) {
   console.log(i);
 }

--- a/packages/babel-plugin-check-constants/test/fixtures/general/nested-update-expressions/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/nested-update-expressions/expected.js
@@ -1,8 +1,8 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var c = 17;
 var a = 0;
 
 function f() {
-  return (function () {
-    throw new Error("\"c\" is read-only");
-  }(), ++c) + --a;
+  return (_readOnlyError("c"), ++c) + --a;
 }

--- a/packages/babel-plugin-check-constants/test/fixtures/general/no-assignment/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/no-assignment/expected.js
@@ -1,4 +1,4 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var MULTIPLIER = 5;
-MULTIPLIER = (function () {
-  throw new Error("\"MULTIPLIER\" is read-only");
-}(), "overwrite");
+MULTIPLIER = (_readOnlyError("MULTIPLIER"), "overwrite");

--- a/packages/babel-plugin-check-constants/test/fixtures/general/no-for-in/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/no-for-in/expected.js
@@ -1,6 +1,9 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var MULTIPLIER = 5;
 
 for (MULTIPLIER in arr) {
-  throw new Error("\"MULTIPLIER\" is read-only");
+  _readOnlyError("MULTIPLIER");
+
   ;
 }

--- a/packages/babel-plugin-check-constants/test/fixtures/general/update-expression-prefix/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/update-expression-prefix/expected.js
@@ -1,4 +1,4 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var a = "str";
-(function () {
-  throw new Error("\"a\" is read-only");
-})(), --a;
+_readOnlyError("a"), --a;

--- a/packages/babel-plugin-check-constants/test/fixtures/general/update-expression/expected.js
+++ b/packages/babel-plugin-check-constants/test/fixtures/general/update-expression/expected.js
@@ -1,4 +1,4 @@
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var foo = 1;
-(function () {
-  throw new Error("\"foo\" is read-only");
-})(), foo++;
+_readOnlyError("foo"), foo++;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6857  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This aims to produce better output code for constant violations by replacing the IIFE's with helper calls.
