### PR TITLE
Porting babel-plugin-transform-for-of-as-array into transform-for-of as option

### DIFF
--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -5,7 +5,7 @@ export default function(api, options) {
 
   if (loose === true && assumeArray === true) {
     throw new Error(
-      `Cannot use loose and assumeArray options together in babel-plugin-transform-for-of`,
+      `The loose and assumeArray options cannot be used together in @babel/plugin-transform-for-of`,
     );
   }
 

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -1,7 +1,7 @@
 import { template, types as t } from "@babel/core";
 
 export default function(api, options) {
-  const { loose, forOfAsArray: isForOfAsArray } = options;
+  const { loose, assumeArray } = options;
   const pushComputedProps = loose
     ? pushComputedPropsLoose
     : pushComputedPropsSpec;
@@ -307,7 +307,7 @@ export default function(api, options) {
     },
   };
 
-  const visitor = isForOfAsArray ? forOfAsArray : defaultForOf;
+  const visitor = assumeArray ? forOfAsArray : defaultForOf;
 
   return {
     visitor,

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -1,7 +1,7 @@
 import { template, types as t } from "@babel/core";
 
 export default function(api, options) {
-  const { loose } = options;
+  const { loose, forOfAsArray: isForOfAsArray } = options;
   const pushComputedProps = loose
     ? pushComputedPropsLoose
     : pushComputedPropsSpec;
@@ -106,49 +106,6 @@ export default function(api, options) {
       path.replaceWithMultiple(_ForOfStatementArray(path));
     }
   }
-
-  return {
-    visitor: {
-      ForOfStatement(path, state) {
-        const right = path.get("right");
-        if (
-          right.isArrayExpression() ||
-          right.isGenericType("Array") ||
-          t.isArrayTypeAnnotation(right.getTypeAnnotation())
-        ) {
-          replaceWithArray(path);
-          return;
-        }
-
-        const { node } = path;
-        const build = pushComputedProps(path, state);
-        const declar = build.declar;
-        const loop = build.loop;
-        const block = loop.body;
-
-        // ensure that it's a block so we can take all its statements
-        path.ensureBlock();
-
-        // add the value declaration to the new loop body
-        if (declar) {
-          block.body.push(declar);
-        }
-
-        // push the rest of the original loop body onto our new body
-        block.body = block.body.concat(node.body.body);
-
-        t.inherits(loop, node);
-        t.inherits(loop.body, node.body);
-
-        if (build.replaceParent) {
-          path.parentPath.replaceWithMultiple(build.node);
-          path.remove();
-        } else {
-          path.replaceWithMultiple(build.node);
-        }
-      },
-    },
-  };
 
   function pushComputedPropsLoose(path, file) {
     const { node, scope, parent } = path;
@@ -258,8 +215,6 @@ export default function(api, options) {
       tryBody[0] = t.labeledStatement(parent.label, loop);
     }
 
-    //
-
     return {
       replaceParent: isLabeledParent,
       declar: declar,
@@ -267,4 +222,94 @@ export default function(api, options) {
       node: template,
     };
   }
+
+  const defaultForOf = {
+    ForOfStatement(path, state) {
+      const right = path.get("right");
+      if (
+        right.isArrayExpression() ||
+        right.isGenericType("Array") ||
+        t.isArrayTypeAnnotation(right.getTypeAnnotation())
+      ) {
+        replaceWithArray(path);
+        return;
+      }
+
+      const { node } = path;
+      const build = pushComputedProps(path, state);
+      const declar = build.declar;
+      const loop = build.loop;
+      const block = loop.body;
+
+      // ensure that it's a block so we can take all its statements
+      path.ensureBlock();
+
+      // add the value declaration to the new loop body
+      if (declar) {
+        block.body.push(declar);
+      }
+
+      // push the rest of the original loop body onto our new body
+      block.body = block.body.concat(node.body.body);
+
+      t.inherits(loop, node);
+      t.inherits(loop.body, node.body);
+
+      if (build.replaceParent) {
+        path.parentPath.replaceWithMultiple(build.node);
+        path.remove();
+      } else {
+        path.replaceWithMultiple(build.node);
+      }
+    },
+  };
+
+  const forOfAsArray = {
+    ForOfStatement(path) {
+      const { scope } = path;
+      const { left, right, body } = path.node;
+      const i = scope.generateUidIdentifier("i");
+      let array = scope.maybeGenerateMemoised(right, true);
+
+      const inits = [t.variableDeclarator(i, t.numericLiteral(0))];
+      if (array) {
+        inits.push(t.variableDeclarator(array, right));
+      } else {
+        array = right;
+      }
+
+      const item = t.memberExpression(array, t.clone(i), true);
+      let assignment;
+      if (t.isVariableDeclaration(left)) {
+        assignment = left;
+        assignment.declarations[0].init = item;
+      } else {
+        assignment = t.expressionStatement(
+          t.assignmentExpression("=", left, item),
+        );
+      }
+
+      const block = t.toBlock(body);
+      block.body.unshift(assignment);
+
+      path.replaceWith(
+        t.forStatement(
+          t.variableDeclaration("let", inits),
+          t.binaryExpression(
+            "<",
+            t.clone(i),
+            t.memberExpression(t.clone(array), t.identifier("length")),
+          ),
+          t.updateExpression("++", t.clone(i)),
+          block,
+        ),
+      );
+    },
+  };
+
+  const visitor = isForOfAsArray ? forOfAsArray : defaultForOf;
+
+  return {
+    visitor,
+  };
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/error/invalid-option/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/error/invalid-option/actual.js
@@ -1,0 +1,4 @@
+let elm;
+for (elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/error/invalid-option/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/error/invalid-option/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": [["transform-for-of", { "assumeArray": true, "loose": true}]],
-  "throws": "Cannot use loose and assumeArray options together in babel-plugin-transform-for-of"
+  "throws": "The loose and assumeArray options cannot be used together in @babel/plugin-transform-for-of"
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/error/invalid-option/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/error/invalid-option/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["transform-for-of", { "assumeArray": true, "loose": true}]],
+  "throws": "Cannot use loose and assumeArray options together in babel-plugin-transform-for-of"
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-array-pattern/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-array-pattern/actual.js
@@ -1,0 +1,4 @@
+let elm;
+for ([elm] of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-array-pattern/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-array-pattern/expected.js
@@ -1,0 +1,6 @@
+let elm;
+
+for (let _i = 0, _array = array; _i < _array.length; _i++) {
+  [elm] = _array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration-array-pattern/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration-array-pattern/actual.js
@@ -1,0 +1,3 @@
+for (const [elm] of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration-array-pattern/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration-array-pattern/expected.js
@@ -1,0 +1,4 @@
+for (let _i = 0, _array = array; _i < _array.length; _i++) {
+  const [elm] = _array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration/actual.js
@@ -1,0 +1,3 @@
+for (const elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-declaration/expected.js
@@ -1,0 +1,4 @@
+for (let _i = 0, _array = array; _i < _array.length; _i++) {
+  const elm = _array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression-declaration/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression-declaration/actual.js
@@ -1,0 +1,1 @@
+for (const i of items) i;

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression-declaration/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression-declaration/expected.js
@@ -1,0 +1,4 @@
+for (let _i = 0, _items = items; _i < _items.length; _i++) {
+  const i = _items[_i];
+  i;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression/actual.js
@@ -1,0 +1,2 @@
+let i;
+for (i of items) i;

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-expression/expected.js
@@ -1,0 +1,6 @@
+let i;
+
+for (let _i = 0, _items = items; _i < _items.length; _i++) {
+  i = _items[_i];
+  i;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/actual.js
@@ -1,0 +1,5 @@
+import { array } from "foo";
+
+for (const elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/expected.js
@@ -1,0 +1,8 @@
+define(["foo"], function (_foo) {
+  "use strict";
+
+  for (let _i = 0; _i < _foo.array.length; _i++) {
+    const elm = _foo.array[_i];
+    console.log(elm);
+  }
+});

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [["transform-for-of", {
-    "forOfAsArray": true
+    "assumeArray": true
     }],
     ["transform-modules-amd"]
   ]

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-amd/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [["transform-for-of", {
+    "forOfAsArray": true
+    }],
+    ["transform-modules-amd"]
+  ]
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/actual.js
@@ -1,0 +1,5 @@
+import { array } from "foo";
+
+for (const elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var _foo = require("foo");
+
+for (let _i = 0; _i < _foo.array.length; _i++) {
+  const elm = _foo.array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [["transform-for-of", {
-    "forOfAsArray": true
+    "assumeArray": true
     }],
     ["transform-modules-commonjs"]
   ]

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-commonjs/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [["transform-for-of", {
+    "forOfAsArray": true
+    }],
+    ["transform-modules-commonjs"]
+  ]
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-es2015/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-es2015/actual.js
@@ -1,0 +1,5 @@
+import { array } from "foo";
+
+for (const elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-es2015/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-import-es2015/expected.js
@@ -1,0 +1,6 @@
+import { array } from "foo";
+
+for (let _i = 0; _i < array.length; _i++) {
+  const elm = array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static-declaration/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static-declaration/actual.js
@@ -1,0 +1,5 @@
+const array = [];
+
+for (const elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static-declaration/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static-declaration/expected.js
@@ -1,0 +1,6 @@
+const array = [];
+
+for (let _i = 0; _i < array.length; _i++) {
+  const elm = array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static/actual.js
@@ -1,0 +1,6 @@
+const array = [];
+let elm;
+
+for (elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-static/expected.js
@@ -1,0 +1,7 @@
+const array = [];
+let elm;
+
+for (let _i = 0; _i < array.length; _i++) {
+  elm = array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of/actual.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of/actual.js
@@ -1,0 +1,5 @@
+let elm;
+
+for (elm of array) {
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of/expected.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of/expected.js
@@ -1,0 +1,6 @@
+let elm;
+
+for (let _i = 0, _array = array; _i < _array.length; _i++) {
+  elm = _array[_i];
+  console.log(elm);
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [["transform-for-of", {
-    "forOfAsArray": true
+    "assumeArray": true
     }]
   ]
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/options.json
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [["transform-for-of", {
+    "forOfAsArray": true
+    }]
+  ]
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #6816 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT