### PR TITLE
options default value

### DIFF
--- a/packages/babel-plugin-transform-arrow-functions/src/index.js
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.js
@@ -1,6 +1,6 @@
 import type NodePath from "@babel/traverse";
 
-export default function(api, options) {
+export default function(api, options={}) {
   const { spec } = options;
   return {
     visitor: {


### PR DESCRIPTION
im not sure how exactly why this is happening, but running babel through webpack is currently giving me an error

> cannot read `spec` of undefined

i passed the `options` param a default value of an empty object in attempt to fix this error:

```
Module build failed: TypeError: Cannot read property ‘spec’ of undefined (While processing preset: “.../babel-preset-andari-react/index.js”)
   at _default (.../node_modules/@babel/plugin-transform-arrow-functions/lib/index.js:7:21)
```


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
