### PR TITLE
[babel-generator] Add check for undefined endToken in whitespace

### DIFF
--- a/packages/babel-generator/src/whitespace.js
+++ b/packages/babel-generator/src/whitespace.js
@@ -41,7 +41,7 @@ export default class Whitespace {
       while (index && node.end === tokens[index - 1].end) --index;
       startToken = tokens[index];
       endToken = tokens[index + 1];
-      if (endToken.type.label === ",") endToken = tokens[index + 2];
+      if (endToken && endToken.type.label === ",") endToken = tokens[index + 2];
     }
 
     if (endToken && endToken.type.label === "eof") {

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -291,6 +291,14 @@ describe("whitespace", function () {
     const w = new Whitespace([]);
     assert.equal(w.getNewlinesBefore(t.stringLiteral("1")), 0);
   });
+  it("handles getNewlinesAfter EOF node", function () {
+    const w = new Whitespace([{
+      type : { label : "eof" },
+      start: 446,
+      end: 446,
+    }]);
+    assert.equal(w.getNewlinesAfter({ end : 446 }), 0);
+  });
 });
 
 const suites = fixtures(`${__dirname}/fixtures`);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT


Hi ! 👋 

In some weird cases, in the following method in ```src/whitespace.js``` : 

```javascript
  getNewlinesAfter(node) {
    let startToken;
    let endToken;
    const tokens = this.tokens;

    let index = this._findToken((token) => token.end - node.end, 0, tokens.length);
    if (index >= 0) {
      while (index && node.end === tokens[index - 1].end) --index;
      startToken = tokens[index];
      endToken = tokens[index + 1];
     // endToken can be undefined if startToken is EOF
      if (endToken.type.label === ",") endToken = tokens[index + 2];
    }

    if (endToken && endToken.type.label === "eof") {
      return 1;
    } else {
      return this._getNewlinesBetween(startToken, endToken);
    }
  }
```

`startToken` can be an `EOF` which leads to `endToken` being `undefined` and the following error : 

```
error: bundling failed: TypeError: Cannot read property 'type' of undefined
    at Whitespace.getNewlinesAfter (/home/user/app/node_modules/babel-generator/lib/whitespace.js:59:20)
    at Generator._printNewline (/home/user/app/node_modules/babel-generator/lib/printer.js:459:34)
    at Generator.printJoin (/home/user/app/node_modules/babel-generator/lib/printer.js:376:32)
    at Generator.printList (/home/user/app/node_modules/babel-generator/lib/printer.js:430:17)
    at Generator.ObjectExpression (/home/user/app/node_modules/babel-generator/lib/generators/types.js:57:10)
    at /home/user/app/node_modules/babel-generator/lib/printer.js:298:23
    at Buffer.withSource (/home/user/app/node_modules/babel-generator/lib/buffer.js:168:5)
    at Generator.withSource (/home/user/app/node_modules/babel-generator/lib/printer.js:189:15)
    at Generator.print (/home/user/app/node_modules/babel-generator/lib/printer.js:297:10)
```

To avoid this issue, this PR adds an undefined check.

You can look into this issue for reference : https://github.com/detrohutt/babel-plugin-inline-import-graphql-ast/issues/2.

You can find a small [reproduction](https://github.com/real34/tmp-babel-inline-gql-issue4) and a [video](https://www.dropbox.com/s/dwcce8skh5eafus/screencast_00000.mp4?dl=0
) showing this weird behavior.






