### PR TITLE
Remove double exports of NodePath, Scope and Hub in traverse

### DIFF
--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -7,6 +7,7 @@ import * as cache from "./cache";
 export { default as NodePath } from "./path";
 export { default as Scope } from "./scope";
 export { default as Hub } from "./hub";
+
 export { visitors };
 
 export default function traverse(
@@ -37,10 +38,6 @@ export default function traverse(
 traverse.visitors = visitors;
 traverse.verify = visitors.verify;
 traverse.explode = visitors.explode;
-
-traverse.NodePath = require("./path");
-traverse.Scope = require("./scope");
-traverse.Hub = require("./hub");
 
 traverse.cheap = function(node, enter) {
   return t.traverseFast(node, enter);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | it reverts one
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Works toward the goal of getting all packages be 100% esmodules.

Babel 7 introduced a breaking change when we removed the `module.exports = exports.default` transform.
Right now accessing `NodePath`, `Scope` and `Hub` can be done in two ways:

```js
import { NodePath } from "@babel/traverse";
new NodePath();

// or
 
import traverse from "@babel/traverse";
const NodePath = traverse.NodePath.default;
new NodePath();
```

The second one makes clearly no sense to me, so at first I wanted it to change to be again like in babel 6
```js
import traverse from "@babel/traverse";
const NodePath = traverse.NodePath;
new NodePath();
```

But the more i thought about it it seems we should only provide one way to access stuff and remove `NodePath`, `Hub` and `Scope` from `traverse` and only export them as named exports.

Would you be okay with that?



