### PR TITLE
Fix publishing process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ publish:
 	make test
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version $(cat lerna.json | jq '.version' | tr '"' ' ')
+	../node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version node -p "require('../lerna.json').version"
 	make clean
 
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,11 @@ publish:
 	make clean-lib
 	rm -rf packages/babel-runtime/helpers
 	rm -rf packages/babel-runtime/core-js
-	./node_modules/.bin/lerna publish --skip-npm --skip-git --skip-temp-tag
 	BABEL_ENV=production make build-dist
 	make test
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version $(node -p "require('./lerna.json').version")
+	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag
 	make clean
 
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ publish:
 	make test
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	../node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version node -p "require('../lerna.json').version"
+	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version node -p "require('../lerna.json').version"
 	make clean
 
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,12 @@ publish:
 	make clean-lib
 	rm -rf packages/babel-runtime/helpers
 	rm -rf packages/babel-runtime/core-js
+	./node_modules/.bin/lerna publish --skip-npm --skip-git --skip-temp-tag
 	BABEL_ENV=production make build-dist
 	make test
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag
+	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version $(cat lerna.json | jq '.version' | tr '"' ' ')
 	make clean
 
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ publish:
 	make test
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version node -p "require('../lerna.json').version"
+	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag --yes --repo-version $(node -p "require('./lerna.json').version")
 	make clean
 
 bootstrap:

--- a/packages/babel-preset-env-standalone/package.json
+++ b/packages/babel-preset-env-standalone/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "scripts": {
-    "prepublish": "make -C ../../ build-preset-env-standalone"
+    "version": "make -C ../../ build-preset-env-standalone"
   },
   "devDependencies": {
     "@babel/plugin-transform-new-target": "7.0.0-beta.35",

--- a/packages/babel-preset-env-standalone/package.json
+++ b/packages/babel-preset-env-standalone/package.json
@@ -8,6 +8,9 @@
     "babel-preset-env.min.js",
     "src"
   ],
+  "scripts": {
+    "prepublish": "make -C ../../ build-preset-env-standalone"
+  },
   "devDependencies": {
     "@babel/plugin-transform-new-target": "7.0.0-beta.35",
     "@babel/preset-env": "7.0.0-beta.35",

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "scripts": {
-    "prepublish": "make -C ../../ build-standalone"
+    "version": "make -C ../../ build-standalone"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.35",

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -8,6 +8,9 @@
     "babel.min.js",
     "src"
   ],
+  "scripts": {
+    "prepublish": "make -C ../../ build-standalone"
+  },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.35",
     "@babel/plugin-check-constants": "7.0.0-beta.35",


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6174 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 🙅
| Minor: New Feature?      | 🙅
| Tests Added + Pass?      | 🙅
| Documentation PR         | 🙅
| Any Dependency Changes?  | 🙅
| License                  | MIT


When we are publishing new packages, we run `BABEL_ENV=production make build-dist` first, and only then `lerna publish`. During `build-dist` process we creating standalone bundles, it takes version from babel-core, which wasn’t actually updated yet, because it will be updated during `lerna publish` on the next step.

Proposed solution runs `lerna publish` 2 times: firstly - before `build-dist` with `--skip-npm --skip-git --skip-temp-tag` arguments, so we just overriding versions for all packages.
For the second run, we ignore step where we select the version and just take it from the `lerna.json`, which was updated during the first `lerna publish`, so it just publishes the new version and creates git commit.

cc @Daniel15 