### PR TITLE
Improve error message in types assert

### DIFF
--- a/packages/babel-types/scripts/generators/generateAsserts.js
+++ b/packages/babel-types/scripts/generators/generateAsserts.js
@@ -18,7 +18,7 @@ import is from "../../validators/is";
 function assert(type: string, node: Object, opts?: Object): void {
   if (!is(type, node, opts)) {
     throw new Error(
-      \`Expected type "\${type}" with option \${JSON.stringify(opts)}\`,
+      \`Expected type "\${type}" with option \${JSON.stringify(opts)}, but instead got "\${node.type}".\`,
     );
   }
 }\n\n`;

--- a/packages/babel-types/src/asserts/generated/index.js
+++ b/packages/babel-types/src/asserts/generated/index.js
@@ -8,7 +8,9 @@ import is from "../../validators/is";
 function assert(type: string, node: Object, opts?: Object): void {
   if (!is(type, node, opts)) {
     throw new Error(
-      `Expected type "${type}" with option ${JSON.stringify(opts)}`,
+      `Expected type "${type}" with option ${JSON.stringify(
+        opts,
+      )}, but instead got "${node.type}".`,
     );
   }
 }

--- a/packages/babel-types/test/asserts.js
+++ b/packages/babel-types/test/asserts.js
@@ -1,0 +1,35 @@
+import * as t from "../lib";
+import assert from "assert";
+
+describe("asserts", () => {
+  const consoleTrace = console.trace;
+
+  beforeEach(() => {
+    console.trace = () => {};
+  });
+
+  afterEach(() => {
+    console.trace = consoleTrace;
+  });
+
+  Object.keys(t).forEach(k => {
+    if (k.startsWith("assert") && k !== "assertNode") {
+      const nodeType = k.replace("assert", "");
+
+      it(nodeType, () => {
+        assert.throws(
+          () => {
+            t[k]({ type: "FlavorTownDeclaration" }, {});
+          },
+          err => {
+            return (
+              err instanceof Error &&
+              err.message ===
+                `Expected type "${nodeType}" with option {}, but instead got "FlavorTownDeclaration".`
+            );
+          },
+        );
+      });
+    }
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | y/y
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

From our slack convo, minor but improves the error message a bit.