### PR TITLE
Add basic support for await with the pipeline operator

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -13,6 +13,7 @@ const awaitVisitor = {
 
   AwaitExpression(path, { wrapAwait }) {
     const argument = path.get("argument");
+    argument.node.__wasAwait = true;
 
     if (path.parentPath.isYieldExpression()) {
       path.replaceWith(argument.node);

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -15,7 +15,10 @@ export default function() {
 
         let optimizeArrow =
           t.isArrowFunctionExpression(right) && t.isExpression(right.body);
-        const wasAwait = right.argument && right.argument.__wasAwait;
+        const wasAwait =
+          t.isYieldExpression(right) &&
+          right.argument &&
+          right.argument.__wasAwait;
         const isAwait = t.isAwaitExpression(right) || wasAwait;
         let param;
 

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -15,8 +15,8 @@ export default function() {
 
         let optimizeArrow =
           t.isArrowFunctionExpression(right) && t.isExpression(right.body);
-        const isAwait = t.isAwaitExpression(right);
-        const isYield = t.isYieldExpression(right);
+        const wasAwait = right.argument && right.argument.__wasAwait;
+        const isAwait = t.isAwaitExpression(right) || wasAwait;
         let param;
 
         if (optimizeArrow) {
@@ -26,7 +26,7 @@ export default function() {
           } else if (params.length > 0) {
             optimizeArrow = false;
           }
-        } else if (isAwait || isYield) {
+        } else if (isAwait) {
           right.argument = t.sequenceExpression([
             t.numericLiteral(0),
             right.argument,
@@ -51,8 +51,8 @@ export default function() {
 
         const call = optimizeArrow
           ? right.body
-          : isAwait || isYield
-            ? t[isAwait ? "awaitExpression" : "yieldExpression"](
+          : isAwait
+            ? t[wasAwait ? "yieldExpression" : "awaitExpression"](
                 t.callExpression(right.argument, [placeholder]),
               )
             : t.callExpression(right, [placeholder]);

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -16,6 +16,7 @@ export default function() {
         let optimizeArrow =
           t.isArrowFunctionExpression(right) && t.isExpression(right.body);
         const isAwait = t.isAwaitExpression(right);
+        const isYield = t.isYieldExpression(right);
         let param;
 
         if (optimizeArrow) {
@@ -25,7 +26,7 @@ export default function() {
           } else if (params.length > 0) {
             optimizeArrow = false;
           }
-        } else if (isAwait) {
+        } else if (isAwait || isYield) {
           right.argument = t.sequenceExpression([
             t.numericLiteral(0),
             right.argument,
@@ -50,8 +51,10 @@ export default function() {
 
         const call = optimizeArrow
           ? right.body
-          : isAwait
-            ? t.awaitExpression(t.callExpression(right.argument, [placeholder]))
+          : isAwait || isYield
+            ? t[isAwait ? "awaitExpression" : "yieldExpression"](
+                t.callExpression(right.argument, [placeholder]),
+              )
             : t.callExpression(right, [placeholder]);
         path.replaceWith(
           t.sequenceExpression([

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/actual.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/actual.js
@@ -1,0 +1,5 @@
+var incPromise = (x) => Promise.resolve(x + 1);
+var double = (x) => x * 2;
+
+var result = async () => 10 |> await incPromise;
+var result2 = async () => 10 |> await incPromise |> double;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/actual.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/actual.js
@@ -1,5 +1,10 @@
 var incPromise = (x) => Promise.resolve(x + 1);
+var incFuncPromise = Promise.resolve(x => x + 10);
 var double = (x) => x * 2;
 
 var result = async () => 10 |> await incPromise;
 var result2 = async () => 10 |> await incPromise |> double;
+
+function* foo() {
+  return 42 |> (yield incFuncPromise);
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/actual.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/actual.js
@@ -1,10 +1,9 @@
 var incPromise = (x) => Promise.resolve(x + 1);
-var incFuncPromise = Promise.resolve(x => x + 10);
 var double = (x) => x * 2;
 
 var result = async () => 10 |> await incPromise;
 var result2 = async () => 10 |> await incPromise |> double;
 
 function* foo() {
-  return 42 |> (yield incFuncPromise);
+  return 42 |> (yield 10);
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
@@ -1,10 +1,20 @@
 var incPromise = x => Promise.resolve(x + 1);
+var incFuncPromise = Promise.resolve(x => x + 10);
 var double = x => x * 2;
 
 var result = async () => 10 |> await incPromise;
 var result2 = async () => 10 |> await incPromise |> double;
 
+function* foo() {
+  return 42 |> (yield 10);
+}
+
+var fooGen;
 return Promise.all([result(), result2()]).then(([r, r2]) => {
   assert.equal(r, 11);
   assert.equal(r2, 22);
+
+  fooGen = foo();
+  var amount = fooGen.next().value;
+  assert.equal(fooGen.next(x => x + amount).value, 52);
 });

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
@@ -10,7 +10,9 @@ function* foo() {
 }
 
 var fooGen;
-return Promise.all([result(), result2()]).then(([r, r2]) => {
+return Promise.all([result(), result2()]).then((results) => {
+  var r = results[0];
+  var r2 = results[1];
   assert.equal(r, 11);
   assert.equal(r2, 22);
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
@@ -1,0 +1,10 @@
+var incPromise = x => Promise.resolve(x + 1);
+var double = x => x * 2;
+
+var result = async () => 10 |> await incPromise;
+var result2 = async () => 10 |> await incPromise |> double;
+
+return Promise.all([result(), result2()]).then(([r, r2]) => {
+  assert.equal(r, 11);
+  assert.equal(r2, 22);
+});

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
@@ -1,6 +1,5 @@
-var incPromise = x => Promise.resolve(x + 1);
-var incFuncPromise = Promise.resolve(x => x + 10);
-var double = x => x * 2;
+var incPromise = (x) => Promise.resolve(x + 1);
+var double = (x) => x * 2;
 
 var result = async () => 10 |> await incPromise;
 var result2 = async () => 10 |> await incPromise |> double;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/exec.js
@@ -9,14 +9,13 @@ function* foo() {
   return 42 |> (yield 10);
 }
 
-var fooGen;
 return Promise.all([result(), result2()]).then((results) => {
   var r = results[0];
   var r2 = results[1];
   assert.equal(r, 11);
   assert.equal(r2, 22);
 
-  fooGen = foo();
+  var fooGen = foo();
   var amount = fooGen.next().value;
   assert.equal(fooGen.next(x => x + amount).value, 52);
 });

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/expected.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/expected.js
@@ -1,0 +1,31 @@
+var incPromise = x => Promise.resolve(x + 1);
+
+var double = x => x * 2;
+
+var result =
+/*#__PURE__*/
+function () {
+  var _ref = babelHelpers.asyncToGenerator(function* () {
+    var _;
+
+    return _ = 10, yield (0, incPromise)(_);
+  });
+
+  return function result() {
+    return _ref.apply(this, arguments);
+  };
+}();
+
+var result2 =
+/*#__PURE__*/
+function () {
+  var _ref2 = babelHelpers.asyncToGenerator(function* () {
+    var _ref3, _2;
+
+    return _ref3 = (_2 = 10, yield (0, incPromise)(_2)), double(_ref3);
+  });
+
+  return function result2() {
+    return _ref2.apply(this, arguments);
+  };
+}();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/expected.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/expected.js
@@ -1,5 +1,7 @@
 var incPromise = x => Promise.resolve(x + 1);
 
+var incFuncPromise = Promise.resolve(x => x + 10);
+
 var double = x => x * 2;
 
 var result =
@@ -29,3 +31,9 @@ function () {
     return _ref2.apply(this, arguments);
   };
 }();
+
+function* foo() {
+  var _3;
+
+  return _3 = 42, (yield incFuncPromise)(_3);
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/expected.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/expected.js
@@ -1,7 +1,5 @@
 var incPromise = x => Promise.resolve(x + 1);
 
-var incFuncPromise = Promise.resolve(x => x + 10);
-
 var double = x => x * 2;
 
 var result =
@@ -35,5 +33,5 @@ function () {
 function* foo() {
   var _3;
 
-  return _3 = 42, (yield incFuncPromise)(_3);
+  return _3 = 42, (yield 10)(_3);
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async-with-transform-async/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["proposal-pipeline-operator", "external-helpers", "transform-async-to-generator"],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/actual.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/actual.js
@@ -1,0 +1,5 @@
+var incPromise = (x) => Promise.resolve(x + 1);
+var double = (x) => x * 2;
+
+var result = async () => 10 |> await incPromise;
+var result2 = async () => 10 |> await incPromise |> double;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/exec.js
@@ -1,0 +1,10 @@
+var incPromise = x => Promise.resolve(x + 1);
+var double = x => x * 2;
+
+var result = async () => 10 |> await incPromise;
+var result2 = async () => 10 |> await incPromise |> double;
+
+return Promise.all([result(), result2()]).then(([r, r2]) => {
+  assert.equal(r, 11);
+  assert.equal(r2, 22);
+});

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/expected.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/expected.js
@@ -1,0 +1,15 @@
+var incPromise = x => Promise.resolve(x + 1);
+
+var double = x => x * 2;
+
+var result = async () => {
+  var _;
+
+  return _ = 10, await (0, incPromise)(_);
+};
+
+var result2 = async () => {
+  var _ref, _2;
+
+  return _ref = (_2 = 10, await (0, incPromise)(_2)), double(_ref);
+};

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/options.json
@@ -1,4 +1,5 @@
 {
+  "minNodeVersion": "7.6.0",
   "parserOpts": {
     "allowReturnOutsideFunction": true
   }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/async/options.json
@@ -1,0 +1,5 @@
+{
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/6889
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This correctly transforms `AwaitExpression`s which appear in pipelines, as shown [here](https://github.com/tc39/proposal-pipeline-operator#use-of-await). It does not support standalone `await` keywords, as was the case in earlier versions of the proposal.