### PR TITLE
Allow configs to have an 'overrides' array

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -517,11 +517,14 @@ function shouldIgnore(
   only: ?IgnoreList,
   dirname: string,
 ): boolean {
-  if (context.filename === null) return false;
-  // $FlowIgnore - Flow refinements aren't quite smart enough for this :(
-  const ctx: ConfigContextNamed = context;
-
   if (ignore) {
+    if (context.filename === null) {
+      throw new Error(
+        `Configuration contains ignore checks, but no filename was passed to Babel`,
+      );
+    }
+    // $FlowIgnore - Flow refinements aren't quite smart enough for this :(
+    const ctx: ConfigContextNamed = context;
     if (matchesPatterns(ctx, ignore, dirname)) {
       debug(
         "Ignored %o because it matched one of %O from %o",
@@ -534,6 +537,14 @@ function shouldIgnore(
   }
 
   if (only) {
+    if (context.filename === null) {
+      throw new Error(
+        `Configuration contains ignore checks, but no filename was passed to Babel`,
+      );
+    }
+    // $FlowIgnore - Flow refinements aren't quite smart enough for this :(
+    const ctx: ConfigContextNamed = context;
+
     if (!matchesPatterns(ctx, only, dirname)) {
       debug(
         "Ignored %o because it failed to match one of %O from %o",

--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -7,6 +7,7 @@ import merge from "lodash/merge";
 import {
   buildRootChain,
   buildPresetChain,
+  type ConfigContext,
   type ConfigChain,
   type PresetInstance,
 } from "./config-chain";
@@ -36,6 +37,12 @@ export type { Plugin };
 export type PluginPassList = Array<Plugin>;
 export type PluginPasses = Array<PluginPassList>;
 
+// Context not including filename since it is used in places that cannot
+// process 'ignore'/'only' and other filename-based logic.
+type SimpleContext = {
+  envName: string,
+};
+
 export default function loadConfig(inputOpts: mixed): ResolvedConfig | null {
   if (
     inputOpts != null &&
@@ -49,27 +56,32 @@ export default function loadConfig(inputOpts: mixed): ResolvedConfig | null {
   const { envName = getEnv(), cwd = "." } = args;
   const absoluteCwd = path.resolve(cwd);
 
-  const configChain = buildRootChain(absoluteCwd, args, envName);
+  const context: ConfigContext = {
+    filename: args.filename ? path.resolve(cwd, args.filename) : null,
+    cwd: absoluteCwd,
+    envName,
+  };
+
+  const configChain = buildRootChain(absoluteCwd, args, context);
   if (!configChain) return null;
 
   const optionDefaults = {};
   const options = {};
   const passes = [[]];
   try {
-    (function recurseDescriptors(
+    const ignored = (function recurseDescriptors(
       config: {
         plugins: Array<UnloadedDescriptor>,
         presets: Array<UnloadedDescriptor>,
       },
       pass: Array<Plugin>,
-      envName: string,
     ) {
       const plugins = config.plugins.map(descriptor =>
-        loadPluginDescriptor(descriptor, envName),
+        loadPluginDescriptor(descriptor, context),
       );
       const presets = config.presets.map(descriptor => {
         return {
-          preset: loadPresetDescriptor(descriptor, envName),
+          preset: loadPresetDescriptor(descriptor, context),
           pass: descriptor.ownPass ? [] : pass,
         };
       });
@@ -85,14 +97,16 @@ export default function loadConfig(inputOpts: mixed): ResolvedConfig | null {
         );
 
         for (const { preset, pass } of presets) {
-          recurseDescriptors(
+          if (!preset) return true;
+
+          const ignored = recurseDescriptors(
             {
               plugins: preset.plugins,
               presets: preset.presets,
             },
             pass,
-            envName,
           );
+          if (ignored) return true;
 
           preset.options.forEach(opts => {
             merge(optionDefaults, opts);
@@ -110,8 +124,9 @@ export default function loadConfig(inputOpts: mixed): ResolvedConfig | null {
         presets: configChain.presets,
       },
       passes[0],
-      envName,
     );
+
+    if (ignored) return null;
 
     configChain.options.forEach(opts => {
       merge(options, opts);
@@ -152,7 +167,7 @@ export default function loadConfig(inputOpts: mixed): ResolvedConfig | null {
 const loadDescriptor = makeWeakCache(
   (
     { value, options, dirname, alias }: UnloadedDescriptor,
-    cache: CacheConfigurator<{ envName: string }>,
+    cache: CacheConfigurator<SimpleContext>,
   ): LoadedDescriptor => {
     // Disabled presets should already have been filtered out
     if (options === false) throw new Error("Assertion failure");
@@ -199,7 +214,7 @@ const loadDescriptor = makeWeakCache(
  */
 function loadPluginDescriptor(
   descriptor: UnloadedDescriptor,
-  envName: string,
+  context: SimpleContext,
 ): Plugin {
   if (descriptor.value instanceof Plugin) {
     if (descriptor.options) {
@@ -211,15 +226,13 @@ function loadPluginDescriptor(
     return descriptor.value;
   }
 
-  return instantiatePlugin(loadDescriptor(descriptor, { envName }), {
-    envName,
-  });
+  return instantiatePlugin(loadDescriptor(descriptor, context), context);
 }
 
 const instantiatePlugin = makeWeakCache(
   (
     { value, options, dirname, alias }: LoadedDescriptor,
-    cache: CacheConfigurator<{ envName: string }>,
+    cache: CacheConfigurator<SimpleContext>,
   ): Plugin => {
     const pluginObj = validatePluginObject(value);
 
@@ -239,7 +252,7 @@ const instantiatePlugin = makeWeakCache(
 
       // If the inherited plugin changes, reinstantiate this plugin.
       const inherits = cache.invalidate(data =>
-        loadPluginDescriptor(inheritsDescriptor, data.envName),
+        loadPluginDescriptor(inheritsDescriptor, data),
       );
 
       plugin.pre = chain(inherits.pre, plugin.pre);
@@ -263,10 +276,11 @@ const instantiatePlugin = makeWeakCache(
  */
 const loadPresetDescriptor = (
   descriptor: UnloadedDescriptor,
-  envName: string,
-): ConfigChain => {
+  context: ConfigContext,
+): ConfigChain | null => {
   return buildPresetChain(
-    instantiatePreset(loadDescriptor(descriptor, { envName })),
+    instantiatePreset(loadDescriptor(descriptor, context)),
+    context,
   );
 };
 

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -105,6 +105,13 @@ export function assertObject(key: string, value: mixed): {} | void {
   return value;
 }
 
+export function assertArray(key: string, value: mixed): ?$ReadOnlyArray<mixed> {
+  if (value != null && !Array.isArray(value)) {
+    throw new Error(`.${key} must be an array, or undefined`);
+  }
+  return value;
+}
+
 export function assertIgnoreList(key: string, value: mixed): IgnoreList | void {
   const arr = assertArray(key, value);
   if (arr) {
@@ -222,13 +229,6 @@ function assertPluginTarget(
         inArray ? `[0]` : ""
       } must be a string, object, function`,
     );
-  }
-  return value;
-}
-
-function assertArray(key: string, value: mixed): ?$ReadOnlyArray<mixed> {
-  if (value != null && !Array.isArray(value)) {
-    throw new Error(`.${key} must be an array, or undefined`);
   }
   return value;
 }

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -6,6 +6,7 @@ import type {
   PluginList,
   PluginItem,
   PluginTarget,
+  ConfigApplicableTest,
   SourceMapsOption,
   SourceTypeOption,
   CompactOption,
@@ -122,10 +123,36 @@ function assertIgnoreItem(
     !(value instanceof RegExp)
   ) {
     throw new Error(
-      `.${key}[${index}] must be an array of string/Funtion/RegExp values, or or undefined`,
+      `.${key}[${index}] must be an array of string/Funtion/RegExp values, or undefined`,
     );
   }
   return value;
+}
+
+export function assertConfigApplicableTest(
+  key: string,
+  value: mixed,
+): ConfigApplicableTest | void {
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => {
+      if (!checkValidTest(item)) {
+        throw new Error(`.${key}[${i}] must be a string/Function/RegExp.`);
+      }
+    });
+  } else if (!checkValidTest(value)) {
+    throw new Error(
+      `.${key} must be a string/Function/RegExp, or an array of those`,
+    );
+  }
+  return (value: any);
+}
+
+function checkValidTest(value: mixed): boolean {
+  return (
+    typeof value === "string" ||
+    typeof value === "function" ||
+    value instanceof RegExp
+  );
 }
 
 export function assertPluginList(key: string, value: mixed): PluginList | void {

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -8,6 +8,7 @@ import {
   assertInputSourceMap,
   assertIgnoreList,
   assertPluginList,
+  assertConfigApplicableTest,
   assertFunction,
   assertSourceMaps,
   assertCompact,
@@ -44,6 +45,19 @@ const NONPRESET_VALIDATORS: ValidatorSet = {
     $PropertyType<ValidatedOptions, "ignore">,
   >),
   only: (assertIgnoreList: Validator<$PropertyType<ValidatedOptions, "only">>),
+
+  // We could limit these to 'overrides' blocks, but it's not clear why we'd
+  // bother, when the ability to limit a config to a specific set of files
+  // is a fairly general useful feature.
+  test: (assertConfigApplicableTest: Validator<
+    $PropertyType<ValidatedOptions, "test">,
+  >),
+  include: (assertConfigApplicableTest: Validator<
+    $PropertyType<ValidatedOptions, "include">,
+  >),
+  exclude: (assertConfigApplicableTest: Validator<
+    $PropertyType<ValidatedOptions, "exclude">,
+  >),
 };
 
 const COMMON_VALIDATORS: ValidatorSet = {
@@ -143,6 +157,11 @@ export type ValidatedOptions = {
   ignore?: IgnoreList,
   only?: IgnoreList,
 
+  // Generally verify if a given config object should be applied to the given file.
+  test?: ConfigApplicableTest,
+  include?: ConfigApplicableTest,
+  exclude?: ConfigApplicableTest,
+
   presets?: PluginList,
   plugins?: PluginList,
   passPerPreset?: boolean,
@@ -195,6 +214,8 @@ export type PluginItem =
   | [PluginTarget, PluginOptions]
   | [PluginTarget, PluginOptions, string];
 export type PluginList = $ReadOnlyArray<PluginItem>;
+
+export type ConfigApplicableTest = IgnoreItem | Array<IgnoreItem>;
 
 export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -5,6 +5,7 @@ import {
   assertString,
   assertBoolean,
   assertObject,
+  assertArray,
   assertInputSourceMap,
   assertIgnoreList,
   assertPluginList,
@@ -45,6 +46,9 @@ const NONPRESET_VALIDATORS: ValidatorSet = {
     $PropertyType<ValidatedOptions, "ignore">,
   >),
   only: (assertIgnoreList: Validator<$PropertyType<ValidatedOptions, "only">>),
+  overrides: (assertOverridesList: Validator<
+    $PropertyType<ValidatedOptions, "overrides">,
+  >),
 
   // We could limit these to 'overrides' blocks, but it's not clear why we'd
   // bother, when the ability to limit a config to a specific set of files
@@ -156,6 +160,7 @@ export type ValidatedOptions = {
   env?: EnvSet<ValidatedOptions>,
   ignore?: IgnoreList,
   only?: IgnoreList,
+  overrides?: OverridesList,
 
   // Generally verify if a given config object should be applied to the given file.
   test?: ConfigApplicableTest,
@@ -215,6 +220,7 @@ export type PluginItem =
   | [PluginTarget, PluginOptions, string];
 export type PluginList = $ReadOnlyArray<PluginItem>;
 
+export type OverridesList = Array<ValidatedOptions>;
 export type ConfigApplicableTest = IgnoreItem | Array<IgnoreItem>;
 
 export type SourceMapsOption = boolean | "inline" | "both";
@@ -222,7 +228,7 @@ export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";
 export type RootInputSourceMapOption = {} | boolean;
 
-export type OptionsType = "arguments" | "file" | "env" | "preset";
+export type OptionsType = "arguments" | "file" | "env" | "preset" | "override";
 
 export function validate(type: OptionsType, opts: {}): ValidatedOptions {
   assertNoDuplicateSourcemap(opts);
@@ -236,6 +242,12 @@ export function validate(type: OptionsType, opts: {}): ValidatedOptions {
     }
     if (type === "env" && key === "env") {
       throw new Error(`.${key} is not allowed inside another env block`);
+    }
+    if (type === "env" && key === "overrides") {
+      throw new Error(`.${key} is not allowed inside an env block`);
+    }
+    if (type === "override" && key === "overrides") {
+      throw new Error(`.${key} is not allowed inside an overrides block`);
     }
 
     const validator =
@@ -286,4 +298,17 @@ function assertEnvSet(key: string, value: mixed): EnvSet<ValidatedOptions> {
     }
   }
   return (obj: any);
+}
+
+function assertOverridesList(key: string, value: mixed): OverridesList {
+  const arr = assertArray(key, value);
+  if (arr) {
+    for (const [index, item] of arr.entries()) {
+      const env = assertObject(`${index}`, item);
+      if (!env) throw new Error(`.${key}[${index}] must be an object`);
+
+      validate("override", env);
+    }
+  }
+  return (arr: any);
 }

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -801,6 +801,40 @@ describe("buildConfigChain", function() {
     });
   });
 
+  describe("overrides merging", () => {
+    it("should apply matching overrides over base configs", () => {
+      const opts = loadOptions({
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        comments: true,
+        overrides: [
+          {
+            test: fixture("nonexistant-fake"),
+            comments: false,
+          },
+        ],
+      });
+
+      assert.equal(opts.comments, false);
+    });
+
+    it("should not apply non-matching overrides over base configs", () => {
+      const opts = loadOptions({
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        comments: true,
+        overrides: [
+          {
+            test: fixture("nonexistant-unknown"),
+            comments: false,
+          },
+        ],
+      });
+
+      assert.equal(opts.comments, true);
+    });
+  });
+
   describe("config files", () => {
     const getDefaults = () => ({
       babelrc: false,

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -8,6 +8,420 @@ function fixture(...args) {
 }
 
 describe("buildConfigChain", function() {
+  describe("test", () => {
+    describe("single", () => {
+      it("should process matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: fixture("nonexistant-fake"),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: new RegExp(fixture("nonexistant-fake")),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: p => p.indexOf(fixture("nonexistant-fake")) === 0,
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: fixture("nonexistant-fake-unknown"),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: new RegExp(fixture("nonexistant-unknown")),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: p => p.indexOf(fixture("nonexistant-unknown")) === 0,
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+    });
+
+    describe("array", () => {
+      it("should process matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: [fixture("nonexistant-fake")],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: [new RegExp(fixture("nonexistant-fake"))],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: [p => p.indexOf(fixture("nonexistant-fake")) === 0],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: [fixture("nonexistant-fake-unknown")],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: [new RegExp(fixture("nonexistant-unknown"))],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          test: [p => p.indexOf(fixture("nonexistant-unknown")) === 0],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+    });
+  });
+
+  describe("include", () => {
+    describe("single", () => {
+      it("should process matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: fixture("nonexistant-fake"),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: new RegExp(fixture("nonexistant-fake")),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: p => p.indexOf(fixture("nonexistant-fake")) === 0,
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: fixture("nonexistant-fake-unknown"),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: new RegExp(fixture("nonexistant-unknown")),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: p => p.indexOf(fixture("nonexistant-unknown")) === 0,
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+    });
+
+    describe("array", () => {
+      it("should process matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: [fixture("nonexistant-fake")],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: [new RegExp(fixture("nonexistant-fake"))],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: [p => p.indexOf(fixture("nonexistant-fake")) === 0],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: [fixture("nonexistant-fake-unknown")],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: [new RegExp(fixture("nonexistant-unknown"))],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          include: [p => p.indexOf(fixture("nonexistant-unknown")) === 0],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+    });
+  });
+
+  describe("exclude", () => {
+    describe("single", () => {
+      it("should process matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: fixture("nonexistant-fake"),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: new RegExp(fixture("nonexistant-fake")),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: p => p.indexOf(fixture("nonexistant-fake")) === 0,
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: fixture("nonexistant-fake-unknown"),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: new RegExp(fixture("nonexistant-unknown")),
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: p => p.indexOf(fixture("nonexistant-unknown")) === 0,
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+    });
+
+    describe("array", () => {
+      it("should process matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: [fixture("nonexistant-fake")],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: [new RegExp(fixture("nonexistant-fake"))],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: [p => p.indexOf(fixture("nonexistant-fake")) === 0],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, undefined);
+      });
+
+      it("should process non-matching string values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: [fixture("nonexistant-fake-unknown")],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching RegExp values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: [new RegExp(fixture("nonexistant-unknown"))],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+
+      it("should process non-matching function values", () => {
+        const opts = loadOptions({
+          filename: fixture("nonexistant-fake", "src.js"),
+          babelrc: false,
+          exclude: [p => p.indexOf(fixture("nonexistant-unknown")) === 0],
+          comments: true,
+        });
+
+        assert.equal(opts.comments, true);
+      });
+    });
+  });
+
   describe("ignore", () => {
     it("should ignore files that match", () => {
       const opts = loadOptions({


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5451
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This does two related things

1. Allow every config object to specify a `test/include/exclude` field, just like you might do for Webpack. Each item allows an item, or array of items that can be a string, RegExp, or function.

    Note, this means you could actually limit a `.babelrc` to only apply to _some_ files inside of a directory, or make an `env` override only apply to certain files in that env, or something, which seemed like it was reasonable to allow and would be an unnecessary restriction to disallow.

2. Allow an `overrides` array of sub-configs that apply on top of the base configs that will apply based on their `test`/`include`/`exclude` values.

As an example, this allows user to do

```
{
  presets: [
    ['env', { 
      targets: { node: 'current' },
    }],
  ],
  overrides: [{
    test: "./client",
    presets: [
      ['env', { 
        targets: { browsers: ["last 2 versions"] },
      }],
    ],
  }],
}
```
or for instance we'll use this in Babel's own codebase to do

```
{
  presets: [
    ['env', {modules: false}],
  ],
  plugins: [
    ['@babel/transform-modules-commonjs', { lazy: true }],
  ],
  overrides: [{
    test: './packages/babel-register',
    plugins: [
      // Override the plugin with an empty module options config to disable lazy modules.
      '@babel/transform-modules-commonjs',
    ],
  }],
}
```
to enable lazy modules for everything except `babel-register`, where it breaks things.