### PR TITLE
TSTypeAliasDeclaration should reference TSTypeAnnotation node

### DIFF
--- a/packages/babel-generator/src/generators/typescript.js
+++ b/packages/babel-generator/src/generators/typescript.js
@@ -348,7 +348,7 @@ export function TSTypeAliasDeclaration(node) {
   this.space();
   this.token("=");
   this.space();
-  this.print(typeAnnotation, node);
+  this.print(typeAnnotation.typeAnnotation, node);
   this.token(";");
 }
 

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -854,7 +854,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node.id = this.parseIdentifier();
       node.typeParameters = this.tsTryParseTypeParameters();
       this.expect(tt.eq);
-      node.typeAnnotation = this.tsParseType();
+      node.typeAnnotation = this.tsParseTypeAnnotation(/* eatColon */ false);
       this.semicolon();
       return this.finishNode(node, "TSTypeAliasDeclaration");
     }

--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -1200,7 +1200,7 @@ export type TsTypeAliasDeclaration = DeclarationBase & {
   type: "TSTypeAliasDeclaration",
   id: Identifier,
   typeParameters: ?TsTypeParameterDeclaration,
-  typeAnnotation: TsType,
+  typeAnnotation: TsTypeAnnotation,
 };
 
 export type TsEnumDeclaration = DeclarationBase & {

--- a/packages/babylon/test/fixtures/experimental/export-extensions/export-with-ts/expected.json
+++ b/packages/babylon/test/fixtures/experimental/export-extensions/export-with-ts/expected.json
@@ -454,7 +454,7 @@
             "name": "G"
           },
           "typeAnnotation": {
-            "type": "TSTypeQuery",
+            "type": "TSTypeAnnotation",
             "start": 153,
             "end": 163,
             "loc": {
@@ -467,22 +467,37 @@
                 "column": 26
               }
             },
-            "exprName": {
-              "type": "Identifier",
-              "start": 160,
+            "typeAnnotation": {
+              "type": "TSTypeQuery",
+              "start": 153,
               "end": 163,
               "loc": {
                 "start": {
                   "line": 7,
-                  "column": 23
+                  "column": 16
                 },
                 "end": {
                   "line": 7,
                   "column": 26
-                },
-                "identifierName": "foo"
+                }
               },
-              "name": "foo"
+              "exprName": {
+                "type": "Identifier",
+                "start": 160,
+                "end": 163,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 26
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              }
             }
           }
         }

--- a/packages/babylon/test/fixtures/typescript/export/declare/expected.json
+++ b/packages/babylon/test/fixtures/typescript/export/declare/expected.json
@@ -391,7 +391,7 @@
             "name": "T"
           },
           "typeAnnotation": {
-            "type": "TSNumberKeyword",
+            "type": "TSTypeAnnotation",
             "start": 147,
             "end": 153,
             "loc": {
@@ -402,6 +402,21 @@
               "end": {
                 "line": 5,
                 "column": 30
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSNumberKeyword",
+              "start": 147,
+              "end": 153,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 24
+                },
+                "end": {
+                  "line": 5,
+                  "column": 30
+                }
               }
             }
           },

--- a/packages/babylon/test/fixtures/typescript/regression/is-default-export/expected.json
+++ b/packages/babylon/test/fixtures/typescript/regression/is-default-export/expected.json
@@ -76,7 +76,7 @@
             "name": "T"
           },
           "typeAnnotation": {
-            "type": "TSNumberKeyword",
+            "type": "TSTypeAnnotation",
             "start": 16,
             "end": 22,
             "loc": {
@@ -87,6 +87,21 @@
               "end": {
                 "line": 1,
                 "column": 22
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSNumberKeyword",
+              "start": 16,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                }
               }
             }
           }

--- a/packages/babylon/test/fixtures/typescript/type-alias/declare/expected.json
+++ b/packages/babylon/test/fixtures/typescript/type-alias/declare/expected.json
@@ -60,7 +60,7 @@
           "name": "T"
         },
         "typeAnnotation": {
-          "type": "TSNumberKeyword",
+          "type": "TSTypeAnnotation",
           "start": 17,
           "end": 23,
           "loc": {
@@ -71,6 +71,21 @@
             "end": {
               "line": 1,
               "column": 23
+            }
+          },
+          "typeAnnotation": {
+            "type": "TSNumberKeyword",
+            "start": 17,
+            "end": 23,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 23
+              }
             }
           }
         },

--- a/packages/babylon/test/fixtures/typescript/type-alias/export/expected.json
+++ b/packages/babylon/test/fixtures/typescript/type-alias/export/expected.json
@@ -76,7 +76,7 @@
             "name": "T"
           },
           "typeAnnotation": {
-            "type": "TSNumberKeyword",
+            "type": "TSTypeAnnotation",
             "start": 16,
             "end": 22,
             "loc": {
@@ -87,6 +87,21 @@
               "end": {
                 "line": 1,
                 "column": 22
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSNumberKeyword",
+              "start": 16,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                }
               }
             }
           },

