### PR TITLE
Fix a regression introduced in #7040

### DIFF
--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/actual.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/actual.js
@@ -1,0 +1,4 @@
+export default {
+  [a]: b,
+  [c]: d
+};

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/expected.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/expected.js
@@ -1,0 +1,3 @@
+var _a$c;
+
+export default (_a$c = {}, babelHelpers.defineProperty(_a$c, a, b), babelHelpers.defineProperty(_a$c, c, d), _a$c);

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/options.json
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/regression/7144/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-computed-properties"]
+}

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -17,7 +17,8 @@ export function insertBefore(nodes) {
   if (
     this.parentPath.isExpressionStatement() ||
     this.parentPath.isLabeledStatement() ||
-    this.parentPath.isExportDeclaration()
+    this.parentPath.isExportNamedDeclaration() ||
+    (this.parentPath.isExportDefaultDeclaration() && this.isDeclaration())
   ) {
     return this.parentPath.insertBefore(nodes);
   } else if (
@@ -98,7 +99,8 @@ export function insertAfter(nodes) {
   if (
     this.parentPath.isExpressionStatement() ||
     this.parentPath.isLabeledStatement() ||
-    this.parentPath.isExportDeclaration()
+    this.parentPath.isExportNamedDeclaration() ||
+    (this.parentPath.isExportDefaultDeclaration() && this.isDeclaration())
   ) {
     return this.parentPath.insertAfter(nodes);
   } else if (

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -143,14 +143,13 @@ describe("modification", function() {
       });
 
       it("the exported expression", function() {
-        const bodyPath = getPath("export default 2;", {
+        const declPath = getPath("export default 2;", {
           sourceType: "module",
-        }).parentPath;
-        const path = bodyPath.get("body.0.declaration");
+        });
+        const path = declPath.get("declaration");
         path.insertBefore(t.identifier("x"));
 
-        assert.equal(bodyPath.get("body").length, 2);
-        assert.deepEqual(bodyPath.get("body.0").node, t.identifier("x"));
+        assert.equal(generateCode(declPath), "export default (x, 2);");
       });
     });
   });
@@ -236,8 +235,10 @@ describe("modification", function() {
         const path = bodyPath.get("body.0.declaration");
         path.insertAfter(t.identifier("x"));
 
-        assert.equal(bodyPath.get("body").length, 2);
-        assert.deepEqual(bodyPath.get("body.1").node, t.identifier("x"));
+        assert.equal(
+          generateCode({ parentPath: bodyPath }),
+          "var _temp;\n\nexport default (_temp = 2, x, _temp);",
+        );
       });
     });
   });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/7114
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR fixes a regression introduced in https://github.com/babel/babel/pull/7040. I actually wrote some tests to prevent this, but they where wrong :rofl: 

Example:
```js
// Input
export default x;

// Plugin
pathToThatX.insertAfter(t.identifier("y"));

// Old output (wrong)
export default x;
y;

// Correct output
export default (_tmp = x, y, _tmp);
```

They might look the same, but when using `path.replaceWithMultiple` (which removes the node and then inserts the new nodes after), it generated something like
```js
export default ;
y;
```
And `export default` got removed since it is invalid.