### PR TITLE
Add a 'cwd' option, and misc refactoring and tweaks before simple config merging

### DIFF
--- a/packages/babel-core/src/config/build-config-chain.js
+++ b/packages/babel-core/src/config/build-config-chain.js
@@ -39,16 +39,17 @@ type ConfigPart =
     };
 
 export default function buildConfigChain(
+  cwd: string,
   opts: ValidatedOptions,
   envName: string,
 ): Array<ConfigItem> | null {
-  const filename = opts.filename ? path.resolve(opts.filename) : null;
+  const filename = opts.filename ? path.resolve(cwd, opts.filename) : null;
   const builder = new ConfigChainBuilder(
     filename ? new LoadedFile(filename) : null,
   );
 
   try {
-    builder.mergeConfigArguments(opts, process.cwd(), envName);
+    builder.mergeConfigArguments(opts, cwd, envName);
 
     // resolve all .babelrc files
     if (opts.babelrc !== false && filename) {

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -366,13 +366,6 @@ function createDescriptor(
     );
   }
 
-  if (options != null && typeof options !== "object") {
-    throw new Error(
-      "Plugin/Preset options must be an object, null, or undefined",
-    );
-  }
-  options = options || undefined;
-
   return {
     alias: filepath || `${alias}$${index}`,
     value,

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -53,7 +53,7 @@ class OptionManager {
       loadPluginDescriptor(descriptor, envName),
     );
     const presets = result.presets.map(descriptor => ({
-      pass: config.options.passPerPreset ? [] : pass,
+      pass: descriptor.ownPass ? [] : pass,
       preset: loadPresetDescriptor(descriptor, envName),
     }));
 
@@ -143,6 +143,7 @@ type BasicDescriptor = {
   options: {} | void,
   dirname: string,
   alias: string,
+  ownPass?: boolean,
 };
 
 type LoadedDescriptor = {
@@ -173,6 +174,7 @@ const loadConfig = makeWeakCache((config: MergeOptions): {
     createDescriptor(preset, loadPreset, config.dirname, {
       index,
       alias: config.alias,
+      ownPass: config.options.passPerPreset,
     }),
   );
 
@@ -316,9 +318,11 @@ function createDescriptor(
   {
     index,
     alias,
+    ownPass,
   }: {
     index: number,
     alias: string,
+    ownPass?: boolean,
   },
 ): BasicDescriptor {
   let options;
@@ -364,6 +368,7 @@ function createDescriptor(
     value,
     options,
     dirname,
+    ownPass,
   };
 }
 

--- a/packages/babel-core/src/config/option-manager.js
+++ b/packages/babel-core/src/config/option-manager.js
@@ -1,5 +1,6 @@
 // @flow
 
+import path from "path";
 import * as context from "../index";
 import Plugin, { validatePluginObject } from "./plugin";
 import merge from "lodash/merge";
@@ -103,9 +104,10 @@ class OptionManager {
   init(inputOpts: {}) {
     const args = validate("arguments", inputOpts);
 
-    const { envName = getEnv() } = args;
+    const { envName = getEnv(), cwd = "." } = args;
+    const absoluteCwd = path.resolve(cwd);
 
-    const configChain = buildConfigChain(args, envName);
+    const configChain = buildConfigChain(absoluteCwd, args, envName);
     if (!configChain) return null;
 
     try {
@@ -134,6 +136,7 @@ class OptionManager {
       .map(plugins => ({ plugins }));
     opts.passPerPreset = opts.presets.length > 0;
     opts.envName = envName;
+    opts.cwd = absoluteCwd;
 
     return {
       options: opts,

--- a/packages/babel-core/src/config/options.js
+++ b/packages/babel-core/src/config/options.js
@@ -206,6 +206,9 @@ export function validate(type: OptionsType, opts: {}): ValidatedOptions {
     if (type !== "arguments" && ROOT_VALIDATORS[key]) {
       throw new Error(`.${key} is only allowed in root programmatic options`);
     }
+    if (type === "env" && key === "env") {
+      throw new Error(`.${key} is not allowed inside another env block`);
+    }
 
     const validator =
       COMMON_VALIDATORS[key] ||

--- a/packages/babel-core/src/config/options.js
+++ b/packages/babel-core/src/config/options.js
@@ -17,6 +17,7 @@ import {
 } from "./option-assertions";
 
 const ROOT_VALIDATORS: ValidatorSet = {
+  cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
   filename: (assertString: Validator<
     $PropertyType<ValidatedOptions, "filename">,
   >),
@@ -128,6 +129,7 @@ const COMMON_VALIDATORS: ValidatorSet = {
 export type InputOptions = ValidatedOptions;
 
 export type ValidatedOptions = {
+  cwd?: string,
   filename?: string,
   filenameRelative?: string,
   babelrc?: boolean,

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -296,12 +296,6 @@ describe("api", function() {
         development: {
           passPerPreset: true,
           presets: [pushPreset("argthree"), pushPreset("argfour")],
-          env: {
-            development: {
-              passPerPreset: true,
-              presets: [pushPreset("argfive"), pushPreset("argsix")],
-            },
-          },
         },
       },
     });
@@ -327,8 +321,6 @@ describe("api", function() {
         "fourteen;",
         "fifteen;",
         "sixteen;",
-        "argfive;",
-        "argsix;",
         "argthree;",
         "argfour;",
         "seven;",

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1,9 +1,13 @@
 import assert from "assert";
 import fs from "fs";
 import path from "path";
-import buildConfigChain from "../lib/config/build-config-chain";
+import buildConfigChainFn from "../lib/config/build-config-chain";
 
 const DEFAULT_ENV = "development";
+
+function buildConfigChain(opts, envName) {
+  return buildConfigChainFn(process.cwd(), opts, envName);
+}
 
 function fixture() {
   const args = [__dirname, "fixtures", "config"];

--- a/packages/babel-preset-es2015/test/fixtures/traceur/options.json
+++ b/packages/babel-preset-es2015/test/fixtures/traceur/options.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "transform-exponentiation-operator",
-    "transform-regenerator",
     "transform-template-literals",
     "transform-literals",
     "transform-arrow-functions",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y (added `cwd` option)
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Only new feature is adding a `cwd` option that Babel will used to resolve relative paths passed programmatically. Defaults to the global cwd. This I think is the last place where we were relying on global state, so technically we would have used the wrong filename in the transform if someone did
```
var opts = babel.loadOptions({ filename: "./file.js"});
process.chdir("/other");
babel.transform("", opts);
```
so now we allow an option for it, and `loadOptions` includes the value that was used in the `opts` it returns.

Everything else in here should be entirely non-controversial too.