### PR TITLE
Fix type definitions to fully support Typescript

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -82,7 +82,7 @@ declare class BabelNodeCallExpression extends BabelNode {
   callee: BabelNodeExpression;
   arguments: any;
   optional?: true | false;
-  typeParameters?: ?BabelNodeTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
 }
 
 declare class BabelNodeCatchClause extends BabelNode {
@@ -153,7 +153,7 @@ declare class BabelNodeFunctionDeclaration extends BabelNode {
   async?: boolean;
   declare?: boolean;
   returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeFunctionExpression extends BabelNode {
@@ -164,7 +164,7 @@ declare class BabelNodeFunctionExpression extends BabelNode {
   generator?: boolean;
   async?: boolean;
   returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeIdentifier extends BabelNode {
@@ -233,7 +233,7 @@ declare class BabelNodeNewExpression extends BabelNode {
   callee: BabelNodeExpression;
   arguments: any;
   optional?: true | false;
-  typeParameters?: ?BabelNodeTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
 }
 
 declare class BabelNodeProgram extends BabelNode {
@@ -260,7 +260,7 @@ declare class BabelNodeObjectMethod extends BabelNode {
   decorators?: any;
   generator?: boolean;
   returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeObjectProperty extends BabelNode {
@@ -379,7 +379,7 @@ declare class BabelNodeArrowFunctionExpression extends BabelNode {
   expression?: boolean;
   generator?: boolean;
   returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeClassBody extends BabelNode {
@@ -396,8 +396,8 @@ declare class BabelNodeClassDeclaration extends BabelNode {
   abstract?: boolean;
   declare?: boolean;
   mixins?: any;
-  superTypeParameters?: ?BabelNodeTypeParameterInstantiation;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  superTypeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeClassExpression extends BabelNode {
@@ -407,8 +407,8 @@ declare class BabelNodeClassExpression extends BabelNode {
   body: BabelNodeClassBody;
   decorators?: any;
   mixins?: any;
-  superTypeParameters?: ?BabelNodeTypeParameterInstantiation;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  superTypeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeExportAllDeclaration extends BabelNode {
@@ -485,7 +485,7 @@ declare class BabelNodeClassMethod extends BabelNode {
   generator?: boolean;
   optional?: boolean;
   returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
 }
 
 declare class BabelNodeObjectPattern extends BabelNode {
@@ -946,9 +946,9 @@ declare class BabelNodeTSParameterProperty extends BabelNode {
 declare class BabelNodeTSDeclareFunction extends BabelNode {
   type: "TSDeclareFunction";
   id?: ?BabelNodeIdentifier;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
   params: any;
-  returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  returnType?: ?BabelNodeTSTypeAnnotation | BabelNodeNoop;
   async?: boolean;
   declare?: boolean;
   generator?: boolean;
@@ -958,9 +958,9 @@ declare class BabelNodeTSDeclareMethod extends BabelNode {
   type: "TSDeclareMethod";
   decorators?: any;
   key: any;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
   params: any;
-  returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  returnType?: ?BabelNodeTSTypeAnnotation | BabelNodeNoop;
   abstract?: boolean;
   access?: any;
   accessibility?: any;
@@ -979,14 +979,14 @@ declare class BabelNodeTSQualifiedName extends BabelNode {
 
 declare class BabelNodeTSCallSignatureDeclaration extends BabelNode {
   type: "TSCallSignatureDeclaration";
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   parameters?: any;
   typeAnnotation?: ?BabelNodeTSTypeAnnotation;
 }
 
 declare class BabelNodeTSConstructSignatureDeclaration extends BabelNode {
   type: "TSConstructSignatureDeclaration";
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   parameters?: any;
   typeAnnotation?: ?BabelNodeTSTypeAnnotation;
 }
@@ -1004,7 +1004,7 @@ declare class BabelNodeTSPropertySignature extends BabelNode {
 declare class BabelNodeTSMethodSignature extends BabelNode {
   type: "TSMethodSignature";
   key: BabelNodeExpression;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   parameters?: any;
   typeAnnotation?: ?BabelNodeTSTypeAnnotation;
   computed?: boolean;
@@ -1064,14 +1064,14 @@ declare class BabelNodeTSThisType extends BabelNode {
 
 declare class BabelNodeTSFunctionType extends BabelNode {
   type: "TSFunctionType";
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   typeAnnotation?: ?BabelNodeTSTypeAnnotation;
   parameters?: any;
 }
 
 declare class BabelNodeTSConstructorType extends BabelNode {
   type: "TSConstructorType";
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   typeAnnotation?: ?BabelNodeTSTypeAnnotation;
   parameters?: any;
 }
@@ -1079,7 +1079,7 @@ declare class BabelNodeTSConstructorType extends BabelNode {
 declare class BabelNodeTSTypeReference extends BabelNode {
   type: "TSTypeReference";
   typeName: BabelNodeTSEntityName;
-  typeParameters?: ?BabelNodeTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTSTypeParameterInstantiation;
 }
 
 declare class BabelNodeTSTypePredicate extends BabelNode {
@@ -1137,7 +1137,7 @@ declare class BabelNodeTSIndexedAccessType extends BabelNode {
 
 declare class BabelNodeTSMappedType extends BabelNode {
   type: "TSMappedType";
-  typeParameter: BabelNodeTypeParameter;
+  typeParameter: BabelNodeTSTypeParameter;
   typeAnnotation?: ?BabelNodeTSType;
   optional?: boolean;
   readonly?: boolean;
@@ -1151,13 +1151,13 @@ declare class BabelNodeTSLiteralType extends BabelNode {
 declare class BabelNodeTSExpressionWithTypeArguments extends BabelNode {
   type: "TSExpressionWithTypeArguments";
   expression: BabelNodeTSEntityName;
-  typeParameters?: ?BabelNodeTypeParameterInstantiation;
+  typeParameters?: ?BabelNodeTSTypeParameterInstantiation;
 }
 
 declare class BabelNodeTSInterfaceDeclaration extends BabelNode {
   type: "TSInterfaceDeclaration";
   id: BabelNodeIdentifier;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   body: BabelNodeTSInterfaceBody;
   declare?: boolean;
 }
@@ -1170,7 +1170,7 @@ declare class BabelNodeTSInterfaceBody extends BabelNode {
 declare class BabelNodeTSTypeAliasDeclaration extends BabelNode {
   type: "TSTypeAliasDeclaration";
   id: BabelNodeIdentifier;
-  typeParameters?: ?BabelNodeTypeParameterDeclaration;
+  typeParameters?: ?BabelNodeTSTypeParameterDeclaration;
   typeAnnotation: BabelNodeTSType;
   declare?: boolean;
 }
@@ -1311,7 +1311,7 @@ declare module "@babel/types" {
   declare function directiveLiteral(value: string): BabelNodeDirectiveLiteral;
   declare function blockStatement(body: any, directives?: any): BabelNodeBlockStatement;
   declare function breakStatement(label?: ?BabelNodeIdentifier): BabelNodeBreakStatement;
-  declare function callExpression(callee: BabelNodeExpression, _arguments: any, optional?: true | false, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeCallExpression;
+  declare function callExpression(callee: BabelNodeExpression, _arguments: any, optional?: true | false, typeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation): BabelNodeCallExpression;
   declare function catchClause(param?: ?BabelNodeIdentifier, body: BabelNodeBlockStatement): BabelNodeCatchClause;
   declare function conditionalExpression(test: BabelNodeExpression, consequent: BabelNodeExpression, alternate: BabelNodeExpression): BabelNodeConditionalExpression;
   declare function continueStatement(label?: ?BabelNodeIdentifier): BabelNodeContinueStatement;
@@ -1322,8 +1322,8 @@ declare module "@babel/types" {
   declare function file(program: BabelNodeProgram, comments: any, tokens: any): BabelNodeFile;
   declare function forInStatement(left: BabelNodeVariableDeclaration | BabelNodeLVal, right: BabelNodeExpression, body: BabelNodeStatement): BabelNodeForInStatement;
   declare function forStatement(init?: ?BabelNodeVariableDeclaration | BabelNodeExpression, test?: ?BabelNodeExpression, update?: ?BabelNodeExpression, body: BabelNodeStatement): BabelNodeForStatement;
-  declare function functionDeclaration(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, declare?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeFunctionDeclaration;
-  declare function functionExpression(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeFunctionExpression;
+  declare function functionDeclaration(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, declare?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeFunctionDeclaration;
+  declare function functionExpression(id?: ?BabelNodeIdentifier, params: any, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeFunctionExpression;
   declare function identifier(name: any, decorators?: any, optional?: boolean, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeIdentifier;
   declare function ifStatement(test: BabelNodeExpression, consequent: BabelNodeStatement, alternate?: ?BabelNodeStatement): BabelNodeIfStatement;
   declare function labeledStatement(label: BabelNodeIdentifier, body: BabelNodeStatement): BabelNodeLabeledStatement;
@@ -1334,10 +1334,10 @@ declare module "@babel/types" {
   declare function regExpLiteral(pattern: string, flags?: string): BabelNodeRegExpLiteral;
   declare function logicalExpression(operator: "||" | "&&" | "??", left: BabelNodeExpression, right: BabelNodeExpression): BabelNodeLogicalExpression;
   declare function memberExpression(object: BabelNodeExpression, property: any, computed?: boolean, optional?: true | false): BabelNodeMemberExpression;
-  declare function newExpression(callee: BabelNodeExpression, _arguments: any, optional?: true | false, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeNewExpression;
+  declare function newExpression(callee: BabelNodeExpression, _arguments: any, optional?: true | false, typeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation): BabelNodeNewExpression;
   declare function program(body: any, directives?: any, sourceType?: "script" | "module", sourceFile?: string): BabelNodeProgram;
   declare function objectExpression(properties: any): BabelNodeObjectExpression;
-  declare function objectMethod(kind?: any, key: any, params: any, body: BabelNodeBlockStatement, computed?: boolean, async?: boolean, decorators?: any, generator?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeObjectMethod;
+  declare function objectMethod(kind?: any, key: any, params: any, body: BabelNodeBlockStatement, computed?: boolean, async?: boolean, decorators?: any, generator?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeObjectMethod;
   declare function objectProperty(key: any, value: BabelNodeExpression | BabelNodePatternLike, computed?: boolean, shorthand?: boolean, decorators?: any): BabelNodeObjectProperty;
   declare function restElement(argument: BabelNodeLVal, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeRestElement;
   declare function returnStatement(argument?: ?BabelNodeExpression): BabelNodeReturnStatement;
@@ -1355,10 +1355,10 @@ declare module "@babel/types" {
   declare function withStatement(object: BabelNodeExpression, body: BabelNodeBlockStatement | BabelNodeStatement): BabelNodeWithStatement;
   declare function assignmentPattern(left: BabelNodeIdentifier | BabelNodeObjectPattern | BabelNodeArrayPattern, right: BabelNodeExpression, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeAssignmentPattern;
   declare function arrayPattern(elements: any, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeArrayPattern;
-  declare function arrowFunctionExpression(params: any, body: BabelNodeBlockStatement | BabelNodeExpression, async?: boolean, expression?: boolean, generator?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeArrowFunctionExpression;
+  declare function arrowFunctionExpression(params: any, body: BabelNodeBlockStatement | BabelNodeExpression, async?: boolean, expression?: boolean, generator?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeArrowFunctionExpression;
   declare function classBody(body: any): BabelNodeClassBody;
-  declare function classDeclaration(id?: ?BabelNodeIdentifier, superClass?: ?BabelNodeExpression, body: BabelNodeClassBody, decorators?: any, abstract?: boolean, declare?: boolean, _implements?: any, mixins?: any, superTypeParameters?: ?BabelNodeTypeParameterInstantiation, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassDeclaration;
-  declare function classExpression(id?: ?BabelNodeIdentifier, superClass?: ?BabelNodeExpression, body: BabelNodeClassBody, decorators?: any, _implements?: any, mixins?: any, superTypeParameters?: ?BabelNodeTypeParameterInstantiation, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassExpression;
+  declare function classDeclaration(id?: ?BabelNodeIdentifier, superClass?: ?BabelNodeExpression, body: BabelNodeClassBody, decorators?: any, abstract?: boolean, declare?: boolean, _implements?: any, mixins?: any, superTypeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassDeclaration;
+  declare function classExpression(id?: ?BabelNodeIdentifier, superClass?: ?BabelNodeExpression, body: BabelNodeClassBody, decorators?: any, _implements?: any, mixins?: any, superTypeParameters?: ?BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassExpression;
   declare function exportAllDeclaration(source: BabelNodeStringLiteral): BabelNodeExportAllDeclaration;
   declare function exportDefaultDeclaration(declaration: BabelNodeFunctionDeclaration | BabelNodeTSDeclareFunction | BabelNodeClassDeclaration | BabelNodeExpression): BabelNodeExportDefaultDeclaration;
   declare function exportNamedDeclaration(declaration?: ?BabelNodeDeclaration, specifiers: any, source?: ?BabelNodeStringLiteral): BabelNodeExportNamedDeclaration;
@@ -1369,7 +1369,7 @@ declare module "@babel/types" {
   declare function importNamespaceSpecifier(local: BabelNodeIdentifier): BabelNodeImportNamespaceSpecifier;
   declare function importSpecifier(local: BabelNodeIdentifier, imported: BabelNodeIdentifier, importKind?: null | "type" | "typeof"): BabelNodeImportSpecifier;
   declare function metaProperty(meta: BabelNodeIdentifier, property: BabelNodeIdentifier): BabelNodeMetaProperty;
-  declare function classMethod(kind?: any, key: any, params: any, body: BabelNodeBlockStatement, computed?: boolean, _static?: boolean, abstract?: boolean, access?: any, accessibility?: any, async?: boolean, decorators?: any, generator?: boolean, optional?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassMethod;
+  declare function classMethod(kind?: any, key: any, params: any, body: BabelNodeBlockStatement, computed?: boolean, _static?: boolean, abstract?: boolean, access?: any, accessibility?: any, async?: boolean, decorators?: any, generator?: boolean, optional?: boolean, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop): BabelNodeClassMethod;
   declare function objectPattern(properties: any, decorators?: any, typeAnnotation?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeObjectPattern;
   declare function spreadElement(argument: BabelNodeExpression): BabelNodeSpreadElement;
   declare function taggedTemplateExpression(tag: BabelNodeExpression, quasi: BabelNodeTemplateLiteral): BabelNodeTaggedTemplateExpression;
@@ -1451,13 +1451,13 @@ declare module "@babel/types" {
   declare function exportDefaultSpecifier(exported: BabelNodeIdentifier): BabelNodeExportDefaultSpecifier;
   declare function exportNamespaceSpecifier(exported: BabelNodeIdentifier): BabelNodeExportNamespaceSpecifier;
   declare function tSParameterProperty(parameter: BabelNodeIdentifier | BabelNodeAssignmentPattern, accessibility?: "public" | "private" | "protected", readonly?: boolean): BabelNodeTSParameterProperty;
-  declare function tSDeclareFunction(id?: ?BabelNodeIdentifier, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop, params: any, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, async?: boolean, declare?: boolean, generator?: boolean): BabelNodeTSDeclareFunction;
-  declare function tSDeclareMethod(decorators?: any, key: any, typeParameters?: ?BabelNodeTypeParameterDeclaration | BabelNodeNoop, params: any, returnType?: ?BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, abstract?: boolean, access?: any, accessibility?: any, async?: boolean, computed?: boolean, generator?: boolean, kind?: any, optional?: boolean, _static?: boolean): BabelNodeTSDeclareMethod;
+  declare function tSDeclareFunction(id?: ?BabelNodeIdentifier, typeParameters?: ?BabelNodeTSTypeParameterDeclaration | BabelNodeNoop, params: any, returnType?: ?BabelNodeTSTypeAnnotation | BabelNodeNoop, async?: boolean, declare?: boolean, generator?: boolean): BabelNodeTSDeclareFunction;
+  declare function tSDeclareMethod(decorators?: any, key: any, typeParameters?: ?BabelNodeTSTypeParameterDeclaration | BabelNodeNoop, params: any, returnType?: ?BabelNodeTSTypeAnnotation | BabelNodeNoop, abstract?: boolean, access?: any, accessibility?: any, async?: boolean, computed?: boolean, generator?: boolean, kind?: any, optional?: boolean, _static?: boolean): BabelNodeTSDeclareMethod;
   declare function tSQualifiedName(left: BabelNodeTSEntityName, right: BabelNodeIdentifier): BabelNodeTSQualifiedName;
-  declare function tSCallSignatureDeclaration(typeParameters?: ?BabelNodeTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation): BabelNodeTSCallSignatureDeclaration;
-  declare function tSConstructSignatureDeclaration(typeParameters?: ?BabelNodeTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation): BabelNodeTSConstructSignatureDeclaration;
+  declare function tSCallSignatureDeclaration(typeParameters?: ?BabelNodeTSTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation): BabelNodeTSCallSignatureDeclaration;
+  declare function tSConstructSignatureDeclaration(typeParameters?: ?BabelNodeTSTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation): BabelNodeTSConstructSignatureDeclaration;
   declare function tSPropertySignature(key: BabelNodeExpression, typeAnnotation?: ?BabelNodeTSTypeAnnotation, initializer?: ?BabelNodeExpression, computed?: boolean, optional?: boolean, readonly?: boolean): BabelNodeTSPropertySignature;
-  declare function tSMethodSignature(key: BabelNodeExpression, typeParameters?: ?BabelNodeTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation, computed?: boolean, optional?: boolean): BabelNodeTSMethodSignature;
+  declare function tSMethodSignature(key: BabelNodeExpression, typeParameters?: ?BabelNodeTSTypeParameterDeclaration, parameters?: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation, computed?: boolean, optional?: boolean): BabelNodeTSMethodSignature;
   declare function tSIndexSignature(parameters: any, typeAnnotation?: ?BabelNodeTSTypeAnnotation, readonly?: boolean): BabelNodeTSIndexSignature;
   declare function tSAnyKeyword(): BabelNodeTSAnyKeyword;
   declare function tSNumberKeyword(): BabelNodeTSNumberKeyword;
@@ -1470,9 +1470,9 @@ declare module "@babel/types" {
   declare function tSNullKeyword(): BabelNodeTSNullKeyword;
   declare function tSNeverKeyword(): BabelNodeTSNeverKeyword;
   declare function tSThisType(): BabelNodeTSThisType;
-  declare function tSFunctionType(typeParameters?: ?BabelNodeTypeParameterDeclaration, typeAnnotation?: ?BabelNodeTSTypeAnnotation, parameters?: any): BabelNodeTSFunctionType;
-  declare function tSConstructorType(typeParameters?: ?BabelNodeTypeParameterDeclaration, typeAnnotation?: ?BabelNodeTSTypeAnnotation, parameters?: any): BabelNodeTSConstructorType;
-  declare function tSTypeReference(typeName: BabelNodeTSEntityName, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeTSTypeReference;
+  declare function tSFunctionType(typeParameters?: ?BabelNodeTSTypeParameterDeclaration, typeAnnotation?: ?BabelNodeTSTypeAnnotation, parameters?: any): BabelNodeTSFunctionType;
+  declare function tSConstructorType(typeParameters?: ?BabelNodeTSTypeParameterDeclaration, typeAnnotation?: ?BabelNodeTSTypeAnnotation, parameters?: any): BabelNodeTSConstructorType;
+  declare function tSTypeReference(typeName: BabelNodeTSEntityName, typeParameters?: ?BabelNodeTSTypeParameterInstantiation): BabelNodeTSTypeReference;
   declare function tSTypePredicate(parameterName: BabelNodeIdentifier | BabelNodeTSThisType, typeAnnotation: BabelNodeTSTypeAnnotation): BabelNodeTSTypePredicate;
   declare function tSTypeQuery(exprName: BabelNodeTSEntityName): BabelNodeTSTypeQuery;
   declare function tSTypeLiteral(members: any): BabelNodeTSTypeLiteral;
@@ -1483,12 +1483,12 @@ declare module "@babel/types" {
   declare function tSParenthesizedType(typeAnnotation: BabelNodeTSType): BabelNodeTSParenthesizedType;
   declare function tSTypeOperator(typeAnnotation: BabelNodeTSType, operator?: string): BabelNodeTSTypeOperator;
   declare function tSIndexedAccessType(objectType: BabelNodeTSType, indexType: BabelNodeTSType): BabelNodeTSIndexedAccessType;
-  declare function tSMappedType(typeParameter: BabelNodeTypeParameter, typeAnnotation?: ?BabelNodeTSType, optional?: boolean, readonly?: boolean): BabelNodeTSMappedType;
+  declare function tSMappedType(typeParameter: BabelNodeTSTypeParameter, typeAnnotation?: ?BabelNodeTSType, optional?: boolean, readonly?: boolean): BabelNodeTSMappedType;
   declare function tSLiteralType(literal: BabelNodeNumericLiteral | BabelNodeStringLiteral | BabelNodeBooleanLiteral): BabelNodeTSLiteralType;
-  declare function tSExpressionWithTypeArguments(expression: BabelNodeTSEntityName, typeParameters?: ?BabelNodeTypeParameterInstantiation): BabelNodeTSExpressionWithTypeArguments;
-  declare function tSInterfaceDeclaration(id: BabelNodeIdentifier, typeParameters?: ?BabelNodeTypeParameterDeclaration, _extends?: any, body: BabelNodeTSInterfaceBody, declare?: boolean): BabelNodeTSInterfaceDeclaration;
+  declare function tSExpressionWithTypeArguments(expression: BabelNodeTSEntityName, typeParameters?: ?BabelNodeTSTypeParameterInstantiation): BabelNodeTSExpressionWithTypeArguments;
+  declare function tSInterfaceDeclaration(id: BabelNodeIdentifier, typeParameters?: ?BabelNodeTSTypeParameterDeclaration, _extends?: any, body: BabelNodeTSInterfaceBody, declare?: boolean): BabelNodeTSInterfaceDeclaration;
   declare function tSInterfaceBody(body: any): BabelNodeTSInterfaceBody;
-  declare function tSTypeAliasDeclaration(id: BabelNodeIdentifier, typeParameters?: ?BabelNodeTypeParameterDeclaration, typeAnnotation: BabelNodeTSType, declare?: boolean): BabelNodeTSTypeAliasDeclaration;
+  declare function tSTypeAliasDeclaration(id: BabelNodeIdentifier, typeParameters?: ?BabelNodeTSTypeParameterDeclaration, typeAnnotation: BabelNodeTSType, declare?: boolean): BabelNodeTSTypeAliasDeclaration;
   declare function tSAsExpression(expression: BabelNodeExpression, typeAnnotation: BabelNodeTSType): BabelNodeTSAsExpression;
   declare function tSTypeAssertion(typeAnnotation: BabelNodeTSType, expression: BabelNodeExpression): BabelNodeTSTypeAssertion;
   declare function tSEnumDeclaration(id: BabelNodeIdentifier, members: any, _const?: boolean, declare?: boolean, initializer?: ?BabelNodeExpression): BabelNodeTSEnumDeclaration;

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -80,7 +80,7 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, 
  - `expression`: `boolean` (default: `null`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -233,7 +233,7 @@ Aliases: `Expression`
  - `callee`: `Expression` (required)
  - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
  - `optional`: `true | false` (default: `null`)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
@@ -279,8 +279,8 @@ Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
  - `declare`: `boolean` (default: `null`)
  - `implements`: `Array<TSExpressionWithTypeArguments | FlowClassImplements>` (default: `null`)
  - `mixins` (default: `null`)
- - `superTypeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -299,8 +299,8 @@ Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
  - `decorators`: `Array<Decorator>` (default: `null`)
  - `implements`: `Array<TSExpressionWithTypeArguments | FlowClassImplements>` (default: `null`)
  - `mixins` (default: `null`)
- - `superTypeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -341,7 +341,7 @@ Aliases: `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`
  - `generator`: `boolean` (default: `false`)
  - `optional`: `boolean` (default: `null`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -829,7 +829,7 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `
  - `async`: `boolean` (default: `false`)
  - `declare`: `boolean` (default: `null`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -848,7 +848,7 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, 
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -1334,7 +1334,7 @@ Aliases: `Expression`
  - `callee`: `Expression` (required)
  - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
  - `optional`: `true | false` (default: `null`)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
@@ -1453,7 +1453,7 @@ Aliases: `UserWhitespacable`, `Function`, `Scopable`, `BlockParent`, `FunctionPa
  - `decorators`: `Array<Decorator>` (default: `null`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
@@ -1821,7 +1821,7 @@ See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatu
 
 Aliases: `TSTypeElement`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
  - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
@@ -1836,7 +1836,7 @@ See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstr
 
 Aliases: `TSTypeElement`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
  - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
@@ -1851,7 +1851,7 @@ See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node
 
 Aliases: `TSType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
  - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
 
@@ -1867,9 +1867,9 @@ See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node
 Aliases: `Statement`, `Declaration`
 
  - `id`: `Identifier` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
  - `params`: `Array<LVal>` (required)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
  - `async`: `boolean` (default: `false`)
  - `declare`: `boolean` (default: `null`)
  - `generator`: `boolean` (default: `false`)
@@ -1885,9 +1885,9 @@ See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, op
 
  - `decorators`: `Array<Decorator>` (default: `null`)
  - `key` (required)
- - `typeParameters`: `TypeParameterDeclaration | Noop` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
  - `params`: `Array<LVal>` (required)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
  - `abstract`: `boolean` (default: `null`)
  - `access`: `"public" | "private" | "protected"` (default: `null`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
@@ -1952,7 +1952,7 @@ See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressi
 Aliases: `TSType`
 
  - `expression`: `TSEntityName` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
@@ -1976,7 +1976,7 @@ See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts
 
 Aliases: `TSType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
  - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
 
@@ -2047,7 +2047,7 @@ See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclar
 Aliases: `Statement`, `Declaration`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
  - `body`: `TSInterfaceBody` (required)
  - `declare`: `boolean` (default: `null`)
@@ -2089,7 +2089,7 @@ See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeParameter`: `TypeParameter` (required)
+ - `typeParameter`: `TSTypeParameter` (required)
  - `typeAnnotation`: `TSType` (default: `null`)
  - `optional`: `boolean` (default: `null`)
  - `readonly`: `boolean` (default: `null`)
@@ -2106,7 +2106,7 @@ See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node
 Aliases: `TSTypeElement`
 
  - `key`: `Expression` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
  - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
  - `computed`: `boolean` (default: `null`)
@@ -2334,7 +2334,7 @@ See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclar
 Aliases: `Statement`, `Declaration`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
  - `typeAnnotation`: `TSType` (required)
  - `declare`: `boolean` (default: `null`)
 
@@ -2464,7 +2464,7 @@ See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, op
 Aliases: `TSType`
 
  - `typeName`: `TSEntityName` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -138,7 +138,10 @@ defineType("CallExpression", {
       optional: true,
     },
     typeParameters: {
-      validate: assertNodeType("TypeParameterInstantiation"),
+      validate: assertNodeType(
+        "TypeParameterInstantiation",
+        "TSTypeParameterInstantiation",
+      ),
       optional: true,
     },
   },
@@ -286,12 +289,19 @@ export const functionCommon = {
     validate: assertValueType("boolean"),
     default: false,
   },
+};
+
+export const functionTypeAnnotationCommon = {
   returnType: {
     validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation", "Noop"),
     optional: true,
   },
   typeParameters: {
-    validate: assertNodeType("TypeParameterDeclaration", "Noop"),
+    validate: assertNodeType(
+      "TypeParameterDeclaration",
+      "TSTypeParameterDeclaration",
+      "Noop",
+    ),
     optional: true,
   },
 };
@@ -313,6 +323,7 @@ defineType("FunctionDeclaration", {
   visitor: ["id", "params", "body", "returnType", "typeParameters"],
   fields: {
     ...functionDeclarationCommon,
+    ...functionTypeAnnotationCommon,
     body: {
       validate: assertNodeType("BlockStatement"),
     },
@@ -340,6 +351,7 @@ defineType("FunctionExpression", {
   ],
   fields: {
     ...functionCommon,
+    ...functionTypeAnnotationCommon,
     id: {
       validate: assertNodeType("Identifier"),
       optional: true,
@@ -559,6 +571,7 @@ defineType("ObjectMethod", {
   builder: ["kind", "key", "params", "body", "computed"],
   fields: {
     ...functionCommon,
+    ...functionTypeAnnotationCommon,
     kind: {
       validate: chain(
         assertValueType("string"),

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -6,7 +6,11 @@ import defineType, {
   assertEach,
   assertOneOf,
 } from "./utils";
-import { functionCommon, patternLikeCommon } from "./core";
+import {
+  functionCommon,
+  functionTypeAnnotationCommon,
+  patternLikeCommon,
+} from "./core";
 
 defineType("AssignmentPattern", {
   visitor: ["left", "right"],
@@ -63,6 +67,7 @@ defineType("ArrowFunctionExpression", {
   ],
   fields: {
     ...functionCommon,
+    ...functionTypeAnnotationCommon,
     expression: {
       // https://github.com/babel/babylon/issues/505
       validate: assertValueType("boolean"),
@@ -94,7 +99,11 @@ defineType("ClassBody", {
 
 const classCommon = {
   typeParameters: {
-    validate: assertNodeType("TypeParameterDeclaration", "Noop"),
+    validate: assertNodeType(
+      "TypeParameterDeclaration",
+      "TSTypeParameterDeclaration",
+      "Noop",
+    ),
     optional: true,
   },
   body: {
@@ -105,7 +114,10 @@ const classCommon = {
     validate: assertNodeType("Expression"),
   },
   superTypeParameters: {
-    validate: assertNodeType("TypeParameterInstantiation"),
+    validate: assertNodeType(
+      "TypeParameterInstantiation",
+      "TSTypeParameterInstantiation",
+    ),
     optional: true,
   },
   implements: {
@@ -442,6 +454,7 @@ defineType("ClassMethod", {
   ],
   fields: {
     ...classMethodOrDeclareMethodCommon,
+    ...functionTypeAnnotationCommon,
     body: {
       validate: assertNodeType("BlockStatement"),
     },

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -45,6 +45,17 @@ function validateArrayOfType(nodeTypeName) {
   return validate(arrayOfType(nodeTypeName));
 }
 
+const tSFunctionTypeAnnotationCommon = {
+  returnType: {
+    validate: assertNodeType("TSTypeAnnotation", "Noop"),
+    optional: true,
+  },
+  typeParameters: {
+    validate: assertNodeType("TSTypeParameterDeclaration", "Noop"),
+    optional: true,
+  },
+};
+
 defineType("TSParameterProperty", {
   aliases: ["LVal"], // TODO: This isn't usable in general as an LVal. Should have a "Parameter" alias.
   visitor: ["parameter"],
@@ -66,12 +77,18 @@ defineType("TSParameterProperty", {
 defineType("TSDeclareFunction", {
   aliases: ["Statement", "Declaration"],
   visitor: ["id", "typeParameters", "params", "returnType"],
-  fields: functionDeclarationCommon,
+  fields: {
+    ...functionDeclarationCommon,
+    ...tSFunctionTypeAnnotationCommon,
+  },
 });
 
 defineType("TSDeclareMethod", {
   visitor: ["decorators", "key", "typeParameters", "params", "returnType"],
-  fields: classMethodOrDeclareMethodCommon,
+  fields: {
+    ...classMethodOrDeclareMethodCommon,
+    ...tSFunctionTypeAnnotationCommon,
+  },
 });
 
 defineType("TSQualifiedName", {
@@ -84,7 +101,7 @@ defineType("TSQualifiedName", {
 });
 
 const signatureDeclarationCommon = {
-  typeParameters: validateOptionalType("TypeParameterDeclaration"),
+  typeParameters: validateOptionalType("TSTypeParameterDeclaration"),
   parameters: validateArrayOfType(["Identifier", "RestElement"]),
   typeAnnotation: validateOptionalType("TSTypeAnnotation"),
 };
@@ -178,7 +195,7 @@ defineType("TSTypeReference", {
   visitor: ["typeName", "typeParameters"],
   fields: {
     typeName: validateType("TSEntityName"),
-    typeParameters: validateOptionalType("TypeParameterInstantiation"),
+    typeParameters: validateOptionalType("TSTypeParameterInstantiation"),
   },
 });
 
@@ -265,7 +282,7 @@ defineType("TSMappedType", {
   visitor: ["typeParameter", "typeAnnotation"],
   fields: {
     readonly: validateOptional(bool),
-    typeParameter: validateType("TypeParameter"),
+    typeParameter: validateType("TSTypeParameter"),
     optional: validateOptional(bool),
     typeAnnotation: validateOptionalType("TSType"),
   },
@@ -288,7 +305,7 @@ defineType("TSExpressionWithTypeArguments", {
   visitor: ["expression", "typeParameters"],
   fields: {
     expression: validateType("TSEntityName"),
-    typeParameters: validateOptionalType("TypeParameterInstantiation"),
+    typeParameters: validateOptionalType("TSTypeParameterInstantiation"),
   },
 });
 
@@ -299,7 +316,7 @@ defineType("TSInterfaceDeclaration", {
   fields: {
     declare: validateOptional(bool),
     id: validateType("Identifier"),
-    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    typeParameters: validateOptionalType("TSTypeParameterDeclaration"),
     extends: validateOptional(arrayOfType("TSExpressionWithTypeArguments")),
     body: validateType("TSInterfaceBody"),
   },
@@ -318,7 +335,7 @@ defineType("TSTypeAliasDeclaration", {
   fields: {
     declare: validateOptional(bool),
     id: validateType("Identifier"),
-    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    typeParameters: validateOptionalType("TSTypeParameterDeclaration"),
     typeAnnotation: validateType("TSType"),
   },
 });


### PR DESCRIPTION


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6933 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

This addresses missing or incorrect Typescript types in other type definitions.

For core, experimental, and ES2015 types, any type definition referencing a Flow node type (for example, the `typeParameters` property of the `ArrowFunctionExpression` node type) now also allows the equivalent Typescript node type. (In the case of `ArrowFunctionExpression.typeParameters`, allowed types became `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop`.

For Typescript types, any type definition referencing a Flow node type replaced that reference with the equivalent Typescript node type. For example, in `TSInterfaceDeclaration.typeParameters`, allowed types became `TSTypeParameterDeclaration` rather than `TypeParameterDeclaration`.
