### PR TITLE
Preserve namespaced attributes when throwIfNamespace is false

### DIFF
--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -92,7 +92,11 @@ You can turn on the 'throwIfNamespace' flag to bypass this warning.`,
     if (t.isValidIdentifier(node.name.name)) {
       node.name.type = "Identifier";
     } else {
-      node.name = t.stringLiteral(node.name.name);
+      node.name = t.stringLiteral(
+        t.isJSXNamespacedName(node.name)
+          ? node.name.namespace.name + ":" + node.name.name.name
+          : node.name.name,
+      );
     }
 
     return t.inherits(t.objectProperty(node.name, value), node);

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-support-xml-namespaces-if-flag/actual.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-support-xml-namespaces-if-flag/actual.js
@@ -1,1 +1,1 @@
-<f:image />;
+<f:image n:attr />;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-support-xml-namespaces-if-flag/expected.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-support-xml-namespaces-if-flag/expected.js
@@ -1,1 +1,3 @@
-h("f:image", null);
+h("f:image", {
+  "n:attr": true
+});


### PR DESCRIPTION
Previously, when using a namespaced attribute, that [part](https://github.com/babel/babel/blob/a19349a22a0c7ca04b2ee0d3c26d46fd39e88e34/packages/babel-helper-builder-react-jsx/src/index.js#L95) would throw since it expects a JSXIdentifier but it (logically) gets a JSXNamespacedName 

*Minor feature, test added, tests & lint passed.*