--- a/packages/babylon/test/fixtures/typescript/type-alias/generic-complex/expected.json
+++ b/packages/babylon/test/fixtures/typescript/type-alias/generic-complex/expected.json
@@ -188,7 +188,7 @@
           ]
         },
         "typeAnnotation": {
-          "type": "TSTypeReference",
+          "type": "TSTypeAnnotation",
           "start": 43,
           "end": 51,
           "loc": {
@@ -201,10 +201,10 @@
               "column": 51
             }
           },
-          "typeName": {
-            "type": "Identifier",
+          "typeAnnotation": {
+            "type": "TSTypeReference",
             "start": 43,
-            "end": 48,
+            "end": 51,
             "loc": {
               "start": {
                 "line": 1,
@@ -212,43 +212,43 @@
               },
               "end": {
                 "line": 1,
-                "column": 48
-              },
-              "identifierName": "Array"
-            },
-            "name": "Array"
-          },
-          "typeParameters": {
-            "type": "TSTypeParameterInstantiation",
-            "start": 48,
-            "end": 51,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 48
-              },
-              "end": {
-                "line": 1,
                 "column": 51
               }
             },
-            "params": [
-              {
-                "type": "TSTypeReference",
-                "start": 49,
-                "end": 50,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 49
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 50
-                  }
+            "typeName": {
+              "type": "Identifier",
+              "start": 43,
+              "end": 48,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 43
                 },
-                "typeName": {
-                  "type": "Identifier",
+                "end": {
+                  "line": 1,
+                  "column": 48
+                },
+                "identifierName": "Array"
+              },
+              "name": "Array"
+            },
+            "typeParameters": {
+              "type": "TSTypeParameterInstantiation",
+              "start": 48,
+              "end": 51,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 48
+                },
+                "end": {
+                  "line": 1,
+                  "column": 51
+                }
+              },
+              "params": [
+                {
+                  "type": "TSTypeReference",
                   "start": 49,
                   "end": 50,
                   "loc": {
@@ -259,13 +259,28 @@
                     "end": {
                       "line": 1,
                       "column": 50
-                    },
-                    "identifierName": "U"
+                    }
                   },
-                  "name": "U"
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 49,
+                    "end": 50,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 49
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 50
+                      },
+                      "identifierName": "U"
+                    },
+                    "name": "U"
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       }

--- a/packages/babylon/test/fixtures/typescript/type-alias/generic/expected.json
+++ b/packages/babylon/test/fixtures/typescript/type-alias/generic/expected.json
@@ -93,7 +93,7 @@
           ]
         },
         "typeAnnotation": {
-          "type": "TSTypeReference",
+          "type": "TSTypeAnnotation",
           "start": 12,
           "end": 13,
           "loc": {
@@ -106,8 +106,8 @@
               "column": 13
             }
           },
-          "typeName": {
-            "type": "Identifier",
+          "typeAnnotation": {
+            "type": "TSTypeReference",
             "start": 12,
             "end": 13,
             "loc": {
@@ -118,10 +118,25 @@
               "end": {
                 "line": 1,
                 "column": 13
-              },
-              "identifierName": "U"
+              }
             },
-            "name": "U"
+            "typeName": {
+              "type": "Identifier",
+              "start": 12,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 12
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "U"
+              },
+              "name": "U"
+            }
           }
         }
       }

--- a/packages/babylon/test/fixtures/typescript/type-alias/plain/expected.json
+++ b/packages/babylon/test/fixtures/typescript/type-alias/plain/expected.json
@@ -60,7 +60,7 @@
           "name": "T"
         },
         "typeAnnotation": {
-          "type": "TSNumberKeyword",
+          "type": "TSTypeAnnotation",
           "start": 9,
           "end": 15,
           "loc": {
@@ -71,6 +71,21 @@
             "end": {
               "line": 1,
               "column": 15
+            }
+          },
+          "typeAnnotation": {
+            "type": "TSNumberKeyword",
+            "start": 9,
+            "end": 15,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 15
+              }
             }
           }
         }

--- a/packages/babylon/test/fixtures/typescript/types/parenthesized/expected.json
+++ b/packages/babylon/test/fixtures/typescript/types/parenthesized/expected.json
@@ -60,7 +60,7 @@
           "name": "T"
         },
         "typeAnnotation": {
-          "type": "TSParenthesizedType",
+          "type": "TSTypeAnnotation",
           "start": 9,
           "end": 13,
           "loc": {
@@ -74,20 +74,35 @@
             }
           },
           "typeAnnotation": {
-            "type": "TSTypeLiteral",
-            "start": 10,
-            "end": 12,
+            "type": "TSParenthesizedType",
+            "start": 9,
+            "end": 13,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 10
+                "column": 9
               },
               "end": {
                 "line": 1,
-                "column": 12
+                "column": 13
               }
             },
-            "members": []
+            "typeAnnotation": {
+              "type": "TSTypeLiteral",
+              "start": 10,
+              "end": 12,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 1,
+                  "column": 12
+                }
+              },
+              "members": []
+            }
           }
         }
       }


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

@andy-ms As discussed on slack, but I'm honestly not sure how I feel either way anymore... 😅  

Obviously I am just striving for consistency here and there isn't a real downside to doing it I don't think. For that reason, I saw it through and opened the PR.