### PR TITLE
[decorators] Only transform declarations to expressions when needed

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/class-decorators/actual.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/class-decorators/actual.js
@@ -1,0 +1,2 @@
+export default @dec class A {}
+@dec class B {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/class-decorators/expected.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/class-decorators/expected.js
@@ -1,0 +1,5 @@
+var _class, _class2;
+
+export default dec(_class = class A {}) || _class;
+
+let B = dec(_class2 = class B {}) || _class2;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/method-decorators/actual.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/method-decorators/actual.js
@@ -1,0 +1,6 @@
+export default class A {
+  @dec foo() {}
+}
+class B {
+  @dec foo() {}
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/method-decorators/expected.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/method-decorators/expected.js
@@ -1,0 +1,13 @@
+var _class, _class2;
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
+
+let A = (_class2 = class A {
+  foo() {}
+
+}, (_applyDecoratedDescriptor(_class2.prototype, "foo", [dec], Object.getOwnPropertyDescriptor(_class2.prototype, "foo"), _class2.prototype)), _class2);
+export { A as default };
+let B = (_class = class B {
+  foo() {}
+
+}, (_applyDecoratedDescriptor(_class.prototype, "foo", [dec], Object.getOwnPropertyDescriptor(_class.prototype, "foo"), _class.prototype)), _class);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/no-decorators/actual.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/no-decorators/actual.js
@@ -1,0 +1,6 @@
+export default class A {
+  foo() {}
+}
+class B {
+  foo() {}
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/no-decorators/expected.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/no-decorators/expected.js
@@ -1,0 +1,9 @@
+export default class A {
+  foo() {}
+
+}
+
+class B {
+  foo() {}
+
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/decl-to-expression/options.json
@@ -1,0 +1,4 @@
+{
+  "presets": [],
+  "plugins": ["proposal-decorators"]
+}


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

### Input
```js
class Foo {}
```

### Old output
```js
let Foo = class Foo {};
```

### New output
```js
class Foo {}
```

---

This also fixed an issue I had with rollup-plugin-babel: since class declarations where transformed, the logic to check how helpers are used  (https://github.com/rollup/rollup-plugin-babel/blob/e74407ee15a9093c2d6e3e5a3ef7691bdc57b3d8/src/preflightCheck.js#L8-L11) didn't run.

