### PR TITLE
Fix O(n^2) getLetReferences – 40% faster on large flat files

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -647,20 +647,20 @@ class BlockScoping {
 
     //
     if (block.body) {
+      const declarPaths = this.blockPath.get("body");
       for (let i = 0; i < block.body.length; i++) {
-        const declarPath = this.blockPath.get("body")[i];
-        addDeclarationsFromChild(declarPath);
+        addDeclarationsFromChild(declarPaths[i]);
       }
     }
 
     if (block.cases) {
+      const declarPaths = this.blockPath.get("cases");
       for (let i = 0; i < block.cases.length; i++) {
         const consequents = block.cases[i].consequent;
 
         for (let j = 0; j < consequents.length; j++) {
-          const declarPath = this.blockPath.get("cases")[i];
           const declar = consequents[j];
-          addDeclarationsFromChild(declarPath, declar);
+          addDeclarationsFromChild(declarPaths[i], declar);
         }
       }
     }


### PR DESCRIPTION
`this.blockPath.get("body")` constructs an array of paths corresponding to each node in `blocks.body` so takes O(n) time if n is that length. We were re-constructing that array on each iteration, so the entire loop was O(n^2).

On files with many statements in a single block (such as Rollup-generated bundles), this takes a large portion of time. In particular, this makes transforming react-dom.development.js about 40% faster because the bundle has 755 statements in one block. Not that you should be transforming our bundle with Babel.

Test Plan:
Make an HTML file with these three lines and watch it in the Chrome Performance tab to see timings (on my machine: 2.9s before, 1.6s after):

```html
<!DOCTYPE html>
<script src="https://unpkg.com/babel-standalone@7.0.0-beta.3/babel.js"></script>
<script type="text/babel" src="https://unpkg.com/react-dom@16.2.0/umd/react-dom.development.js"></script>
```