### PR TITLE
Quick fix for typescript import crash.

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -44,7 +44,14 @@ export default function() {
 
         for (const specifier of path.node.specifiers) {
           const binding = path.scope.getBinding(specifier.local.name);
-          if (isImportTypeOnly(binding, state.programPath)) {
+
+          // The binding may not exist if the import node was explicitly
+          // injected by another plugin. Currently core does not do a good job
+          // of keeping scope bindings synchronized with the AST. For now we
+          // just bail if there is no binding, since chances are good that if
+          // the import statement was injected then it wasn't a typescript type
+          // import anyway.
+          if (binding && isImportTypeOnly(binding, state.programPath)) {
             importsToRemove.push(binding.path);
           } else {
             allElided = false;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6093
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Not pretty, but probably the only fix we can realistically do right now.