### PR TITLE
Disallow duplicated nodes (only in tests output)

### DIFF
--- a/packages/babel-core/src/tools/build-external-helpers.js
+++ b/packages/babel-core/src/tools/build-external-helpers.js
@@ -69,7 +69,7 @@ function buildModule(whitelist) {
     t.exportNamedDeclaration(
       null,
       Object.keys(refs).map(name => {
-        return t.exportSpecifier(t.clone(refs[name]), t.identifier(name));
+        return t.exportSpecifier(t.cloneNode(refs[name]), t.identifier(name));
       }),
     ),
   );

--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -131,7 +131,7 @@ export default class File {
       const res = generator(name);
       if (res) return res;
     } else if (runtime) {
-      return t.memberExpression(runtime, t.identifier(name));
+      return t.memberExpression(t.cloneNode(runtime), t.identifier(name));
     }
 
     const uid = (this.declarations[name] = this.scope.generateUidIdentifier(

--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -123,7 +123,7 @@ export default class File {
 
   addHelper(name: string): Object {
     const declar = this.declarations[name];
-    if (declar) return declar;
+    if (declar) return t.cloneNode(declar);
 
     const generator = this.get("helperGenerator");
     const runtime = this.get("helpersNamespace");

--- a/packages/babel-helper-explode-assignable-expression/src/index.js
+++ b/packages/babel-helper-explode-assignable-expression/src/index.js
@@ -33,7 +33,7 @@ function getObjRef(node, nodes, file, scope) {
 
   const temp = scope.generateUidIdentifierBasedOnNode(ref);
   scope.push({ id: temp });
-  nodes.push(t.assignmentExpression("=", temp, ref));
+  nodes.push(t.assignmentExpression("=", t.cloneNode(temp), t.cloneNode(ref)));
   return temp;
 }
 
@@ -44,7 +44,7 @@ function getPropRef(node, nodes, file, scope) {
 
   const temp = scope.generateUidIdentifierBasedOnNode(prop);
   scope.push({ id: temp });
-  nodes.push(t.assignmentExpression("=", temp, prop));
+  nodes.push(t.assignmentExpression("=", t.cloneNode(temp), t.cloneNode(prop)));
   return temp;
 }
 
@@ -68,12 +68,13 @@ export default function(
   let ref, uid;
 
   if (t.isIdentifier(node)) {
-    ref = node;
+    ref = t.cloneNode(node);
     uid = obj;
   } else {
     const prop = getPropRef(node, nodes, file, scope);
     const computed = node.computed || t.isLiteral(prop);
-    uid = ref = t.memberExpression(obj, prop, computed);
+    uid = t.memberExpression(t.cloneNode(obj), t.cloneNode(prop), computed);
+    ref = t.memberExpression(t.cloneNode(obj), t.cloneNode(prop), computed);
   }
 
   return {

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -154,7 +154,7 @@ export default function({ node, parent, scope, id }, localBinding = false) {
         scope.getBinding(id.name) === binding
       ) {
         // always going to reference this method
-        node.id = id;
+        node.id = t.cloneNode(id);
         node.id[t.NOT_LOCAL_BINDING] = true;
         return;
       }

--- a/packages/babel-helper-module-imports/src/import-builder.js
+++ b/packages/babel-helper-module-imports/src/import-builder.js
@@ -50,7 +50,7 @@ export default class ImportBuilder {
     assert(statement.type === "ImportDeclaration");
     assert(statement.specifiers.length === 0);
     statement.specifiers = [t.importNamespaceSpecifier(name)];
-    this._resultName = t.clone(name);
+    this._resultName = t.cloneNode(name);
     return this;
   }
   default(name) {
@@ -59,7 +59,7 @@ export default class ImportBuilder {
     assert(statement.type === "ImportDeclaration");
     assert(statement.specifiers.length === 0);
     statement.specifiers = [t.importDefaultSpecifier(name)];
-    this._resultName = t.clone(name);
+    this._resultName = t.cloneNode(name);
     return this;
   }
   named(name, importName) {
@@ -70,7 +70,7 @@ export default class ImportBuilder {
     assert(statement.type === "ImportDeclaration");
     assert(statement.specifiers.length === 0);
     statement.specifiers = [t.importSpecifier(name, t.identifier(importName))];
-    this._resultName = t.clone(name);
+    this._resultName = t.cloneNode(name);
     return this;
   }
 
@@ -86,7 +86,7 @@ export default class ImportBuilder {
       "var",
       [t.variableDeclarator(name, statement.expression)],
     );
-    this._resultName = t.clone(name);
+    this._resultName = t.cloneNode(name);
     return this;
   }
 

--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -128,7 +128,7 @@ export function buildNamespaceInitStatements(
     statements.push(
       template.statement`var NAME = SOURCE;`({
         NAME: localName,
-        SOURCE: t.cloneDeep(srcNamespace),
+        SOURCE: t.cloneNode(srcNamespace),
       }),
     );
   }
@@ -150,14 +150,14 @@ export function buildNamespaceInitStatements(
         : template.statement`EXPORTS.NAME = NAMESPACE;`)({
         EXPORTS: metadata.exportName,
         NAME: exportName,
-        NAMESPACE: t.cloneDeep(srcNamespace),
+        NAMESPACE: t.cloneNode(srcNamespace),
       }),
     );
   }
   if (sourceMetadata.reexportAll) {
     const statement = buildNamespaceReexport(
       metadata,
-      t.cloneDeep(srcNamespace),
+      t.cloneNode(srcNamespace),
       loose,
     );
     statement.loc = sourceMetadata.reexportAll.loc;
@@ -191,7 +191,7 @@ const buildReexportsFromMeta = (meta, metadata, loose) => {
     templateForCurrentMode({
       EXPORTS: meta.exportName,
       EXPORT_NAME: exportName,
-      NAMESPACE: t.cloneDeep(namespace),
+      NAMESPACE: t.cloneNode(namespace),
       IMPORT_NAME: importName,
     }),
   );

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -22,7 +22,7 @@ const awaitVisitor = {
     path.replaceWith(
       t.yieldExpression(
         wrapAwait
-          ? t.callExpression(wrapAwait, [argument.node])
+          ? t.callExpression(t.cloneNode(wrapAwait), [argument.node])
           : argument.node,
       ),
     );
@@ -73,7 +73,7 @@ export default function(path: NodePath, file: Object, helpers: Object) {
   path.node.async = false;
   path.node.generator = true;
 
-  wrapFunction(path, helpers.wrapAsync);
+  wrapFunction(path, t.cloneNode(helpers.wrapAsync));
 
   const isProperty =
     path.isObjectMethod() ||

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -206,9 +206,12 @@ export default class ReplaceSupers {
       return;
     } else if (t.isMemberExpression(parent) && !methodNode.static) {
       // super.test -> objectRef.prototype.test
-      return t.memberExpression(superRef, t.identifier("prototype"));
+      return t.memberExpression(
+        t.cloneNode(superRef),
+        t.identifier("prototype"),
+      );
     } else {
-      return superRef;
+      return t.cloneNode(superRef);
     }
   }
 
@@ -240,12 +243,18 @@ export default class ReplaceSupers {
       // super.age += 2; -> let _ref = super.age; super.age = _ref + 2;
       ref = ref || path.scope.generateUidIdentifier("ref");
       return [
-        t.variableDeclaration("var", [t.variableDeclarator(ref, node.left)]),
+        t.variableDeclaration("var", [
+          t.variableDeclarator(t.cloneNode(ref), node.left),
+        ]),
         t.expressionStatement(
           t.assignmentExpression(
             "=",
             node.left,
-            t.binaryExpression(node.operator.slice(0, -1), ref, node.right),
+            t.binaryExpression(
+              node.operator.slice(0, -1),
+              t.cloneNode(ref),
+              node.right,
+            ),
           ),
         ),
       ];

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -41,7 +41,7 @@ function getPrototypeOfExpression(objectRef, isStatic) {
         t.identifier("Object"),
         t.identifier("getPrototypeOf"),
       ),
-      [targetRef],
+      [t.cloneNode(targetRef)],
     ),
   );
 }
@@ -141,7 +141,7 @@ export default class ReplaceSupers {
   };
 
   getObjectRef() {
-    return this.opts.objectRef || this.opts.getObjectRef();
+    return t.cloneNode(this.opts.objectRef || this.opts.getObjectRef());
   }
 
   /**
@@ -244,7 +244,7 @@ export default class ReplaceSupers {
       ref = ref || path.scope.generateUidIdentifier("ref");
       return [
         t.variableDeclaration("var", [
-          t.variableDeclarator(t.cloneNode(ref), node.left),
+          t.variableDeclarator(t.cloneNode(ref), t.cloneNode(node.left)),
         ]),
         t.expressionStatement(
           t.assignmentExpression(

--- a/packages/babel-helper-simple-access/src/index.js
+++ b/packages/babel-helper-simple-access/src/index.js
@@ -33,20 +33,20 @@ const simpleAssignmentVisitor = {
           t.assignmentExpression("+=", arg.node, t.numericLiteral(1)),
         );
       } else {
-        const varName = path.scope.generateDeclaredUidIdentifier("old");
+        const varName = path.scope.generateDeclaredUidIdentifier("old").name;
 
-        const assignment = t.binaryExpression(
+        const binary = t.binaryExpression(
           path.node.operator.slice(0, 1),
-          varName,
+          t.identifier(varName),
           t.numericLiteral(1),
         );
 
         // i++ => (_tmp = i, i = _tmp + 1, _tmp)
         path.replaceWith(
           t.sequenceExpression([
-            t.assignmentExpression("=", varName, arg.node),
-            t.assignmentExpression("=", arg.node, assignment),
-            varName,
+            t.assignmentExpression("=", t.identifier(varName), arg.node),
+            t.assignmentExpression("=", t.cloneNode(arg.node), binary),
+            t.identifier(varName),
           ]),
         );
       }
@@ -78,7 +78,7 @@ const simpleAssignmentVisitor = {
 
       path.node.right = t.binaryExpression(
         path.node.operator.slice(0, -1),
-        path.node.left,
+        t.cloneNode(path.node.left),
         path.node.right,
       );
       path.node.operator = "=";

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -309,7 +309,7 @@ function checkDuplicatedNodes(ast) {
     if (isByRegenerator(node)) return;
     if (nodes.has(node)) {
       throw new Error(
-        "Do not reuse nodes. Use `t.clone` or `t.cloneDeep` to copy them.\n" +
+        "Do not reuse nodes. Use `t.cloneNode` to copy them.\n" +
           JSON.stringify(node, hidePrivateProperties, 2) +
           "\nParent:\n" +
           JSON.stringify(parents.get(node), hidePrivateProperties, 2),

--- a/packages/babel-helpers/src/index.js
+++ b/packages/babel-helpers/src/index.js
@@ -215,7 +215,7 @@ function permuteHelperAST(file, metadata, id, localBindings, getDependency) {
 
       for (const path of imps) path.remove();
       for (const path of impsBindingRefs) {
-        const node = t.cloneDeep(dependenciesRefs[path.node.name]);
+        const node = t.cloneNode(dependenciesRefs[path.node.name]);
         path.replaceWith(node);
       }
 

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -128,7 +128,7 @@ export default function(api, options) {
                 t.variableDeclarator(ident, computedNode.key),
               ]),
             );
-            computedNode.key = t.clone(ident);
+            computedNode.key = t.cloneNode(ident);
           }
         }
 

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -54,7 +54,7 @@ export default function(api, options) {
         value: VALUE
       });
     `({
-      REF: ref,
+      REF: t.cloneNode(ref),
       KEY: t.isIdentifier(key) && !computed ? t.stringLiteral(key.name) : key,
       VALUE: value || scope.buildUndefinedNode(),
     });
@@ -62,7 +62,11 @@ export default function(api, options) {
 
   const buildClassPropertyLoose = (ref, { key, value, computed }, scope) => {
     return template.statement`MEMBER = VALUE`({
-      MEMBER: t.memberExpression(ref, key, computed || t.isLiteral(key)),
+      MEMBER: t.memberExpression(
+        t.cloneNode(ref),
+        key,
+        computed || t.isLiteral(key),
+      ),
       VALUE: value || scope.buildUndefinedNode(),
     });
   };
@@ -199,7 +203,10 @@ export default function(api, options) {
             instanceBody = [
               t.expressionStatement(
                 t.callExpression(
-                  t.memberExpression(initialisePropsRef, t.identifier("call")),
+                  t.memberExpression(
+                    t.cloneNode(initialisePropsRef),
+                    t.identifier("call"),
+                  ),
                   [t.thisExpression()],
                 ),
               ),
@@ -227,7 +234,9 @@ export default function(api, options) {
 
         if (path.isClassExpression()) {
           path.scope.push({ id: ref });
-          path.replaceWith(t.assignmentExpression("=", ref, path.node));
+          path.replaceWith(
+            t.assignmentExpression("=", t.cloneNode(ref), path.node),
+          );
         } else if (!path.node.id) {
           // Anonymous class declaration
           path.node.id = ref;

--- a/packages/babel-plugin-proposal-decorators/src/index.js
+++ b/packages/babel-plugin-proposal-decorators/src/index.js
@@ -75,8 +75,8 @@ export default function() {
       .reverse()
       .reduce(function(acc, decorator) {
         return buildClassDecorator({
-          CLASS_REF: name,
-          DECORATOR: decorator,
+          CLASS_REF: t.cloneNode(name),
+          DECORATOR: t.cloneNode(decorator),
           INNER: acc,
         }).expression;
       }, classPath.node);
@@ -166,9 +166,11 @@ export default function() {
             "=",
             descriptor,
             t.callExpression(state.addHelper("applyDecoratedDescriptor"), [
-              target,
-              property,
-              t.arrayExpression(decorators.map(dec => dec.expression)),
+              t.cloneNode(target),
+              t.cloneNode(property),
+              t.arrayExpression(
+                decorators.map(dec => t.cloneNode(dec.expression)),
+              ),
               t.objectExpression([
                 t.objectProperty(
                   t.identifier("enumerable"),
@@ -182,21 +184,23 @@ export default function() {
       } else {
         acc = acc.concat(
           t.callExpression(state.addHelper("applyDecoratedDescriptor"), [
-            target,
-            property,
-            t.arrayExpression(decorators.map(dec => dec.expression)),
+            t.cloneNode(target),
+            t.cloneNode(property),
+            t.arrayExpression(
+              decorators.map(dec => t.cloneNode(dec.expression)),
+            ),
             t.isObjectProperty(node) ||
             t.isClassProperty(node, { static: true })
               ? buildGetObjectInitializer({
                   TEMP: path.scope.generateDeclaredUidIdentifier("init"),
-                  TARGET: target,
-                  PROPERTY: property,
+                  TARGET: t.cloneNode(target),
+                  PROPERTY: t.cloneNode(property),
                 }).expression
               : buildGetDescriptor({
-                  TARGET: target,
-                  PROPERTY: property,
+                  TARGET: t.cloneNode(target),
+                  PROPERTY: t.cloneNode(property),
                 }).expression,
-            target,
+            t.cloneNode(target),
           ]),
         );
       }
@@ -205,9 +209,9 @@ export default function() {
     }, []);
 
     return t.sequenceExpression([
-      t.assignmentExpression("=", name, path.node),
+      t.assignmentExpression("=", t.cloneNode(name), path.node),
       t.sequenceExpression(exprs),
-      name,
+      t.cloneNode(name),
     ]);
   }
 
@@ -222,7 +226,9 @@ export default function() {
           return;
         }
 
-        const ref = node.id || path.scope.generateUidIdentifier("class");
+        const ref = node.id
+          ? t.cloneNode(node.id)
+          : path.scope.generateUidIdentifier("class");
         const letDeclaration = t.variableDeclaration("let", [
           t.variableDeclarator(ref, t.toExpression(node)),
         ]);
@@ -232,7 +238,7 @@ export default function() {
           path.parentPath.replaceWithMultiple([
             letDeclaration,
             t.exportNamedDeclaration(null, [
-              t.exportSpecifier(ref, t.identifier("default")),
+              t.exportSpecifier(t.cloneNode(ref), t.identifier("default")),
             ]),
           ]);
         } else {
@@ -261,10 +267,10 @@ export default function() {
 
         path.replaceWith(
           t.callExpression(state.addHelper("initializerDefineProperty"), [
-            path.get("left.object").node,
+            t.cloneNode(path.get("left.object").node),
             t.stringLiteral(path.get("left.property").node.name),
-            path.get("right.arguments")[0].node,
-            path.get("right.arguments")[1].node,
+            t.cloneNode(path.get("right.arguments")[0].node),
+            t.cloneNode(path.get("right.arguments")[1].node),
           ]),
         );
       },

--- a/packages/babel-plugin-proposal-export-default-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.js
@@ -16,8 +16,13 @@ export default function() {
         const uid = scope.generateUidIdentifier(exported.name);
 
         const nodes = [
-          t.importDeclaration([t.importDefaultSpecifier(uid)], node.source),
-          t.exportNamedDeclaration(null, [t.exportSpecifier(uid, exported)]),
+          t.importDeclaration(
+            [t.importDefaultSpecifier(uid)],
+            t.cloneNode(node.source),
+          ),
+          t.exportNamedDeclaration(null, [
+            t.exportSpecifier(t.cloneNode(uid), exported),
+          ]),
         ];
 
         if (specifiers.length >= 1) {

--- a/packages/babel-plugin-proposal-export-namespace-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-namespace-from/src/index.js
@@ -26,8 +26,13 @@ export default function() {
         const uid = scope.generateUidIdentifier(exported.name);
 
         nodes.push(
-          t.importDeclaration([t.importNamespaceSpecifier(uid)], node.source),
-          t.exportNamedDeclaration(null, [t.exportSpecifier(uid, exported)]),
+          t.importDeclaration(
+            [t.importNamespaceSpecifier(uid)],
+            t.cloneNode(node.source),
+          ),
+          t.exportNamedDeclaration(null, [
+            t.exportSpecifier(t.cloneNode(uid), exported),
+          ]),
         );
 
         if (node.specifiers.length >= 1) {

--- a/packages/babel-plugin-proposal-function-bind/src/index.js
+++ b/packages/babel-plugin-proposal-function-bind/src/index.js
@@ -17,7 +17,7 @@ export default function() {
 
   function inferBindContext(bind, scope) {
     const staticContext = getStaticContext(bind, scope);
-    if (staticContext) return t.cloneDeep(staticContext);
+    if (staticContext) return t.cloneNode(staticContext);
 
     const tempId = getTempId(scope);
     if (bind.object) {

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
@@ -15,7 +15,11 @@ export default function(api, { loose = false }) {
         const ref = scope.generateUidIdentifierBasedOnNode(node.left);
         scope.push({ id: ref });
 
-        const assignment = t.assignmentExpression("=", t.clone(ref), node.left);
+        const assignment = t.assignmentExpression(
+          "=",
+          t.cloneNode(ref),
+          node.left,
+        );
 
         path.replaceWith(
           t.conditionalExpression(
@@ -28,11 +32,11 @@ export default function(api, { loose = false }) {
                   t.binaryExpression("!==", assignment, t.nullLiteral()),
                   t.binaryExpression(
                     "!==",
-                    t.clone(ref),
+                    t.cloneNode(ref),
                     scope.buildUndefinedNode(),
                   ),
                 ),
-            t.clone(ref),
+            t.cloneNode(ref),
             node.right,
           ),
         );

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -95,7 +95,7 @@ export default function(api, opts) {
       impureComputedPropertyDeclarators,
       restElement.argument,
       t.callExpression(file.addHelper("objectWithoutProperties"), [
-        objRef,
+        t.cloneNode(objRef),
         keyExpression,
       ]),
     ];
@@ -124,7 +124,7 @@ export default function(api, opts) {
 
       parentPath.ensureBlock();
       parentPath.get("body").unshiftContainer("body", declar);
-      paramPath.replaceWith(uid);
+      paramPath.replaceWith(t.cloneNode(uid));
     }
   }
 
@@ -180,7 +180,10 @@ export default function(api, opts) {
                 );
                 // replace foo() with _foo
                 this.originalPath.replaceWith(
-                  t.variableDeclarator(this.originalPath.node.id, initRef),
+                  t.variableDeclarator(
+                    this.originalPath.node.id,
+                    t.cloneNode(initRef),
+                  ),
                 );
 
                 return;
@@ -247,8 +250,9 @@ export default function(api, opts) {
         const specifiers = [];
 
         for (const name in path.getOuterBindingIdentifiers(path)) {
-          const id = t.identifier(name);
-          specifiers.push(t.exportSpecifier(id, id));
+          specifiers.push(
+            t.exportSpecifier(t.identifier(name), t.identifier(name)),
+          );
         }
 
         // Split the declaration and export list into two declarations so that the variable
@@ -324,7 +328,9 @@ export default function(api, opts) {
           path.ensureBlock();
 
           node.body.body.unshift(
-            t.variableDeclaration("var", [t.variableDeclarator(left, temp)]),
+            t.variableDeclaration("var", [
+              t.variableDeclarator(left, t.cloneNode(temp)),
+            ]),
           );
 
           return;
@@ -344,7 +350,7 @@ export default function(api, opts) {
 
         node.body.body.unshift(
           t.variableDeclaration(node.left.kind, [
-            t.variableDeclarator(pattern, key),
+            t.variableDeclarator(pattern, t.cloneNode(key)),
           ]),
         );
       },

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -74,7 +74,7 @@ export default function(api, opts) {
     const props = path.get("properties");
     const last = props[props.length - 1];
     t.assertRestElement(last.node);
-    const restElement = t.clone(last.node);
+    const restElement = t.cloneNode(last.node);
     last.remove();
 
     const impureComputedPropertyDeclarators = replaceImpureComputedKeys(path);
@@ -291,7 +291,7 @@ export default function(api, opts) {
             );
           }
 
-          const nodeWithoutSpread = t.clone(path.node);
+          const nodeWithoutSpread = t.cloneNode(path.node);
           nodeWithoutSpread.right = ref;
           nodes.push(t.expressionStatement(nodeWithoutSpread));
           nodes.push(

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -7,7 +7,6 @@ export default function(api, options) {
   function optional(path, replacementPath) {
     const { scope } = path;
     const optionals = [];
-    const nil = scope.buildUndefinedNode();
 
     let objectPath = path;
     while (objectPath.isMemberExpression() || objectPath.isCallExpression()) {
@@ -40,7 +39,11 @@ export default function(api, options) {
       } else {
         ref = scope.maybeGenerateMemoised(chain);
         if (ref) {
-          check = t.assignmentExpression("=", ref, chain);
+          check = t.assignmentExpression(
+            "=",
+            t.cloneNode(ref),
+            t.cloneNode(chain),
+          );
           node[replaceKey] = ref;
         } else {
           check = ref = chain;
@@ -65,7 +68,7 @@ export default function(api, options) {
             context = object;
           }
 
-          node.arguments.unshift(context);
+          node.arguments.unshift(t.cloneNode(context));
           node.callee = t.memberExpression(node.callee, t.identifier("call"));
         }
       }
@@ -83,7 +86,7 @@ export default function(api, options) {
                   scope.buildUndefinedNode(),
                 ),
               ),
-          nil,
+          scope.buildUndefinedNode(),
           replacementPath.node,
         ),
       );

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -42,7 +42,9 @@ export default function(api, options) {
           check = t.assignmentExpression(
             "=",
             t.cloneNode(ref),
-            t.cloneNode(chain),
+            // Here `chain` MUST NOT be cloned because it could be updated
+            // when generating the memoised context of a call espression
+            chain,
           );
           node[replaceKey] = ref;
         } else {

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -73,13 +73,13 @@ export default function(api, options) {
       replacementPath.replaceWith(
         t.conditionalExpression(
           loose
-            ? t.binaryExpression("==", t.clone(check), t.nullLiteral())
+            ? t.binaryExpression("==", t.cloneNode(check), t.nullLiteral())
             : t.logicalExpression(
                 "||",
-                t.binaryExpression("===", t.clone(check), t.nullLiteral()),
+                t.binaryExpression("===", t.cloneNode(check), t.nullLiteral()),
                 t.binaryExpression(
                   "===",
-                  t.clone(ref),
+                  t.cloneNode(ref),
                   scope.buildUndefinedNode(),
                 ),
               ),

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/function-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/function-call/output.js
@@ -1,12 +1,12 @@
-var _foo, _foo2, _foo$bar, _foo3, _foo4, _foo4$bar, _foo5, _foo6, _foo7, _foo$bar2, _foo8, _foo$bar3, _foo9, _foo$bar3$call, _foo10, _foo10$bar, _foo11, _foo11$bar, _foo11$bar$call;
+var _foo, _foo2, _foo$bar, _foo3, _foo3$bar, _foo4, _foo5, _foo6, _foo$bar2, _foo$bar3, _foo$bar3$call, _foo7, _foo7$bar, _foo8, _foo8$bar, _foo8$bar$call;
 
 (_foo = foo) === null || _foo === void 0 ? void 0 : _foo(foo);
 (_foo2 = foo) === null || _foo2 === void 0 ? void 0 : _foo2.bar();
-(_foo$bar = (_foo3 = foo).bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.call(_foo3, foo.bar, false);
-(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : (_foo4$bar = _foo4.bar) === null || _foo4$bar === void 0 ? void 0 : _foo4$bar.call(_foo4, foo.bar, true);
-(_foo5 = foo) === null || _foo5 === void 0 ? void 0 : _foo5().bar;
-(_foo6 = foo) === null || _foo6 === void 0 ? void 0 : (_foo7 = _foo6()) === null || _foo7 === void 0 ? void 0 : _foo7.bar;
-(_foo$bar2 = (_foo8 = foo).bar) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2.call(_foo8).baz;
-(_foo$bar3 = (_foo9 = foo).bar) === null || _foo$bar3 === void 0 ? void 0 : (_foo$bar3$call = _foo$bar3.call(_foo9)) === null || _foo$bar3$call === void 0 ? void 0 : _foo$bar3$call.baz;
-(_foo10 = foo) === null || _foo10 === void 0 ? void 0 : (_foo10$bar = _foo10.bar) === null || _foo10$bar === void 0 ? void 0 : _foo10$bar.call(_foo10).baz;
-(_foo11 = foo) === null || _foo11 === void 0 ? void 0 : (_foo11$bar = _foo11.bar) === null || _foo11$bar === void 0 ? void 0 : (_foo11$bar$call = _foo11$bar.call(_foo11)) === null || _foo11$bar$call === void 0 ? void 0 : _foo11$bar$call.baz;
+(_foo$bar = foo.bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.call(foo, foo.bar, false);
+(_foo3 = foo) === null || _foo3 === void 0 ? void 0 : (_foo3$bar = _foo3.bar) === null || _foo3$bar === void 0 ? void 0 : _foo3$bar.call(_foo3, foo.bar, true);
+(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : _foo4().bar;
+(_foo5 = foo) === null || _foo5 === void 0 ? void 0 : (_foo6 = _foo5()) === null || _foo6 === void 0 ? void 0 : _foo6.bar;
+(_foo$bar2 = foo.bar) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2.call(foo).baz;
+(_foo$bar3 = foo.bar) === null || _foo$bar3 === void 0 ? void 0 : (_foo$bar3$call = _foo$bar3.call(foo)) === null || _foo$bar3$call === void 0 ? void 0 : _foo$bar3$call.baz;
+(_foo7 = foo) === null || _foo7 === void 0 ? void 0 : (_foo7$bar = _foo7.bar) === null || _foo7$bar === void 0 ? void 0 : _foo7$bar.call(_foo7).baz;
+(_foo8 = foo) === null || _foo8 === void 0 ? void 0 : (_foo8$bar = _foo8.bar) === null || _foo8$bar === void 0 ? void 0 : (_foo8$bar$call = _foo8$bar.call(_foo8)) === null || _foo8$bar$call === void 0 ? void 0 : _foo8$bar$call.baz;

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/function-call/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/function-call/output.js
@@ -1,12 +1,12 @@
-var _foo, _foo2, _foo$bar, _foo3, _foo3$bar, _foo4, _foo5, _foo6, _foo$bar2, _foo$bar3, _foo$bar3$call, _foo7, _foo7$bar, _foo8, _foo8$bar, _foo8$bar$call;
+var _foo, _foo2, _foo$bar, _foo3, _foo4, _foo4$bar, _foo5, _foo6, _foo7, _foo$bar2, _foo8, _foo$bar3, _foo9, _foo$bar3$call, _foo10, _foo10$bar, _foo11, _foo11$bar, _foo11$bar$call;
 
 (_foo = foo) === null || _foo === void 0 ? void 0 : _foo(foo);
 (_foo2 = foo) === null || _foo2 === void 0 ? void 0 : _foo2.bar();
-(_foo$bar = foo.bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.call(foo, foo.bar, false);
-(_foo3 = foo) === null || _foo3 === void 0 ? void 0 : (_foo3$bar = _foo3.bar) === null || _foo3$bar === void 0 ? void 0 : _foo3$bar.call(_foo3, foo.bar, true);
-(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : _foo4().bar;
-(_foo5 = foo) === null || _foo5 === void 0 ? void 0 : (_foo6 = _foo5()) === null || _foo6 === void 0 ? void 0 : _foo6.bar;
-(_foo$bar2 = foo.bar) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2.call(foo).baz;
-(_foo$bar3 = foo.bar) === null || _foo$bar3 === void 0 ? void 0 : (_foo$bar3$call = _foo$bar3.call(foo)) === null || _foo$bar3$call === void 0 ? void 0 : _foo$bar3$call.baz;
-(_foo7 = foo) === null || _foo7 === void 0 ? void 0 : (_foo7$bar = _foo7.bar) === null || _foo7$bar === void 0 ? void 0 : _foo7$bar.call(_foo7).baz;
-(_foo8 = foo) === null || _foo8 === void 0 ? void 0 : (_foo8$bar = _foo8.bar) === null || _foo8$bar === void 0 ? void 0 : (_foo8$bar$call = _foo8$bar.call(_foo8)) === null || _foo8$bar$call === void 0 ? void 0 : _foo8$bar$call.baz;
+(_foo$bar = (_foo3 = foo).bar) === null || _foo$bar === void 0 ? void 0 : _foo$bar.call(_foo3, foo.bar, false);
+(_foo4 = foo) === null || _foo4 === void 0 ? void 0 : (_foo4$bar = _foo4.bar) === null || _foo4$bar === void 0 ? void 0 : _foo4$bar.call(_foo4, foo.bar, true);
+(_foo5 = foo) === null || _foo5 === void 0 ? void 0 : _foo5().bar;
+(_foo6 = foo) === null || _foo6 === void 0 ? void 0 : (_foo7 = _foo6()) === null || _foo7 === void 0 ? void 0 : _foo7.bar;
+(_foo$bar2 = (_foo8 = foo).bar) === null || _foo$bar2 === void 0 ? void 0 : _foo$bar2.call(_foo8).baz;
+(_foo$bar3 = (_foo9 = foo).bar) === null || _foo$bar3 === void 0 ? void 0 : (_foo$bar3$call = _foo$bar3.call(_foo9)) === null || _foo$bar3$call === void 0 ? void 0 : _foo$bar3$call.baz;
+(_foo10 = foo) === null || _foo10 === void 0 ? void 0 : (_foo10$bar = _foo10.bar) === null || _foo10$bar === void 0 ? void 0 : _foo10$bar.call(_foo10).baz;
+(_foo11 = foo) === null || _foo11 === void 0 ? void 0 : (_foo11$bar = _foo11.bar) === null || _foo11$bar === void 0 ? void 0 : (_foo11$bar$call = _foo11$bar.call(_foo11)) === null || _foo11$bar$call === void 0 ? void 0 : _foo11$bar$call.baz;

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -44,10 +44,10 @@ export default function() {
 
         const call = optimizeArrow
           ? right.body
-          : t.callExpression(right, [placeholder]);
+          : t.callExpression(right, [t.cloneNode(placeholder)]);
         path.replaceWith(
           t.sequenceExpression([
-            t.assignmentExpression("=", placeholder, left),
+            t.assignmentExpression("=", t.cloneNode(placeholder), left),
             call,
           ]),
         );

--- a/packages/babel-plugin-proposal-throw-expressions/src/index.js
+++ b/packages/babel-plugin-proposal-throw-expressions/src/index.js
@@ -10,11 +10,10 @@ export default function() {
         const { operator, argument } = path.node;
         if (operator !== "throw") return;
 
-        const arg = t.identifier("e");
         const arrow = t.functionExpression(
           null,
-          [arg],
-          t.blockStatement([t.throwStatement(arg)]),
+          [t.identifier("e")],
+          t.blockStatement([t.throwStatement(t.identifier("e"))]),
         );
 
         path.replaceWith(t.callExpression(arrow, [argument]));

--- a/packages/babel-plugin-transform-async-to-generator/src/index.js
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.js
@@ -13,7 +13,7 @@ export default function(api, options) {
 
           let wrapAsync = state.methodWrapper;
           if (wrapAsync) {
-            wrapAsync = t.cloneDeep(wrapAsync);
+            wrapAsync = t.cloneNode(wrapAsync);
           } else {
             wrapAsync = state.methodWrapper = addNamed(path, method, module);
           }

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -525,7 +525,7 @@ class BlockScoping {
 
     // turn outsideLetReferences into an array
     const args = values(outsideRefs);
-    const params = args.map(id => t.clone(id));
+    const params = args.map(id => t.cloneNode(id));
 
     const isSwitch = this.blockPath.isSwitchStatement();
 

--- a/packages/babel-plugin-transform-classes/src/index.js
+++ b/packages/babel-plugin-transform-classes/src/index.js
@@ -34,7 +34,7 @@ export default function(api, options) {
         path.replaceWith(node.declaration);
         path.insertAfter(
           t.exportNamedDeclaration(null, [
-            t.exportSpecifier(ref, t.identifier("default")),
+            t.exportSpecifier(t.cloneNode(ref), t.identifier("default")),
           ]),
         );
       },

--- a/packages/babel-plugin-transform-classes/src/loose.js
+++ b/packages/babel-plugin-transform-classes/src/loose.js
@@ -34,7 +34,7 @@ export default class LooseClassTransformer extends VanillaTransformer {
         classRef = this._protoAlias;
       }
       const methodName = t.memberExpression(
-        classRef,
+        t.cloneNode(classRef),
         node.key,
         node.computed || t.isLiteral(node.key),
       );

--- a/packages/babel-plugin-transform-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-classes/src/vanilla.js
@@ -387,12 +387,12 @@ export default class ClassTransformer {
         // special case single arguments spread
         bareSuperNode.arguments[1] = bareSuperNode.arguments[1].argument;
         bareSuperNode.callee = t.memberExpression(
-          superRef,
+          t.cloneNode(superRef),
           t.identifier("apply"),
         );
       } else {
         bareSuperNode.callee = t.memberExpression(
-          superRef,
+          t.cloneNode(superRef),
           t.identifier("call"),
         );
       }
@@ -456,7 +456,7 @@ export default class ClassTransformer {
     const superRef = this.superName || t.identifier("Function");
     let thisRef = function() {
       const ref = path.scope.generateDeclaredUidIdentifier("this");
-      thisRef = () => ref;
+      thisRef = () => t.cloneNode(ref);
       return ref;
     };
 

--- a/packages/babel-plugin-transform-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-classes/src/vanilla.js
@@ -122,16 +122,18 @@ export default class ClassTransformer {
     if (this.isDerived) {
       if (this.extendsNative) {
         closureArgs.push(
-          t.callExpression(this.file.addHelper("wrapNativeSuper"), [superName]),
+          t.callExpression(this.file.addHelper("wrapNativeSuper"), [
+            t.cloneNode(superName),
+          ]),
         );
       } else {
-        closureArgs.push(superName);
+        closureArgs.push(t.cloneNode(superName));
       }
 
       superName = this.scope.generateUidIdentifierBasedOnNode(superName);
       closureParams.push(superName);
 
-      this.superName = superName;
+      this.superName = t.cloneNode(superName);
     }
 
     //
@@ -143,13 +145,15 @@ export default class ClassTransformer {
         t.expressionStatement(
           t.callExpression(file.addHelper("classCallCheck"), [
             t.thisExpression(),
-            this.classRef,
+            t.cloneNode(this.classRef),
           ]),
         ),
       );
     }
 
-    body = body.concat(this.staticPropBody.map(fn => fn(this.classRef)));
+    body = body.concat(
+      this.staticPropBody.map(fn => fn(t.cloneNode(this.classRef))),
+    );
 
     if (this.classId) {
       // named class with only a constructor
@@ -157,7 +161,7 @@ export default class ClassTransformer {
     }
 
     //
-    body.push(t.returnStatement(this.classRef));
+    body.push(t.returnStatement(t.cloneNode(this.classRef)));
 
     const container = t.arrowFunctionExpression(
       closureParams,
@@ -167,7 +171,11 @@ export default class ClassTransformer {
   }
 
   buildConstructor() {
-    const func = t.functionDeclaration(this.classRef, [], this.constructorBody);
+    const func = t.functionDeclaration(
+      t.cloneNode(this.classRef),
+      [],
+      this.constructorBody,
+    );
     t.inherits(func, this.node);
     return func;
   }
@@ -327,14 +335,12 @@ export default class ClassTransformer {
         staticProps = defineMap.toComputedObjectFromClass(staticProps);
       }
 
-      const nullNode = t.nullLiteral();
-
       let args = [
-        this.classRef, // Constructor
-        nullNode, // instanceDescriptors
-        nullNode, // staticDescriptors
-        nullNode, // instanceInitializers
-        nullNode, // staticInitializers
+        t.cloneNode(this.classRef), // Constructor
+        t.nullLiteral(), // instanceDescriptors
+        t.nullLiteral(), // staticDescriptors
+        t.nullLiteral(), // instanceInitializers
+        t.nullLiteral(), // staticInitializers
       ];
 
       if (instanceProps) args[1] = instanceProps;
@@ -352,7 +358,7 @@ export default class ClassTransformer {
 
       let lastNonNullIndex = 0;
       for (let i = 0; i < args.length; i++) {
-        if (args[i] !== nullNode) lastNonNullIndex = i;
+        if (!t.isNullLiteral(args[i])) lastNonNullIndex = i;
       }
       args = args.slice(0, lastNonNullIndex + 1);
 
@@ -400,13 +406,16 @@ export default class ClassTransformer {
       bareSuperNode = optimiseCall(
         t.logicalExpression(
           "||",
-          t.memberExpression(this.classRef, t.identifier("__proto__")),
+          t.memberExpression(
+            t.cloneNode(this.classRef),
+            t.identifier("__proto__"),
+          ),
           t.callExpression(
             t.memberExpression(
               t.identifier("Object"),
               t.identifier("getPrototypeOf"),
             ),
-            [this.classRef],
+            [t.cloneNode(this.classRef)],
           ),
         ),
         t.thisExpression(),
@@ -607,7 +616,7 @@ export default class ClassTransformer {
           this.isLoose
             ? this.file.addHelper("inheritsLoose")
             : this.file.addHelper("inherits"),
-          [this.classRef, this.superName],
+          [t.cloneNode(this.classRef), t.cloneNode(this.superName)],
         ),
       ),
     );

--- a/packages/babel-plugin-transform-computed-properties/src/index.js
+++ b/packages/babel-plugin-transform-computed-properties/src/index.js
@@ -34,7 +34,7 @@ export default function(api, options) {
           t.assignmentExpression(
             "=",
             t.memberExpression(
-              objId,
+              t.cloneNode(objId),
               prop.key,
               prop.computed || t.isLiteral(prop.key),
             ),
@@ -62,7 +62,7 @@ export default function(api, options) {
     body.push(
       ...buildMutatorMapAssign({
         MUTATOR_MAP_REF: getMutatorId(),
-        KEY: key,
+        KEY: t.cloneNode(key),
         VALUE: getValue(prop),
         KIND: t.identifier(prop.kind),
       }),
@@ -74,7 +74,7 @@ export default function(api, options) {
       if (prop.kind === "get" || prop.kind === "set") {
         pushMutatorDefine(info, prop);
       } else {
-        pushAssign(info.objId, prop, info.body);
+        pushAssign(t.cloneNode(info.objId), prop, info.body);
       }
     }
   }
@@ -100,7 +100,7 @@ export default function(api, options) {
           body.push(
             t.expressionStatement(
               t.callExpression(state.addHelper("defineProperty"), [
-                objId,
+                t.cloneNode(objId),
                 key,
                 getValue(prop),
               ]),
@@ -165,7 +165,7 @@ export default function(api, options) {
               );
             }
 
-            return mutatorRef;
+            return t.cloneNode(mutatorRef);
           };
 
           const single = pushComputedProps({
@@ -183,7 +183,7 @@ export default function(api, options) {
               t.expressionStatement(
                 t.callExpression(
                   state.addHelper("defineEnumerableProperties"),
-                  [objId, mutatorRef],
+                  [t.cloneNode(objId), t.cloneNode(mutatorRef)],
                 ),
               ),
             );
@@ -192,7 +192,7 @@ export default function(api, options) {
           if (single) {
             path.replaceWith(single);
           } else {
-            body.push(t.expressionStatement(objId));
+            body.push(t.expressionStatement(t.cloneNode(objId)));
             path.replaceWithMultiple(body);
           }
         },

--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -221,7 +221,7 @@ export default function(api, options) {
         if (t.isRestElement(prop)) {
           this.pushObjectRest(pattern, objRef, prop, i);
         } else {
-          this.pushObjectProperty(prop, t.clone(objRef));
+          this.pushObjectProperty(prop, t.cloneNode(objRef));
         }
       }
     }

--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -62,10 +62,12 @@ export default function(api, options) {
       let node;
 
       if (op) {
-        node = t.expressionStatement(t.assignmentExpression(op, id, init));
+        node = t.expressionStatement(
+          t.assignmentExpression(op, id, t.cloneNode(init)),
+        );
       } else {
         node = t.variableDeclaration(this.kind, [
-          t.variableDeclarator(id, init),
+          t.variableDeclarator(id, t.cloneNode(init)),
         ]);
       }
 
@@ -76,13 +78,14 @@ export default function(api, options) {
 
     buildVariableDeclaration(id, init) {
       const declar = t.variableDeclaration("var", [
-        t.variableDeclarator(id, init),
+        t.variableDeclarator(t.cloneNode(id), t.cloneNode(init)),
       ]);
       declar._blockHoist = this.blockHoist;
       return declar;
     }
 
-    push(id, init) {
+    push(id, _init) {
+      const init = t.cloneNode(_init);
       if (t.isObjectPattern(id)) {
         this.pushObjectPattern(id, init);
       } else if (t.isArrayPattern(id)) {
@@ -164,7 +167,7 @@ export default function(api, options) {
         if (t.isIdentifier(key) && !prop.computed) {
           key = t.stringLiteral(prop.key.name);
         }
-        keys.push(key);
+        keys.push(t.cloneNode(key));
       }
 
       keys = t.arrayExpression(keys);
@@ -173,7 +176,7 @@ export default function(api, options) {
 
       const value = t.callExpression(
         this.addHelper("objectWithoutProperties"),
-        [objRef, keys],
+        [t.cloneNode(objRef), keys],
       );
       this.nodes.push(this.buildVariableAssignment(spreadProp.argument, value));
     }
@@ -182,7 +185,11 @@ export default function(api, options) {
       if (t.isLiteral(prop.key)) prop.computed = true;
 
       const pattern = prop.value;
-      const objRef = t.memberExpression(propRef, prop.key, prop.computed);
+      const objRef = t.memberExpression(
+        t.cloneNode(propRef),
+        prop.key,
+        prop.computed,
+      );
 
       if (t.isPattern(pattern)) {
         this.push(pattern, objRef);
@@ -221,7 +228,7 @@ export default function(api, options) {
         if (t.isRestElement(prop)) {
           this.pushObjectRest(pattern, objRef, prop, i);
         } else {
-          this.pushObjectProperty(prop, t.cloneNode(objRef));
+          this.pushObjectProperty(prop, objRef);
         }
       }
     }
@@ -344,7 +351,9 @@ export default function(api, options) {
       if (!t.isArrayExpression(ref) && !t.isMemberExpression(ref)) {
         const memo = this.scope.maybeGenerateMemoised(ref, true);
         if (memo) {
-          this.nodes.push(this.buildVariableDeclaration(memo, ref));
+          this.nodes.push(
+            this.buildVariableDeclaration(memo, t.cloneNode(ref)),
+          );
           ref = memo;
         }
       }
@@ -367,8 +376,9 @@ export default function(api, options) {
         const specifiers = [];
 
         for (const name in path.getOuterBindingIdentifiers(path)) {
-          const id = t.identifier(name);
-          specifiers.push(t.exportSpecifier(id, id));
+          specifiers.push(
+            t.exportSpecifier(t.identifier(name), t.identifier(name)),
+          );
         }
 
         // Split the declaration and export list into two declarations so that the variable
@@ -484,7 +494,7 @@ export default function(api, options) {
         destructuring.init(node.left, ref || node.right);
 
         if (ref) {
-          nodes.push(t.expressionStatement(ref));
+          nodes.push(t.expressionStatement(t.cloneNode(ref)));
         }
 
         path.replaceWithMultiple(nodes);
@@ -526,7 +536,10 @@ export default function(api, options) {
           } else {
             nodes.push(
               t.inherits(
-                destructuring.buildVariableAssignment(declar.id, declar.init),
+                destructuring.buildVariableAssignment(
+                  declar.id,
+                  t.cloneNode(declar.init),
+                ),
                 declar,
               ),
             );

--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -112,12 +112,10 @@ export default function(api, options) {
       // we need to assign the current value of the assignment to avoid evaluating
       // it more than once
 
-      const tempValueRef = this.scope.generateUidIdentifierBasedOnNode(
-        valueRef,
-      );
+      const tempValueRef = this.scope.generateUidBasedOnNode(valueRef);
 
       const declar = t.variableDeclaration("var", [
-        t.variableDeclarator(tempValueRef, valueRef),
+        t.variableDeclarator(t.identifier(tempValueRef), valueRef),
       ]);
       declar._blockHoist = this.blockHoist;
       this.nodes.push(declar);
@@ -127,22 +125,26 @@ export default function(api, options) {
       const tempConditional = t.conditionalExpression(
         t.binaryExpression(
           "===",
-          tempValueRef,
+          t.identifier(tempValueRef),
           this.scope.buildUndefinedNode(),
         ),
         pattern.right,
-        tempValueRef,
+        t.identifier(tempValueRef),
       );
 
       const left = pattern.left;
       if (t.isPattern(left)) {
         const tempValueDefault = t.expressionStatement(
-          t.assignmentExpression("=", tempValueRef, tempConditional),
+          t.assignmentExpression(
+            "=",
+            t.identifier(tempValueRef),
+            tempConditional,
+          ),
         );
         tempValueDefault._blockHoist = this.blockHoist;
 
         this.nodes.push(tempValueDefault);
-        this.push(left, tempValueRef);
+        this.push(left, t.identifier(tempValueRef));
       } else {
         this.nodes.push(this.buildVariableAssignment(left, tempConditional));
       }

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -25,7 +25,11 @@ export default function(api, options) {
             array = right;
           }
 
-          const item = t.memberExpression(array, t.cloneNode(i), true);
+          const item = t.memberExpression(
+            t.cloneNode(array),
+            t.cloneNode(i),
+            true,
+          );
           let assignment;
           if (t.isVariableDeclaration(left)) {
             assignment = left;
@@ -112,11 +116,13 @@ export default function(api, options) {
     let right = node.right;
 
     if (!t.isIdentifier(right) || !scope.hasBinding(right.name)) {
-      const uid = scope.generateUidIdentifier("arr");
+      const uid = scope.generateUid("arr");
       nodes.push(
-        t.variableDeclaration("var", [t.variableDeclarator(uid, right)]),
+        t.variableDeclaration("var", [
+          t.variableDeclarator(t.identifier(uid), right),
+        ]),
       );
-      right = uid;
+      right = t.identifier(uid);
     }
 
     const iterationKey = scope.generateUidIdentifier("i");
@@ -130,7 +136,11 @@ export default function(api, options) {
     t.inherits(loop, node);
     t.ensureBlock(loop);
 
-    const iterationValue = t.memberExpression(right, iterationKey, true);
+    const iterationValue = t.memberExpression(
+      t.cloneNode(right),
+      t.cloneNode(iterationKey),
+      true,
+    );
 
     const left = node.left;
     if (t.isVariableDeclaration(left)) {
@@ -221,9 +231,11 @@ export default function(api, options) {
       // for (let i of test)
       id = scope.generateUidIdentifier("ref");
       declar = t.variableDeclaration(left.kind, [
-        t.variableDeclarator(left.declarations[0].id, id),
+        t.variableDeclarator(left.declarations[0].id, t.identifier(id.name)),
       ]);
-      intermediate = t.variableDeclaration("var", [t.variableDeclarator(id)]);
+      intermediate = t.variableDeclaration("var", [
+        t.variableDeclarator(t.identifier(id.name)),
+      ]);
     } else {
       throw file.buildCodeFrameError(
         left,
@@ -264,8 +276,11 @@ export default function(api, options) {
     const left = node.left;
     let declar;
 
-    const stepKey = scope.generateUidIdentifier("step");
-    const stepValue = t.memberExpression(stepKey, t.identifier("value"));
+    const stepKey = scope.generateUid("step");
+    const stepValue = t.memberExpression(
+      t.identifier(stepKey),
+      t.identifier("value"),
+    );
 
     if (
       t.isIdentifier(left) ||
@@ -288,18 +303,14 @@ export default function(api, options) {
       );
     }
 
-    //
-
-    const iteratorKey = scope.generateUidIdentifier("iterator");
-
     const template = buildForOf({
       ITERATOR_HAD_ERROR_KEY: scope.generateUidIdentifier("didIteratorError"),
       ITERATOR_COMPLETION: scope.generateUidIdentifier(
         "iteratorNormalCompletion",
       ),
       ITERATOR_ERROR_KEY: scope.generateUidIdentifier("iteratorError"),
-      ITERATOR_KEY: iteratorKey,
-      STEP_KEY: stepKey,
+      ITERATOR_KEY: scope.generateUidIdentifier("iterator"),
+      STEP_KEY: t.identifier(stepKey),
       OBJECT: node.right,
     });
 

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -25,7 +25,7 @@ export default function(api, options) {
             array = right;
           }
 
-          const item = t.memberExpression(array, t.clone(i), true);
+          const item = t.memberExpression(array, t.cloneNode(i), true);
           let assignment;
           if (t.isVariableDeclaration(left)) {
             assignment = left;
@@ -44,10 +44,10 @@ export default function(api, options) {
               t.variableDeclaration("let", inits),
               t.binaryExpression(
                 "<",
-                t.clone(i),
-                t.memberExpression(t.clone(array), t.identifier("length")),
+                t.cloneNode(i),
+                t.memberExpression(t.cloneNode(array), t.identifier("length")),
               ),
-              t.updateExpression("++", t.clone(i)),
+              t.updateExpression("++", t.cloneNode(i)),
               block,
             ),
           );

--- a/packages/babel-plugin-transform-jscript/src/index.js
+++ b/packages/babel-plugin-transform-jscript/src/index.js
@@ -15,7 +15,7 @@ export default function() {
                 [],
                 t.blockStatement([
                   t.toStatement(node),
-                  t.returnStatement(node.id),
+                  t.returnStatement(t.cloneNode(node.id)),
                 ]),
               ),
               [],

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -68,7 +68,9 @@ export default function(api, options) {
         const members = globalName.split(".");
         globalToAssign = members.slice(1).reduce((accum, curr) => {
           initAssignments.push(
-            buildPrerequisiteAssignment({ GLOBAL_REFERENCE: accum }),
+            buildPrerequisiteAssignment({
+              GLOBAL_REFERENCE: t.cloneNode(accum),
+            }),
           );
           return t.memberExpression(accum, t.identifier(curr));
         }, t.memberExpression(t.identifier("global"), t.identifier(members[0])));

--- a/packages/babel-plugin-transform-new-target/src/index.js
+++ b/packages/babel-plugin-transform-new-target/src/index.js
@@ -54,7 +54,11 @@ export default function() {
 
           path.replaceWith(
             t.conditionalExpression(
-              t.binaryExpression("instanceof", t.thisExpression(), node.id),
+              t.binaryExpression(
+                "instanceof",
+                t.thisExpression(),
+                t.cloneNode(node.id),
+              ),
               constructor,
               scope.buildUndefinedNode(),
             ),

--- a/packages/babel-plugin-transform-object-super/src/index.js
+++ b/packages/babel-plugin-transform-object-super/src/index.js
@@ -39,8 +39,10 @@ export default function() {
         });
 
         if (objectRef) {
-          path.scope.push({ id: objectRef });
-          path.replaceWith(t.assignmentExpression("=", objectRef, path.node));
+          path.scope.push({ id: t.cloneNode(objectRef) });
+          path.replaceWith(
+            t.assignmentExpression("=", t.cloneNode(objectRef), path.node),
+          );
         }
       },
     },

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -69,7 +69,7 @@ export default function convertFunctionParams(path, loose) {
       if (left.isIdentifier()) {
         body.push(
           buildLooseDefaultParam({
-            ASSIGNMENT_IDENTIFIER: left.node,
+            ASSIGNMENT_IDENTIFIER: t.cloneNode(left.node),
             DEFAULT_VALUE: right.node,
             UNDEFINED: undefinedNode,
           }),
@@ -81,7 +81,7 @@ export default function convertFunctionParams(path, loose) {
           buildLooseDestructuredDefaultParam({
             ASSIGNMENT_IDENTIFIER: left.node,
             DEFAULT_VALUE: right.node,
-            PARAMETER_NAME: paramName,
+            PARAMETER_NAME: t.cloneNode(paramName),
             UNDEFINED: undefinedNode,
           }),
         );
@@ -123,7 +123,7 @@ export default function convertFunctionParams(path, loose) {
       ]);
       body.push(defNode);
 
-      param.replaceWith(uid);
+      param.replaceWith(t.cloneNode(uid));
     }
 
     if (!state.iife && !param.isIdentifier()) {

--- a/packages/babel-plugin-transform-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-parameters/src/rest.js
@@ -289,8 +289,7 @@ export default function convertFunctionRest(path) {
   const key = scope.generateUidIdentifier("key");
   const len = scope.generateUidIdentifier("len");
 
-  let arrKey = key;
-  let arrLen = len;
+  let arrKey, arrLen;
   if (node.params.length) {
     // this method has additional params, so we need to subtract
     // the index of the current argument position from the
@@ -308,6 +307,9 @@ export default function convertFunctionRest(path) {
       t.binaryExpression("-", t.cloneNode(len), t.cloneNode(start)),
       t.numericLiteral(0),
     );
+  } else {
+    arrKey = t.identifier(key.name);
+    arrLen = t.identifier(len.name);
   }
 
   const loop = buildRest({

--- a/packages/babel-plugin-transform-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-parameters/src/rest.js
@@ -168,7 +168,11 @@ function optimiseIndexGetter(path, argsId, offset) {
     // Avoid unnecessary '+ 0'
     index = path.parent.property;
   } else {
-    index = t.binaryExpression("+", path.parent.property, offsetLiteral);
+    index = t.binaryExpression(
+      "+",
+      path.parent.property,
+      t.cloneNode(offsetLiteral),
+    );
   }
 
   const { scope } = path;
@@ -180,7 +184,7 @@ function optimiseIndexGetter(path, argsId, offset) {
         ARGUMENTS: argsId,
         OFFSET: offsetLiteral,
         INDEX: index,
-        REF: temp,
+        REF: t.cloneNode(temp),
       }),
     );
   } else {
@@ -262,15 +266,16 @@ export default function convertFunctionRest(path) {
   // There are only "shorthand" references
   if (!state.deopted && !state.references.length) {
     for (const { path, cause } of (state.candidates: Array)) {
+      const clonedArgsId = t.cloneNode(argsId);
       switch (cause) {
         case "indexGetter":
-          optimiseIndexGetter(path, argsId, state.offset);
+          optimiseIndexGetter(path, clonedArgsId, state.offset);
           break;
         case "lengthGetter":
-          optimiseLengthGetter(path, argsId, state.offset);
+          optimiseLengthGetter(path, clonedArgsId, state.offset);
           break;
         default:
-          path.replaceWith(argsId);
+          path.replaceWith(clonedArgsId);
       }
     }
     return true;
@@ -290,7 +295,7 @@ export default function convertFunctionRest(path) {
     // this method has additional params, so we need to subtract
     // the index of the current argument position from the
     // position in the array that we want to populate
-    arrKey = t.binaryExpression("-", key, start);
+    arrKey = t.binaryExpression("-", t.cloneNode(key), t.cloneNode(start));
 
     // we need to work out the size of the array that we're
     // going to store all the rest parameters
@@ -299,8 +304,8 @@ export default function convertFunctionRest(path) {
     // with <0 if there are less arguments than params as it'll
     // cause an error
     arrLen = t.conditionalExpression(
-      t.binaryExpression(">", len, start),
-      t.binaryExpression("-", len, start),
+      t.binaryExpression(">", t.cloneNode(len), t.cloneNode(start)),
+      t.binaryExpression("-", t.cloneNode(len), t.cloneNode(start)),
       t.numericLiteral(0),
     );
   }

--- a/packages/babel-plugin-transform-proto-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-proto-to-assign/src/index.js
@@ -34,8 +34,14 @@ export default function() {
             t.expressionStatement(t.assignmentExpression("=", temp, left)),
           );
         }
-        nodes.push(buildDefaultsCallExpression(path.node, temp || left, file));
-        if (temp) nodes.push(temp);
+        nodes.push(
+          buildDefaultsCallExpression(
+            path.node,
+            t.cloneNode(temp || left),
+            file,
+          ),
+        );
+        if (temp) nodes.push(t.cloneNode(temp));
 
         path.replaceWithMultiple(nodes);
       },

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -63,7 +63,7 @@ export default function(api, options) {
 
         let cached = cache.get(key);
         if (cached) {
-          cached = t.cloneDeep(cached);
+          cached = t.cloneNode(cached);
         } else {
           cached = addDefault(file.path, source, {
             importedInterop: "uncompiled",

--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -107,7 +107,7 @@ export default function(api, options) {
             callee.object = t.assignmentExpression("=", temp, callee.object);
             contextLiteral = temp;
           } else {
-            contextLiteral = t.cloneDeep(callee.object);
+            contextLiteral = t.cloneNode(callee.object);
           }
           t.appendToMemberExpression(callee, t.identifier("apply"));
         } else {

--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -118,7 +118,7 @@ export default function(api, options) {
           contextLiteral = t.thisExpression();
         }
 
-        node.arguments.unshift(contextLiteral);
+        node.arguments.unshift(t.cloneNode(contextLiteral));
       },
 
       NewExpression(path, state) {

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -72,7 +72,7 @@ export default function(api, options) {
 
         let templateObject = this.templates.get(name);
         if (templateObject) {
-          templateObject = t.clone(templateObject);
+          templateObject = t.cloneNode(templateObject);
         } else {
           const programPath = path.find(p => p.isProgram());
           templateObject = programPath.scope.generateUidIdentifier(

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -96,7 +96,10 @@ export default function(api, options) {
         }
 
         path.replaceWith(
-          t.callExpression(node.tag, [templateObject, ...quasi.expressions]),
+          t.callExpression(node.tag, [
+            t.cloneNode(templateObject),
+            ...quasi.expressions,
+          ]),
         );
       },
 

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.js
@@ -48,12 +48,11 @@ export default function() {
         const call = t.callExpression(helper, [node.argument]);
         const arg = path.get("argument");
         if (arg.isIdentifier() && !path.scope.hasBinding(arg.node.name)) {
-          const undefLiteral = t.stringLiteral("undefined");
-          const unary = t.unaryExpression("typeof", node.argument);
+          const unary = t.unaryExpression("typeof", t.cloneNode(node.argument));
           path.replaceWith(
             t.conditionalExpression(
-              t.binaryExpression("===", unary, undefLiteral),
-              undefLiteral,
+              t.binaryExpression("===", unary, t.stringLiteral("undefined")),
+              t.stringLiteral("undefined"),
               call,
             ),
           );

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -114,9 +114,11 @@ export default function() {
             );
           }
 
-          const id = t.identifier(name);
-          const thisDotName = t.memberExpression(t.thisExpression(), id);
-          const assign = t.assignmentExpression("=", thisDotName, id);
+          const assign = t.assignmentExpression(
+            "=",
+            t.memberExpression(t.thisExpression(), t.identifier(name)),
+            t.identifier(name),
+          );
           return t.expressionStatement(assign);
         });
 

--- a/packages/babel-template/src/populate.js
+++ b/packages/babel-template/src/populate.js
@@ -8,7 +8,7 @@ export default function populatePlaceholders(
   metadata: Metadata,
   replacements: TemplateReplacements,
 ): BabelNodeFile {
-  const ast = t.cloneDeep(metadata.ast);
+  const ast = t.cloneNode(metadata.ast);
 
   if (replacements) {
     metadata.placeholders.forEach(placeholder => {
@@ -57,9 +57,9 @@ function applyReplacement(
   // once to avoid injecting the same node multiple times.
   if (placeholder.isDuplicate) {
     if (Array.isArray(replacement)) {
-      replacement = replacement.map(node => t.cloneDeep(node));
+      replacement = replacement.map(node => t.cloneNode(node));
     } else if (typeof replacement === "object") {
-      replacement = t.cloneDeep(replacement);
+      replacement = t.cloneNode(replacement);
     }
   }
 

--- a/packages/babel-traverse/src/path/lib/hoister.js
+++ b/packages/babel-traverse/src/path/lib/hoister.js
@@ -222,6 +222,6 @@ export default class PathHoister {
       uid = t.JSXExpressionContainer(uid);
     }
 
-    this.path.replaceWith(uid);
+    this.path.replaceWith(t.cloneNode(uid));
   }
 }

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -110,9 +110,11 @@ export function insertAfter(nodes) {
     if (this.node) {
       const temp = this.scope.generateDeclaredUidIdentifier();
       nodes.unshift(
-        t.expressionStatement(t.assignmentExpression("=", temp, this.node)),
+        t.expressionStatement(
+          t.assignmentExpression("=", t.cloneNode(temp), this.node),
+        ),
       );
-      nodes.push(t.expressionStatement(temp));
+      nodes.push(t.expressionStatement(t.cloneNode(temp)));
     }
     return this.replaceExpressionWithStatements(nodes);
   } else if (Array.isArray(this.container)) {

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -237,7 +237,9 @@ export function replaceExpressionWithStatements(nodes: Array<Object>) {
       if (!uid) {
         const callee = this.get("callee");
         uid = callee.scope.generateDeclaredUidIdentifier("ret");
-        callee.get("body").pushContainer("body", t.returnStatement(uid));
+        callee
+          .get("body")
+          .pushContainer("body", t.returnStatement(t.cloneNode(uid)));
         loop.setData("expressionReplacementReturnUid", uid);
       } else {
         uid = t.identifier(uid.name);
@@ -245,7 +247,9 @@ export function replaceExpressionWithStatements(nodes: Array<Object>) {
 
       path
         .get("expression")
-        .replaceWith(t.assignmentExpression("=", uid, path.node.expression));
+        .replaceWith(
+          t.assignmentExpression("=", t.cloneNode(uid), path.node.expression),
+        );
     } else {
       path.replaceWith(t.returnStatement(path.node.expression));
     }

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -213,7 +213,7 @@ export default class Scope {
   generateDeclaredUidIdentifier(name: string = "temp") {
     const id = this.generateUidIdentifier(name);
     this.push({ id });
-    return id;
+    return t.cloneNode(id);
   }
 
   /**
@@ -326,7 +326,10 @@ export default class Scope {
       return null;
     } else {
       const id = this.generateUidIdentifierBasedOnNode(node);
-      if (!dontPush) this.push({ id });
+      if (!dontPush) {
+        this.push({ id });
+        return t.cloneNode(id);
+      }
       return id;
     }
   }

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -263,14 +263,7 @@ export default class Scope {
     return `_${id}`;
   }
 
-  /**
-   * Generate a unique identifier based on a node.
-   */
-
-  generateUidIdentifierBasedOnNode(
-    parent: Object,
-    defaultName?: String,
-  ): Object {
+  generateUidBasedOnNode(parent: Object, defaultName?: String) {
     let node = parent;
 
     if (t.isAssignmentExpression(parent)) {
@@ -287,7 +280,18 @@ export default class Scope {
     let id = parts.join("$");
     id = id.replace(/^_/, "") || defaultName || "ref";
 
-    return this.generateUidIdentifier(id.slice(0, 20));
+    return this.generateUid(id.slice(0, 20));
+  }
+
+  /**
+   * Generate a unique identifier based on a node.
+   */
+
+  generateUidIdentifierBasedOnNode(
+    parent: Object,
+    defaultName?: String,
+  ): Object {
+    return t.identifier(this.generateUidBasedOnNode(parent, defaultName));
   }
 
   /**

--- a/packages/babel-types/src/clone/clone.js
+++ b/packages/babel-types/src/clone/clone.js
@@ -1,16 +1,12 @@
 // @flow
 
+import cloneNode from "./cloneNode";
+
 /**
- * Create a shallow clone of a `node` excluding `_private` properties.
+ * Create a shallow clone of a `node`, including only
+ * properties belonging to the node.
+ * @deprecated Use t.cloneNode instead.
  */
 export default function clone<T: Object>(node: T): T {
-  if (!node) return node;
-  const newNode = (({}: any): T);
-
-  Object.keys(node).forEach(key => {
-    if (key[0] === "_") return;
-    newNode[key] = node[key];
-  });
-
-  return newNode;
+  return cloneNode(node, /* deep */ false);
 }

--- a/packages/babel-types/src/clone/cloneDeep.js
+++ b/packages/babel-types/src/clone/cloneDeep.js
@@ -1,28 +1,12 @@
 // @flow
 
+import cloneNode from "./cloneNode";
+
 /**
  * Create a deep clone of a `node` and all of it's child nodes
- * excluding `_private` properties.
+ * including only properties belonging to the node.
+ * @deprecated Use t.cloneNode instead.
  */
 export default function cloneDeep<T: Object>(node: T): T {
-  if (!node) return node;
-  const newNode = (({}: any): T);
-
-  Object.keys(node).forEach(key => {
-    if (key[0] === "_") return;
-
-    let val = node[key];
-
-    if (val) {
-      if (val.type) {
-        val = cloneDeep(val);
-      } else if (Array.isArray(val)) {
-        val = val.map(cloneDeep);
-      }
-    }
-
-    newNode[key] = val;
-  });
-
-  return newNode;
+  return cloneNode(node);
 }

--- a/packages/babel-types/src/clone/cloneNode.js
+++ b/packages/babel-types/src/clone/cloneNode.js
@@ -1,0 +1,69 @@
+import { NODE_FIELDS } from "../definitions";
+
+const has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+function cloneIfNode(obj, deep) {
+  if (
+    obj &&
+    typeof obj.type === "string" &&
+    // CommentLine and CommentBlock are used in File#comments, but they are
+    // not defined in babel-types
+    obj.type !== "CommentLine" &&
+    obj.type !== "CommentBlock"
+  ) {
+    return cloneNode(obj, deep);
+  }
+
+  return obj;
+}
+
+function cloneIfNodeOrArray(obj, deep) {
+  if (Array.isArray(obj)) {
+    return obj.map(node => cloneIfNode(node, deep));
+  }
+  return cloneIfNode(obj, deep);
+}
+
+/**
+ * Create a clone of a `node` including only properties belonging to the node.
+ * If the second parameter is `false`, cloneNode performs a shallow clone.
+ */
+export default function cloneNode<T: Object>(node: T, deep: boolean = true): T {
+  if (!node) return node;
+
+  const { type } = node;
+  const newNode = (({ type }: any): T);
+
+  // Special-case identifiers since they are the most cloned nodes.
+  if (type === "Identifier") {
+    newNode.name = node.name;
+  } else if (!has(NODE_FIELDS, type)) {
+    throw new Error(`Unknown node type: "${type}"`);
+  } else {
+    for (const field of Object.keys(NODE_FIELDS[type])) {
+      if (has(node, field)) {
+        newNode[field] = deep
+          ? cloneIfNodeOrArray(node[field], true)
+          : node[field];
+      }
+    }
+  }
+
+  if (has(node, "loc")) {
+    newNode.loc = node.loc;
+  }
+  if (has(node, "leadingComments")) {
+    newNode.leadingComments = node.leadingComments;
+  }
+  if (has(node, "innerComments")) {
+    newNode.innerComments = node.innerCmments;
+  }
+  if (has(node, "trailingComments")) {
+    newNode.trailingComments = node.trailingComments;
+  }
+  if (has(node, "extra")) {
+    newNode.extra = Object.assign({}, node.extra);
+  }
+
+  return newNode;
+}

--- a/packages/babel-types/src/converters/gatherSequenceExpressions.js
+++ b/packages/babel-types/src/converters/gatherSequenceExpressions.js
@@ -14,6 +14,7 @@ import {
   assignmentExpression,
   conditionalExpression,
 } from "../builders/generated";
+import cloneNode from "../clone/cloneNode";
 
 export default function gatherSequenceExpressions(
   nodes: Array<Object>,
@@ -38,7 +39,7 @@ export default function gatherSequenceExpressions(
         for (const key in bindings) {
           declars.push({
             kind: node.kind,
-            id: bindings[key],
+            id: cloneNode(bindings[key]),
           });
         }
 

--- a/packages/babel-types/src/converters/toKeyAlias.js
+++ b/packages/babel-types/src/converters/toKeyAlias.js
@@ -1,6 +1,6 @@
 // @flow
 import { isIdentifier, isStringLiteral } from "../validators/generated";
-import cloneDeep from "../clone/cloneDeep";
+import cloneNode from "../clone/cloneNode";
 import removePropertiesDeep from "../modifications/removePropertiesDeep";
 
 export default function toKeyAlias(
@@ -16,7 +16,7 @@ export default function toKeyAlias(
   } else if (isStringLiteral(key)) {
     alias = JSON.stringify(key.value);
   } else {
-    alias = JSON.stringify(removePropertiesDeep(cloneDeep(key)));
+    alias = JSON.stringify(removePropertiesDeep(cloneNode(key)));
   }
 
   if (node.computed) {

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -17,6 +17,7 @@ export {
 export * from "./builders/generated";
 
 // clone
+export { default as cloneNode } from "./clone/cloneNode";
 export { default as clone } from "./clone/clone";
 export { default as cloneDeep } from "./clone/cloneDeep";
 export { default as cloneWithoutLoc } from "./clone/cloneWithoutLoc";

--- a/packages/babel-types/test/cloning.js
+++ b/packages/babel-types/test/cloning.js
@@ -2,68 +2,61 @@ import * as t from "../lib";
 import assert from "assert";
 import { parse } from "babylon";
 
-suite("cloning", function() {
-  suite("clone", function() {
-    it("should handle undefined", function() {
-      const node = undefined;
-      const cloned = t.clone(node);
-      assert(cloned === undefined);
-    });
-
-    it("should handle null", function() {
-      const node = null;
-      const cloned = t.clone(node);
-      assert(cloned === null);
-    });
-
-    it("should handle simple cases", function() {
-      const node = t.arrayExpression([null, t.identifier("a")]);
-      const cloned = t.clone(node);
-      assert(node !== cloned);
-      assert(t.isNodesEquivalent(node, cloned) === true);
-    });
+suite("cloneNode", function() {
+  it("should handle undefined", function() {
+    const node = undefined;
+    const cloned = t.cloneNode(node);
+    assert(cloned === undefined);
   });
 
-  suite("cloneDeep", function() {
-    it("should handle undefined", function() {
-      const node = undefined;
-      const cloned = t.cloneDeep(node);
-      assert(cloned === undefined);
-    });
+  it("should handle null", function() {
+    const node = null;
+    const cloned = t.cloneNode(node);
+    assert(cloned === null);
+  });
 
-    it("should handle null", function() {
-      const node = null;
-      const cloned = t.cloneDeep(node);
-      assert(cloned === null);
-    });
+  it("should handle simple cases", function() {
+    const node = t.identifier("a");
+    const cloned = t.cloneNode(node);
+    assert(node !== cloned);
+    assert(t.isNodesEquivalent(node, cloned) === true);
+  });
 
-    it("should handle simple cases", function() {
-      const node = t.arrayExpression([null, t.identifier("a")]);
-      const cloned = t.cloneDeep(node);
-      assert(node !== cloned);
-      assert(t.isNodesEquivalent(node, cloned) === true);
-    });
+  it("should handle full programs", function() {
+    const file = parse("1 + 1");
+    const cloned = t.cloneNode(file);
+    assert(file !== cloned);
+    assert(
+      file.program.body[0].expression.right !==
+        cloned.program.body[0].expression.right,
+    );
+    assert(
+      file.program.body[0].expression.left !==
+        cloned.program.body[0].expression.left,
+    );
+    assert(t.isNodesEquivalent(file, cloned) === true);
+  });
 
-    it("should handle full programs", function() {
-      const node = parse("1 + 1");
-      const cloned = t.cloneDeep(node);
-      assert(node !== cloned);
-      assert(t.isNodesEquivalent(node, cloned) === true);
-    });
+  it("should handle complex programs", function() {
+    const program = "'use strict'; function lol() { wow();return 1; }";
+    const node = parse(program);
+    const cloned = t.cloneNode(node);
+    assert(node !== cloned);
+    assert(t.isNodesEquivalent(node, cloned) === true);
+  });
 
-    it("should handle complex programs", function() {
-      const program = "'use strict'; function lol() { wow();return 1; }";
-      const node = parse(program);
-      const cloned = t.cloneDeep(node);
-      assert(node !== cloned);
-      assert(t.isNodesEquivalent(node, cloned) === true);
-    });
+  it("should handle missing array element", function() {
+    const node = parse("[,0]");
+    const cloned = t.cloneNode(node);
+    assert(node !== cloned);
+    assert(t.isNodesEquivalent(node, cloned) === true);
+  });
 
-    it("should handle missing array element", function() {
-      const node = parse("[,0]");
-      const cloned = t.cloneDeep(node);
-      assert(node !== cloned);
-      assert(t.isNodesEquivalent(node, cloned) === true);
-    });
+  it("should support shallow cloning", function() {
+    const node = t.memberExpression(t.identifier("foo"), t.identifier("bar"));
+    const cloned = t.cloneNode(node, /* deep */ false);
+    assert.notStrictEqual(node, cloned);
+    assert.strictEqual(node.object, cloned.object);
+    assert.strictEqual(node.property, cloned.property);
   });
 });


### PR DESCRIPTION
Unfortunately this PR won't be easy to review :slightly_frowning_face: 

Anyway, currently there are 604 failing tests :stuck_out_tongue_closed_eyes: 

I had to add some logic do skip validating nodes generated by regenerator-transform, since it isn't in this repository and it duplicates *a lot* of nodes.

cc @Andarist @existentialism 
  
Closes #6375 