### PR TITLE
[preset-env] Move all defaults to the separate module

### DIFF
--- a/packages/babel-preset-env/src/defaults.js
+++ b/packages/babel-preset-env/src/defaults.js
@@ -1,0 +1,25 @@
+import type { Targets } from "./types";
+
+const defaultWebIncludes = ["web.timers", "web.immediate", "web.dom.iterable"];
+const defaultExcludesForLooseMode = ["transform-typeof-symbol"];
+
+export const getPlatformSpecificDefaultFor = (
+  targets: Targets,
+): ?Array<string> => {
+  const targetNames = Object.keys(targets);
+  const isAnyTarget = !targetNames.length;
+  const isWebTarget = targetNames.some(name => name !== "node");
+
+  return isAnyTarget || isWebTarget ? defaultWebIncludes : null;
+};
+
+export const getOptionSpecificExcludesFor = ({
+  loose,
+}: {
+  loose: boolean,
+}): ?Array<string> => {
+  if (loose) {
+    return defaultExcludesForLooseMode;
+  }
+  return null;
+};

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -3,7 +3,10 @@
 import semver from "semver";
 import builtInsList from "../data/built-ins.json";
 import { logPlugin } from "./debug";
-import { defaultWebIncludes } from "./default-includes";
+import {
+  getPlatformSpecificDefaultFor,
+  getOptionSpecificExcludesFor,
+} from "./defaults";
 import moduleTransformations from "./module-transformations";
 import normalizeOptions from "./normalize-options.js";
 import pluginList from "../data/plugins.json";
@@ -113,26 +116,6 @@ export const transformIncludesAndExcludes = (opts: Array<string>): Object => {
       builtIns: new Set(),
     },
   );
-};
-
-const getPlatformSpecificDefaultFor = (targets: Targets): ?Array<string> => {
-  const targetNames = Object.keys(targets);
-  const isAnyTarget = !targetNames.length;
-  const isWebTarget = targetNames.some(name => name !== "node");
-
-  return isAnyTarget || isWebTarget ? defaultWebIncludes : null;
-};
-
-const getOptionSpecificExcludesFor = ({
-  loose,
-}: {
-  loose: boolean,
-}): Array<string> => {
-  const defaultExcludes = [];
-  if (loose) {
-    defaultExcludes.push("transform-typeof-symbol");
-  }
-  return defaultExcludes;
 };
 
 const filterItems = (

--- a/packages/babel-preset-env/test/defaults.js
+++ b/packages/babel-preset-env/test/defaults.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const defaults = require("../lib/defaults.js");
+const assert = require("assert");
+
+const {
+  getPlatformSpecificDefaultFor,
+  getOptionSpecificExcludesFor,
+} = defaults;
+
+describe("defaults", () => {
+  describe("getPlatformSpecificDefaultFor", () => {
+    it("should return web polyfills for non-`node` platform", () => {
+      const defaultWebIncludesForChromeAndNode = getPlatformSpecificDefaultFor({
+        chrome: "63",
+        node: "8",
+      });
+      assert.deepEqual(defaultWebIncludesForChromeAndNode, [
+        "web.timers",
+        "web.immediate",
+        "web.dom.iterable",
+      ]);
+    });
+
+    it("shouldn't return web polyfills for node platform", () => {
+      const defaultWebIncludesForChromeAndNode = getPlatformSpecificDefaultFor({
+        node: "8",
+      });
+      assert.equal(defaultWebIncludesForChromeAndNode, null);
+    });
+  });
+
+  describe("getOptionSpecificExcludesFor", () => {
+    it("should return correct excludes for `loose` mode", () => {
+      const defaultWebIncludesForChromeAndNode = getOptionSpecificExcludesFor({
+        loose: true,
+      });
+      assert.deepEqual(defaultWebIncludesForChromeAndNode, [
+        "transform-typeof-symbol",
+      ]);
+    });
+
+    it("shouldn't return excludes for non-`loose` mode", () => {
+      const defaultWebIncludesForChromeAndNode = getOptionSpecificExcludesFor({
+        loose: false,
+      });
+      assert.deepEqual(defaultWebIncludesForChromeAndNode, null);
+    });
+  });
+});


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Followup for https://github.com/babel/babel/pull/6831.
Refactor a bit and move all defaults to the separate module.
Also, should be useful for scaling in the future.
