### PR TITLE
Make .insert{Before,After} work by default when the parent is an eport declaration

### DIFF
--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -89,11 +89,8 @@ function plainFunction(path: NodePath, callId: Object) {
   });
 
   if (isDeclaration) {
-    const basePath = path.parentPath.isExportDeclaration()
-      ? path.parentPath
-      : path;
-    basePath.insertAfter(container[1]);
     path.replaceWith(container[0]);
+    path.insertAfter(container[1]);
   } else {
     const retFunction = container.callee.body.body[1].argument;
     if (!functionId) {

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -228,15 +228,9 @@ export default function(api, options) {
         if (path.isClassExpression()) {
           path.scope.push({ id: ref });
           path.replaceWith(t.assignmentExpression("=", ref, path.node));
-        } else {
-          // path.isClassDeclaration()
-          if (!path.node.id) {
-            path.node.id = ref;
-          }
-
-          if (path.parentPath.isExportDeclaration()) {
-            path = path.parentPath;
-          }
+        } else if (!path.node.id) {
+          // Anonymous class declaration
+          path.node.id = ref;
         }
 
         path.insertAfter(nodes);

--- a/packages/babel-plugin-transform-typescript/src/enum.js
+++ b/packages/babel-plugin-transform-typescript/src/enum.js
@@ -28,7 +28,7 @@ export default function transpileEnum(path, t) {
     }
 
     case "ExportNamedDeclaration": {
-      path.parentPath.insertAfter(fill);
+      path.insertAfter(fill);
       if (seen(path.parentPath.parentPath)) {
         path.remove();
       } else {

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -128,12 +128,6 @@ export default class PathHoister {
       }
     }
 
-    // We can't insert before/after a child of an export declaration, so move up
-    // to the declaration itself.
-    if (path.parentPath.isExportDeclaration()) {
-      path = path.parentPath;
-    }
-
     return path;
   }
 

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -17,7 +17,7 @@ export function insertBefore(nodes) {
   if (
     this.parentPath.isExpressionStatement() ||
     this.parentPath.isLabeledStatement() ||
-    (this.parentPath.isExportDeclaration() && this.isDeclaration())
+    this.parentPath.isExportDeclaration()
   ) {
     return this.parentPath.insertBefore(nodes);
   } else if (
@@ -98,7 +98,7 @@ export function insertAfter(nodes) {
   if (
     this.parentPath.isExpressionStatement() ||
     this.parentPath.isLabeledStatement() ||
-    (this.parentPath.isExportDeclaration() && this.isDeclaration())
+    this.parentPath.isExportDeclaration()
   ) {
     return this.parentPath.insertAfter(nodes);
   } else if (

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -16,7 +16,8 @@ export function insertBefore(nodes) {
 
   if (
     this.parentPath.isExpressionStatement() ||
-    this.parentPath.isLabeledStatement()
+    this.parentPath.isLabeledStatement() ||
+    (this.parentPath.isExportDeclaration() && this.isDeclaration())
   ) {
     return this.parentPath.insertBefore(nodes);
   } else if (
@@ -96,7 +97,8 @@ export function insertAfter(nodes) {
 
   if (
     this.parentPath.isExpressionStatement() ||
-    this.parentPath.isLabeledStatement()
+    this.parentPath.isLabeledStatement() ||
+    (this.parentPath.isExportDeclaration() && this.isDeclaration())
   ) {
     return this.parentPath.insertAfter(nodes);
   } else if (

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -4,8 +4,8 @@ import { parse } from "babylon";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-function getPath(code) {
-  const ast = parse(code);
+function getPath(code, parserOpts) {
+  const ast = parse(code, parserOpts);
   let path;
   traverse(ast, {
     Program: function(_path) {
@@ -118,6 +118,44 @@ describe("modification", function() {
         "if (x) {\n  b\n\n  for (var i = 0; i < 0; i++) {}\n}",
       );
     });
+
+    describe("when the parent is an export declaration inserts the node before", function() {
+      it("the ExportNamedDeclaration", function() {
+        const bodyPath = getPath("export function a() {}", {
+          sourceType: "module",
+        }).parentPath;
+        const fnPath = bodyPath.get("body.0.declaration");
+        fnPath.insertBefore(t.identifier("x"));
+
+        assert.equal(bodyPath.get("body").length, 2);
+        assert.deepEqual(bodyPath.get("body.0").node, t.identifier("x"));
+      });
+
+      it("the ExportDefaultDeclaration, if a declaration is exported", function() {
+        const bodyPath = getPath("export default function () {}", {
+          sourceType: "module",
+        }).parentPath;
+        const fnPath = bodyPath.get("body.0.declaration");
+        fnPath.insertBefore(t.identifier("x"));
+
+        assert.equal(bodyPath.get("body").length, 2);
+        assert.deepEqual(bodyPath.get("body.0").node, t.identifier("x"));
+      });
+
+      it("the exported expression", function() {
+        const bodyPath = getPath("export default 2;", {
+          sourceType: "module",
+        }).parentPath;
+        const path = bodyPath.get("body.0.declaration");
+        path.insertBefore(t.identifier("x"));
+
+        assert.equal(bodyPath.get("body").length, 1);
+        assert.deepEqual(
+          bodyPath.get("body.0.declaration.expressions.0").node,
+          t.identifier("x"),
+        );
+      });
+    });
   });
 
   describe("insertAfter", function() {
@@ -169,6 +207,49 @@ describe("modification", function() {
         generateCode(rootPath),
         "if (x) {\n  for (var i = 0; i < 0; i++) {}\n\n  b\n}",
       );
+    });
+
+    describe("when the parent is an export declaration inserts the node after", function() {
+      it("the ExportNamedDeclaration", function() {
+        const bodyPath = getPath("export function a() {}", {
+          sourceType: "module",
+        }).parentPath;
+        const fnPath = bodyPath.get("body.0.declaration");
+        fnPath.insertAfter(t.identifier("x"));
+
+        assert.equal(bodyPath.get("body").length, 2);
+        assert.deepEqual(bodyPath.get("body.1").node, t.identifier("x"));
+      });
+
+      it("the ExportDefaultDeclaration, if a declaration is exported", function() {
+        const bodyPath = getPath("export default function () {}", {
+          sourceType: "module",
+        }).parentPath;
+        const fnPath = bodyPath.get("body.0.declaration");
+        fnPath.insertAfter(t.identifier("x"));
+
+        assert.equal(bodyPath.get("body").length, 2);
+        assert.deepEqual(bodyPath.get("body.1").node, t.identifier("x"));
+      });
+
+      it("the exported expression", function() {
+        const bodyPath = getPath("export default 2;", {
+          sourceType: "module",
+        }).parentPath;
+        const path = bodyPath.get("body.0.declaration");
+        path.insertAfter(t.identifier("x"));
+
+        assert.equal(bodyPath.get("body").length, 2);
+        0 &&
+          assert.deepEqual(
+            bodyPath.get("body.1.declaration.expressions.1").node,
+            t.identifier("x"),
+          );
+        assert.equal(
+          generateCode({ parentPath: bodyPath }),
+          "var _temp;\n\nexport default (_temp = 2, x, _temp);",
+        );
+      });
     });
   });
 });

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -149,11 +149,8 @@ describe("modification", function() {
         const path = bodyPath.get("body.0.declaration");
         path.insertBefore(t.identifier("x"));
 
-        assert.equal(bodyPath.get("body").length, 1);
-        assert.deepEqual(
-          bodyPath.get("body.0.declaration.expressions.0").node,
-          t.identifier("x"),
-        );
+        assert.equal(bodyPath.get("body").length, 2);
+        assert.deepEqual(bodyPath.get("body.0").node, t.identifier("x"));
       });
     });
   });
@@ -240,15 +237,7 @@ describe("modification", function() {
         path.insertAfter(t.identifier("x"));
 
         assert.equal(bodyPath.get("body").length, 2);
-        0 &&
-          assert.deepEqual(
-            bodyPath.get("body.1.declaration.expressions.1").node,
-            t.identifier("x"),
-          );
-        assert.equal(
-          generateCode({ parentPath: bodyPath }),
-          "var _temp;\n\nexport default (_temp = 2, x, _temp);",
-        );
+        assert.deepEqual(bodyPath.get("body.1").node, t.identifier("x"));
       });
     });
   });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR makes `declarationPath.insertBefore()` and `declarationPath.insertAfter()` work by default even if `declarationPath.parentPath.isExportDeclaration()`.
Babel already handles it in a similar way when `path.parentPath.isLabelledStatement()`: https://astexplorer.net/#/gist/192e79a63708ad6195496dffe34b6fd7/35538c7478fe1340c9e8bdb2e6c40f24f5adc40b
As you can see by the diff, we already had to handle insertion before/after exported declarations in different places. Less special cases to think about -> less probability of forgetting about them.

This PR doesn't introduce breaking changes, because it only makes cases that previously threw do what it is actually expected.