### PR TITLE
Bump globals to version 11.1.0

### DIFF
--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -13,7 +13,7 @@
     "@babel/types": "7.0.0-beta.34",
     "babylon": "7.0.0-beta.34",
     "debug": "^3.0.1",
-    "globals": "^10.0.0",
+    "globals": "^11.1.0",
     "invariant": "^2.2.0",
     "lodash": "^4.2.0"
   },


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | Yes
| License                  | MIT

[Changes](https://github.com/sindresorhus/globals/compare/v10.4.0...v11.1.0)

The only relevant change for babel is that `System` was mistakingly identified as global.

Should this be backported to babel 6?
