### PR TITLE
Fix typo [skip ci]

### DIFF
--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -30,7 +30,7 @@ export function _call(fns?: Array<Function>): boolean {
     const ret = fn.call(this.state, this, this.state);
     if (ret && typeof ret === "object" && typeof ret.then === "function") {
       throw new Error(
-        `You appear to be using a plugin with an async traversay visitors, ` +
+        `You appear to be using a plugin with an async traversal visitor, ` +
           `which your current version of Babel does not support.` +
           `If you're using a published plugin, you may need to upgrade ` +
           `your @babel/core version.`,

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -30,7 +30,7 @@ export function _call(fns?: Array<Function>): boolean {
     const ret = fn.call(this.state, this, this.state);
     if (ret && typeof ret === "object" && typeof ret.then === "function") {
       throw new Error(
-        `You appear to be using an plugin with an async traversay visitors, ` +
+        `You appear to be using a plugin with an async traversay visitors, ` +
           `which your current version of Babel does not support.` +
           `If you're using a published plugin, you may need to upgrade ` +
           `your @babel/core version.`,


### PR DESCRIPTION
Fixed a small typo in a `@babel/traverse` error message. Just noticed when playing around with visitors.

OT: Is there currently a way to use an async visitor?