### PR TITLE
Better error messages when Babel fails to parse import = and export =…

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -206,7 +206,7 @@ export default function() {
 
       TSImportEqualsDeclaration(path) {
         throw path.buildCodeFrameError(
-          "`import =` is not supported by @babel/plugin-transform-typescript \n" +
+          "`import =` is not supported by @babel/plugin-transform-typescript\n" +
             "Please consider using " +
             "`import <moduleName> from '<moduleName>';` alongside " +
             "Typescript's --allowSyntheticDefaultImports option.",

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -206,8 +206,8 @@ export default function() {
 
       TSImportEqualsDeclaration(path) {
         throw path.buildCodeFrameError(
-          "`import =` is not supported in Babel's Typescript parser " +
-            "because there is no valid ES6 implementation for it.\nPlease consider using " +
+          "`import =` is not supported by @babel/plugin-transform-typescript \n" +
+            "Please consider using " +
             "`import <moduleName> from '<moduleName>';` alongside " +
             "Typescript's --allowSyntheticDefaultImports option.",
         );
@@ -215,8 +215,8 @@ export default function() {
 
       TSExportAssignment(path) {
         throw path.buildCodeFrameError(
-          "`export =` is not supported in Babel's Typescript parser because " +
-            "there is no valid ES6 implementation for it.\nPlease consider using `export <value>;`.",
+          "`export =` is not supported by @babel/plugin-transform-typescript\n" +
+            "Please consider using `export <value>;`.",
         );
       },
 

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -205,11 +205,19 @@ export default function() {
       },
 
       TSImportEqualsDeclaration(path) {
-        throw path.buildCodeFrameError("`import =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option.");
+        throw path.buildCodeFrameError(
+          "`import =` is not supported in Babel's Typescript parser " +
+            "because there is no valid ES6 implementation for it.\nPlease consider using " +
+            "`import <moduleName> from '<moduleName>';` alongside " +
+            "Typescript's --allowSyntheticDefaultImports option.",
+        );
       },
 
       TSExportAssignment(path) {
-        throw path.buildCodeFrameError("`export =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `export <value>;`.");
+        throw path.buildCodeFrameError(
+          "`export =` is not supported in Babel's Typescript parser because " +
+            "there is no valid ES6 implementation for it.\nPlease consider using `export <value>;`.",
+        );
       },
 
       TSTypeAssertion(path) {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -205,11 +205,11 @@ export default function() {
       },
 
       TSImportEqualsDeclaration(path) {
-        throw path.buildCodeFrameError("`import =` is not supported.");
+        throw path.buildCodeFrameError("`import =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option.");
       },
 
       TSExportAssignment(path) {
-        throw path.buildCodeFrameError("`export =` is not supported.");
+        throw path.buildCodeFrameError("`export =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `export <value>;`.");
       },
 
       TSTypeAssertion(path) {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/export=/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/export=/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "`export =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `export <value>;`."
+  "throws": "`export =` is not supported by @babel/plugin-transform-typescript\nPlease consider using `export <value>;`."
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/export=/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/export=/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "`export =` is not supported."
+  "throws": "`export =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `export <value>;`."
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "`import =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option."
+  "throws": "`import =` is not supported by @babel/plugin-transform-typescript \nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option."
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "`import =` is not supported by @babel/plugin-transform-typescript \nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option."
+  "throws": "`import =` is not supported by @babel/plugin-transform-typescript\nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option."
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "`import =` is not supported."
+  "throws": "`import =` is not supported in Babel's Typescript parser because there is no valid ES6 implementation for it.\nPlease consider using `import <moduleName> from '<moduleName>';` alongside Typescript's --allowSyntheticDefaultImports option."
 }


### PR DESCRIPTION
… syntax from typescript when using babel-plugin-transform-typescript


| Q | A
| ------------------------ | ------|
| Fixed Issues? | #7067
| Patch: Bug Fix? | No
| Major: Breaking Change? | No
| Minor: New Feature? | No
| Tests Added + Pass? | Yes
| Documentation PR | 
| Any Dependency Changes? | No
| License | MIT


The error messages displayed when Typescript's ```import = ``` and ```export = ``` were very less descriptive. Giving users no clue about what to do next..
Hence this messages can improve things regarding on how to fix their imports and exports in Typescript. 

Detailed discussion can be found at 
https://github.com/babel/babel/issues/7062
https://github.com/babel/babel/issues/7067

Thanks 
