### PR TITLE
Fix up flow errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,8 +13,8 @@ codemods/*/src
 [libs]
 lib/file.js
 lib/parser.js
-lib/packages/babel-types/lib/index.js.flow
 lib/third-party-libs.js.flow
+packages/babel-types/lib/index.js.flow
 
 [options]
 include_warnings=true

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bundle-collapser": "^1.2.1",
     "chai": "^4.1.0",
     "chalk": "^2.0.0",
-    "charcodes": "0.0.10",
+    "charcodes": "0.1.0",
     "derequire": "^2.0.2",
     "eslint": "^4.5.0",
     "eslint-config-babel": "^7.0.2",

--- a/packages/babel-template/src/formatters.js
+++ b/packages/babel-template/src/formatters.js
@@ -12,7 +12,7 @@ function makeStatementFormatter<T>(
   return {
     // We need to prepend a ";" to force statement parsing so that
     // ExpressionStatement strings won't be parsed as directives.
-    // Alonside that, we also prepend a comment so that when a syntax error
+    // Alongside that, we also prepend a comment so that when a syntax error
     // is encountered, the user will be less likely to get confused about
     // where the random semicolon came from.
     code: str => `/* @babel/template */;\n${str}`,
@@ -54,16 +54,17 @@ export const statement: Formatter<BabelNodeStatement> = makeStatementFormatter(
 
 export const expression: Formatter<BabelNodeExpression> = {
   code: str => `(\n${str}\n)`,
-  validate: (ast: BabelNodeFile) => {
-    const { program } = ast;
+  validate: ({ program }) => {
     if (program.body.length > 1) {
       throw new Error("Found multiple statements but wanted one");
     }
+    // $FlowFixMe
     const expression = program.body[0].expression;
     if (expression.start === 0) {
       throw new Error("Parse result included parens.");
     }
   },
+  // $FlowFixMe
   unwrap: ast => ast.program.body[0].expression,
 };
 

--- a/packages/babel-types/src/definitions/utils.js
+++ b/packages/babel-types/src/definitions/utils.js
@@ -21,10 +21,10 @@ function getType(val) {
 }
 
 // TODO: Import and use Node instead of any
-opaque type Validator = (any, string, any) => void;
+type Validator = (any, string, any) => void;
 
 type FieldOptions = {
-  default?: boolean,
+  default?: any,
   optional?: boolean,
   validate?: Validator,
 };

--- a/packages/babylon/package.json
+++ b/packages/babylon/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@babel/helper-fixtures": "7.0.0-beta.40",
-    "charcodes": "0.0.10",
+    "charcodes": "0.1.0",
     "unicode-10.0.0": "^0.7.4"
   },
   "bin": {

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -426,7 +426,10 @@ export default class ExpressionParser extends LValParser {
     startLoc: Position,
     noCalls?: ?boolean,
   ): N.Expression {
-    const state = { stop: false };
+    const state = {
+      optionalChainMember: false,
+      stop: false,
+    };
     do {
       base = this.parseSubscript(base, startPos, startLoc, noCalls, state);
     } while (!state.stop);
@@ -439,7 +442,7 @@ export default class ExpressionParser extends LValParser {
     startPos: number,
     startLoc: Position,
     noCalls: ?boolean,
-    state: { stop: boolean, optionalChainMember?: boolean },
+    state: N.ParseSubscriptState,
   ): N.Expression {
     if (!noCalls && this.eat(tt.doubleColon)) {
       const node = this.startNodeAt(startPos, startLoc);

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -557,14 +557,13 @@ export default class ExpressionParser extends LValParser {
       const node = this.startNodeAt(startPos, startLoc);
       node.tag = base;
       node.quasi = this.parseTemplate(true);
-      if (!state.optionalChainMember) {
-        return this.finishNode(node, "TaggedTemplateExpression");
-      } else {
+      if (state.optionalChainMember) {
         this.raise(
           startPos,
           "Tagged Template Literals are not allowed in optionalChain",
         );
       }
+      return this.finishNode(node, "TaggedTemplateExpression");
     } else {
       state.stop = true;
       return base;

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -1632,7 +1632,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return this.finishOp(tt.relational, 1);
       } else if (isIteratorStart(code, next)) {
         this.state.isIterator = true;
-        return super.readWord(code);
+        return super.readWord();
       } else {
         return super.readToken(code);
       }

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -860,7 +860,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
     }
 
-    tsEatThenParseType(token: TokenType): N.TsType | undefined {
+    tsEatThenParseType(token: TokenType): N.TsType | typeof undefined {
       return !this.match(token) ? undefined : this.tsNextThenParseType();
     }
 

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -1300,7 +1300,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       startPos: number,
       startLoc: Position,
       noCalls: ?boolean,
-      state: { stop: boolean },
+      state: N.ParseSubscriptState,
     ): N.Expression {
       if (!this.hasPrecedingLineBreak() && this.eat(tt.bang)) {
         const nonNullExpression: N.TsNonNullExpression = this.startNodeAt(

--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -467,6 +467,7 @@ export default class Tokenizer extends LocationParser {
       const assign =
         this.input.charCodeAt(this.state.pos + 2) === charCodes.equalsTo;
       if (assign) {
+        // $FlowFixMe
         this.expectPlugin("logicalAssignment");
       }
       this.finishOp(

--- a/packages/babylon/src/tokenizer/index.js
+++ b/packages/babylon/src/tokenizer/index.js
@@ -1280,7 +1280,7 @@ export default class Tokenizer extends LocationParser {
     return word + this.input.slice(chunkStart, this.state.pos);
   }
 
-  isIterator(word): boolean {
+  isIterator(word: string): boolean {
     return word === "@@iterator" || word === "@@asyncIterator";
   }
 

--- a/packages/babylon/src/tokenizer/state.js
+++ b/packages/babylon/src/tokenizer/state.js
@@ -21,7 +21,7 @@ export default class State {
     this.noArrowParamsConversionAt = [];
 
     // eslint-disable-next-line max-len
-    this.inMethod = this.inFunction = this.inParameters = this.maybeInArrowParameters = this.inGenerator = this.inAsync = this.inPropertyName = this.inType = this.inClassProperty = this.noAnonFunctionType = this.hasFlowComment = false;
+    this.inMethod = this.inFunction = this.inParameters = this.maybeInArrowParameters = this.inGenerator = this.inAsync = this.inPropertyName = this.inType = this.inClassProperty = this.noAnonFunctionType = this.hasFlowComment = this.isIterator = false;
 
     this.classLevel = 0;
 
@@ -99,6 +99,7 @@ export default class State {
   inPropertyName: boolean;
   inClassProperty: boolean;
   hasFlowComment: boolean;
+  isIterator: boolean;
 
   // Check whether we are in a (nested) class or not.
   classLevel: number;

--- a/packages/babylon/src/tokenizer/state.js
+++ b/packages/babylon/src/tokenizer/state.js
@@ -21,7 +21,7 @@ export default class State {
     this.noArrowParamsConversionAt = [];
 
     // eslint-disable-next-line max-len
-    this.inMethod = this.inFunction = this.inParameters = this.maybeInArrowParameters = this.inGenerator = this.inAsync = this.inPropertyName = this.inType = this.inClassProperty = this.noAnonFunctionType = false;
+    this.inMethod = this.inFunction = this.inParameters = this.maybeInArrowParameters = this.inGenerator = this.inAsync = this.inPropertyName = this.inType = this.inClassProperty = this.noAnonFunctionType = this.hasFlowComment = false;
 
     this.classLevel = 0;
 
@@ -98,6 +98,7 @@ export default class State {
   noAnonFunctionType: boolean;
   inPropertyName: boolean;
   inClassProperty: boolean;
+  hasFlowComment: boolean;
 
   // Check whether we are in a (nested) class or not.
   classLevel: number;

--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -1298,3 +1298,12 @@ export type TsNonNullExpression = NodeBase & {
   type: "TSNonNullExpression",
   expression: Expression,
 };
+
+// ================
+// Other
+// ================
+
+export type ParseSubscriptState = {
+  optionalChainMember: boolean,
+  stop: boolean,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,9 +1665,9 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-charcodes@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/charcodes/-/charcodes-0.0.10.tgz#98d67a7a1e17ce154d1faafd01e72e9a6cff54f5"
+charcodes@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/charcodes/-/charcodes-0.1.0.tgz#61f8c244fc7f94f186fe74f31078901a3ed7928e"
 
 chardet@^0.4.0:
   version "0.4.2"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Pretty straightforward, but couple notes:

* The remaining flow error related to the variance node is fixed in https://github.com/babel/babel/pull/7101

* We should really rethink all the is/has state booleans in tokenzier/state

* Since we run flow from root, it couldn't resolve charcodes in `babylon`. I originally used `--hoist` with lerna, but @hzoo mentioned it was buggy, and `--hoist charcodes` wouldn't build (likely related to https://github.com/lerna/lerna/issues/1028)... so for now, added it as a top level dep, not great, but couldn't get anything else to work that wasn't also just as hacky. Open to suggestions!