### PR TITLE
Lower env's min firefox version for native generator support

### DIFF
--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -201,7 +201,7 @@
   "transform-regenerator": {
     "chrome": "50",
     "edge": "13",
-    "firefox": "53",
+    "firefox": "38",
     "safari": "10",
     "node": "6",
     "ios": "10",


### PR DESCRIPTION
Firefox's native generator support was set super high in 4367fba31e5ae79a2882b61cb6950586337a5810 and I have no idea why...

The latest addition I could find in MDN is the return method for the [Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) object itself, so I set it to that.

The generator transform is particularly bulky, so bad in fact that I can not use async/await on my own projects, so getting it back would be much appreciated.