### PR TITLE
Handling babylon parsing errors in a better way

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -6,7 +6,7 @@ import convertSourceMap, { typeof Converter } from "convert-source-map";
 import { parse } from "babylon";
 import { codeFrameColumns } from "@babel/code-frame";
 import File from "./file/file";
-import generateHelpMessage from "./util/missing-plugin-helper";
+import generateMissingPluginMessage from "./util/missing-plugin-helper";
 
 const shebangRegex = /^#!.*/;
 
@@ -89,7 +89,7 @@ function parser(pluginPasses, options, code) {
     }
     throw new Error("More than one plugin attempted to override parsing.");
   } catch (err) {
-    const loc = err.loc;
+    const { loc, missingPlugin } = err;
     if (loc) {
       err.loc = null;
       err.message =
@@ -103,8 +103,11 @@ function parser(pluginPasses, options, code) {
             },
           },
           options,
-        ) +
-        `\n${generateHelpMessage(err.missingPlugin)}`;
+        );
+      const missingPluginMessage = generateMissingPluginMessage(missingPlugin);
+      if (missingPluginMessage) {
+        err.message += `\n${missingPluginMessage}`;
+      }
     }
     throw err;
   }

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -92,21 +92,23 @@ function parser(pluginPasses, options, code) {
     const { loc, missingPlugin } = err;
     if (loc) {
       err.loc = null;
-      err.message =
-        `${options.filename || "unknown"}: ${err.message}\n` +
-        codeFrameColumns(
-          code,
-          {
-            start: {
-              line: loc.line,
-              column: loc.column + 1,
-            },
+      const codeFrame = codeFrameColumns(
+        code,
+        {
+          start: {
+            line: loc.line,
+            column: loc.column + 1,
           },
-          options,
-        );
-      const missingPluginMessage = generateMissingPluginMessage(missingPlugin);
-      if (missingPluginMessage) {
-        err.message += `\n${missingPluginMessage}`;
+        },
+        options,
+      );
+      if (missingPlugin) {
+        err.message =
+          `${options.filename || "unknown"}: ` +
+          generateMissingPluginMessage(missingPlugin[0], loc, codeFrame);
+      } else {
+        err.message =
+          `${options.filename || "unknown"}: ${err.message}\n\n` + codeFrame;
       }
     }
     throw err;

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -6,6 +6,7 @@ import convertSourceMap, { typeof Converter } from "convert-source-map";
 import { parse } from "babylon";
 import { codeFrameColumns } from "@babel/code-frame";
 import File from "./file/file";
+import generateHelpMessage from "./util/missing-plugin-helper";
 
 const shebangRegex = /^#!.*/;
 
@@ -102,7 +103,8 @@ function parser(pluginPasses, options, code) {
             },
           },
           options,
-        );
+        ) +
+        `\n${generateHelpMessage(err.missingPlugin)}`;
     }
     throw err;
   }

--- a/packages/babel-core/src/transformation/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/transformation/util/missing-plugin-helper.js
@@ -97,6 +97,12 @@ const pluginNameMap = {
       url: "https://git.io/vb4SZ",
     },
   },
