### PR TITLE
Fix typescript import eliding

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -42,7 +42,7 @@ export default function() {
         let allElided = true;
         const importsToRemove: Path<Node>[] = [];
 
-        for (let i = 0, len = path.node.specifiers.length; i < len; i++) {
+        for (let i = 0; i < path.node.specifiers.length; i++) {
           const specifier = path.node.specifiers[i];
           const binding = path.scope.getBinding(specifier.local.name);
 

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/actual.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/actual.js
@@ -1,0 +1,6 @@
+import {A, B, c, d} from "./lib";
+
+const a: A = 1;
+const b: B = {};
+const cc = c;
+const dd = d;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/actual.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/actual.js
@@ -1,6 +1,6 @@
 import {A, B, c, d} from "./lib";
 
 const a: A = 1;
-const b: B = {};
+const b: B = new A();
 const cc = c;
 const dd = d;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/expected.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/expected.js
@@ -1,6 +1,6 @@
-import { d } from "./lib/foo";
+import { A, d } from "./lib/foo";
 import { c } from "./lib";
 const a = 1;
-const b = {};
+const b = new A();
 const cc = c;
 const dd = d;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/expected.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/expected.js
@@ -1,0 +1,6 @@
+import { d } from "./lib/foo";
+import { c } from "./lib";
+const a = 1;
+const b = {};
+const cc = c;
+const dd = d;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "./plugin",
+    "transform-typescript"
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/plugin.js
@@ -3,10 +3,7 @@ const t = require('@babel/types');
 module.exports = () => ({
   visitor: {
     ImportDeclaration(path) {
-      const {
-        specifiers,
-        source: {value: library},
-      } = path.node;
+      const library = path.node.source.value;
 
       if (library !== './lib' || path.node.skip) {
         return;
@@ -14,7 +11,7 @@ module.exports = () => ({
 
       const newSpecifiers1 = [];
       const newSpecifiers2 = [];
-      for (const specifier of specifiers) {
+      for (const specifier of path.node.specifiers) {
         if (specifier.local.name === 'd' || specifier.local.name === 'A') {
           newSpecifiers1.push(t.importSpecifier(specifier.local, specifier.imported));
           continue;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/plugin.js
@@ -1,18 +1,22 @@
-const t = require('@babel/types');
+"use strict";
+
+const t = require("@babel/types");
 
 module.exports = () => ({
   visitor: {
     ImportDeclaration(path) {
       const library = path.node.source.value;
 
-      if (library !== './lib' || path.node.skip) {
+      if (library !== "./lib" || path.node.skip) {
         return;
       }
 
       const newSpecifiers1 = [];
       const newSpecifiers2 = [];
-      for (const specifier of path.node.specifiers) {
-        if (specifier.local.name === 'd' || specifier.local.name === 'A') {
+      for (let i = 0; i < path.node.specifiers.length; i++) {
+        const specifier = path.node.specifiers[i];
+
+        if (specifier.local.name === "d" || specifier.local.name === "A") {
           newSpecifiers1.push(t.importSpecifier(specifier.local, specifier.imported));
           continue;
         }
@@ -24,7 +28,7 @@ module.exports = () => ({
       newDeclaration.skip = true;
 
       path.replaceWithMultiple([
-        t.importDeclaration(newSpecifiers1, t.stringLiteral(`${library}/foo`)),
+        t.importDeclaration(newSpecifiers1, t.stringLiteral(library + "/foo")),
         newDeclaration,
       ]);
     },

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-change/plugin.js
@@ -1,0 +1,35 @@
+const t = require('@babel/types');
+
+module.exports = () => ({
+  visitor: {
+    ImportDeclaration(path) {
+      const {
+        specifiers,
+        source: {value: library},
+      } = path.node;
+
+      if (library !== './lib' || path.node.skip) {
+        return;
+      }
+
+      const newSpecifiers1 = [];
+      const newSpecifiers2 = [];
+      for (const specifier of specifiers) {
+        if (specifier.local.name === 'd' || specifier.local.name === 'A') {
+          newSpecifiers1.push(t.importSpecifier(specifier.local, specifier.imported));
+          continue;
+        }
+
+        newSpecifiers2.push(specifier);
+      }
+
+      const newDeclaration = t.importDeclaration(newSpecifiers2, t.stringLiteral(library));
+      newDeclaration.skip = true;
+
+      path.replaceWithMultiple([
+        t.importDeclaration(newSpecifiers1, t.stringLiteral(`${library}/foo`)),
+        newDeclaration,
+      ]);
+    },
+  },
+});

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/actual.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/actual.js
@@ -1,0 +1,5 @@
+import {A, B, c} from "./lib";
+
+const a: A = 1;
+const b: B = {};
+const cc = c;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/expected.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/expected.js
@@ -1,0 +1,4 @@
+import { c } from "./lib-mod";
+const a = 1;
+const b = {};
+const cc = c;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "./plugin",
+    "transform-typescript"
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/plugin.js
@@ -1,20 +1,23 @@
-const t = require('@babel/types');
+"use strict";
+
+const t = require("@babel/types");
 
 module.exports = () => ({
   visitor: {
     ImportDeclaration(path) {
       const library = path.node.source.value;
 
-      if (library !== './lib') {
+      if (library !== "./lib") {
         return;
       }
 
       const newSpecifiers = [];
-      for (const specifier of path.node.specifiers) {
+      for (let i = 0; i < path.node.specifiers.length; i++) {
+        const specifier = path.node.specifiers[i];
         newSpecifiers.push(t.importSpecifier(specifier.local, specifier.imported));
       }
 
-      path.replaceWith(t.importDeclaration(newSpecifiers, t.stringLiteral(`${library}-mod`)));
+      path.replaceWith(t.importDeclaration(newSpecifiers, t.stringLiteral(library + "-mod")));
     }
   }
 });

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/plugin.js
@@ -3,17 +3,14 @@ const t = require('@babel/types');
 module.exports = () => ({
   visitor: {
     ImportDeclaration(path) {
-      const {
-        specifiers,
-        source: {value: library},
-      } = path.node;
+      const library = path.node.source.value;
 
       if (library !== './lib') {
         return;
       }
 
       const newSpecifiers = [];
-      for (const specifier of specifiers) {
+      for (const specifier of path.node.specifiers) {
         newSpecifiers.push(t.importSpecifier(specifier.local, specifier.imported));
       }
 

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-with-previous-source-rename/plugin.js
@@ -1,0 +1,23 @@
+const t = require('@babel/types');
+
+module.exports = () => ({
+  visitor: {
+    ImportDeclaration(path) {
+      const {
+        specifiers,
+        source: {value: library},
+      } = path.node;
+
+      if (library !== './lib') {
+        return;
+      }
+
+      const newSpecifiers = [];
+      for (const specifier of specifiers) {
+        newSpecifiers.push(t.importSpecifier(specifier.local, specifier.imported));
+      }
+
+      path.replaceWith(t.importDeclaration(newSpecifiers, t.stringLiteral(`${library}-mod`)));
+    }
+  }
+});


### PR DESCRIPTION
another plugin

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No (perhaps)
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

Creating custom plugin to work with imports I found strange issue: if I recreate any import declaration or import specifier and replace original, instead of eliding import specifiers during typescript transformation it leaves all types as is.

I assume that it happes because current code uses bindings from scope to elide import specifiers. And binding points to specific object that dissappears from path when plugin replaces it. So even if bindings are removed import specifiers created by plugin are still in path and affect output code.

This patch fixes the issue.

**P.S.** I added two tests, because `elide-with-previous-source-rename` fails with error. They are connected, so if it is necessary, I can remove one.

### Example
Input:
```typescript
import {A, B, c, d} from "./lib";

const a: A = 1;
const b: B = {};
const cc = c;
const dd = d;
```
Plugin moves `A` and `d` to `./lib/foo`.
So input after plugin is following:
```typescript
import {A, d} from "./lib/foo";
import {B, c} from "./lib";

const a: A = 1;
const b: B = {};
const cc = c;
const dd = d;
```
Expected output:
```javascript
import { d } from "./lib/foo";
import { c } from "./lib";
const a = 1;
const b = {};
const cc = c;
const dd = d;
```
Actual output:
```javascript
import { A, d } from "./lib/foo";
import { B, c } from "./lib";
const a = 1;
const b = {};
const cc = c;
const dd = d;
```