### PR TITLE
Remove "quotes" internal flag from babel-generator

### DIFF
--- a/packages/babel-generator/src/generators/types.js
+++ b/packages/babel-generator/src/generators/types.js
@@ -124,7 +124,7 @@ export function NumericLiteral(node: Object) {
   }
 }
 
-export function StringLiteral(node: Object, parent: Object) {
+export function StringLiteral(node: Object) {
   const raw = this.getPossibleRaw(node);
   if (!this.format.minified && raw != null) {
     this.token(raw);
@@ -133,7 +133,7 @@ export function StringLiteral(node: Object, parent: Object) {
 
   // ensure the output is ASCII-safe
   const opts = {
-    quotes: t.isJSX(parent) ? "double" : this.format.quotes,
+    quotes: "double",
     wrap: true,
   };
   if (this.format.jsonCompatibleStrings) {

--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -46,7 +46,6 @@ function normalizeOptions(code, opts): Format {
     compact: opts.compact,
     minified: opts.minified,
     concise: opts.concise,
-    quotes: "double",
     jsonCompatibleStrings: opts.jsonCompatibleStrings,
     indent: {
       adjustMultilineComment: true,

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -19,7 +19,6 @@ export type Format = {
   auxiliaryCommentAfter: string,
   compact: boolean | "auto",
   minified: boolean,
-  quotes: "single" | "double",
   concise: boolean,
   indent: {
     adjustMultilineComment: boolean,


### PR DESCRIPTION
It was missed in https://github.com/babel/babel/pull/5824