+  importMeta: {
+    syntax: {
+      name: "@babel/plugin-syntax-import-meta",
+      url: "https://git.io/vbKK6",
+    },
+  },
   jsx: {
     syntax: {
       name: "@babel/plugin-syntax-jsx",

--- a/packages/babel-core/src/transformation/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/transformation/util/missing-plugin-helper.js
@@ -191,28 +191,38 @@ const pluginNameMap = {
 
 const getNameURLCombination = ({ name, url }) => `${name} (${url})`;
 
+/*
+Returns a string of the format:
+Support for the experimental syntax [babylon plugin name] isn't currently enabled ([loc]):
+
+[code frame]
+
+Add [npm package name] ([url]) to the 'plugins' section of your Babel config
+to enable [parsing|transformation].
+*/
 export default function generateMissingPluginMessage(
-  missingPlugins: string[] = [],
+  missingPluginName: string,
+  loc,
+  codeFrame,
 ): string {
-  let helpMessage = "";
-  const pluginName = missingPlugins.length && missingPlugins[0];
-  if (pluginName) {
-    const pluginInfo = pluginNameMap[pluginName];
-    if (pluginInfo) {
-      const { syntax: syntaxPlugin, transform: transformPlugin } = pluginInfo;
-      if (syntaxPlugin) {
+  let helpMessage =
+    `Support for the experimental syntax '${missingPluginName}' isn't currently enabled ` +
+    `(${loc.line}:${loc.column + 1}):\n\n` +
+    codeFrame;
+  const pluginInfo = pluginNameMap[missingPluginName];
+  if (pluginInfo) {
+    const { syntax: syntaxPlugin, transform: transformPlugin } = pluginInfo;
+    if (syntaxPlugin) {
+      if (transformPlugin) {
+        const transformPluginInfo = getNameURLCombination(transformPlugin);
+        helpMessage +=
+          `\n\nAdd ${transformPluginInfo} to the 'plugins' section of your Babel config ` +
+          `to enable transformation.`;
+      } else {
         const syntaxPluginInfo = getNameURLCombination(syntaxPlugin);
-        if (transformPlugin) {
-          const transformPluginInfo = getNameURLCombination(syntaxPlugin);
-          helpMessage =
-            `Support for this experimental syntax isn't currently enabled. ` +
-            `Add either ${transformPluginInfo} or ${syntaxPluginInfo} (if you only need parsing support) ` +
-            `to the 'plugins' section of your Babel config.`;
-        } else {
-          helpMessage =
-            `Support for this experimental syntax isn't currently enabled. ` +
-            `Add ${syntaxPluginInfo} to the 'plugins' section of your Babel config.`;
-        }
+        helpMessage +=
+          `\n\nAdd ${syntaxPluginInfo} to the 'plugins' section of your Babel config ` +
+          `to enable parsing.`;
       }
     }
   }

--- a/packages/babel-core/src/transformation/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/transformation/util/missing-plugin-helper.js
@@ -1,0 +1,129 @@
+// @flow
+
+const pluginNameMap = {
+  asyncGenerators: {
+    syntax: "@babel/plugin-syntax-async-generators",
+    transform: "@babel/plugin-proposal-async-generator-functions",
+  },
+  bigInt: {
+    issueLink: "https://github.com/babel/proposals/issues/2",
+  },
+  classPrivateMethods: {
+    issueLink: "https://github.com/babel/proposals/issues/22",
+  },
+  classPrivateProperties: {
+    issueLink: "https://github.com/babel/proposals/issues/22",
+  },
+  classProperties: {
+    syntax: "@babel/plugin-syntax-class-properties",
+    transform: "@babel/plugin-proposal-class-properties",
+  },
+  decorators: {
+    syntax: "@babel/plugin-syntax-decorators",
+    transform: "@babel/plugin-proposal-decorators",
+  },
+  doExpressions: {
+    syntax: "@babel/plugin-syntax-do-expressions",
+    transform: "@babel/plugin-proposal-do-expressions",
+  },
+  dynamicImport: {
+    syntax: "@babel/plugin-syntax-dynamic-import",
+  },
+  // Not required to be handled.
+  // (See https://github.com/babel/babel/issues/6205#issuecomment-346997662).
+  // Here just to complete the plugin map
+  estree: {},
+  exportDefaultFrom: {
+    syntax: "@babel/plugin-syntax-export-default-from",
+    transform: "@babel/plugin-proposal-export-default-from",
+  },
+  exportNamespaceFrom: {
+    syntax: "@babel/plugin-syntax-export-namespace-from",
+    transform: "@babel/plugin-proposal-export-namespace-from",
+  },
+  flow: {
+    syntax: "@babel/plugin-syntax-flow",
+    transform: "@babel/plugin-transform-flow-strip-type",
+  },
+  functionBind: {
+    syntax: "@babel/plugin-syntax-function-bind",
+    transform: "@babel/plugin-proposal-function-bind",
+  },
+  functionSent: {
+    syntax: "@babel/plugin-syntax-function-sent",
+    transform: "@babel/plugin-proposal-function-sent",
+  },
+  importMeta: {
+    issueLink: "https://github.com/babel/proposals/issues/10",
+  },
+  jsx: {
+    syntax: "@babel/plugin-syntax-jsx",
+    transform: "@babel/plugin-transform-react-jsx",
+  },
+  nullishCoalescingOperator: {
+    syntax: "@babel/plugin-syntax-nullish-coalescing-operator",
+    transform: "@babel/plugin-proposal-nullish-coalescing-operator",
+  },
+  numericSeparator: {
+    syntax: "@babel/plugin-syntax-numeric-separator",
+    transform: "@babel/plugin-proposal-numeric-separator",
+  },
+  objectRestSpread: {
+    syntax: "@babel/plugin-syntax-object-rest-spread",
+    transform: "@babel/plugin-proposal-object-rest-spread",
+  },
+  optionalCatchBinding: {
+    syntax: "@babel/plugin-syntax-optional-catch-binding",
+    transform: "@babel/plugin-proposal-optional-catch-binding",
+  },
+  optionalChaining: {
+    syntax: "@babel/plugin-syntax-optional-chaining",
+    transform: "@babel/plugin-proposal-optional-chaining",
+  },
+  pipelineOperator: {
+    syntax: "@babel/plugin-syntax-pipeline-operator",
+    transform: "@babel/plugin-proposal-pipeline-operator",
+  },
+  throwExpressions: {
+    syntax: "@babel/plugin-syntax-throw-expressions",
+    transform: "@babel/plugin-proposal-throw-expressions",
+  },
+  typescript: {
+    syntax: "@babel/plugin-syntax-typescript",
+    transform: "@babel/plugin-transform-typescript",
+  },
+};
+
+export default function generateHelpMessage(
+  missingPlugins: string[] = [],
+): string {
+  let helpMessage = "";
+  const pluginName = missingPlugins.length && missingPlugins[0];
+  if (pluginName) {
+    const pluginInfo = pluginNameMap[pluginName];
+    if (pluginInfo) {
+      const {
+        syntax: syntaxPlugin,
+        transform: transformPlugin,
+        issueLink,
+      } = pluginInfo;
+      if (syntaxPlugin) {
+        if (transformPlugin) {
+          helpMessage =
+            `Use the ${syntaxPlugin} plugin to enable parsing. ` +
+            `Use the ${transformPlugin} plugin to enable transformation.` +
+            `\nNote: The transform plugins already include the syntax plugins, so you don't need both.`;
+        } else {
+          helpMessage =
+            `Use the ${syntaxPlugin} plugin to enable parsing. ` +
+            `Babel doesn't support transforming this syntax.`;
+        }
+      } else if (issueLink) {
+        helpMessage =
+          `This syntax is not supported yet. ` +
+          `Follow it's development at ${issueLink}.`;
+      }
+    }
+  }
+  return helpMessage;
+}

--- a/packages/babel-core/src/transformation/util/missing-plugin-helper.js
+++ b/packages/babel-core/src/transformation/util/missing-plugin-helper.js
@@ -2,99 +2,196 @@
 
 const pluginNameMap = {
   asyncGenerators: {
-    syntax: "@babel/plugin-syntax-async-generators",
-    transform: "@babel/plugin-proposal-async-generator-functions",
-  },
-  bigInt: {
-    issueLink: "https://github.com/babel/proposals/issues/2",
-  },
-  classPrivateMethods: {
-    issueLink: "https://github.com/babel/proposals/issues/22",
-  },
-  classPrivateProperties: {
-    issueLink: "https://github.com/babel/proposals/issues/22",
+    syntax: {
+      name: "@babel/plugin-syntax-async-generators",
+      url: "https://git.io/vb4SY",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-async-generator-functions",
+      url: "https://git.io/vb4yp",
+    },
   },
   classProperties: {
-    syntax: "@babel/plugin-syntax-class-properties",
-    transform: "@babel/plugin-proposal-class-properties",
+    syntax: {
+      name: "@babel/plugin-syntax-class-properties",
+      url: "https://git.io/vb4yQ",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-class-properties",
+      url: "https://git.io/vb4SL",
+    },
   },
   decorators: {
-    syntax: "@babel/plugin-syntax-decorators",
-    transform: "@babel/plugin-proposal-decorators",
+    syntax: {
+      name: "@babel/plugin-syntax-decorators",
+      url: "https://git.io/vb4y9",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-decorators",
+      url: "https://git.io/vb4ST",
+    },
   },
   doExpressions: {
-    syntax: "@babel/plugin-syntax-do-expressions",
-    transform: "@babel/plugin-proposal-do-expressions",
+    syntax: {
+      name: "@babel/plugin-syntax-do-expressions",
+      url: "https://git.io/vb4yh",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-do-expressions",
+      url: "https://git.io/vb4S3",
+    },
   },
   dynamicImport: {
-    syntax: "@babel/plugin-syntax-dynamic-import",
+    syntax: {
+      name: "@babel/plugin-syntax-dynamic-import",
+      url: "https://git.io/vb4Sv",
+    },
   },
-  // Not required to be handled.
-  // (See https://github.com/babel/babel/issues/6205#issuecomment-346997662).
-  // Here just to complete the plugin map
-  estree: {},
   exportDefaultFrom: {
-    syntax: "@babel/plugin-syntax-export-default-from",
-    transform: "@babel/plugin-proposal-export-default-from",
+    syntax: {
+      name: "@babel/plugin-syntax-export-default-from",
+      url: "https://git.io/vb4SO",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-export-default-from",
+      url: "https://git.io/vb4yH",
+    },
   },
   exportNamespaceFrom: {
-    syntax: "@babel/plugin-syntax-export-namespace-from",
-    transform: "@babel/plugin-proposal-export-namespace-from",
+    syntax: {
+      name: "@babel/plugin-syntax-export-namespace-from",
+      url: "https://git.io/vb4Sf",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-export-namespace-from",
+      url: "https://git.io/vb4SG",
+    },
   },
   flow: {
-    syntax: "@babel/plugin-syntax-flow",
-    transform: "@babel/plugin-transform-flow-strip-type",
+    syntax: {
+      name: "@babel/plugin-syntax-flow",
+      url: "https://git.io/vb4yb",
+    },
+    transform: {
+      name: "@babel/plugin-transform-flow-strip-types",
+      url: "https://git.io/vb49g",
+    },
   },
   functionBind: {
-    syntax: "@babel/plugin-syntax-function-bind",
-    transform: "@babel/plugin-proposal-function-bind",
+    syntax: {
+      name: "@babel/plugin-syntax-function-bind",
+      url: "https://git.io/vb4y7",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-function-bind",
+      url: "https://git.io/vb4St",
+    },
   },
   functionSent: {
-    syntax: "@babel/plugin-syntax-function-sent",
-    transform: "@babel/plugin-proposal-function-sent",
-  },
-  importMeta: {
-    issueLink: "https://github.com/babel/proposals/issues/10",
+    syntax: {
+      name: "@babel/plugin-syntax-function-sent",
+      url: "https://git.io/vb4yN",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-function-sent",
+      url: "https://git.io/vb4SZ",
+    },
   },
   jsx: {
-    syntax: "@babel/plugin-syntax-jsx",
-    transform: "@babel/plugin-transform-react-jsx",
+    syntax: {
+      name: "@babel/plugin-syntax-jsx",
+      url: "https://git.io/vb4yA",
+    },
+    transform: {
+      name: "@babel/plugin-transform-react-jsx",
+      url: "https://git.io/vb4yd",
+    },
   },
   nullishCoalescingOperator: {
-    syntax: "@babel/plugin-syntax-nullish-coalescing-operator",
-    transform: "@babel/plugin-proposal-nullish-coalescing-operator",
+    syntax: {
+      name: "@babel/plugin-syntax-nullish-coalescing-operator",
+      url: "https://git.io/vb4yx",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-nullish-coalescing-operator",
+      url: "https://git.io/vb4Se",
+    },
   },
   numericSeparator: {
-    syntax: "@babel/plugin-syntax-numeric-separator",
-    transform: "@babel/plugin-proposal-numeric-separator",
+    syntax: {
+      name: "@babel/plugin-syntax-numeric-separator",
+      url: "https://git.io/vb4Sq",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-numeric-separator",
+      url: "https://git.io/vb4yS",
+    },
   },
   objectRestSpread: {
-    syntax: "@babel/plugin-syntax-object-rest-spread",
-    transform: "@babel/plugin-proposal-object-rest-spread",
+    syntax: {
+      name: "@babel/plugin-syntax-object-rest-spread",
+      url: "https://git.io/vb4y5",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-object-rest-spread",
+      url: "https://git.io/vb4Ss",
+    },
   },
   optionalCatchBinding: {
-    syntax: "@babel/plugin-syntax-optional-catch-binding",
-    transform: "@babel/plugin-proposal-optional-catch-binding",
+    syntax: {
+      name: "@babel/plugin-syntax-optional-catch-binding",
+      url: "https://git.io/vb4Sn",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-optional-catch-binding",
+      url: "https://git.io/vb4SI",
+    },
   },
   optionalChaining: {
-    syntax: "@babel/plugin-syntax-optional-chaining",
-    transform: "@babel/plugin-proposal-optional-chaining",
+    syntax: {
+      name: "@babel/plugin-syntax-optional-chaining",
+      url: "https://git.io/vb4Sc",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-optional-chaining",
+      url: "https://git.io/vb4Sk",
+    },
   },
   pipelineOperator: {
-    syntax: "@babel/plugin-syntax-pipeline-operator",
-    transform: "@babel/plugin-proposal-pipeline-operator",
+    syntax: {
+      name: "@babel/plugin-syntax-pipeline-operator",
+      url: "https://git.io/vb4yj",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-pipeline-operator",
+      url: "https://git.io/vb4SU",
+    },
   },
   throwExpressions: {
-    syntax: "@babel/plugin-syntax-throw-expressions",
-    transform: "@babel/plugin-proposal-throw-expressions",
+    syntax: {
+      name: "@babel/plugin-syntax-throw-expressions",
+      url: "https://git.io/vb4SJ",
+    },
+    transform: {
+      name: "@babel/plugin-proposal-throw-expressions",
+      url: "https://git.io/vb4yF",
+    },
   },
   typescript: {
-    syntax: "@babel/plugin-syntax-typescript",
-    transform: "@babel/plugin-transform-typescript",
+    syntax: {
+      name: "@babel/plugin-syntax-typescript",
+      url: "https://git.io/vb4SC",
+    },
+    transform: {
+      name: "@babel/plugin-transform-typescript",
+      url: "https://git.io/vb4Sm",
+    },
   },
 };
 
-export default function generateHelpMessage(
+const getNameURLCombination = ({ name, url }) => `${name} (${url})`;
+
+export default function generateMissingPluginMessage(
   missingPlugins: string[] = [],
 ): string {
   let helpMessage = "";
@@ -102,26 +199,20 @@ export default function generateHelpMessage(
   if (pluginName) {
     const pluginInfo = pluginNameMap[pluginName];
     if (pluginInfo) {
-      const {
-        syntax: syntaxPlugin,
-        transform: transformPlugin,
-        issueLink,
-      } = pluginInfo;
+      const { syntax: syntaxPlugin, transform: transformPlugin } = pluginInfo;
       if (syntaxPlugin) {
+        const syntaxPluginInfo = getNameURLCombination(syntaxPlugin);
         if (transformPlugin) {
+          const transformPluginInfo = getNameURLCombination(syntaxPlugin);
           helpMessage =
-            `Use the ${syntaxPlugin} plugin to enable parsing. ` +
-            `Use the ${transformPlugin} plugin to enable transformation.` +
-            `\nNote: The transform plugins already include the syntax plugins, so you don't need both.`;
+            `Support for this experimental syntax isn't currently enabled. ` +
+            `Add either ${transformPluginInfo} or ${syntaxPluginInfo} (if you only need parsing support) ` +
+            `to the 'plugins' section of your Babel config.`;
         } else {
           helpMessage =
-            `Use the ${syntaxPlugin} plugin to enable parsing. ` +
-            `Babel doesn't support transforming this syntax.`;
+            `Support for this experimental syntax isn't currently enabled. ` +
+            `Add ${syntaxPluginInfo} to the 'plugins' section of your Babel config.`;
         }
-      } else if (issueLink) {
-        helpMessage =
-          `This syntax is not supported yet. ` +
-          `Follow it's development at ${issueLink}.`;
       }
     }
   }

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -599,4 +599,42 @@ describe("api", function() {
       assert.ok(script.indexOf("typeof") >= 0);
     });
   });
+
+  describe("handle parsing errors", function() {
+    const options = {
+      babelrc: false,
+    };
+
+    it("only syntax plugin available", function() {
+      assert.throws(
+        () =>
+          babel.transformFileSync(
+            __dirname + "/fixtures/api/parsing-errors/only-syntax/file.js",
+            options,
+          ),
+        RegExp(
+          "Support for this experimental syntax isn't currently enabled. " +
+            "Add @babel/plugin-syntax-dynamic-import \\(https://git.io/vb4Sv\\) to the 'plugins' " +
+            "section of your Babel config.",
+        ),
+      );
+    });
+
+    it("both syntax and transform plugin available", function() {
+      assert.throws(
+        () =>
+          babel.transformFileSync(
+            __dirname +
+              "/fixtures/api/parsing-errors/syntax-and-transform/file.js",
+            options,
+          ),
+        RegExp(
+          "Support for this experimental syntax isn't currently enabled. Add either " +
+            "@babel/plugin-syntax-async-generators \\(https://git.io/vb4SY\\) or " +
+            "@babel/plugin-syntax-async-generators \\(https://git.io/vb4SY\\) " +
+            "\\(if you only need parsing support\\) to the 'plugins' section of your Babel config.",
+        ),
+      );
+    });
+  });
 });

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -605,35 +605,45 @@ describe("api", function() {
       babelrc: false,
     };
 
-    it("only syntax plugin available", function() {
-      assert.throws(
-        () =>
-          babel.transformFileSync(
-            __dirname + "/fixtures/api/parsing-errors/only-syntax/file.js",
-            options,
-          ),
-        RegExp(
-          "Support for this experimental syntax isn't currently enabled. " +
-            "Add @babel/plugin-syntax-dynamic-import \\(https://git.io/vb4Sv\\) to the 'plugins' " +
-            "section of your Babel config.",
-        ),
+    it("only syntax plugin available", function(done) {
+      babel.transformFile(
+        __dirname + "/fixtures/api/parsing-errors/only-syntax/file.js",
+        options,
+        function(err) {
+          assert.ok(
+            RegExp(
+              "Support for the experimental syntax 'dynamicImport' isn't currently enabled \\(1:9\\):",
+            ).exec(err.message),
+          );
+          assert.ok(
+            RegExp(
+              "Add @babel/plugin-syntax-dynamic-import \\(https://git.io/vb4Sv\\) to the " +
+                "'plugins' section of your Babel config to enable parsing.",
+            ).exec(err.message),
+          );
+          done();
+        },
       );
     });
 
-    it("both syntax and transform plugin available", function() {
-      assert.throws(
-        () =>
-          babel.transformFileSync(
-            __dirname +
-              "/fixtures/api/parsing-errors/syntax-and-transform/file.js",
-            options,
-          ),
-        RegExp(
-          "Support for this experimental syntax isn't currently enabled. Add either " +
-            "@babel/plugin-syntax-async-generators \\(https://git.io/vb4SY\\) or " +
-            "@babel/plugin-syntax-async-generators \\(https://git.io/vb4SY\\) " +
-            "\\(if you only need parsing support\\) to the 'plugins' section of your Babel config.",
-        ),
+    it("both syntax and transform plugin available", function(done) {
+      babel.transformFile(
+        __dirname + "/fixtures/api/parsing-errors/syntax-and-transform/file.js",
+        options,
+        function(err) {
+          assert.ok(
+            RegExp(
+              "Support for the experimental syntax 'asyncGenerators' isn't currently enabled \\(1:15\\):",
+            ).exec(err.message),
+          );
+          assert.ok(
+            RegExp(
+              "Add @babel/plugin-proposal-async-generator-functions \\(https://git.io/vb4yp\\) to the " +
+                "'plugins' section of your Babel config to enable transformation.",
+            ).exec(err.message),
+          );
+          done();
+        },
       );
     });
   });

--- a/packages/babel-core/test/fixtures/api/parsing-errors/only-syntax/file.js
+++ b/packages/babel-core/test/fixtures/api/parsing-errors/only-syntax/file.js
@@ -1,0 +1,1 @@
+var $ = import("jquery");

--- a/packages/babel-core/test/fixtures/api/parsing-errors/syntax-and-transform/file.js
+++ b/packages/babel-core/test/fixtures/api/parsing-errors/syntax-and-transform/file.js
@@ -1,0 +1,4 @@
+async function* agf() {
+  await 1;
+  yield 2;
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6205 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Introduces a better way to handle missing plugin errors from babylon, in babel. Previously, the errors used to be directly displayed, as is, from babylon. This was not so friendly as the error used to have only an internal name of the plugin required.

With this change, there is a mapping done between internal plugin names to the external plugin names, where required. There are **2** possible messages that are generated

1. When a plugin has both syntax and transform plugins:
>Support for the experimental syntax [babylon plugin name] isn't currently enabled ([loc]):
>
>[code frame]
>
>Add [npm package name] ([url]) to the 'plugins' section of your Babel config to enable transformation.

2. When a plugin has only a syntax plugin:
>Support for the experimental syntax [babylon plugin name] isn't currently enabled ([loc]):
>
>[code frame]
>
>Add [npm package name] ([url]) to the 'plugins' section of your Babel config to enable parsing.

All the URLs are shortened using [git.io](https://git.io), and point directly to the `repository` field of the plugin's `package.json`.