### PR TITLE
Fixed _containerInsertAfter setting path key as stringified index

### DIFF
--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/input.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/input.js
@@ -1,0 +1,5 @@
+const title = "Neem contact op";
+
+async function action() {
+  return <Contact title={title} />;
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/options.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "external-helpers",
+    "transform-async-to-generator",
+    "transform-react-jsx",
+    "transform-react-constant-elements"
+  ]
+}

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
@@ -1,0 +1,16 @@
+const title = "Neem contact op";
+
+function action() {
+  return _action.apply(this, arguments);
+}
+
+var _ref = React.createElement(Contact, {
+  title: title
+});
+
+function _action() {
+  _action = babelHelpers.asyncToGenerator(function* () {
+    return _ref;
+  });
+  return _action.apply(this, arguments);
+}

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -56,7 +56,7 @@ export function _containerInsert(from, nodes) {
   this.container.splice(from, 0, ...nodes);
   for (let i = 0; i < nodes.length; i++) {
     const to = from + i;
-    const path = this.getSibling(`${to}`);
+    const path = this.getSibling(to);
     paths.push(path);
 
     if (this.context && this.context.queue) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7178
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

This caused paths being not requeued later, when something was i.e. insertedBefore a damaged path - while the insertion worked, the inserted path was not requeued and missed by subsequent traversals.

cc @jorrit @Imundy 