### PR TITLE
Fixes #6954

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/README.md
+++ b/packages/babel-plugin-transform-modules-commonjs/README.md
@@ -68,10 +68,7 @@ require("@babel/core").transform("code", {
 
 `boolean`, defaults to `false`.
 
-As per the spec, `import` and `export` are only allowed to be used at the top
-level. When in loose mode these are allowed to be used anywhere.
-
-And by default, when using exports with babel a non-enumerable `__esModule` property
+By default, when using exports with babel a non-enumerable `__esModule` property
 is exported.
 
 ```javascript


### PR DESCRIPTION
accurately describe behavior of 'loose' option in
'babel-plugin-transform-modules-commonjs'
[skip-ci]

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| ------------------------ | ---
| Fixed Issues?            | Fixes #6954 
|   Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | Yes
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The reference to option 'loose' allowing imports other than at the top level is removed.
