### PR TITLE
publish babylon as next tag since it's not a scoped module yet [ski…

### DIFF
--- a/packages/babylon/package.json
+++ b/packages/babylon/package.json
@@ -36,6 +36,6 @@
     "babylon": "./bin/babylon.js"
   },
   "publishConfig": {
-    "tag": "latest" 
+    "tag": "next" 
   }
 }

--- a/packages/babylon/package.json
+++ b/packages/babylon/package.json
@@ -34,5 +34,8 @@
   },
   "bin": {
     "babylon": "./bin/babylon.js"
+  },
+  "publishConfig": {
+    "tag": "latest" 
   }
 }


### PR DESCRIPTION
…p ci]

We are publishing everything as latest since scoped packages are all on v7 and never had a v6.x release before so there isn't a need to publish as `next` anymore except for babylon until we decide to switch to `@babel/babylon` or `@babel/parser`