### PR TITLE
Remove redundant property declarations

### DIFF
--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -1280,8 +1280,6 @@ export type TsAsExpression = TsTypeAssertionLikeBase & {
 
 export type TsTypeAssertion = TsTypeAssertionLikeBase & {
   type: "TSTypeAssertion",
-  typeAnnotation: TsType,
-  expression: Expression,
 };
 
 export type TsNonNullExpression = NodeBase & {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         |
| Any Dependency Changes?  | No
| License                  | MIT

`TsTypeAssertion` unnecessarily redeclared properties already declared on `TsTypeAssertionLikeBase`.