### PR TITLE
Add firefox 58 mappings to preset-env data

### DIFF
--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -948,6 +948,7 @@
   },
   "es7.promise.finally": {
     "chrome": "63",
+    "firefox": "58",
     "safari": "tp",
     "opera": "50"
   }

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -242,7 +242,10 @@
     "opera": "47"
   },
   "proposal-optional-catch-binding": {
+    "firefox": "58",
     "safari": "tp"
   },
-  "proposal-unicode-property-regex": {}
+  "proposal-unicode-property-regex": {
+    "safari": "tp"
+  }
 }

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -57,7 +57,7 @@
     "@babel/core": "7.0.0-beta.32",
     "@babel/helper-fixtures": "7.0.0-beta.32",
     "@babel/helper-plugin-test-runner": "7.0.0-beta.32",
-    "compat-table": "kangax/compat-table#957f1ff15972e8fb2892a172f985e9af27bf1c75",
+    "compat-table": "kangax/compat-table#baed064b31147eda2fb268ea708013d6208b8615",
     "electron-to-chromium": "^1.3.27"
   }
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | n/y
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT
