### PR TITLE
Fixes #6870

### DIFF
--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -16,7 +16,6 @@
     "compiler"
   ],
   "dependencies": {
-    "@babel/polyfill": "7.0.0-beta.32",
     "@babel/register": "7.0.0-beta.32",
     "commander": "^2.8.1",
     "fs-readdir-recursive": "^1.0.0",

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -5,9 +5,7 @@ import path from "path";
 import repl from "repl";
 import * as babel from "@babel/core";
 import vm from "vm";
-import "@babel/polyfill";
 import register from "@babel/register";
-
 import pkg from "../package.json";
 
 const program = new commander.Command("babel-node");


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6870 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | true
| Major: Breaking Change?  | false
| Minor: New Feature?      | false
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | true
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`babel-node/src/_babel-node.js` require `@babel/polyfill` on top of the file for unknown reason, cause code don't use any of polyfill-ed methods or objects
I've removed `require` and dependency, rebuild _babel-node, and run it in node@4
- in cli mode
- in file mode
- `TEST_ONLY=babel-node make test`

everything passed correctly

