### PR TITLE
Add proposal-async-generator-functions to babel-standalone

### DIFF
--- a/packages/babel-standalone/src/index.js
+++ b/packages/babel-standalone/src/index.js
@@ -158,6 +158,7 @@ registerPlugins({
   "syntax-optional-catch-binding": require("@babel/plugin-syntax-optional-catch-binding"),
   "syntax-pipeline-operator": require("@babel/plugin-syntax-pipeline-operator"),
   "transform-async-to-generator": require("@babel/plugin-transform-async-to-generator"),
+  "proposal-async-generator-functions": require("@babel/plugin-proposal-async-generator-functions"),
   "proposal-class-properties": require("@babel/plugin-proposal-class-properties"),
   "proposal-decorators": require("@babel/plugin-proposal-decorators"),
   "proposal-do-expressions": require("@babel/plugin-proposal-do-expressions"),


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | 
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Register proposal-async-generator-functions as availablePlugin for babel-standalone. It's the only missed plugin from the stage 3.
https://github.com/babel/website/pull/1415#issuecomment-352285491
