### PR TITLE
Async to generator fixes

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -68,6 +68,8 @@ export default function(path: NodePath, file: Object, helpers: Object) {
     wrapAwait: helpers.wrapAwait,
   });
 
+  const isIIFE = path.parentPath.isCallExpression({ callee: path.node });
+
   path.node.async = false;
   path.node.generator = true;
 
@@ -79,7 +81,7 @@ export default function(path: NodePath, file: Object, helpers: Object) {
     path.parentPath.isObjectProperty() ||
     path.parentPath.isClassProperty();
 
-  if (!isProperty) {
+  if (!isProperty && !isIIFE) {
     annotateAsPure(
       path.isDeclaration() ? path.get("declarations.0.init") : path,
     );

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/actual.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/actual.js
@@ -1,0 +1,4 @@
+(async function() { await 'ok' })();
+(async () => { await 'ok' })();
+async function notIIFE() { await 'ok' }
+notIIFE();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/expected.js
@@ -1,0 +1,19 @@
+let notIIFE =
+/*#__PURE__*/
+(() => {
+  var _ref3 = babelHelpers.asyncToGenerator(function* () {
+    yield 'ok';
+  });
+
+  return function notIIFE() {
+    return _ref3.apply(this, arguments);
+  };
+})();
+
+babelHelpers.asyncToGenerator(function* () {
+  yield 'ok';
+})();
+babelHelpers.asyncToGenerator(function* () {
+  yield 'ok';
+})();
+notIIFE();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/arrow-function/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/arrow-function/expected.js
@@ -1,6 +1,5 @@
 var _coroutine = require("bluebird").coroutine;
 
-/*#__PURE__*/
 _coroutine(function* () {
   yield foo();
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/5880/expected.js
@@ -1,4 +1,3 @@
-/*#__PURE__*/
 babelHelpers.asyncToGenerator(function* () {
   var _iteratorNormalCompletion = true;
   var _didIteratorError = false;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #6973
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 🤔
| Minor: New Feature?      | 🙅‍♀️
| Tests Added + Pass?      | Yes
| License                  | MIT

Fixes async arrow functions that are immediately invoked to not annotate the `asyncToGenerator` call as pure. The original fix was suggested on https://github.com/babel/babel/issues/6973#issuecomment-349218627 but modified to also verify whether the callee is the arrow function itself, to make sure values given as arguments in a function call are still annotated as pure. An alternative would be to add parens, but I don't know of any way of doing it without making an invalid tree (e.g. wrapping in a `SequenceExpression` with only one element).