### PR TITLE
Update README.md

### DIFF
--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -52,11 +52,8 @@ require("@babel/register")({
   // When a file path **matchs** this regex then then it is **not** compiled.
   // When a function is invoked, it is called with the file path, and is **not** compiled if it returns true.
   ignore: [
-    // if any filenames **do** match this regex then they aren't compiled.
     /regex/,
-    
-    // Ignore entries can also be functions.
-    // A function receives the filename, and should return a boolean. 
+
     function( filepath ) {
       if (filepath === "/path/to/es6-file.js") {
         return false;

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -47,15 +47,18 @@ require("@babel/register")({
 
 ```javascript
 require("@babel/register")({
-  // Optional ignore array
+  // Array of ignore conditions ( Optional )
+  // A condition can be either a regex, or a function.
+  // When a file path **matchs** this regex then then it is **not** compiled.
+  // When a function is invoked, it is called with the file path, and is **not** compiled if it returns true.
   ignore: [
     // if any filenames **do** match this regex then they aren't compiled.
     /regex/,
     
     // Ignore entries can also be functions.
     // A function receives the filename, and should return a boolean. 
-    function( filename ) {
-      if (filename === "/path/to/es6-file.js") {
+    function( filepath ) {
+      if (filepath === "/path/to/es6-file.js") {
         return false;
       } else {
 

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -49,7 +49,7 @@ require("@babel/register")({
 require("@babel/register")({
   // Array of ignore conditions ( Optional )
   // A condition can be either a regex, or a function.
-  // When a file path **matchs** this regex then then it is **not** compiled.
+  // When a file path matches this regex then it is **not** compiled
   // When a function is invoked, it is called with the file path, and is **not** compiled if it returns true.
   ignore: [
     /regex/,
@@ -57,11 +57,11 @@ require("@babel/register")({
     function( filepath ) {
       if (filepath === "/path/to/es6-file.js") {
         return false;
-      } else {
-
-      return true;
+      }
+      else {
+        return true;
+      }
     }
-  } 
   ],
 
   // Optional only regex - if any filenames **don't** match this regex then they

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -47,20 +47,15 @@ require("@babel/register")({
 
 ```javascript
 require("@babel/register")({
-  // Array of ignore conditions (Optional)
-  // A condition can be either a regex, or a function.
-  // When a file path matches this regex then it is **not** compiled
-  // When a function is invoked, it is called with the file path, and is **not** compiled if it returns true.
+  // Array of ignore conditions, either a regex or a function. (Optional)
   ignore: [
+    // When a file path matches this regex then it is **not** compiled
     /regex/,
 
-    function( filepath ) {
-      if (filepath === "/path/to/es6-file.js") {
-        return false;
-      }
-      else {
-        return true;
-      }
+    // The file's path is also passed to any ignore functions. It will
+    // **not** be compiled if `true` is returned.
+    function (filepath) {
+      return filepath !== "/path/to/es6-file.js";
     }
   ],
 

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -47,7 +47,7 @@ require("@babel/register")({
 
 ```javascript
 require("@babel/register")({
-  // Array of ignore conditions ( Optional )
+  // Array of ignore conditions (Optional)
   // A condition can be either a regex, or a function.
   // When a file path matches this regex then it is **not** compiled
   // When a function is invoked, it is called with the file path, and is **not** compiled if it returns true.

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -47,18 +47,22 @@ require("@babel/register")({
 
 ```javascript
 require("@babel/register")({
-  // Optional ignore regex - if any filenames **do** match this regex then they
-  // aren't compiled.
-  ignore: [/regex/],
+  // Optional ignore array
+  ignore: [
+    // if any filenames **do** match this regex then they aren't compiled.
+    /regex/,
+    
+    // Ignore entries can also be functions.
+    // A function receives the filename, and should return a boolean. 
+    function( filename ) {
+      if (filename === "/path/to/es6-file.js") {
+        return false;
+      } else {
 
-  // Ignore can also be specified as a function.
-  ignore: [function(filename) {
-    if (filename === "/path/to/es6-file.js") {
-      return false;
-    } else {
       return true;
     }
-  }],
+  } 
+  ],
 
   // Optional only regex - if any filenames **don't** match this regex then they
   // aren't compiled


### PR DESCRIPTION
The previous version of the api allowed passing ignore options as a function, which now can only be an array of regex / functions.

The current docs are somewhat ambiguous with regards to this breaking change.
Anyway I did some editing, let me know if this is ok with you guys.

[skip ci]
