### PR TITLE
Wrap FunctionDeclarations with FunctionDeclarations, instead of using _blockHoist.

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/expected.js
@@ -5,54 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var foo =
-/*#__PURE__*/
-function () {
-  var _ref2 = _asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
-    var bar =
-    /*#__PURE__*/
-    function () {
-      var _ref3 = _asyncToGenerator(
-      /*#__PURE__*/
-      regeneratorRuntime.mark(function _callee2() {
-        var baz;
-        return regeneratorRuntime.wrap(function _callee2$(_context2) {
-          while (1) {
-            switch (_context2.prev = _context2.next) {
-              case 0:
-                baz = {};
-
-              case 1:
-              case "end":
-                return _context2.stop();
-            }
-          }
-        }, _callee2, this);
-      }));
-
-      return function bar() {
-        return _ref3.apply(this, arguments);
-      };
-    }();
-
-    return regeneratorRuntime.wrap(function _callee3$(_context3) {
-      while (1) {
-        switch (_context3.prev = _context3.next) {
-          case 0:
-          case "end":
-            return _context3.stop();
-        }
-      }
-    }, _callee3, this);
-  }));
-
-  return function foo() {
-    return _ref2.apply(this, arguments);
-  };
-}();
-
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
@@ -73,7 +25,7 @@ function () {
   _createClass(Foo, [{
     key: "bar",
     value: function () {
-      var _ref = _asyncToGenerator(
+      var _bar = _asyncToGenerator(
       /*#__PURE__*/
       regeneratorRuntime.mark(function _callee() {
         var baz;
@@ -91,11 +43,9 @@ function () {
         }, _callee, this);
       }));
 
-      function bar() {
-        return _ref.apply(this, arguments);
-      }
-
-      return bar;
+      return function bar() {
+        return _bar.apply(this, arguments);
+      };
     }()
   }]);
 
@@ -103,3 +53,52 @@ function () {
 }();
 
 exports.default = Foo;
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee3() {
+    var bar, _bar2;
+
+    return regeneratorRuntime.wrap(function _callee3$(_context3) {
+      while (1) {
+        switch (_context3.prev = _context3.next) {
+          case 0:
+            _bar2 = function _bar2() {
+              _bar2 = _asyncToGenerator(
+              /*#__PURE__*/
+              regeneratorRuntime.mark(function _callee2() {
+                var baz;
+                return regeneratorRuntime.wrap(function _callee2$(_context2) {
+                  while (1) {
+                    switch (_context2.prev = _context2.next) {
+                      case 0:
+                        baz = {};
+
+                      case 1:
+                      case "end":
+                        return _context2.stop();
+                    }
+                  }
+                }, _callee2, this);
+              }));
+              return _bar2.apply(this, arguments);
+            };
+
+            bar = function bar() {
+              return _bar2.apply(this, arguments);
+            };
+
+          case 2:
+          case "end":
+            return _context3.stop();
+        }
+      }
+    }, _callee3, this);
+  }));
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -81,9 +81,7 @@ export default function(path: NodePath, file: Object, helpers: Object) {
     path.parentPath.isObjectProperty() ||
     path.parentPath.isClassProperty();
 
-  if (!isProperty && !isIIFE) {
-    annotateAsPure(
-      path.isDeclaration() ? path.get("declarations.0.init") : path,
-    );
+  if (!isProperty && !isIIFE && path.isExpression()) {
+    annotateAsPure(path);
   }
 }

--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -3,23 +3,21 @@ import nameFunction from "@babel/helper-function-name";
 import template from "@babel/template";
 import * as t from "@babel/types";
 
-const buildWrapper = template(`
-  (() => {
+const buildExpressionWrapper = template.expression(`
+  (function () {
     var REF = FUNCTION;
     return function NAME(PARAMS) {
       return REF.apply(this, arguments);
     };
-  })
+  })()
 `);
 
-const namedBuildWrapper = template(`
-  (() => {
-    var REF = FUNCTION;
-    function NAME(PARAMS) {
-      return REF.apply(this, arguments);
-    }
-    return NAME;
-  })
+const buildDeclarationWrapper = template(`
+  function NAME(PARAMS) { return REF.apply(this, arguments); }
+  function REF() {
+    REF = FUNCTION;
+    return REF.apply(this, arguments);
+  }
 `);
 
 function classOrObjectMethod(path: NodePath, callId: Object) {
@@ -53,12 +51,12 @@ function plainFunction(path: NodePath, callId: Object) {
   const node = path.node;
   const isDeclaration = path.isFunctionDeclaration();
   const functionId = node.id;
-  let wrapper = buildWrapper;
+  const wrapper = isDeclaration
+    ? buildDeclarationWrapper
+    : buildExpressionWrapper;
 
   if (path.isArrowFunctionExpression()) {
     path.arrowFunctionToExpression();
-  } else if (!isDeclaration && functionId) {
-    wrapper = namedBuildWrapper;
   }
 
   node.id = null;
@@ -70,7 +68,7 @@ function plainFunction(path: NodePath, callId: Object) {
   const built = t.callExpression(callId, [node]);
   const container = wrapper({
     NAME: functionId || null,
-    REF: path.scope.generateUidIdentifier("ref"),
+    REF: path.scope.generateUidIdentifier(functionId ? functionId.name : "ref"),
     FUNCTION: built,
     PARAMS: node.params.reduce(
       (acc, param) => {
@@ -88,35 +86,16 @@ function plainFunction(path: NodePath, callId: Object) {
         done: false,
       },
     ).params,
-  }).expression;
+  });
 
-  if (isDeclaration && functionId) {
-    const declar = t.variableDeclaration("let", [
-      t.variableDeclarator(
-        t.identifier(functionId.name),
-        t.callExpression(container, []),
-      ),
-    ]);
-    (declar: any)._blockHoist = true;
-
-    if (path.parentPath.isExportDefaultDeclaration()) {
-      // change the path type so that replaceWith() does not wrap
-      // the identifier into an expressionStatement
-      path.parentPath.insertBefore(declar);
-      path.parentPath.replaceWith(
-        t.exportNamedDeclaration(null, [
-          t.exportSpecifier(
-            t.identifier(functionId.name),
-            t.identifier("default"),
-          ),
-        ]),
-      );
-      return;
-    }
-
-    path.replaceWith(declar);
+  if (isDeclaration) {
+    const basePath = path.parentPath.isExportDeclaration()
+      ? path.parentPath
+      : path;
+    basePath.insertAfter(container[1]);
+    path.replaceWith(container[0]);
   } else {
-    const retFunction = container.body.body[1].argument;
+    const retFunction = container.callee.body.body[1].argument;
     if (!functionId) {
       nameFunction({
         node: retFunction,
@@ -127,7 +106,7 @@ function plainFunction(path: NodePath, callId: Object) {
 
     if (!retFunction || retFunction.id || node.params.length) {
       // we have an inferred function id or params so we need this wrapper
-      path.replaceWith(t.callExpression(container, []));
+      path.replaceWith(container);
     } else {
       // we can omit this wrapper as the conditions it protects for do not apply
       path.replaceWith(built);

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/declaration/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/declaration/expected.js
@@ -1,14 +1,13 @@
-let agf =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
+function agf() {
+  return _agf.apply(this, arguments);
+}
+
+function _agf() {
+  _agf = babelHelpers.wrapAsyncGenerator(function* () {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
-
-  return function agf() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _agf.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/expression/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/expression/expected.js
@@ -1,15 +1,13 @@
 /*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
+(function () {
+  var _agf = babelHelpers.wrapAsyncGenerator(function* () {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
 
-  function agf() {
-    return _ref.apply(this, arguments);
-  }
-
-  return agf;
+  return function agf() {
+    return _agf.apply(this, arguments);
+  };
 })();

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/yield-star/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/yield-star/expected.js
@@ -1,12 +1,11 @@
-let g =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
+function g() {
+  return _g.apply(this, arguments);
+}
+
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* () {
     yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator([1, 2, 3]), babelHelpers.awaitAsyncGenerator);
     yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator(iterable), babelHelpers.awaitAsyncGenerator);
   });
-
-  return function g() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _g.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/expected.js
@@ -1,7 +1,9 @@
-let f =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
+function f() {
+  return _f.apply(this, arguments);
+}
+
+function _f() {
+  _f = babelHelpers.asyncToGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
 
@@ -27,8 +29,5 @@ let f =
       }
     }
   });
-
-  return function f() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _f.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/expected.js
@@ -1,7 +1,9 @@
-let g =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
+function g() {
+  return _g.apply(this, arguments);
+}
+
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
 
@@ -27,8 +29,5 @@ let g =
       }
     }
   });
-
-  return function g() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _g.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/expected.js
@@ -1,7 +1,9 @@
-let f =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
+function f() {
+  return _f.apply(this, arguments);
+}
+
+function _f() {
+  _f = babelHelpers.asyncToGenerator(function* () {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
 
@@ -30,8 +32,5 @@ let f =
       }
     }
   });
-
-  return function f() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _f.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/arrows-in-declaration/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/arrows-in-declaration/expected.js
@@ -1,7 +1,9 @@
-let g =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.wrapAsyncGenerator(function* () {
+function g() {
+  return _g.apply(this, arguments);
+}
+
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* () {
     var _this = this;
 
     () => this;
@@ -17,8 +19,5 @@ let g =
     });
     yield babelHelpers.awaitAsyncGenerator(1);
   });
-
-  return function g() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _g.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/async-in-params/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/async-in-params/expected.js
@@ -1,7 +1,9 @@
-let g =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.wrapAsyncGenerator(function* (x =
+function g() {
+  return _g.apply(this, arguments);
+}
+
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* (x =
   /*#__PURE__*/
   babelHelpers.asyncToGenerator(function* () {
     yield 1;
@@ -9,8 +11,5 @@ let g =
     yield babelHelpers.awaitAsyncGenerator(2);
     yield 3;
   });
-
-  return function g() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _g.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/generator-in-async/expected.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/generator-in-async/expected.js
@@ -1,24 +1,22 @@
-let f =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
-    let g =
-    /*#__PURE__*/
-    (() => {
-      var _ref2 = babelHelpers.wrapAsyncGenerator(function* () {
+function f() {
+  return _f.apply(this, arguments);
+}
+
+function _f() {
+  _f = babelHelpers.asyncToGenerator(function* () {
+    yield 1;
+
+    function g() {
+      return _g.apply(this, arguments);
+    }
+
+    function _g() {
+      _g = babelHelpers.wrapAsyncGenerator(function* () {
         yield babelHelpers.awaitAsyncGenerator(2);
         yield 3;
       });
-
-      return function g() {
-        return _ref2.apply(this, arguments);
-      };
-    })();
-
-    yield 1;
+      return _g.apply(this, arguments);
+    }
   });
-
-  return function f() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _f.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/general/regression-T7364/expected.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/general/regression-T7364/expected.js
@@ -6,7 +6,7 @@ class MyClass {
       configurable: true,
       enumerable: true,
       writable: true,
-      value: (() => {
+      value: function () {
         var _ref = babelHelpers.asyncToGenerator(function* () {
           console.log(_this);
         });
@@ -14,7 +14,7 @@ class MyClass {
         return function value() {
           return _ref.apply(this, arguments);
         };
-      })()
+      }()
     });
   }
 
@@ -28,7 +28,7 @@ class MyClass {
       configurable: true,
       enumerable: true,
       writable: true,
-      value: (() => {
+      value: function () {
         var _ref2 = babelHelpers.asyncToGenerator(function* () {
           console.log(_this2);
         });
@@ -36,7 +36,7 @@ class MyClass {
         return function value() {
           return _ref2.apply(this, arguments);
         };
-      })()
+      }()
     });
   }
 
@@ -50,7 +50,7 @@ export default class MyClass3 {
       configurable: true,
       enumerable: true,
       writable: true,
-      value: (() => {
+      value: function () {
         var _ref3 = babelHelpers.asyncToGenerator(function* () {
           console.log(_this3);
         });
@@ -58,7 +58,7 @@ export default class MyClass3 {
         return function value() {
           return _ref3.apply(this, arguments);
         };
-      })()
+      }()
     });
   }
 

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/basic/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/basic/expected.js
@@ -1,13 +1,14 @@
-let gen = (() => {
-  var _ref = _skipFirstGeneratorNext(function* () {
+function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+
+function gen() {
+  return _gen.apply(this, arguments);
+}
+
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
     let sent = _functionSent;
   });
-
-  return function gen() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+  return _gen.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/async-generator/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/async-generator/expected.js
@@ -1,17 +1,3 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = _wrapAsyncGenerator(_skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
-
-    _functionSent = yield _awaitAsyncGenerator(_functionSent);
-  }));
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
 function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
@@ -29,3 +15,16 @@ _AsyncGenerator.prototype.throw = function (arg) { return this._invoke("throw", 
 _AsyncGenerator.prototype.return = function (arg) { return this._invoke("return", arg); };
 
 function _AwaitValue(value) { this.wrapped = value; }
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _wrapAsyncGenerator(_skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
+
+    _functionSent = yield _awaitAsyncGenerator(_functionSent);
+  }));
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-anonymous/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-anonymous/expected.js
@@ -1,7 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export default _skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+export default function () {
+  return _ref.apply(this, arguments);
+}
 
-  return _functionSent;
-});
+function _ref() {
+  _ref = _skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
+
+    return _functionSent;
+  });
+  return _ref.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-named/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-named/expected.js
@@ -1,15 +1,14 @@
-let gen = (() => {
-  var _ref = _skipFirstGeneratorNext(function* () {
+function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+
+export default function gen() {
+  return _gen.apply(this, arguments);
+}
+
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
     return _functionSent;
   });
-
-  return function gen() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
-
-export { gen as default };
+  return _gen.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export/expected.js
@@ -1,13 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export let gen = (() => {
-  var _ref = _skipFirstGeneratorNext(function* () {
+export function gen() {
+  return _gen.apply(this, arguments);
+}
+
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
     return _functionSent;
   });
-
-  return function gen() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _gen.apply(this, arguments);
+}

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-named/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-named/expected.js
@@ -1,15 +1,13 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-const foo = (() => {
-  var _ref = _skipFirstGeneratorNext(function* () {
+const foo = function () {
+  var _gen = _skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
     return _functionSent;
   });
 
-  function gen() {
-    return _ref.apply(this, arguments);
-  }
-
-  return gen;
-})();
+  return function gen() {
+    return _gen.apply(this, arguments);
+  };
+}();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/statement/expected.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/statement/expected.js
@@ -1,13 +1,14 @@
-let gen = (() => {
-  var _ref = _skipFirstGeneratorNext(function* () {
+function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+
+function gen() {
+  return _gen.apply(this, arguments);
+}
+
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
     return _functionSent;
   });
-
-  return function gen() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
-function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
+  return _gen.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/expected.js
@@ -6,7 +6,7 @@ let TestClass = {
 
     return new Promise(
     /*#__PURE__*/
-    (() => {
+    function () {
       var _ref = babelHelpers.asyncToGenerator(function* (resolve) {
         console.log(_this);
         setTimeout(resolve, 1000);
@@ -15,7 +15,7 @@ let TestClass = {
       return function (_x) {
         return _ref.apply(this, arguments);
       };
-    })());
+    }());
   }
 
 };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-default-arguments/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-default-arguments/expected.js
@@ -1,19 +1,18 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref2 = babelHelpers.asyncToGenerator(function* (_ref) {
+function mandatory(paramName) {
+  throw new Error(`Missing parameter: ${paramName}`);
+}
+
+function foo(_x) {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* (_ref) {
     let {
       a,
       b = mandatory("b")
     } = _ref;
     return Promise.resolve(b);
   });
-
-  return function foo(_x) {
-    return _ref2.apply(this, arguments);
-  };
-})();
-
-function mandatory(paramName) {
-  throw new Error(`Missing parameter: ${paramName}`);
+  return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/actual.js
@@ -1,4 +1,3 @@
 (async function() { await 'ok' })();
 (async () => { await 'ok' })();
-async function notIIFE() { await 'ok' }
-notIIFE();
+(async function notIIFE() { await 'ok' });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/expected.js
@@ -1,19 +1,17 @@
-let notIIFE =
+babelHelpers.asyncToGenerator(function* () {
+  yield 'ok';
+})();
+babelHelpers.asyncToGenerator(function* () {
+  yield 'ok';
+})();
+
 /*#__PURE__*/
-(() => {
-  var _ref3 = babelHelpers.asyncToGenerator(function* () {
+(function () {
+  var _notIIFE = babelHelpers.asyncToGenerator(function* () {
     yield 'ok';
   });
 
   return function notIIFE() {
-    return _ref3.apply(this, arguments);
+    return _notIIFE.apply(this, arguments);
   };
 })();
-
-babelHelpers.asyncToGenerator(function* () {
-  yield 'ok';
-})();
-babelHelpers.asyncToGenerator(function* () {
-  yield 'ok';
-})();
-notIIFE();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/expected.js
@@ -1,7 +1,9 @@
-let s =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* (x) {
+function s(_x) {
+  return _s.apply(this, arguments);
+}
+
+function _s() {
+  _s = babelHelpers.asyncToGenerator(function* (x) {
     var _this = this,
         _arguments = arguments;
 
@@ -11,12 +13,12 @@ let s =
 
     let t =
     /*#__PURE__*/
-    (() => {
-      var _ref2 = babelHelpers.asyncToGenerator(function* (y, a) {
+    function () {
+      var _ref = babelHelpers.asyncToGenerator(function* (y, a) {
         let r =
         /*#__PURE__*/
-        (() => {
-          var _ref3 = babelHelpers.asyncToGenerator(function* (z, b) {
+        function () {
+          var _ref2 = babelHelpers.asyncToGenerator(function* (z, b) {
             yield z;
 
             for (var _len2 = arguments.length, innerArgs = new Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
@@ -28,9 +30,9 @@ let s =
           });
 
           return function r(_x4, _x5) {
-            return _ref3.apply(this, arguments);
+            return _ref2.apply(this, arguments);
           };
-        })();
+        }();
 
         yield r();
         console.log(_this, args, _arguments);
@@ -38,15 +40,12 @@ let s =
       });
 
       return function t(_x2, _x3) {
-        return _ref2.apply(this, arguments);
+        return _ref.apply(this, arguments);
       };
-    })();
+    }();
 
     yield t();
     return this.h(t);
   });
-
-  return function s(_x) {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _s.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/expected.js
@@ -1,6 +1,6 @@
 var foo =
 /*#__PURE__*/
-(() => {
+function () {
   var _ref = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
@@ -8,11 +8,11 @@ var foo =
   return function foo() {
     return _ref.apply(this, arguments);
   };
-})();
+}();
 
 var foo2 =
 /*#__PURE__*/
-(() => {
+function () {
   var _ref2 = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
@@ -20,10 +20,10 @@ var foo2 =
   return function foo2() {
     return _ref2.apply(this, arguments);
   };
-})(),
+}(),
     bar =
 /*#__PURE__*/
-(() => {
+function () {
   var _ref3 = babelHelpers.asyncToGenerator(function* () {
     var wat = yield foo();
   });
@@ -31,4 +31,4 @@ var foo2 =
   return function bar() {
     return _ref3.apply(this, arguments);
   };
-})();
+}();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/expected.js
@@ -1,63 +1,57 @@
-let one =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* (a, b = 1) {});
+function one(_x) {
+  return _one.apply(this, arguments);
+}
 
-  return function one(_x) {
-    return _ref.apply(this, arguments);
-  };
-})();
+function _one() {
+  _one = babelHelpers.asyncToGenerator(function* (a, b = 1) {});
+  return _one.apply(this, arguments);
+}
 
-let two =
-/*#__PURE__*/
-(() => {
-  var _ref2 = babelHelpers.asyncToGenerator(function* (a, b, ...c) {});
+function two(_x2, _x3) {
+  return _two.apply(this, arguments);
+}
 
-  return function two(_x2, _x3) {
-    return _ref2.apply(this, arguments);
-  };
-})();
+function _two() {
+  _two = babelHelpers.asyncToGenerator(function* (a, b, ...c) {});
+  return _two.apply(this, arguments);
+}
 
-let three =
-/*#__PURE__*/
-(() => {
-  var _ref3 = babelHelpers.asyncToGenerator(function* (a, b = 1, c, d = 3) {});
+function three(_x4) {
+  return _three.apply(this, arguments);
+}
 
-  return function three(_x4) {
-    return _ref3.apply(this, arguments);
-  };
-})();
+function _three() {
+  _three = babelHelpers.asyncToGenerator(function* (a, b = 1, c, d = 3) {});
+  return _three.apply(this, arguments);
+}
 
-let four =
-/*#__PURE__*/
-(() => {
-  var _ref4 = babelHelpers.asyncToGenerator(function* (a, b = 1, c, ...d) {});
+function four(_x5) {
+  return _four.apply(this, arguments);
+}
 
-  return function four(_x5) {
-    return _ref4.apply(this, arguments);
-  };
-})();
+function _four() {
+  _four = babelHelpers.asyncToGenerator(function* (a, b = 1, c, ...d) {});
+  return _four.apply(this, arguments);
+}
 
-let five =
-/*#__PURE__*/
-(() => {
-  var _ref5 = babelHelpers.asyncToGenerator(function* (a, {
+function five(_x6, _x7) {
+  return _five.apply(this, arguments);
+}
+
+function _five() {
+  _five = babelHelpers.asyncToGenerator(function* (a, {
     b
   }) {});
+  return _five.apply(this, arguments);
+}
 
-  return function five(_x6, _x7) {
-    return _ref5.apply(this, arguments);
-  };
-})();
+function six(_x8) {
+  return _six.apply(this, arguments);
+}
 
-let six =
-/*#__PURE__*/
-(() => {
-  var _ref6 = babelHelpers.asyncToGenerator(function* (a, {
+function _six() {
+  _six = babelHelpers.asyncToGenerator(function* (a, {
     b
   } = {}) {});
-
-  return function six(_x8) {
-    return _ref6.apply(this, arguments);
-  };
-})();
+  return _six.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/expected.js
@@ -1,13 +1,11 @@
 var foo =
 /*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
+function () {
+  var _bar = babelHelpers.asyncToGenerator(function* () {
     console.log(bar);
   });
 
-  function bar() {
-    return _ref.apply(this, arguments);
-  }
-
-  return bar;
-})();
+  return function bar() {
+    return _bar.apply(this, arguments);
+  };
+}();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/expected.js
@@ -1,9 +1,8 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* (bar) {});
+function foo(_x) {
+  return _foo.apply(this, arguments);
+}
 
-  return function foo(_x) {
-    return _ref.apply(this, arguments);
-  };
-})();
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* (bar) {});
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/expected.js
@@ -1,15 +1,14 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = _asyncToGenerator(function* () {
-    yield _Promise.resolve();
-  });
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 import _Promise from 'somewhere';
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(function* () {
+    yield _Promise.resolve();
+  });
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/expected.js
@@ -1,28 +1,26 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = _asyncToGenerator(function* () {
-    let bar =
-    /*#__PURE__*/
-    (() => {
-      var _ref2 = _asyncToGenerator(function* () {
-        return Promise.resolve();
-      });
-
-      return function bar() {
-        return _ref2.apply(this, arguments);
-      };
-    })();
-
-    let Promise;
-    yield bar();
-  });
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 let _Promise;
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(function* () {
+    let Promise;
+    yield bar();
+
+    function bar() {
+      return _bar.apply(this, arguments);
+    }
+
+    function _bar() {
+      _bar = _asyncToGenerator(function* () {
+        return Promise.resolve();
+      });
+      return _bar.apply(this, arguments);
+    }
+  });
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/expected.js
@@ -1,17 +1,16 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = _asyncToGenerator(function* () {
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+
+let _Promise;
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(function* () {
     yield new _Promise(resolve => {
       resolve();
     });
   });
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
-
-let _Promise;
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/expected.js
@@ -1,11 +1,10 @@
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* () {
     var wat = yield bar();
   });
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/expression/expected.js
@@ -2,7 +2,7 @@ var _coroutine = require("bluebird").coroutine;
 
 var foo =
 /*#__PURE__*/
-(() => {
+function () {
   var _ref = _coroutine(function* () {
     var wat = yield bar();
   });
@@ -10,4 +10,4 @@ var foo =
   return function foo() {
     return _ref.apply(this, arguments);
   };
-})();
+}();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/named-expression/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/named-expression/expected.js
@@ -2,14 +2,12 @@ var _coroutine = require("bluebird").coroutine;
 
 var foo =
 /*#__PURE__*/
-(() => {
-  var _ref = _coroutine(function* () {
+function () {
+  var _bar = _coroutine(function* () {
     console.log(bar);
   });
 
-  function bar() {
-    return _ref.apply(this, arguments);
-  }
-
-  return bar;
-})();
+  return function bar() {
+    return _bar.apply(this, arguments);
+  };
+}();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/statement/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/statement/expected.js
@@ -1,13 +1,12 @@
 var _coroutine = require("bluebird").coroutine;
 
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = _coroutine(function* () {
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _coroutine(function* () {
     var wat = yield bar();
   });
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/expected.js
@@ -3,16 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
-
-let myFunc = (() => {
-  var _ref = babelHelpers.asyncToGenerator(
-  /*#__PURE__*/
-  function* () {});
-
-  return function myFunc() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 exports.default = myFunc;
+
+function myFunc() {
+  return _myFunc.apply(this, arguments);
+}
+
+function _myFunc() {
+  _myFunc = babelHelpers.asyncToGenerator(function* () {});
+  return _myFunc.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/expected.js
@@ -3,18 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.foo = void 0;
+exports.foo = foo;
 
 var _bar = babelHelpers.interopRequireDefault(require("bar"));
 
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {});
+function foo() {
+  return _foo.apply(this, arguments);
+}
 
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
-exports.foo = foo;
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* () {});
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/expected.js
@@ -3,16 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.foo = void 0;
-
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = babelHelpers.asyncToGenerator(function* () {});
-
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 exports.foo = foo;
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* () {});
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/expected.js
@@ -1,22 +1,21 @@
 "use strict";
 
-let foo =
-/*#__PURE__*/
-(() => {
-  var _ref = _asyncToGenerator(function* (_ref2) {
-    let a = _ref2.a,
-        _ref2$b = _ref2.b,
-        b = _ref2$b === void 0 ? mandatory("b") : _ref2$b;
-    return Promise.resolve(b);
-  });
-
-  return function foo(_x) {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
 
 function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);
+}
+
+function foo(_x) {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(function* (_ref) {
+    let a = _ref.a,
+        _ref$b = _ref.b,
+        b = _ref$b === void 0 ? mandatory("b") : _ref$b;
+    return Promise.resolve(b);
+  });
+  return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/expected.js
@@ -19,7 +19,7 @@ class Test {
       console.log(_this2);
       setTimeout(
       /*#__PURE__*/
-      (() => {
+      function () {
         var _ref2 = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this2);
         });
@@ -27,7 +27,7 @@ class Test {
         return function (_x) {
           return _ref2.apply(this, arguments);
         };
-      })());
+      }());
     })();
   }
 
@@ -51,7 +51,7 @@ class Test {
       console.log(_this4);
       setTimeout(
       /*#__PURE__*/
-      (() => {
+      function () {
         var _ref4 = babelHelpers.asyncToGenerator(function* (arg) {
           console.log(_this4);
         });
@@ -59,7 +59,7 @@ class Test {
         return function (_x2) {
           return _ref4.apply(this, arguments);
         };
-      })());
+      }());
     })();
   }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/expected.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/expected.js
@@ -1,10 +1,14 @@
-import "core-js/modules/es6.promise";
 import "regenerator-runtime/runtime";
+import "core-js/modules/es6.promise";
 
-var a =
-/*#__PURE__*/
-function () {
-  var _ref = _asyncToGenerator(
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+
+function a() {
+  return _a.apply(this, arguments);
+}
+
+function _a() {
+  _a = _asyncToGenerator(
   /*#__PURE__*/
   regeneratorRuntime.mark(function _callee() {
     return regeneratorRuntime.wrap(function _callee$(_context) {
@@ -17,10 +21,5 @@ function () {
       }
     }, _callee, this);
   }));
-
-  return function a() {
-    return _ref.apply(this, arguments);
-  };
-}();
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+  return _a.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/expected.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/expected.js
@@ -1,33 +1,3 @@
-var agf =
-/*#__PURE__*/
-function () {
-  var _ref = _wrapAsyncGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.next = 2;
-            return _awaitAsyncGenerator(1);
-
-          case 2:
-            _context.next = 4;
-            return 2;
-
-          case 4:
-          case "end":
-            return _context.stop();
-        }
-      }
-    }, _callee, this);
-  }));
-
-  return function agf() {
-    return _ref.apply(this, arguments);
-  };
-}();
-
 function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
 function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
@@ -60,3 +30,32 @@ var n = Object.assign({
   x: x,
   y: y
 }, z);
+
+function agf() {
+  return _agf.apply(this, arguments);
+}
+
+function _agf() {
+  _agf = _wrapAsyncGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee() {
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.next = 2;
+            return _awaitAsyncGenerator(1);
+
+          case 2:
+            _context.next = 4;
+            return 2;
+
+          case 4:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, this);
+  }));
+  return _agf.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/expected.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/expected.js
@@ -1,42 +1,12 @@
 "use strict";
 
+require("regenerator-runtime/runtime");
+
 require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.promise");
 
-require("regenerator-runtime/runtime");
-
 require("core-js/modules/es6.object.assign");
-
-var agf =
-/*#__PURE__*/
-function () {
-  var _ref = _wrapAsyncGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.next = 2;
-            return _awaitAsyncGenerator(1);
-
-          case 2:
-            _context.next = 4;
-            return 2;
-
-          case 4:
-          case "end":
-            return _context.stop();
-        }
-      }
-    }, _callee, this);
-  }));
-
-  return function agf() {
-    return _ref.apply(this, arguments);
-  };
-}();
 
 function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
@@ -70,3 +40,32 @@ var n = Object.assign({
   x: x,
   y: y
 }, z);
+
+function agf() {
+  return _agf.apply(this, arguments);
+}
+
+function _agf() {
+  _agf = _wrapAsyncGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee() {
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.next = 2;
+            return _awaitAsyncGenerator(1);
+
+          case 2:
+            _context.next = 4;
+            return 2;
+
+          case 4:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, this);
+  }));
+  return _agf.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/expected.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/expected.js
@@ -1,33 +1,3 @@
-var agf =
-/*#__PURE__*/
-function () {
-  var _ref = _wrapAsyncGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.next = 2;
-            return _awaitAsyncGenerator(1);
-
-          case 2:
-            _context.next = 4;
-            return 2;
-
-          case 4:
-          case "end":
-            return _context.stop();
-        }
-      }
-    }, _callee, this);
-  }));
-
-  return function agf() {
-    return _ref.apply(this, arguments);
-  };
-}();
-
 function _awaitAsyncGenerator(value) { return new _AwaitValue(value); }
 
 function _wrapAsyncGenerator(fn) { return function () { return new _AsyncGenerator(fn.apply(this, arguments)); }; }
@@ -62,3 +32,32 @@ var n = _extends({
   x: x,
   y: y
 }, z);
+
+function agf() {
+  return _agf.apply(this, arguments);
+}
+
+function _agf() {
+  _agf = _wrapAsyncGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee() {
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.next = 2;
+            return _awaitAsyncGenerator(1);
+
+          case 2:
+            _context.next = 4;
+            return 2;
+
+          case 4:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, this);
+  }));
+  return _agf.apply(this, arguments);
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6206, fixes #6956
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> Use function declarations to wrap declarations.  …
  e.g.
> ```
>  function fn() {}
>  ```
> becomes
>  ```
>  function fn() { return _ref.apply(this, arguments) }
>  function _ref() { _ref = _wrapper(/* ... */); return _ref.apply(this, arguments); }
>  ```
>
> This has two advantages:
>  1) The wrapper isn't executed until the function is invoked. This avoids bugs when transpiled generators are hoisted before the `require("babel-polyfill")` statement.
>  2) Avoid using _blockHoist, and use real JavaScript hoisting.