### PR TITLE
TypeScript: Support parsing 'unique' type operator

### DIFF
--- a/packages/babel-generator/test/fixtures/typescript/types-type-operator/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-type-operator/input.js
@@ -1,1 +1,2 @@
 let x: keyof T;
+let y: unique symbol;

--- a/packages/babel-generator/test/fixtures/typescript/types-type-operator/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-type-operator/output.js
@@ -1,1 +1,2 @@
 let x: keyof T;
+let y: unique symbol;

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -616,8 +616,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return type;
     }
 
-    tsParseTypeOperator(operator: "keyof"): N.TsTypeOperator {
-      const node = this.startNode();
+    tsParseTypeOperator(operator: "keyof" | "unique"): N.TsTypeOperator {
+      const node: N.TsTypeOperator = this.startNode();
       this.expectContextual(operator);
       node.operator = operator;
       node.typeAnnotation = this.tsParseTypeOperatorOrHigher();
@@ -625,10 +625,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsParseTypeOperatorOrHigher(): N.TsType {
-      if (this.isContextual("keyof")) {
-        return this.tsParseTypeOperator("keyof");
-      }
-      return this.tsParseArrayTypeOrHigher();
+      const operator = ["keyof", "unique"].find(kw => this.isContextual(kw));
+      return operator
+        ? this.tsParseTypeOperator(operator)
+        : this.tsParseArrayTypeOrHigher();
     }
 
     tsParseUnionOrIntersectionType(

--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -1149,7 +1149,7 @@ export type TsParenthesizedType = TsTypeBase & {
 
 export type TsTypeOperator = TsTypeBase & {
   type: "TSTypeOperator",
-  operator: "keyof",
+  operator: "keyof" | "unique",
   typeAnnotation: TsType,
 };
 

--- a/packages/babylon/test/fixtures/typescript/types/type-operator/input.js
+++ b/packages/babylon/test/fixtures/typescript/types/type-operator/input.js
@@ -1,1 +1,2 @@
 let x: keyof T;
+let y: unique symbol;

--- a/packages/babylon/test/fixtures/typescript/types/type-operator/output.json
+++ b/packages/babylon/test/fixtures/typescript/types/type-operator/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 15,
+  "end": 37,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 1,
-      "column": 15
+      "line": 2,
+      "column": 21
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 15,
+    "end": 37,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 1,
-        "column": 15
+        "line": 2,
+        "column": 21
       }
     },
     "sourceType": "module",
@@ -132,6 +132,103 @@
                         "identifierName": "T"
                       },
                       "name": "T"
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 16,
+        "end": 37,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 21
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 20,
+            "end": 36,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 20,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                },
+                "identifierName": "y"
+              },
+              "name": "y",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 21,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSTypeOperator",
+                  "start": 23,
+                  "end": 36,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 20
+                    }
+                  },
+                  "operator": "unique",
+                  "typeAnnotation": {
+                    "type": "TSSymbolKeyword",
+                    "start": 30,
+                    "end": 36,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 20
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         |
| Any Dependency Changes?  | No
| License                  | MIT

Microsoft/TypeScript#15473 added the `unique` keyword to the language. This adds support in babylon to parse it. There were no necessary changes to the generator, which already handles any keyword, or to the plugin, which erases all types without needing to look at their contents.
@rbuckton and @DanielRosenwasser for review.
See also eslint/typescript-eslint-parser#433, which does the same thing in their parser. @azz @JamesHenry