### PR TITLE
Update flow to 0.59 and fix some flow issues

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,6 +17,7 @@ lib/types.js
 lib/third-party-libs.js.flow
 
 [options]
+include_warnings=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment= \\(.\\|\n\\)*\\$FlowIssue
 suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-config-babel": "^7.0.2",
     "eslint-plugin-flowtype": "^2.20.0",
     "eslint-plugin-prettier": "^2.2.0",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.59.0",
     "graceful-fs": "^4.1.11",
     "gulp": "^3.9.0",
     "gulp-babel": "^8.0.0-beta.0",

--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -1513,10 +1513,9 @@ export default class StatementParser extends ExpressionParser {
     }
   }
 
-  checkDeclaration(node: N.Pattern): void {
+  checkDeclaration(node: N.Pattern | N.ObjectProperty): void {
     if (node.type === "ObjectPattern") {
       for (const prop of node.properties) {
-        // $FlowFixMe (prop may be an AssignmentProperty, in which case this does nothing?)
         this.checkDeclaration(prop);
       }
     } else if (node.type === "ArrayPattern") {

--- a/packages/babylon/src/plugins/estree.js
+++ b/packages/babylon/src/plugins/estree.js
@@ -74,10 +74,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node.expression = false;
     }
 
-    checkDeclaration(node: N.Pattern): void {
+    checkDeclaration(node: N.Pattern | N.ObjectProperty): void {
       if (isSimpleProperty(node)) {
-        // $FlowFixMe
-        this.checkDeclaration(node.value);
+        this.checkDeclaration(((node: any): N.EstreeProperty).value);
       } else {
         super.checkDeclaration(node);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,9 +2754,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.57.3:
-  version "0.57.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
+flow-bin@^0.59.0:
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | Yes
| License                  | MIT

0.60 cannot be used yet because of https://github.com/facebook/flow/issues/5449
