### PR TITLE
Allow yielding an arrow function withour parens around the param

### DIFF
--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -620,8 +620,12 @@ export default class ExpressionParser extends LValParser {
     node: N.ArrowFunctionExpression,
     call: N.CallExpression,
   ): N.ArrowFunctionExpression {
+    const oldYield = this.state.yieldInPossibleArrowParameters;
+    this.state.yieldInPossibleArrowParameters = null;
     this.expect(tt.arrow);
-    return this.parseArrowExpression(node, call.arguments, true);
+    this.parseArrowExpression(node, call.arguments, true);
+    this.state.yieldInPossibleArrowParameters = oldYield;
+    return node;
   }
 
   // Parse a no-call expression (like argument of `new` or `::` operators).

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -715,14 +715,22 @@ export default class ExpressionParser extends LValParser {
           this.next();
           return this.parseFunction(node, false, false, true);
         } else if (canBeArrow && id.name === "async" && this.match(tt.name)) {
+          const oldYield = this.state.yieldInPossibleArrowParameters;
+          this.state.yieldInPossibleArrowParameters = null;
           const params = [this.parseIdentifier()];
           this.expect(tt.arrow);
           // let foo = bar => {};
-          return this.parseArrowExpression(node, params, true);
+          this.parseArrowExpression(node, params, true);
+          this.state.yieldInPossibleArrowParameters = oldYield;
+          return node;
         }
 
         if (canBeArrow && !this.canInsertSemicolon() && this.eat(tt.arrow)) {
-          return this.parseArrowExpression(node, [id]);
+          const oldYield = this.state.yieldInPossibleArrowParameters;
+          this.state.yieldInPossibleArrowParameters = null;
+          this.parseArrowExpression(node, [id]);
+          this.state.yieldInPossibleArrowParameters = oldYield;
+          return node;
         }
 
         return id;

--- a/packages/babylon/test/fixtures/es2015/regression/6864/actual.js
+++ b/packages/babylon/test/fixtures/es2015/regression/6864/actual.js
@@ -1,4 +1,5 @@
 function *f() {
   (yield a => a);
   (yield async a => a);
+  (yield async (a) => a);
 }

--- a/packages/babylon/test/fixtures/es2015/regression/6864/actual.js
+++ b/packages/babylon/test/fixtures/es2015/regression/6864/actual.js
@@ -1,0 +1,4 @@
+function *f() {
+  (yield a => a);
+  (yield async a => a);
+}

--- a/packages/babylon/test/fixtures/es2015/regression/6864/expected.json
+++ b/packages/babylon/test/fixtures/es2015/regression/6864/expected.json
@@ -1,28 +1,28 @@
 {
   "type": "File",
   "start": 0,
-  "end": 59,
+  "end": 85,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 4,
+      "line": 5,
       "column": 1
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 59,
+    "end": 85,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 4,
+        "line": 5,
         "column": 1
       }
     },
@@ -31,14 +31,14 @@
       {
         "type": "FunctionDeclaration",
         "start": 0,
-        "end": 59,
+        "end": 85,
         "loc": {
           "start": {
             "line": 1,
             "column": 0
           },
           "end": {
-            "line": 4,
+            "line": 5,
             "column": 1
           }
         },
@@ -66,14 +66,14 @@
         "body": {
           "type": "BlockStatement",
           "start": 14,
-          "end": 59,
+          "end": 85,
           "loc": {
             "start": {
               "line": 1,
               "column": 14
             },
             "end": {
-              "line": 4,
+              "line": 5,
               "column": 1
             }
           },
@@ -255,6 +255,96 @@
                 "extra": {
                   "parenthesized": true,
                   "parenStart": 36
+                }
+              }
+            },
+            {
+              "type": "ExpressionStatement",
+              "start": 60,
+              "end": 83,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 25
+                }
+              },
+              "expression": {
+                "type": "YieldExpression",
+                "start": 61,
+                "end": 81,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 23
+                  }
+                },
+                "delegate": false,
+                "argument": {
+                  "type": "ArrowFunctionExpression",
+                  "start": 67,
+                  "end": 81,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 23
+                    }
+                  },
+                  "id": null,
+                  "generator": false,
+                  "expression": true,
+                  "async": true,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 74,
+                      "end": 75,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 17
+                        },
+                        "identifierName": "a"
+                      },
+                      "name": "a"
+                    }
+                  ],
+                  "body": {
+                    "type": "Identifier",
+                    "start": 80,
+                    "end": 81,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 23
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  }
+                },
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 60
                 }
               }
             }

--- a/packages/babylon/test/fixtures/es2015/regression/6864/expected.json
+++ b/packages/babylon/test/fixtures/es2015/regression/6864/expected.json
@@ -1,0 +1,268 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 59,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 59,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 59,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 10,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            },
+            "identifierName": "f"
+          },
+          "name": "f"
+        },
+        "generator": true,
+        "expression": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 14,
+          "end": 59,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 18,
+              "end": 33,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                }
+              },
+              "expression": {
+                "type": "YieldExpression",
+                "start": 19,
+                "end": 31,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 15
+                  }
+                },
+                "delegate": false,
+                "argument": {
+                  "type": "ArrowFunctionExpression",
+                  "start": 25,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 15
+                    }
+                  },
+                  "id": null,
+                  "generator": false,
+                  "expression": true,
+                  "async": false,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 25,
+                      "end": 26,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 10
+                        },
+                        "identifierName": "a"
+                      },
+                      "name": "a"
+                    }
+                  ],
+                  "body": {
+                    "type": "Identifier",
+                    "start": 30,
+                    "end": 31,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  }
+                },
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 18
+                }
+              }
+            },
+            {
+              "type": "ExpressionStatement",
+              "start": 36,
+              "end": 57,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 23
+                }
+              },
+              "expression": {
+                "type": "YieldExpression",
+                "start": 37,
+                "end": 55,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 21
+                  }
+                },
+                "delegate": false,
+                "argument": {
+                  "type": "ArrowFunctionExpression",
+                  "start": 43,
+                  "end": 55,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 21
+                    }
+                  },
+                  "id": null,
+                  "generator": false,
+                  "expression": true,
+                  "async": true,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 49,
+                      "end": 50,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 15
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 16
+                        },
+                        "identifierName": "a"
+                      },
+                      "name": "a"
+                    }
+                  ],
+                  "body": {
+                    "type": "Identifier",
+                    "start": 54,
+                    "end": 55,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 21
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  }
+                },
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 36
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6864
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
 - [x] `(yield a => a)`
 - [x] `(yield async a => a)`
 - [x] `(yield async (a) => a)`