### PR TITLE
Create method combinedRestSpread for merging rest/spread operations

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -128,6 +128,18 @@ export default function(api, opts) {
     }
   }
 
+  function combinedRestSpread(copiedObj, newObj, excludedNames) {
+    const rest = {};
+
+    for (const prop in copiedObj) {
+      if (!excludedNames.includes(prop)) {
+        rest[prop] = copiedObj[prop];
+      }
+    }
+
+    return { ...rest, ...newObj };
+  }
+
   return {
     inherits: syntaxObjectRestSpread,
 


### PR DESCRIPTION
Create method combinedRestSpread for merging rest/spread operations into single operation. This partially resolves #3840

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
