### PR TITLE
Keep user options intact in transformFile

### DIFF
--- a/packages/babel-core/src/transform-file-sync.js
+++ b/packages/babel-core/src/transform-file-sync.js
@@ -8,13 +8,14 @@ export default function transformFileSync(
   filename: string,
   opts: ?InputOptions,
 ): FileResult | null {
+  let options;
   if (opts == null) {
-    opts = { filename };
+    options = { filename };
   } else if (opts && typeof opts === "object") {
-    opts = Object.assign(opts, { filename });
+    options = Object.assign({}, opts, { filename });
   }
 
-  const config = loadConfig(opts);
+  const config = loadConfig(options);
   if (config === null) return null;
 
   return runSync(config, fs.readFileSync(filename, "utf8"));

--- a/packages/babel-core/src/transform-file.js
+++ b/packages/babel-core/src/transform-file.js
@@ -10,21 +10,22 @@ type TransformFile = {
 };
 
 export default ((function transformFile(filename, opts, callback) {
+  let options;
   if (typeof opts === "function") {
     callback = opts;
     opts = undefined;
   }
 
   if (opts == null) {
-    opts = { filename };
+    options = { filename };
   } else if (opts && typeof opts === "object") {
-    opts = Object.assign(opts, { filename });
+    options = Object.assign({}, opts, { filename });
   }
 
   process.nextTick(() => {
     let cfg;
     try {
-      cfg = loadConfig(opts);
+      cfg = loadConfig(options);
       if (cfg === null) return callback(null, null);
     } catch (err) {
       return callback(err);

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -121,6 +121,7 @@ describe("api", function() {
     const options = {
       babelrc: false,
     };
+    Object.freeze(options);
     babel.transformFile(__dirname + "/fixtures/api/file.js", options, function(
       err,
       res,
@@ -128,7 +129,7 @@ describe("api", function() {
       if (err) return done(err);
       assert.equal(res.code, "foo();");
       // keep user options untouched
-      assert.equal(Object.keys(options).length, 1);
+      assert.deepEqual(options, { babelrc: false });
       done();
     });
   });
@@ -137,12 +138,13 @@ describe("api", function() {
     const options = {
       babelrc: false,
     };
+    Object.freeze(options);
     assert.equal(
       babel.transformFileSync(__dirname + "/fixtures/api/file.js", options)
         .code,
       "foo();",
     );
-    assert.equal(Object.keys(options).length, 1);
+    assert.deepEqual(options, { babelrc: false });
   });
 
   it("options throw on falsy true", function() {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -118,26 +118,31 @@ describe("api", function() {
   });
 
   it("transformFile", function(done) {
-    babel.transformFile(
-      __dirname + "/fixtures/api/file.js",
-      {
-        babelrc: false,
-      },
-      function(err, res) {
-        if (err) return done(err);
-        assert.equal(res.code, "foo();");
-        done();
-      },
-    );
+    const options = {
+      babelrc: false,
+    };
+    babel.transformFile(__dirname + "/fixtures/api/file.js", options, function(
+      err,
+      res,
+    ) {
+      if (err) return done(err);
+      assert.equal(res.code, "foo();");
+      // keep user options untouched
+      assert.equal(Object.keys(options).length, 1);
+      done();
+    });
   });
 
   it("transformFileSync", function() {
+    const options = {
+      babelrc: false,
+    };
     assert.equal(
-      babel.transformFileSync(__dirname + "/fixtures/api/file.js", {
-        babelrc: false,
-      }).code,
+      babel.transformFileSync(__dirname + "/fixtures/api/file.js", options)
+        .code,
       "foo();",
     );
+    assert.equal(Object.keys(options).length, 1);
   });
 
   it("options throw on falsy true", function() {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6885 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

As stated in #6885 I changed the user options handling in `transformFile` and `transformFileSync` to prevent the `filename` key from altering the user provided object.

(For the tests,  es2015/regression/6864 is failing, but was failing before any modifications)
