### PR TITLE
Fix generation flow unnamed computed property

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -384,9 +384,11 @@ export function ObjectTypeIndexer(node: Object) {
   }
   this._variance(node);
   this.token("[");
-  this.print(node.id, node);
-  this.token(":");
-  this.space();
+  if (node.id) {
+    this.print(node.id, node);
+    this.token(":");
+    this.space();
+  }
   this.print(node.key, node);
   this.token("]");
   this.token(":");

--- a/packages/babel-generator/test/fixtures/flow/object-literal-types/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/object-literal-types/actual.js
@@ -5,3 +5,5 @@ type T = { ...U, ...V };
 type T = { p: V, ...U };
 type T = { ...U, p: V, };
 type T = { ...{}|{ p: V, }};
+type T = { [string]: U };
+type T = { [param: string]: U };

--- a/packages/babel-generator/test/fixtures/flow/object-literal-types/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/object-literal-types/expected.js
@@ -5,3 +5,5 @@ type T = { ...U; ...V; };
 type T = { p: V; ...U; };
 type T = { ...U; p: V; };
 type T = { ...{} | { p: V } };
+type T = { [string]: U };
+type T = { [param: string]: U };


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | no
| License                  | MIT

Currently this thing happens in babel-generator
```js
type A = {
  [string]: string
}
```
is generated as
```js

type A = {
  [: string]: string
}
```