### PR TITLE
Add validators for Flow AST node fields

### DIFF
--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -335,7 +335,7 @@ describe("programmatic generation", function() {
         t.objectTypeIndexer(
           t.identifier("key"),
           t.anyTypeAnnotation(),
-          t.identifier("Test"),
+          t.numberTypeAnnotation(),
         ),
       ],
     );
@@ -345,7 +345,7 @@ describe("programmatic generation", function() {
     assert.equal(
       output,
       `{
-  [key: any]: Test
+  [key: any]: number
 }`,
     );
   });

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -61,7 +61,7 @@ See also `t.isArrayTypeAnnotation(node, opts)` and `t.assertArrayTypeAnnotation(
 
 Aliases: `Flow`
 
- - `elementType` (required)
+ - `elementType`: `Flow` (required)
 
 ---
 
@@ -193,6 +193,7 @@ See also `t.isBooleanLiteralTypeAnnotation(node, opts)` and `t.assertBooleanLite
 
 Aliases: `Flow`
 
+ - `value`: `boolean` (default: `null`)
 
 ---
 
@@ -313,8 +314,8 @@ See also `t.isClassImplements(node, opts)` and `t.assertClassImplements(node, op
 
 Aliases: `Flow`
 
- - `id` (required)
- - `typeParameters` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
 
@@ -416,10 +417,11 @@ See also `t.isDeclareClass(node, opts)` and `t.assertDeclareClass(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `extends` (required)
- - `body` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+ - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `mixins`: `Array<InterfaceExtends>` (default: `null`)
 
 ---
 
@@ -432,7 +434,8 @@ See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExpor
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `source` (required)
+ - `source`: `StringLiteral` (required)
+ - `exportKind`: `[ 'type', 'value' ]` (default: `null`)
 
 ---
 
@@ -445,9 +448,10 @@ See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDe
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `declaration` (required)
- - `specifiers` (required)
- - `source` (required)
+ - `declaration`: `Flow` (default: `null`)
+ - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
+ - `source`: `StringLiteral` (default: `null`)
+ - `default`: `boolean` (default: `null`)
 
 ---
 
@@ -460,7 +464,8 @@ See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, op
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
+ - `id`: `Identifier` (required)
+ - `predicate`: `DeclaredPredicate` (default: `null`)
 
 ---
 
@@ -473,24 +478,26 @@ See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, 
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `extends` (required)
- - `body` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `extends`: `InterfaceExtends` (default: `null`)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `mixins`: `Array<Flow>` (default: `null`)
 
 ---
 
 ### declareModule
 ```javascript
-t.declareModule(id, body)
+t.declareModule(id, body, kind)
 ```
 
 See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `body` (required)
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `BlockStatement` (required)
+ - `kind`: `'CommonJS' | 'ES'` (default: `null`)
 
 ---
 
@@ -503,7 +510,7 @@ See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExport
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `typeAnnotation` (required)
+ - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
@@ -516,9 +523,9 @@ See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `supertype` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `supertype`: `Flow` (default: `null`)
 
 ---
 
@@ -531,9 +538,9 @@ See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, 
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `right` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `right`: `Flow` (required)
 
 ---
 
@@ -546,7 +553,7 @@ See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, op
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
+ - `id`: `Identifier` (required)
 
 ---
 
@@ -559,7 +566,7 @@ See also `t.isDeclaredPredicate(node, opts)` and `t.assertDeclaredPredicate(node
 
 Aliases: `Flow`, `FlowPredicate`
 
- - `value` (required)
+ - `value`: `Flow` (required)
 
 ---
 
@@ -861,10 +868,10 @@ See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnot
 
 Aliases: `Flow`
 
- - `typeParameters` (required)
- - `params` (required)
- - `rest` (required)
- - `returnType` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `params`: `Array<FunctionTypeParam>` (required)
+ - `rest`: `FunctionTypeParam` (default: `null`)
+ - `returnType`: `Flow` (required)
 
 ---
 
@@ -877,8 +884,9 @@ See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node
 
 Aliases: `Flow`
 
- - `name` (required)
- - `typeAnnotation` (required)
+ - `name`: `Identifier` (default: `null`)
+ - `typeAnnotation`: `Flow` (required)
+ - `optional`: `boolean` (default: `null`)
 
 ---
 
@@ -891,8 +899,8 @@ See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotat
 
 Aliases: `Flow`
 
- - `id` (required)
- - `typeParameters` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
 
@@ -1015,10 +1023,11 @@ See also `t.isInterfaceDeclaration(node, opts)` and `t.assertInterfaceDeclaratio
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `extends` (required)
- - `body` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `extends`: `Array<InterfaceExtends>` (required)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `mixins`: `Array<InterfaceExtends>` (default: `null`)
 
 ---
 
@@ -1031,8 +1040,8 @@ See also `t.isInterfaceExtends(node, opts)` and `t.assertInterfaceExtends(node, 
 
 Aliases: `Flow`
 
- - `id` (required)
- - `typeParameters` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
 
@@ -1045,7 +1054,7 @@ See also `t.isIntersectionTypeAnnotation(node, opts)` and `t.assertIntersectionT
 
 Aliases: `Flow`
 
- - `types` (required)
+ - `types`: `Array<Flow>` (required)
 
 ---
 
@@ -1381,7 +1390,7 @@ See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnot
 
 Aliases: `Flow`
 
- - `typeAnnotation` (required)
+ - `typeAnnotation`: `Flow` (required)
 
 ---
 
@@ -1394,6 +1403,7 @@ See also `t.isNumberLiteralTypeAnnotation(node, opts)` and `t.assertNumberLitera
 
 Aliases: `Flow`
 
+ - `value`: `number` (default: `null`)
 
 ---
 
@@ -1498,9 +1508,10 @@ See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotatio
 
 Aliases: `Flow`
 
- - `properties` (required)
- - `indexers` (required)
- - `callProperties` (required)
+ - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
+ - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
+ - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
+ - `exact`: `boolean` (default: `null`)
 
 ---
 
@@ -1513,7 +1524,8 @@ See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallPro
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `value` (required)
+ - `value`: `Flow` (required)
+ - `static`: `boolean` (default: `null`)
 
 ---
 
@@ -1526,9 +1538,11 @@ See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id` (required)
- - `key` (required)
- - `value` (required)
+ - `id`: `Identifier` (default: `null`)
+ - `key`: `Flow` (required)
+ - `value`: `Flow | Identifier` (required)
+ - `static`: `boolean` (default: `null`)
+ - `variance`: `Variance` (default: `null`)
 
 ---
 
@@ -1541,8 +1555,12 @@ See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(no
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `key` (required)
- - `value` (required)
+ - `key`: `Identifier` (required)
+ - `value`: `Flow | Identifier` (required)
+ - `kind`: `'init' | 'get' | 'set'` (default: `null`)
+ - `optional`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `null`)
+ - `variance`: `Variance` (default: `null`)
 
 ---
 
@@ -1555,7 +1573,7 @@ See also `t.isObjectTypeSpreadProperty(node, opts)` and `t.assertObjectTypeSprea
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `argument` (required)
+ - `argument`: `Flow` (required)
 
 ---
 
@@ -1568,10 +1586,10 @@ See also `t.isOpaqueType(node, opts)` and `t.assertOpaqueType(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `supertype` (required)
- - `impltype` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `supertype`: `Flow` (default: `null`)
+ - `impltype`: `Flow` (required)
 
 ---
 
@@ -1613,8 +1631,9 @@ See also `t.isQualifiedTypeIdentifier(node, opts)` and `t.assertQualifiedTypeIde
 
 Aliases: `Flow`
 
- - `id` (required)
+ - `id`: `Identifier` (required)
  - `qualification` (required)
+ - `qualifications`: `Identifier` (default: `null`)
 
 ---
 
@@ -1708,6 +1727,7 @@ See also `t.isStringLiteralTypeAnnotation(node, opts)` and `t.assertStringLitera
 
 Aliases: `Flow`
 
+ - `value`: `string` (default: `null`)
 
 ---
 
@@ -2606,7 +2626,7 @@ See also `t.isTupleTypeAnnotation(node, opts)` and `t.assertTupleTypeAnnotation(
 
 Aliases: `Flow`
 
- - `types` (required)
+ - `types`: `Array<Flow>` (required)
 
 ---
 
@@ -2619,9 +2639,9 @@ See also `t.isTypeAlias(node, opts)` and `t.assertTypeAlias(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id` (required)
- - `typeParameters` (required)
- - `right` (required)
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `right`: `Flow` (required)
 
 ---
 
@@ -2647,8 +2667,8 @@ See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(no
 
 Aliases: `Flow`, `ExpressionWrapper`, `Expression`
 
- - `expression` (required)
- - `typeAnnotation` (required)
+ - `expression`: `Flow` (required)
+ - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
@@ -2664,6 +2684,7 @@ Aliases: `Flow`
  - `bound`: `TypeAnnotation` (default: `null`)
  - `default`: `Flow` (default: `null`)
  - `name`: `string` (default: `null`)
+ - `variance`: `Variance` (default: `null`)
 
 ---
 
@@ -2702,7 +2723,7 @@ See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotatio
 
 Aliases: `Flow`
 
- - `argument` (required)
+ - `argument`: `Flow` (required)
 
 ---
 
@@ -2730,7 +2751,7 @@ See also `t.isUnionTypeAnnotation(node, opts)` and `t.assertUnionTypeAnnotation(
 
 Aliases: `Flow`
 
- - `types` (required)
+ - `types`: `Array<Flow>` (required)
 
 ---
 

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -19,7 +19,7 @@ t.anyTypeAnnotation()
 
 See also `t.isAnyTypeAnnotation(node, opts)` and `t.assertAnyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -59,9 +59,9 @@ t.arrayTypeAnnotation(elementType)
 
 See also `t.isArrayTypeAnnotation(node, opts)` and `t.assertArrayTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
- - `elementType`: `Flow` (required)
+ - `elementType`: `FlowType` (required)
 
 ---
 
@@ -191,7 +191,7 @@ t.booleanLiteralTypeAnnotation()
 
 See also `t.isBooleanLiteralTypeAnnotation(node, opts)` and `t.assertBooleanLiteralTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `value`: `boolean` (default: `null`)
 
@@ -204,7 +204,7 @@ t.booleanTypeAnnotation()
 
 See also `t.isBooleanTypeAnnotation(node, opts)` and `t.assertBooleanTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -540,7 +540,7 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
  - `id`: `Identifier` (required)
  - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `Flow` (required)
+ - `right`: `FlowType` (required)
 
 ---
 
@@ -649,7 +649,7 @@ t.emptyTypeAnnotation()
 
 See also `t.isEmptyTypeAnnotation(node, opts)` and `t.assertEmptyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -661,7 +661,7 @@ t.existsTypeAnnotation()
 
 See also `t.isExistsTypeAnnotation(node, opts)` and `t.assertExistsTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
 
 ---
@@ -866,7 +866,7 @@ t.functionTypeAnnotation(typeParameters, params, rest, returnType)
 
 See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
  - `params`: `Array<FunctionTypeParam>` (required)
@@ -897,7 +897,7 @@ t.genericTypeAnnotation(id, typeParameters)
 
 See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `id`: `Identifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
@@ -1052,7 +1052,7 @@ t.intersectionTypeAnnotation(types)
 
 See also `t.isIntersectionTypeAnnotation(node, opts)` and `t.assertIntersectionTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `types`: `Array<Flow>` (required)
 
@@ -1326,7 +1326,7 @@ t.mixedTypeAnnotation()
 
 See also `t.isMixedTypeAnnotation(node, opts)` and `t.assertMixedTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -1376,7 +1376,7 @@ t.nullLiteralTypeAnnotation()
 
 See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -1388,7 +1388,7 @@ t.nullableTypeAnnotation(typeAnnotation)
 
 See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `typeAnnotation`: `Flow` (required)
 
@@ -1401,7 +1401,7 @@ t.numberLiteralTypeAnnotation()
 
 See also `t.isNumberLiteralTypeAnnotation(node, opts)` and `t.assertNumberLiteralTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `value`: `number` (default: `null`)
 
@@ -1414,7 +1414,7 @@ t.numberTypeAnnotation()
 
 See also `t.isNumberTypeAnnotation(node, opts)` and `t.assertNumberTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -1506,7 +1506,7 @@ t.objectTypeAnnotation(properties, indexers, callProperties)
 
 See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
  - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
@@ -1531,7 +1531,7 @@ Aliases: `Flow`, `UserWhitespacable`
 
 ### objectTypeIndexer
 ```javascript
-t.objectTypeIndexer(id, key, value)
+t.objectTypeIndexer(id, key, value, variance)
 ```
 
 See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node, opts)`.
@@ -1541,14 +1541,14 @@ Aliases: `Flow`, `UserWhitespacable`
  - `id`: `Identifier` (default: `null`)
  - `key`: `Flow` (required)
  - `value`: `Flow | Identifier` (required)
- - `static`: `boolean` (default: `null`)
  - `variance`: `Variance` (default: `null`)
+ - `static`: `boolean` (default: `null`)
 
 ---
 
 ### objectTypeProperty
 ```javascript
-t.objectTypeProperty(key, value)
+t.objectTypeProperty(key, value, variance)
 ```
 
 See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(node, opts)`.
@@ -1557,10 +1557,10 @@ Aliases: `Flow`, `UserWhitespacable`
 
  - `key`: `Identifier` (required)
  - `value`: `Flow | Identifier` (required)
+ - `variance`: `Variance` (default: `null`)
  - `kind`: `'init' | 'get' | 'set'` (default: `null`)
  - `optional`: `boolean` (default: `null`)
  - `static`: `boolean` (default: `null`)
- - `variance`: `Variance` (default: `null`)
 
 ---
 
@@ -1725,7 +1725,7 @@ t.stringLiteralTypeAnnotation()
 
 See also `t.isStringLiteralTypeAnnotation(node, opts)` and `t.assertStringLiteralTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `value`: `string` (default: `null`)
 
@@ -1738,7 +1738,7 @@ t.stringTypeAnnotation()
 
 See also `t.isStringTypeAnnotation(node, opts)` and `t.assertStringTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -2584,7 +2584,7 @@ t.thisTypeAnnotation()
 
 See also `t.isThisTypeAnnotation(node, opts)` and `t.assertThisTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---
@@ -2624,7 +2624,7 @@ t.tupleTypeAnnotation(types)
 
 See also `t.isTupleTypeAnnotation(node, opts)` and `t.assertTupleTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `types`: `Array<Flow>` (required)
 
@@ -2674,7 +2674,7 @@ Aliases: `Flow`, `ExpressionWrapper`, `Expression`
 
 ### typeParameter
 ```javascript
-t.typeParameter(bound, default)
+t.typeParameter(bound, default, variance)
 ```
 
 See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`.
@@ -2683,8 +2683,8 @@ Aliases: `Flow`
 
  - `bound`: `TypeAnnotation` (default: `null`)
  - `default`: `Flow` (default: `null`)
- - `name`: `string` (default: `null`)
  - `variance`: `Variance` (default: `null`)
+ - `name`: `string` (default: `null`)
 
 ---
 
@@ -2721,7 +2721,7 @@ t.typeofTypeAnnotation(argument)
 
 See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `argument`: `Flow` (required)
 
@@ -2749,7 +2749,7 @@ t.unionTypeAnnotation(types)
 
 See also `t.isUnionTypeAnnotation(node, opts)` and `t.assertUnionTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`
+Aliases: `Flow`, `FlowType`
 
  - `types`: `Array<Flow>` (required)
 
@@ -2804,7 +2804,7 @@ t.voidTypeAnnotation()
 
 See also `t.isVoidTypeAnnotation(node, opts)` and `t.assertVoidTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
 
 ---

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -525,7 +525,7 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
  - `id`: `Identifier` (required)
  - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `Flow` (default: `null`)
+ - `supertype`: `FlowType` (default: `null`)
 
 ---
 
@@ -871,7 +871,7 @@ Aliases: `Flow`, `FlowType`
  - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
  - `params`: `Array<FunctionTypeParam>` (required)
  - `rest`: `FunctionTypeParam` (default: `null`)
- - `returnType`: `Flow` (required)
+ - `returnType`: `FlowType` (required)
 
 ---
 
@@ -885,7 +885,7 @@ See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node
 Aliases: `Flow`
 
  - `name`: `Identifier` (default: `null`)
- - `typeAnnotation`: `Flow` (required)
+ - `typeAnnotation`: `FlowType` (required)
  - `optional`: `boolean` (default: `null`)
 
 ---
@@ -1054,7 +1054,7 @@ See also `t.isIntersectionTypeAnnotation(node, opts)` and `t.assertIntersectionT
 
 Aliases: `Flow`, `FlowType`
 
- - `types`: `Array<Flow>` (required)
+ - `types`: `Array<FlowType>` (required)
 
 ---
 
@@ -1390,7 +1390,7 @@ See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnot
 
 Aliases: `Flow`, `FlowType`
 
- - `typeAnnotation`: `Flow` (required)
+ - `typeAnnotation`: `FlowType` (required)
 
 ---
 
@@ -1524,7 +1524,7 @@ See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallPro
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `value`: `Flow` (required)
+ - `value`: `FlowType` (required)
  - `static`: `boolean` (default: `null`)
 
 ---
@@ -1539,8 +1539,8 @@ See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node
 Aliases: `Flow`, `UserWhitespacable`
 
  - `id`: `Identifier` (default: `null`)
- - `key`: `Flow` (required)
- - `value`: `Flow | Identifier` (required)
+ - `key`: `FlowType` (required)
+ - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `static`: `boolean` (default: `null`)
 
@@ -1556,7 +1556,7 @@ See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(no
 Aliases: `Flow`, `UserWhitespacable`
 
  - `key`: `Identifier` (required)
- - `value`: `Flow | Identifier` (required)
+ - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `kind`: `'init' | 'get' | 'set'` (default: `null`)
  - `optional`: `boolean` (default: `null`)
@@ -1573,7 +1573,7 @@ See also `t.isObjectTypeSpreadProperty(node, opts)` and `t.assertObjectTypeSprea
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `argument`: `Flow` (required)
+ - `argument`: `FlowType` (required)
 
 ---
 
@@ -1588,8 +1588,8 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
  - `id`: `Identifier` (required)
  - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `Flow` (default: `null`)
- - `impltype`: `Flow` (required)
+ - `supertype`: `FlowType` (default: `null`)
+ - `impltype`: `FlowType` (required)
 
 ---
 
@@ -1632,8 +1632,7 @@ See also `t.isQualifiedTypeIdentifier(node, opts)` and `t.assertQualifiedTypeIde
 Aliases: `Flow`
 
  - `id`: `Identifier` (required)
- - `qualification` (required)
- - `qualifications`: `Identifier` (default: `null`)
+ - `qualification`: `Identifier | QualifiedTypeIdentifier` (required)
 
 ---
 
@@ -2626,7 +2625,7 @@ See also `t.isTupleTypeAnnotation(node, opts)` and `t.assertTupleTypeAnnotation(
 
 Aliases: `Flow`, `FlowType`
 
- - `types`: `Array<Flow>` (required)
+ - `types`: `Array<FlowType>` (required)
 
 ---
 
@@ -2641,7 +2640,7 @@ Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
  - `id`: `Identifier` (required)
  - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `Flow` (required)
+ - `right`: `FlowType` (required)
 
 ---
 
@@ -2654,7 +2653,7 @@ See also `t.isTypeAnnotation(node, opts)` and `t.assertTypeAnnotation(node, opts
 
 Aliases: `Flow`
 
- - `typeAnnotation`: `Flow` (required)
+ - `typeAnnotation`: `FlowType` (required)
 
 ---
 
@@ -2667,7 +2666,7 @@ See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(no
 
 Aliases: `Flow`, `ExpressionWrapper`, `Expression`
 
- - `expression`: `Flow` (required)
+ - `expression`: `Expression` (required)
  - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
@@ -2682,7 +2681,7 @@ See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`
 Aliases: `Flow`
 
  - `bound`: `TypeAnnotation` (default: `null`)
- - `default`: `Flow` (default: `null`)
+ - `default`: `FlowType` (default: `null`)
  - `variance`: `Variance` (default: `null`)
  - `name`: `string` (default: `null`)
 
@@ -2710,7 +2709,7 @@ See also `t.isTypeParameterInstantiation(node, opts)` and `t.assertTypeParameter
 
 Aliases: `Flow`
 
- - `params`: `Array<Flow>` (required)
+ - `params`: `Array<FlowType>` (required)
 
 ---
 
@@ -2723,7 +2722,7 @@ See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotatio
 
 Aliases: `Flow`, `FlowType`
 
- - `argument`: `Flow` (required)
+ - `argument`: `FlowType` (required)
 
 ---
 
@@ -2751,7 +2750,7 @@ See also `t.isUnionTypeAnnotation(node, opts)` and `t.assertUnionTypeAnnotation(
 
 Aliases: `Flow`, `FlowType`
 
- - `types`: `Array<Flow>` (required)
+ - `types`: `Array<FlowType>` (required)
 
 ---
 

--- a/packages/babel-types/src/asserts/generated/index.js
+++ b/packages/babel-types/src/asserts/generated/index.js
@@ -1017,6 +1017,9 @@ export function assertModuleSpecifier(node: Object, opts?: Object = {}): void {
 export function assertFlow(node: Object, opts?: Object = {}): void {
   assert("Flow", node, opts);
 }
+export function assertFlowType(node: Object, opts?: Object = {}): void {
+  assert("FlowType", node, opts);
+}
 export function assertFlowBaseAnnotation(
   node: Object,
   opts?: Object = {},

--- a/packages/babel-types/src/constants/generated/index.js
+++ b/packages/babel-types/src/constants/generated/index.js
@@ -40,6 +40,7 @@ export const MODULEDECLARATION_TYPES = FLIPPED_ALIAS_KEYS["ModuleDeclaration"];
 export const EXPORTDECLARATION_TYPES = FLIPPED_ALIAS_KEYS["ExportDeclaration"];
 export const MODULESPECIFIER_TYPES = FLIPPED_ALIAS_KEYS["ModuleSpecifier"];
 export const FLOW_TYPES = FLIPPED_ALIAS_KEYS["Flow"];
+export const FLOWTYPE_TYPES = FLIPPED_ALIAS_KEYS["FlowType"];
 export const FLOWBASEANNOTATION_TYPES =
   FLIPPED_ALIAS_KEYS["FlowBaseAnnotation"];
 export const FLOWDECLARATION_TYPES = FLIPPED_ALIAS_KEYS["FlowDeclaration"];

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -79,15 +79,12 @@ defineType("DeclareInterface", {
 });
 
 defineType("DeclareModule", {
-  visitor: ["id", "body"],
+  visitor: ["id", "body", "kind"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     id: validateType(["Identifier", "StringLiteral"]),
     body: validateType("BlockStatement"),
-    kind: {
-      optional: true,
-      validate: validate(assertOneOf("CommonJS", "ES")),
-    },
+    kind: validateOptional(assertOneOf("CommonJS", "ES")),
   },
 });
 
@@ -131,7 +128,7 @@ defineType("DeclareExportDeclaration", {
   visitor: ["declaration", "specifiers", "source"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    declaration: validateOptionalType("TSType"),
+    declaration: validateOptionalType("Flow"),
     specifiers: validateOptional(
       arrayOfType(["ExportSpecifier", "ExportNamespaceSpecifier"]),
     ),
@@ -281,6 +278,7 @@ defineType("ObjectTypeIndexer", {
     key: validateType("Flow"),
     value: validateType(["Flow", "Identifier"]),
     static: validate(assertValueType("boolean")),
+    variance: validateOptionalType("Variance"),
   },
 });
 
@@ -290,7 +288,7 @@ defineType("ObjectTypeProperty", {
   fields: {
     key: validateType("Identifier"),
     value: validateType(["Flow", "Identifier"]),
-    kind: validate(assertOneOf("init")),
+    kind: validate(assertOneOf("init", "get", "set")),
     static: validate(assertValueType("boolean")),
     optional: validate(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -113,7 +113,7 @@ defineType("DeclareOpaqueType", {
   fields: {
     id: validateType("Identifier"),
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
-    supertype: validateOptionalType("Flow"),
+    supertype: validateOptionalType("FlowType"),
   },
 });
 
@@ -166,7 +166,7 @@ defineType("FunctionTypeAnnotation", {
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
     params: validate(arrayOfType("FunctionTypeParam")),
     rest: validateOptionalType("FunctionTypeParam"),
-    returnType: validateType("Flow"),
+    returnType: validateType("FlowType"),
   },
 });
 
@@ -175,7 +175,7 @@ defineType("FunctionTypeParam", {
   aliases: ["Flow"],
   fields: {
     name: validateOptionalType("Identifier"),
-    typeAnnotation: validateType("Flow"),
+    typeAnnotation: validateType("FlowType"),
     optional: validateOptional(assertValueType("boolean")),
   },
 });
@@ -218,7 +218,7 @@ defineType("IntersectionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow", "FlowType"],
   fields: {
-    types: validate(arrayOfType("Flow")),
+    types: validate(arrayOfType("FlowType")),
   },
 });
 
@@ -234,7 +234,7 @@ defineType("NullableTypeAnnotation", {
   visitor: ["typeAnnotation"],
   aliases: ["Flow", "FlowType"],
   fields: {
-    typeAnnotation: validateType("Flow"),
+    typeAnnotation: validateType("FlowType"),
   },
 });
 
@@ -266,7 +266,7 @@ defineType("ObjectTypeCallProperty", {
   visitor: ["value"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    value: validateType("Flow"),
+    value: validateType("FlowType"),
     static: validate(assertValueType("boolean")),
   },
 });
@@ -276,8 +276,8 @@ defineType("ObjectTypeIndexer", {
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     id: validateOptionalType("Identifier"),
-    key: validateType("Flow"),
-    value: validateType(["Flow", "Identifier"]),
+    key: validateType("FlowType"),
+    value: validateType("FlowType"),
     static: validate(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),
   },
@@ -288,7 +288,7 @@ defineType("ObjectTypeProperty", {
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     key: validateType("Identifier"),
-    value: validateType(["Flow", "Identifier"]),
+    value: validateType("FlowType"),
     kind: validate(assertOneOf("init", "get", "set")),
     static: validate(assertValueType("boolean")),
     optional: validate(assertValueType("boolean")),
@@ -300,7 +300,7 @@ defineType("ObjectTypeSpreadProperty", {
   visitor: ["argument"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    argument: validateType("Flow"),
+    argument: validateType("FlowType"),
   },
 });
 
@@ -310,8 +310,8 @@ defineType("OpaqueType", {
   fields: {
     id: validateType("Identifier"),
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
-    supertype: validateOptionalType("Flow"),
-    impltype: validateType("Flow"),
+    supertype: validateOptionalType("FlowType"),
+    impltype: validateType("FlowType"),
   },
 });
 
@@ -320,7 +320,7 @@ defineType("QualifiedTypeIdentifier", {
   aliases: ["Flow"],
   fields: {
     id: validateType("Identifier"),
-    qualifications: validateType("Identifier"),
+    qualification: validateType(["Identifier", "QualifiedTypeIdentifier"]),
   },
 });
 
@@ -343,7 +343,7 @@ defineType("TupleTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow", "FlowType"],
   fields: {
-    types: validate(arrayOfType("Flow")),
+    types: validate(arrayOfType("FlowType")),
   },
 });
 
@@ -351,7 +351,7 @@ defineType("TypeofTypeAnnotation", {
   visitor: ["argument"],
   aliases: ["Flow", "FlowType"],
   fields: {
-    argument: validateType("Flow"),
+    argument: validateType("FlowType"),
   },
 });
 
@@ -361,7 +361,7 @@ defineType("TypeAlias", {
   fields: {
     id: validateType("Identifier"),
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
-    right: validateType("Flow"),
+    right: validateType("FlowType"),
   },
 });
 
@@ -369,7 +369,7 @@ defineType("TypeAnnotation", {
   aliases: ["Flow"],
   visitor: ["typeAnnotation"],
   fields: {
-    typeAnnotation: validateType("Flow"),
+    typeAnnotation: validateType("FlowType"),
   },
 });
 
@@ -377,7 +377,7 @@ defineType("TypeCastExpression", {
   visitor: ["expression", "typeAnnotation"],
   aliases: ["Flow", "ExpressionWrapper", "Expression"],
   fields: {
-    expression: validateType("Flow"),
+    expression: validateType("Expression"),
     typeAnnotation: validateType("TypeAnnotation"),
   },
 });
@@ -388,7 +388,7 @@ defineType("TypeParameter", {
   fields: {
     name: validate(assertValueType("string")),
     bound: validateOptionalType("TypeAnnotation"),
-    default: validateOptionalType("Flow"),
+    default: validateOptionalType("FlowType"),
     variance: validateOptionalType("Variance"),
   },
 });
@@ -405,7 +405,7 @@ defineType("TypeParameterInstantiation", {
   aliases: ["Flow"],
   visitor: ["params"],
   fields: {
-    params: validate(arrayOfType("Flow")),
+    params: validate(arrayOfType("FlowType")),
   },
 });
 
@@ -413,7 +413,7 @@ defineType("UnionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow", "FlowType"],
   fields: {
-    types: validate(arrayOfType("Flow")),
+    types: validate(arrayOfType("FlowType")),
   },
 });
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -1,48 +1,47 @@
 // @flow
 import defineType, {
-  assertEach,
-  assertNodeType,
+  arrayOfType,
+  assertOneOf,
   assertValueType,
-  chain,
+  validate,
+  validateOptional,
+  validateOptionalType,
+  validateType,
 } from "./utils";
 
 defineType("AnyTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {
-    // todo
-  },
 });
 
 defineType("ArrayTypeAnnotation", {
   visitor: ["elementType"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    elementType: validateType("Flow"),
   },
 });
 
 defineType("BooleanTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {
-    // todo
-  },
 });
 
 defineType("BooleanLiteralTypeAnnotation", {
   aliases: ["Flow"],
-  fields: {},
+  fields: {
+    value: validate(assertValueType("boolean")),
+  },
 });
 
 defineType("NullLiteralTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {},
 });
 
 defineType("ClassImplements", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterInstantiation"),
   },
 });
 
@@ -50,7 +49,11 @@ defineType("DeclareClass", {
   visitor: ["id", "typeParameters", "extends", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterInstantiation"),
+    extends: validateOptional(arrayOfType("InterfaceExtends")),
+    mixins: validateOptional(arrayOfType("InterfaceExtends")),
+    body: validateType("ObjectTypeAnnotation"),
   },
 });
 
@@ -58,7 +61,8 @@ defineType("DeclareFunction", {
   visitor: ["id"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    predicate: validateOptionalType("DeclaredPredicate"),
   },
 });
 
@@ -66,7 +70,11 @@ defineType("DeclareInterface", {
   visitor: ["id", "typeParameters", "extends", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    extends: validateOptionalType("InterfaceExtends"),
+    mixins: validateOptional(arrayOfType("Flow")),
+    body: validateType("ObjectTypeAnnotation"),
   },
 });
 
@@ -74,7 +82,12 @@ defineType("DeclareModule", {
   visitor: ["id", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType(["Identifier", "StringLiteral"]),
+    body: validateType("BlockStatement"),
+    kind: {
+      optional: true,
+      validate: validate(assertOneOf("CommonJS", "ES")),
+    },
   },
 });
 
@@ -82,7 +95,7 @@ defineType("DeclareModuleExports", {
   visitor: ["typeAnnotation"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    typeAnnotation: validateType("TypeAnnotation"),
   },
 });
 
@@ -90,7 +103,9 @@ defineType("DeclareTypeAlias", {
   visitor: ["id", "typeParameters", "right"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    right: validateType("Flow"),
   },
 });
 
@@ -98,7 +113,9 @@ defineType("DeclareOpaqueType", {
   visitor: ["id", "typeParameters", "supertype"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    supertype: validateOptionalType("Flow"),
   },
 });
 
@@ -106,7 +123,7 @@ defineType("DeclareVariable", {
   visitor: ["id"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
   },
 });
 
@@ -114,7 +131,12 @@ defineType("DeclareExportDeclaration", {
   visitor: ["declaration", "specifiers", "source"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    declaration: validateOptionalType("TSType"),
+    specifiers: validateOptional(
+      arrayOfType(["ExportSpecifier", "ExportNamespaceSpecifier"]),
+    ),
+    source: validateOptionalType("StringLiteral"),
+    default: validateOptional(assertValueType("boolean")),
   },
 });
 
@@ -122,7 +144,8 @@ defineType("DeclareExportAllDeclaration", {
   visitor: ["source"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    source: validateType("StringLiteral"),
+    exportKind: validateOptional(assertOneOf(["type", "value"])),
   },
 });
 
@@ -130,7 +153,7 @@ defineType("DeclaredPredicate", {
   visitor: ["value"],
   aliases: ["Flow", "FlowPredicate"],
   fields: {
-    // todo
+    value: validateType("Flow"),
   },
 });
 
@@ -142,7 +165,10 @@ defineType("FunctionTypeAnnotation", {
   visitor: ["typeParameters", "params", "rest", "returnType"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    params: validate(arrayOfType("FunctionTypeParam")),
+    rest: validateOptionalType("FunctionTypeParam"),
+    returnType: validateType("Flow"),
   },
 });
 
@@ -150,7 +176,9 @@ defineType("FunctionTypeParam", {
   visitor: ["name", "typeAnnotation"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    name: validateOptionalType("Identifier"),
+    typeAnnotation: validateType("Flow"),
+    optional: validateOptional(assertValueType("boolean")),
   },
 });
 
@@ -158,22 +186,21 @@ defineType("GenericTypeAnnotation", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterInstantiation"),
   },
 });
 
 defineType("InferredPredicate", {
   aliases: ["Flow", "FlowPredicate"],
-  fields: {
-    // todo
-  },
 });
 
 defineType("InterfaceExtends", {
   visitor: ["id", "typeParameters"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterInstantiation"),
   },
 });
 
@@ -181,7 +208,11 @@ defineType("InterfaceDeclaration", {
   visitor: ["id", "typeParameters", "extends", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    extends: validate(arrayOfType("InterfaceExtends")),
+    mixins: validate(arrayOfType("InterfaceExtends")),
+    body: validateType("ObjectTypeAnnotation"),
   },
 });
 
@@ -189,7 +220,7 @@ defineType("IntersectionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    types: validate(arrayOfType("Flow")),
   },
 });
 
@@ -205,29 +236,31 @@ defineType("NullableTypeAnnotation", {
   visitor: ["typeAnnotation"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    typeAnnotation: validateType("Flow"),
   },
 });
 
 defineType("NumberLiteralTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
-    // todo
+    value: validate(assertValueType("number")),
   },
 });
 
 defineType("NumberTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {
-    // todo
-  },
 });
 
 defineType("ObjectTypeAnnotation", {
   visitor: ["properties", "indexers", "callProperties"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    properties: validate(
+      arrayOfType(["ObjectTypeProperty", "ObjectTypeSpreadProperty"]),
+    ),
+    indexers: validateOptional(arrayOfType("ObjectTypeIndexer")),
+    callProperties: validateOptional(arrayOfType("ObjectTypeCallProperty")),
+    exact: validate(assertValueType("boolean")),
   },
 });
 
@@ -235,7 +268,8 @@ defineType("ObjectTypeCallProperty", {
   visitor: ["value"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    // todo
+    value: validateType("Flow"),
+    static: validate(assertValueType("boolean")),
   },
 });
 
@@ -243,7 +277,10 @@ defineType("ObjectTypeIndexer", {
   visitor: ["id", "key", "value"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    // todo
+    id: validateOptionalType("Identifier"),
+    key: validateType("Flow"),
+    value: validateType(["Flow", "Identifier"]),
+    static: validate(assertValueType("boolean")),
   },
 });
 
@@ -251,7 +288,12 @@ defineType("ObjectTypeProperty", {
   visitor: ["key", "value"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    // todo
+    key: validateType("Identifier"),
+    value: validateType(["Flow", "Identifier"]),
+    kind: validate(assertOneOf("init")),
+    static: validate(assertValueType("boolean")),
+    optional: validate(assertValueType("boolean")),
+    variance: validateOptionalType("Variance"),
   },
 });
 
@@ -259,7 +301,7 @@ defineType("ObjectTypeSpreadProperty", {
   visitor: ["argument"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    // todo
+    argument: validateType("Flow"),
   },
 });
 
@@ -267,7 +309,10 @@ defineType("OpaqueType", {
   visitor: ["id", "typeParameters", "supertype", "impltype"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    supertype: validateOptionalType("Flow"),
+    impltype: validateType("Flow"),
   },
 });
 
@@ -275,34 +320,31 @@ defineType("QualifiedTypeIdentifier", {
   visitor: ["id", "qualification"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    qualifications: validateType("Identifier"),
   },
 });
 
 defineType("StringLiteralTypeAnnotation", {
   aliases: ["Flow"],
   fields: {
-    // todo
+    value: validate(assertValueType("string")),
   },
 });
 
 defineType("StringTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {
-    // todo
-  },
 });
 
 defineType("ThisTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {},
 });
 
 defineType("TupleTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    types: validate(arrayOfType("Flow")),
   },
 });
 
@@ -310,7 +352,7 @@ defineType("TypeofTypeAnnotation", {
   visitor: ["argument"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    argument: validateType("Flow"),
   },
 });
 
@@ -318,7 +360,9 @@ defineType("TypeAlias", {
   visitor: ["id", "typeParameters", "right"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
-    // todo
+    id: validateType("Identifier"),
+    typeParameters: validateOptionalType("TypeParameterDeclaration"),
+    right: validateType("Flow"),
   },
 });
 
@@ -326,9 +370,7 @@ defineType("TypeAnnotation", {
   aliases: ["Flow"],
   visitor: ["typeAnnotation"],
   fields: {
-    typeAnnotation: {
-      validate: assertNodeType("Flow"),
-    },
+    typeAnnotation: validateType("Flow"),
   },
 });
 
@@ -336,7 +378,8 @@ defineType("TypeCastExpression", {
   visitor: ["expression", "typeAnnotation"],
   aliases: ["Flow", "ExpressionWrapper", "Expression"],
   fields: {
-    // todo
+    expression: validateType("Flow"),
+    typeAnnotation: validateType("TypeAnnotation"),
   },
 });
 
@@ -344,17 +387,10 @@ defineType("TypeParameter", {
   aliases: ["Flow"],
   visitor: ["bound", "default"],
   fields: {
-    name: {
-      validate: assertValueType("string"),
-    },
-    bound: {
-      validate: assertNodeType("TypeAnnotation"),
-      optional: true,
-    },
-    default: {
-      validate: assertNodeType("Flow"),
-      optional: true,
-    },
+    name: validate(assertValueType("string")),
+    bound: validateOptionalType("TypeAnnotation"),
+    default: validateOptionalType("Flow"),
+    variance: validateOptionalType("Variance"),
   },
 });
 
@@ -362,12 +398,7 @@ defineType("TypeParameterDeclaration", {
   aliases: ["Flow"],
   visitor: ["params"],
   fields: {
-    params: {
-      validate: chain(
-        assertValueType("array"),
-        assertEach(assertNodeType("TypeParameter")),
-      ),
-    },
+    params: validate(arrayOfType("TypeParameter")),
   },
 });
 
@@ -375,12 +406,7 @@ defineType("TypeParameterInstantiation", {
   aliases: ["Flow"],
   visitor: ["params"],
   fields: {
-    params: {
-      validate: chain(
-        assertValueType("array"),
-        assertEach(assertNodeType("Flow")),
-      ),
-    },
+    params: validate(arrayOfType("Flow")),
   },
 });
 
@@ -388,13 +414,10 @@ defineType("UnionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow"],
   fields: {
-    // todo
+    types: validate(arrayOfType("Flow")),
   },
 });
 
 defineType("VoidTypeAnnotation", {
   aliases: ["Flow", "FlowBaseAnnotation"],
-  fields: {
-    // todo
-  },
 });

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -79,7 +79,8 @@ defineType("DeclareInterface", {
 });
 
 defineType("DeclareModule", {
-  visitor: ["id", "body", "kind"],
+  builder: ["id", "body", "kind"],
+  visitor: ["id", "body"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     id: validateType(["Identifier", "StringLiteral"]),
@@ -271,7 +272,7 @@ defineType("ObjectTypeCallProperty", {
 });
 
 defineType("ObjectTypeIndexer", {
-  visitor: ["id", "key", "value"],
+  visitor: ["id", "key", "value", "variance"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     id: validateOptionalType("Identifier"),
@@ -283,7 +284,7 @@ defineType("ObjectTypeIndexer", {
 });
 
 defineType("ObjectTypeProperty", {
-  visitor: ["key", "value"],
+  visitor: ["key", "value", "variance"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     key: validateType("Identifier"),
@@ -383,7 +384,7 @@ defineType("TypeCastExpression", {
 
 defineType("TypeParameter", {
   aliases: ["Flow"],
-  visitor: ["bound", "default"],
+  visitor: ["bound", "default", "variance"],
   fields: {
     name: validate(assertValueType("string")),
     bound: validateOptionalType("TypeAnnotation"),

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -10,30 +10,30 @@ import defineType, {
 } from "./utils";
 
 defineType("AnyTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("ArrayTypeAnnotation", {
   visitor: ["elementType"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
-    elementType: validateType("Flow"),
+    elementType: validateType("FlowType"),
   },
 });
 
 defineType("BooleanTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("BooleanLiteralTypeAnnotation", {
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     value: validate(assertValueType("boolean")),
   },
 });
 
 defineType("NullLiteralTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("ClassImplements", {
@@ -103,7 +103,7 @@ defineType("DeclareTypeAlias", {
   fields: {
     id: validateType("Identifier"),
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
-    right: validateType("Flow"),
+    right: validateType("FlowType"),
   },
 });
 
@@ -156,12 +156,12 @@ defineType("DeclaredPredicate", {
 });
 
 defineType("ExistsTypeAnnotation", {
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
 });
 
 defineType("FunctionTypeAnnotation", {
   visitor: ["typeParameters", "params", "rest", "returnType"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
     params: validate(arrayOfType("FunctionTypeParam")),
@@ -182,7 +182,7 @@ defineType("FunctionTypeParam", {
 
 defineType("GenericTypeAnnotation", {
   visitor: ["id", "typeParameters"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     id: validateType("Identifier"),
     typeParameters: validateOptionalType("TypeParameterInstantiation"),
@@ -216,42 +216,42 @@ defineType("InterfaceDeclaration", {
 
 defineType("IntersectionTypeAnnotation", {
   visitor: ["types"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     types: validate(arrayOfType("Flow")),
   },
 });
 
 defineType("MixedTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("EmptyTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("NullableTypeAnnotation", {
   visitor: ["typeAnnotation"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     typeAnnotation: validateType("Flow"),
   },
 });
 
 defineType("NumberLiteralTypeAnnotation", {
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     value: validate(assertValueType("number")),
   },
 });
 
 defineType("NumberTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("ObjectTypeAnnotation", {
   visitor: ["properties", "indexers", "callProperties"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     properties: validate(
       arrayOfType(["ObjectTypeProperty", "ObjectTypeSpreadProperty"]),
@@ -325,23 +325,23 @@ defineType("QualifiedTypeIdentifier", {
 });
 
 defineType("StringLiteralTypeAnnotation", {
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     value: validate(assertValueType("string")),
   },
 });
 
 defineType("StringTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("ThisTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });
 
 defineType("TupleTypeAnnotation", {
   visitor: ["types"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     types: validate(arrayOfType("Flow")),
   },
@@ -349,7 +349,7 @@ defineType("TupleTypeAnnotation", {
 
 defineType("TypeofTypeAnnotation", {
   visitor: ["argument"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     argument: validateType("Flow"),
   },
@@ -411,12 +411,12 @@ defineType("TypeParameterInstantiation", {
 
 defineType("UnionTypeAnnotation", {
   visitor: ["types"],
-  aliases: ["Flow"],
+  aliases: ["Flow", "FlowType"],
   fields: {
     types: validate(arrayOfType("Flow")),
   },
 });
 
 defineType("VoidTypeAnnotation", {
-  aliases: ["Flow", "FlowBaseAnnotation"],
+  aliases: ["Flow", "FlowType", "FlowBaseAnnotation"],
 });

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -1,49 +1,21 @@
 // @flow
 import defineType, {
+  arrayOfType,
   assertEach,
   assertNodeType,
   assertOneOf,
   assertValueType,
   chain,
+  validate,
+  validateArrayOfType,
+  validateOptional,
+  validateOptionalType,
+  validateType,
 } from "./utils";
 import { functionDeclarationCommon } from "./core";
 import { classMethodOrDeclareMethodCommon } from "./es2015";
 
 const bool = assertValueType("boolean");
-
-function validate(validate) {
-  return { validate };
-}
-
-function typeIs(typeName) {
-  return typeof typeName === "string"
-    ? assertNodeType(typeName)
-    : assertNodeType(...typeName);
-}
-
-function validateType(name) {
-  return validate(typeIs(name));
-}
-
-function validateOptional(validate) {
-  return { validate, optional: true };
-}
-
-function validateOptionalType(typeName) {
-  return { validate: typeIs(typeName), optional: true };
-}
-
-function arrayOf(elementType) {
-  return chain(assertValueType("array"), assertEach(elementType));
-}
-
-function arrayOfType(nodeTypeName) {
-  return arrayOf(typeIs(nodeTypeName));
-}
-
-function validateArrayOfType(nodeTypeName) {
-  return validate(arrayOfType(nodeTypeName));
-}
 
 const tSFunctionTypeAnnotationCommon = {
   returnType: {

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -788,6 +788,9 @@ export function isModuleSpecifier(node: Object, opts?: Object): boolean {
 export function isFlow(node: Object, opts?: Object): boolean {
   return is("Flow", node, opts);
 }
+export function isFlowType(node: Object, opts?: Object): boolean {
+  return is("FlowType", node, opts);
+}
 export function isFlowBaseAnnotation(node: Object, opts?: Object): boolean {
   return is("FlowBaseAnnotation", node, opts);
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | no
| Patch: Bug Fix?          | YES
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | YES
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

In this PR, we add types to the existing Flow AST nodes. This brings the quality of Flow AST node definitions up to par with existing definitions for TypeScript/Core/Experimental/etc. nodes, and enables:

- Run time type checking for Flow node fields
- Compile time type checking for Flow node fields (once we regenerate Flow & TS types)

I tried my best to make sure field type definitions are thorough and complete. I used existing Babel unit tests as my source of truth.

This PR complements, and is independent of, https://github.com/babel/babel/pull/7101.
