### PR TITLE
Add eslint plugin to disallow `t.clone` and `t.cloneDeep`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,8 @@
         "codemods/*/src/**/*.js"
       ],
       "rules": {
-        "no-undefined-identifier": "error"
+        "no-undefined-identifier": "error",
+        "no-deprecated-clone": "error"
       }
     },
     {

--- a/scripts/eslint_rules/no-deprecated-clone.js
+++ b/scripts/eslint_rules/no-deprecated-clone.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const isInIncludedFolder = filename => {
+  return /(?:packages|codemods|experimental)\/babel-/.test(filename);
+};
+
+const message =
+  "t.clone() and t.cloneDeep() are deprecated. Use t.cloneNode() instead.";
+
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  fixable: "code",
+  create(context) {
+    if (!isInIncludedFolder(context.getFilename())) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+
+        if (callee.type !== "MemberExpression") return;
+        if (callee.computed) return;
+
+        const object = callee.object;
+        if (object.type !== "Identifier" || object.name !== "t") return;
+
+        const property = callee.property;
+        if (property.type !== "Identifier") return;
+        if (property.name !== "clone" && property.name !== "cloneDeep") return;
+
+        context.report({
+          node,
+          message,
+          fix(fixer) {
+            fixer.replaceText(property, "cloneNode");
+          },
+        });
+      },
+    };
+  },
+};

--- a/scripts/eslint_rules/no-deprecated-clone.js
+++ b/scripts/eslint_rules/no-deprecated-clone.js
@@ -1,44 +1,129 @@
+// @flow
+
 "use strict";
 
-const isInIncludedFolder = filename => {
-  return /(?:packages|codemods|experimental)\/babel-/.test(filename);
-};
+function getVariableDefinition(name /*: string */, scope /*: Scope */) {
+  let currentScope = scope;
+  do {
+    const variable = currentScope.set.get(name);
+    if (variable) return variable.defs[0];
+  } while ((currentScope = currentScope.upper));
+}
 
-const message =
-  "t.clone() and t.cloneDeep() are deprecated. Use t.cloneNode() instead.";
+function isImportedFrom(
+  node /*: Node */,
+  scope /*: Scope */,
+  module /*: string */,
+  kind /*: "named" | "namespace" */
+) {
+  const definition = getVariableDefinition(node.name, scope);
+  if (!definition) return false;
+
+  if (
+    definition.type === "ImportBinding" &&
+    definition.parent.source.value === module
+  ) {
+    if (kind === "named") {
+      return definition.node.type === "ImportSpecifier";
+    }
+    if (kind === "namespace") {
+      return definition.node.type === "ImportNamespaceSpecifier";
+    }
+  }
+
+  return false;
+}
+
+function isIdentifier(node /*: Node */, name /*?: string */) {
+  return node.type === "Identifier" && (!name || node.name === name);
+}
+
+function isDeprecatedFunctionId(node /*: Node */) {
+  return isIdentifier(node, "clone") || isIdentifier(node, "cloneDeep");
+}
 
 module.exports = {
   meta: {
     schema: [],
+    fixable: "code",
   },
-  fixable: "code",
-  create(context) {
-    if (!isInIncludedFolder(context.getFilename())) {
-      return {};
-    }
-
+  create(context /*: Context */) {
     return {
-      CallExpression(node) {
-        const callee = node.callee;
+      CallExpression(node /*: Node */) {
+        const callee /*: Node */ = node.callee;
 
-        if (callee.type !== "MemberExpression") return;
-        if (callee.computed) return;
+        let maybeDeprecatedIdentifier /*: ?Node */;
 
-        const object = callee.object;
-        if (object.type !== "Identifier" || object.name !== "t") return;
+        if (
+          isDeprecatedFunctionId(callee) &&
+          isImportedFrom(callee, context.getScope(), "@babel/types", "named")
+        ) {
+          maybeDeprecatedIdentifier = callee;
+        }
 
-        const property = callee.property;
-        if (property.type !== "Identifier") return;
-        if (property.name !== "clone" && property.name !== "cloneDeep") return;
+        if (callee.type === "MemberExpression" && isIdentifier(callee.object)) {
+          if (
+            isDeprecatedFunctionId(callee.property) &&
+            isImportedFrom(
+              callee.object,
+              context.getScope(),
+              "@babel/types",
+              "namespace"
+            )
+          ) {
+            maybeDeprecatedIdentifier = callee.property;
+          }
+        }
 
-        context.report({
-          node,
-          message,
-          fix(fixer) {
-            fixer.replaceText(property, "cloneNode");
-          },
-        });
+        if (maybeDeprecatedIdentifier) {
+          // This is needed because type refinements are lost inside callbacks.
+          const deprecatedIdentifier /*: Node */ = maybeDeprecatedIdentifier;
+
+          context.report({
+            node,
+            message:
+              "t.clone() and t.cloneDeep() are deprecated. " +
+              "Use t.cloneNode() instead.",
+            fix(fixer) {
+              return fixer.replaceText(deprecatedIdentifier, "cloneNode");
+            },
+          });
+        }
       },
     };
   },
 };
+
+/*:: // ESLint types
+
+type Node = { type: string, [string]: any };
+
+type Definition = {
+  type: "ImportedBinding",
+  node: Node,
+  parent: Node,
+};
+
+type Variable = {
+  defs: Definition[],
+};
+
+type Scope = {
+  set: Map<string, Variable>,
+  upper: ?Scope,
+};
+
+type Context = {
+  report(options: {
+    node: Node,
+    message: string,
+    fix?: (fixer: Fixer) => Fixer,
+  }): void,
+
+  getScope(): Scope,
+};
+
+type Fixer = {
+  replaceText(node: Node, replacement: string): Fixer,
+};
+*/

--- a/scripts/eslint_rules/no-deprecated-clone.js
+++ b/scripts/eslint_rules/no-deprecated-clone.js
@@ -6,7 +6,9 @@ function getVariableDefinition(name /*: string */, scope /*: Scope */) {
   let currentScope = scope;
   do {
     const variable = currentScope.set.get(name);
-    if (variable) return { scope: currentScope, definition: variable.defs[0] };
+    if (variable && variable.defs[0]) {
+      return { scope: currentScope, definition: variable.defs[0] };
+    }
   } while ((currentScope = currentScope.upper));
 }
 
@@ -165,13 +167,13 @@ function getPatternPath(node /*: Node */) /*: ?string[] */ {
 
 function reportError(context /*: Context */, node /*: Node */) {
   const isMemberExpression = node.type === "MemberExpression";
+  const id = isMemberExpression ? node.property : node;
   context.report({
-    node: isMemberExpression ? node.property : node,
-    message:
-      "t.clone() and t.cloneDeep() are deprecated. Use t.cloneNode() instead.",
+    node: id,
+    message: `t.${id.name}() is deprecated. Use t.cloneNode() instead.`,
     fix(fixer) {
       if (isMemberExpression) {
-        return fixer.replaceText(node.property, "cloneNode");
+        return fixer.replaceText(id, "cloneNode");
       }
     },
   });


### PR DESCRIPTION
Follow up to https://github.com/babel/babel/pull/7149

I made this rule autofixable.