### PR TITLE
Better error message for invalid plugin/preset

### DIFF
--- a/packages/babel-core/src/config/config-descriptors.js
+++ b/packages/babel-core/src/config/config-descriptors.js
@@ -226,7 +226,7 @@ function createDescriptor(
     // config object, because it can be useful to define them in nested
     // configuration contexts.
     throw new Error(
-      "Plugin/Preset files are not allowed to export objects, only functions.",
+      `Plugin/Preset files are not allowed to export objects, only functions. In ${filepath}`,
     );
   }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/A
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

While upgrading from Babel 6 to 7, I encountered this error several times.  However, without knowing which plugin the error was referring to, the error wasn't super helpful.  This adds the file path to the error message.


Changes:

- Error for invalid plugin/preset now includes file path