### PR TITLE
Highlight code frame with highlightFrame option

### DIFF
--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -193,7 +193,10 @@ export function codeFrameColumns(
     chalk = new Chalk.constructor({ enabled: true });
   }
   const maybeHighlight = (chalkFn, string) => {
-    return highlighted ? chalkFn(string) : string;
+    if (highlighted || opts.highlightFrame) {
+      return chalkFn(string);
+    }
+    return string;
   };
   const defs = getDefs(chalk);
   if (highlighted) rawLines = highlight(defs, rawLines);
@@ -237,7 +240,7 @@ export function codeFrameColumns(
     })
     .join("\n");
 
-  if (highlighted) {
+  if (highlighted || opts.highlightFrame) {
     return chalk.reset(frame);
   } else {
     return frame;


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      |
| Documentation PR         |
| Any Dependency Changes?  |
| License                  | MIT

Add `highlightFrame` option for `@babel/code-frame` so gutters and markers can be highlighted for non-javascript code.
