### PR TITLE
Fixes React isCompatTag validator accepting leading dash character

### DIFF
--- a/packages/babel-types/src/validators/react/isCompatTag.js
+++ b/packages/babel-types/src/validators/react/isCompatTag.js
@@ -1,4 +1,5 @@
 // @flow
 export default function isCompatTag(tagName?: string): boolean {
-  return !!tagName && /^[a-z]|-/.test(tagName);
+  // Must start with a lowercase ASCII letter
+  return !!tagName && /^[a-z]/.test(tagName);
 }

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -32,6 +32,52 @@ suite("validators", function() {
     });
   });
 
+  suite("isCompatTag", function() {
+    it("should handle lowercase tag names", function() {
+      assert(t.react.isCompatTag("div"));
+      assert(t.react.isCompatTag("a")); // one letter
+      assert(t.react.isCompatTag("h3")); // letters and numbers
+    });
+
+    it("should handle custom element tag names", function() {
+      assert(t.react.isCompatTag("plastic-button")); // ascii letters
+      assert(t.react.isCompatTag("math-α")); // non-latin chars
+      assert(t.react.isCompatTag("img-viewer2")); // numbers
+      assert(t.react.isCompatTag("emotion-😍")); // emoji
+    });
+
+    it("accepts trailing dash '-' in custom element tag names", function() {
+      assert(t.react.isCompatTag("div-"));
+      assert(t.react.isCompatTag("a-"));
+      assert(t.react.isCompatTag("h3-"));
+    });
+
+    it("rejects empty or null tag names", function() {
+      assert(t.react.isCompatTag(null) === false);
+      assert(t.react.isCompatTag() === false);
+      assert(t.react.isCompatTag(undefined) === false);
+      assert(t.react.isCompatTag("") === false);
+    });
+
+    it("rejects tag names starting with an uppercase letter", function() {
+      assert(t.react.isCompatTag("Div") === false);
+      assert(t.react.isCompatTag("A") === false);
+      assert(t.react.isCompatTag("H3") === false);
+    });
+
+    it("rejects all uppercase tag names", function() {
+      assert(t.react.isCompatTag("DIV") === false);
+      assert(t.react.isCompatTag("A") === false);
+      assert(t.react.isCompatTag("H3") === false);
+    });
+
+    it("rejects leading dash '-'", function() {
+      assert(t.react.isCompatTag("-div") === false);
+      assert(t.react.isCompatTag("-a") === false);
+      assert(t.react.isCompatTag("-h3") === false);
+    });
+  });
+
   suite("patterns", function() {
     it("allows nested pattern structures", function() {
       const pattern = t.objectPattern([


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7163
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes + Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixed regexp test in `isCompatTag` React validator allowing leading dash `'-'` characters.

Was:
```
/^[a-z]|-/.test(tagName)
```

Is:
```
// Must start with a lowercase ASCII letter
/^[a-z]/.test(tagName)
```

  