### PR TITLE
Fix setting deopt properly after evaluating multiple expressions

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.js
+++ b/packages/babel-traverse/src/path/evaluation.js
@@ -211,11 +211,11 @@ function _evaluate(path, state) {
   if (path.isArrayExpression()) {
     const arr = [];
     const elems: Array<NodePath> = path.get("elements");
-    for (let elem of elems) {
-      elem = elem.evaluate();
+    for (const elem of elems) {
+      const elemValue = elem.evaluate();
 
-      if (elem.confident) {
-        arr.push(elem.value);
+      if (elemValue.confident) {
+        arr.push(elemValue.value);
       } else {
         return deopt(elem, state);
       }
@@ -268,7 +268,7 @@ function _evaluate(path, state) {
     switch (node.operator) {
       case "||":
         // TODO consider having a "truthy type" that doesn't bail on
-        // left uncertainity but can still evaluate to truthy.
+        // left uncertainty but can still evaluate to truthy.
         if (left && leftConfident) {
           state.confident = true;
           return left;

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -216,4 +216,48 @@ describe("evaluation", function() {
       "\\d",
     );
   });
+
+  it("sets deopt properly when not confident after evaluating multiple expressions", () => {
+    const ast = parse(`
+      const parts = [foo, bar];
+      console.log(parts.join('-'));
+    `);
+
+    let result;
+
+    traverse(ast, {
+      MemberExpression: {
+        enter(path) {
+          result = path.get("object").evaluate();
+        },
+      },
+    });
+
+    assert.strictEqual(result.confident, false);
+    assert.strictEqual(result.deopt.type, "Identifier");
+    assert.strictEqual(result.deopt.node.name, "foo");
+  });
+
+  it("sets deopt properly when confident after evaluating multiple expressions", () => {
+    const ast = parse(`
+      const foo = 'foo';
+      const bar = 'bar';
+      const parts = [foo, bar];
+      console.log(parts.join('-'))
+    `);
+
+    let result;
+
+    traverse(ast, {
+      MemberExpression: {
+        enter(path) {
+          result = path.get("object").evaluate();
+        },
+      },
+    });
+
+    assert.strictEqual(result.confident, true);
+    assert.strictEqual(result.deopt, null);
+    assert.deepStrictEqual(result.value, ["foo", "bar"]);
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #6745
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | y/y
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

While digging into https://github.com/babel/babel/pull/6745, I noticed that the `evaluate` call returned something odd:

```js
{
  confident: false,
  deopt: {
    confident: false,
    deopt: { // path },
  },
};
```

Easy to see why calling `result.deopt.isIdentifier()` would fail with this, like preset-env's `useBuiltIns: usage` does.

It looks like we're passing the results of `evaluate` to `deopt` instead of the path.

/cc: @jrylan @colinrotherham @Zephir77167 sorry for the delay in getting this up, got caught up with work :D