### PR TITLE
bugfix: set color level when color is forced

### DIFF
--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -190,7 +190,7 @@ export function codeFrameColumns(
     (opts.highlightCode && Chalk.supportsColor) || opts.forceColor;
   let chalk = Chalk;
   if (opts.forceColor) {
-    chalk = new Chalk.constructor({ enabled: true });
+    chalk = new Chalk.constructor({ enabled: true, level: 1 });
   }
   const maybeHighlight = (chalkFn, string) => {
     return highlighted ? chalkFn(string) : string;


### PR DESCRIPTION
This fixes a bug introduced when the package was upgraded to `chalk@^2`.

Chalk 2 detects color support and level separately, so you must set enabled and level to gain color in a non-terminal environment.