### PR TITLE
Add regexp support to include/exclude

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -229,7 +229,7 @@ Outputs the targets/plugins used and the version specified in [plugin data versi
 
 ### `include`
 
-`Array<string>`, defaults to `[]`.
+`Array<string|RegExp>`, defaults to `[]`.
 
 An array of plugins to always include.
 
@@ -239,6 +239,16 @@ Valid options include any:
 
 - [Built-ins](https://github.com/babel/packages/babel-preset-env/blob/master/data/built-in-features.js), such as `map`, `set`, or `object.assign`.
 
+Plugin names can be fully or partially specified (or using `RegExp`).
+
+Acceptable inputs:
+
+- Full name (`string`): `"es6.math.sign"`
+- Partial name (`string`): `"es6.math.*"` (resolves to all plugins with `es6.math` prefix)
+- `RegExp` Object: `/^transform-.*$/` or `new RegExp("^transform-modules-.*")`
+
+Note that the above `.` is the `RegExp` equivalent to match any character, and not the actual `'.'` character. Also note that to match any character `.*` is used in `RegExp` as opposed to `*` in `glob` format.
+
 This option is useful if there is a bug in a native implementation, or a combination of a non-supported feature + a supported one doesn't work.
 
 For example, Node 4 supports native classes but not spread. If `super` is used with a spread argument, then the `@babel/plugin-transform-classes` transform needs to be `include`d, as it is not possible to transpile a spread with `super` otherwise.
@@ -247,7 +257,7 @@ For example, Node 4 supports native classes but not spread. If `super` is used w
 
 ### `exclude`
 
-`Array<string>`, defaults to `[]`.
+`Array<string|RegExp>`, defaults to `[]`.
 
 An array of plugins to always exclude/remove.
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -26,8 +26,10 @@ const pluginToRegExp = (plugin: any): RegExp => {
 
 const selectPlugins = (regexp: RegExp): Array<string> =>
   Array.from(validIncludesAndExcludes).filter(
-    item => regexp instanceof RegExp && item.match(regexp),
+    item => regexp instanceof RegExp && regexp.test(item),
   );
+
+const flatten = array => [].concat(...array);
 
 const expandIncludesAndExcludes = (
   plugins: Array<string | RegExp> = [],
@@ -50,7 +52,7 @@ const expandIncludesAndExcludes = (
     valid. Please check data/[plugin-features|built-in-features].js in babel-preset-env`,
   );
 
-  return [].concat(...selectedPlugins);
+  return flatten(selectedPlugins);
 };
 
 const validBrowserslistTargets = [
@@ -58,8 +60,8 @@ const validBrowserslistTargets = [
   ...Object.keys(browserslist.aliases),
 ];
 
-const normalizePluginName = (plugin: string): string =>
-  plugin.replace("babel-plugin-", "");
+export const normalizePluginName = (plugin: string): string =>
+  plugin.replace(/^babel-plugin-/, "");
 
 export const checkDuplicateIncludeExcludes = (
   include: Array<string> = [],

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -30,7 +30,7 @@ const selectPlugins = (regexp: RegExp): Array<string> =>
 const pluginToRegExp = (plugin: any): RegExp => {
   return plugin instanceof RegExp
     ? plugin
-    : new RegExp(normalizePluginName(plugin));
+    : new RegExp(`^${normalizePluginName(plugin)}$`);
 };
 
 const populatePlugins = (
@@ -39,7 +39,8 @@ const populatePlugins = (
 ): Array<string> => pluginList.concat(selectPlugins(regexp));
 
 const isValidPlugin = (plugin: any): boolean =>
-  validRegExp(plugin) && selectPlugins(pluginToRegExp(plugin)).length > 0;
+  validRegExp(plugin) &&
+  selectPlugins(`^${normalizePluginName(plugin)}$`).length > 0;
 
 const expandIncludesAndExcludes = (
   plugins: Array<string>,

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -85,7 +85,7 @@ const validBrowserslistTargets = [
 ];
 
 const normalizePluginName = (plugin: string): string =>
-  plugin.replace(/^babel-plugin-/, "");
+  plugin.replace(/babel-plugin-/, "");
 
 export const checkDuplicateIncludeExcludes = (
   include: Array<string> = [],

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -31,9 +31,11 @@ const selectPlugins = (regexp: RegExp): Array<string> =>
   );
 
 const expandIncludesAndExcludes = (
-  plugins: Array<string>,
+  plugins: Array<string> = [],
   type: string,
 ): Array<string> => {
+  if (plugins.length === 0) return plugins;
+
   const selectedPlugins = plugins.map(plugin =>
     selectPlugins(pluginToRegExp(plugin)),
   );
@@ -150,20 +152,16 @@ export const validateUseBuiltInsOption = (
 };
 
 export default function normalizeOptions(opts: Options) {
-  if (opts.exclude) {
-    opts.exclude = expandIncludesAndExcludes(opts.exclude, "exclude");
-  }
+  const include = expandIncludesAndExcludes(opts.include, "include");
+  const exclude = expandIncludesAndExcludes(opts.exclude, "exclude");
 
-  if (opts.include) {
-    opts.include = expandIncludesAndExcludes(opts.include, "include");
-  }
-
-  checkDuplicateIncludeExcludes(opts.include, opts.exclude);
+  checkDuplicateIncludeExcludes(include, exclude);
 
   return {
     configPath: validateConfigPathOption(opts.configPath),
     debug: opts.debug,
-    exclude: opts.exclude,
+    include,
+    exclude,
     forceAllTransforms: validateBoolOption(
       "forceAllTransforms",
       opts.forceAllTransforms,
@@ -172,7 +170,6 @@ export default function normalizeOptions(opts: Options) {
     ignoreBrowserslistConfig: validateIgnoreBrowserslistConfig(
       opts.ignoreBrowserslistConfig,
     ),
-    include: opts.include,
     loose: validateBoolOption("loose", opts.loose, false),
     modules: validateModulesOption(opts.modules),
     shippedProposals: validateBoolOption(

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -85,7 +85,7 @@ const validBrowserslistTargets = [
 ];
 
 const normalizePluginName = (plugin: string): string =>
-  plugin.replace(/babel-plugin-/, "");
+  plugin.replace("babel-plugin-", "");
 
 export const checkDuplicateIncludeExcludes = (
   include: Array<string> = [],

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -16,10 +16,9 @@ const validIncludesAndExcludes = new Set([
 ]);
 
 const pluginToRegExp = (plugin: any): RegExp => {
+  if (plugin instanceof RegExp) return plugin;
   try {
-    return plugin instanceof RegExp
-      ? plugin
-      : new RegExp(`^${normalizePluginName(plugin)}$`);
+    return  new RegExp(`^${normalizePluginName(plugin)}$`);
   } catch (e) {
     return null;
   }
@@ -31,7 +30,7 @@ const selectPlugins = (regexp: RegExp): Array<string> =>
   );
 
 const expandIncludesAndExcludes = (
-  plugins: Array<string> = [],
+  plugins: Array<string|RegExp> = [],
   type: string,
 ): Array<string> => {
   if (plugins.length === 0) return plugins;

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -26,19 +26,20 @@ const pluginToRegExp = (plugin: any): RegExp => {
 };
 
 const selectPlugins = (regexp: RegExp): Array<string> =>
-  Array.from(validIncludesAndExcludes).filter(item => item.match(regexp));
-
-const populatePlugins = (
-  pluginList: Array<RegExp>,
-  regexp: RegExp,
-): Array<string> => pluginList.concat(selectPlugins(regexp));
+  Array.from(validIncludesAndExcludes).filter(
+    item => regexp instanceof RegExp && item.match(regexp),
+  );
 
 const expandIncludesAndExcludes = (
   plugins: Array<string>,
   type: string,
 ): Array<string> => {
-  const pluginRegExpList = plugins.map(pluginToRegExp);
-  const invalidRegExpList = plugins.filter((p, i) => !pluginRegExpList[i]);
+  const selectedPlugins = plugins.map(plugin =>
+    selectPlugins(pluginToRegExp(plugin)),
+  );
+  const invalidRegExpList = plugins.filter(
+    (p, i) => selectedPlugins[i].length === 0,
+  );
 
   invariant(
     invalidRegExpList.length === 0,
@@ -48,7 +49,7 @@ const expandIncludesAndExcludes = (
     valid. Please check data/[plugin-features|built-in-features].js in babel-preset-env`,
   );
 
-  return pluginRegExpList.reduce(populatePlugins, []);
+  return [].concat(...selectedPlugins);
 };
 
 const validBrowserslistTargets = [

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -15,15 +15,6 @@ const validIncludesAndExcludes = new Set([
   ...defaultWebIncludes,
 ]);
 
-const validRegExp = (regexp: string): boolean => {
-  try {
-    new RegExp(regexp);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};
-
 const selectPlugins = (regexp: RegExp): Array<string> =>
   Array.from(validIncludesAndExcludes).filter(item => item.match(regexp));
 
@@ -39,8 +30,7 @@ const populatePlugins = (
 ): Array<string> => pluginList.concat(selectPlugins(regexp));
 
 const isValidPlugin = (plugin: any): boolean =>
-  validRegExp(plugin) &&
-  selectPlugins(`^${normalizePluginName(plugin)}$`).length > 0;
+  selectPlugins(pluginToRegExp(plugin)).length > 0;
 
 const expandIncludesAndExcludes = (
   plugins: Array<string>,

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -41,10 +41,13 @@ const expandIncludesAndExcludes = (
 
   const pluginRegExpList = plugins.map(plugin => new RegExp(plugin));
 
-  const pluginIsSpecified = plugin =>
-    !!pluginRegExpList.find(regexp => plugin.match(regexp));
+  const selectPlugins = regexp =>
+    validIncludesAndExcludesArray.filter(item => item.match(regexp));
 
-  return validIncludesAndExcludesArray.filter(pluginIsSpecified);
+  const populatePlugins = (pluginList, regexp) =>
+    pluginList.concat(selectPlugins(regexp));
+
+  return pluginRegExpList.reduce(populatePlugins, []);
 };
 
 export const validateIncludesAndExcludes = (
@@ -171,14 +174,14 @@ export const validateUseBuiltInsOption = (
 
 export default function normalizeOptions(opts: Options) {
   if (opts.exclude) {
-    opts.exclude = normalizePluginNames(
-      expandIncludesAndExcludes(opts.exclude),
+    opts.exclude = expandIncludesAndExcludes(
+      normalizePluginNames(opts.exclude),
     );
   }
 
   if (opts.include) {
-    opts.include = normalizePluginNames(
-      expandIncludesAndExcludes(opts.include),
+    opts.include = expandIncludesAndExcludes(
+      normalizePluginNames(opts.include),
     );
   }
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -18,7 +18,7 @@ const validIncludesAndExcludes = new Set([
 const pluginToRegExp = (plugin: any): RegExp => {
   if (plugin instanceof RegExp) return plugin;
   try {
-    return  new RegExp(`^${normalizePluginName(plugin)}$`);
+    return new RegExp(`^${normalizePluginName(plugin)}$`);
   } catch (e) {
     return null;
   }
@@ -30,7 +30,7 @@ const selectPlugins = (regexp: RegExp): Array<string> =>
   );
 
 const expandIncludesAndExcludes = (
-  plugins: Array<string|RegExp> = [],
+  plugins: Array<string | RegExp> = [],
   type: string,
 ): Array<string> => {
   if (plugins.length === 0) return plugins;

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -32,6 +32,16 @@ describe("normalize-options", () => {
       };
       assert.throws(normalizeWithSameIncludes, Error);
     });
+
+    it("should expand regular expressions in `include` and `exclude`", () => {
+      const normalized = normalizeOptions.default({
+        include: ["transform-spread", "transform-class"],
+      });
+      assert.deepEqual(normalized.include, [
+        "transform-spread",
+        "transform-classes",
+      ]);
+    });
   });
 
   describe("validateBoolOption", () => {

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -35,21 +35,32 @@ describe("normalize-options", () => {
 
   describe("RegExp include/excludes", () => {
     it("should not allow invalid plugins in `include` and `exclude`", () => {
-      const normalizeWithInvalidPlugin = () => {
+      const normalizeWithNonExistingPlugin = () => {
         normalizeOptions.default({
-          include: ["invalid"],
+          include: ["non-existing-plugin"],
         });
       };
-      assert.throws(normalizeWithInvalidPlugin, Error);
+      assert.throws(normalizeWithNonExistingPlugin, Error);
     });
 
     it("should expand regular expressions in `include` and `exclude`", () => {
       const normalized = normalizeOptions.default({
-        include: ["^[a-z]*-spread", "transform-class"],
+        include: ["^[a-z]*-spread", "babel-plugin-transform-classes"],
       });
       assert.deepEqual(normalized.include, [
         "transform-spread",
         "transform-classes",
+      ]);
+    });
+
+    it("should expand regular expressions in `include` and `exclude`", () => {
+      const normalized = normalizeOptions.default({
+        exclude: ["es6.math.log"],
+      });
+      assert.deepEqual(normalized.exclude, [
+        "es6.math.log1p",
+        "es6.math.log10",
+        "es6.math.log2",
       ]);
     });
   });

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -33,7 +33,7 @@ describe("normalize-options", () => {
     });
   });
 
-  describe("RegExp include/excludes", () => {
+  describe("RegExp include/exclude", () => {
     it("should not allow invalid plugins in `include` and `exclude`", () => {
       const normalizeWithNonExistingPlugin = () => {
         normalizeOptions.default({
@@ -55,7 +55,7 @@ describe("normalize-options", () => {
 
     it("should expand regular expressions in `include` and `exclude`", () => {
       const normalized = normalizeOptions.default({
-        exclude: ["es6.math.log"],
+        exclude: ["es6.math.log.*"],
       });
       assert.deepEqual(normalized.exclude, [
         "es6.math.log1p",
@@ -68,10 +68,19 @@ describe("normalize-options", () => {
       const normalizeWithNonExistingPlugin = () => {
         normalizeOptions.default({
           include: ["es6.math.log2"],
-          exclude: ["es6.math.log"],
+          exclude: ["es6.math.log.*"],
         });
       };
       assert.throws(normalizeWithNonExistingPlugin, Error);
+    });
+
+    it("should not do partial match if not explicitly defined `include` and `exclude`", () => {
+      const normalized = normalizeOptions.default({
+        include: ["es6.reflect.set-prototype-of"],
+        exclude: ["es6.reflect.set"],
+      });
+      assert.deepEqual(normalized.include, ["es6.reflect.set-prototype-of"]);
+      assert.deepEqual(normalized.exclude, ["es6.reflect.set"]);
     });
   });
 

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -6,7 +6,6 @@ const assert = require("assert");
 const {
   checkDuplicateIncludeExcludes,
   validateBoolOption,
-  validateIncludesAndExcludes,
   validateModulesOption,
 } = normalizeOptions;
 
@@ -155,16 +154,6 @@ describe("normalize-options", () => {
     it("array option is invalid", () => {
       assert.throws(() => {
         assert(validateModulesOption([]));
-      }, Error);
-    });
-  });
-  describe("validateIncludesAndExcludes", function() {
-    it("should return empty arrays if undefined", function() {
-      assert.deepEqual(validateIncludesAndExcludes(), []);
-    });
-    it("should throw if not in features", function() {
-      assert.throws(() => {
-        validateIncludesAndExcludes(["asdf"]);
       }, Error);
     });
   });

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -7,8 +7,8 @@ const {
   checkDuplicateIncludeExcludes,
   validateBoolOption,
   validateModulesOption,
+  normalizePluginName,
 } = normalizeOptions;
-
 describe("normalize-options", () => {
   describe("normalizeOptions", () => {
     it("should return normalized `include` and `exclude`", () => {
@@ -19,6 +19,11 @@ describe("normalize-options", () => {
         "transform-spread",
         "transform-classes",
       ]);
+    });
+
+    it("should not normalize babel-plugin with prefix", () => {
+      const normalized = normalizePluginName("prefix-babel-plugin-postfix");
+      assert.equal(normalized, "prefix-babel-plugin-postfix");
     });
 
     it("should throw if duplicate names in `include` and `exclude`", () => {

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -5,7 +5,6 @@ const assert = require("assert");
 
 const {
   checkDuplicateIncludeExcludes,
-  normalizePluginNames,
   validateBoolOption,
   validateIncludesAndExcludes,
   validateModulesOption,
@@ -32,10 +31,21 @@ describe("normalize-options", () => {
       };
       assert.throws(normalizeWithSameIncludes, Error);
     });
+  });
+
+  describe("RegExp include/excludes", () => {
+    it("should not allow invalid plugins in `include` and `exclude`", () => {
+      const normalizeWithInvalidPlugin = () => {
+        normalizeOptions.default({
+          include: ["invalid"],
+        });
+      };
+      assert.throws(normalizeWithInvalidPlugin, Error);
+    });
 
     it("should expand regular expressions in `include` and `exclude`", () => {
       const normalized = normalizeOptions.default({
-        include: ["transform-spread", "transform-class"],
+        include: ["^[a-z]*-spread", "transform-class"],
       });
       assert.deepEqual(normalized.include, [
         "transform-spread",
@@ -72,24 +82,6 @@ describe("normalize-options", () => {
           ["transform-regenerator", "map"],
         );
       }, Error);
-    });
-
-    it("should not throw if no duplicate names in both", function() {
-      assert.doesNotThrow(() => {
-        checkDuplicateIncludeExcludes(["transform-regenerator"], ["map"]);
-      }, Error);
-    });
-  });
-
-  describe("normalizePluginNames", function() {
-    it("should drop `babel-plugin-` prefix if needed", function() {
-      assert.deepEqual(
-        normalizePluginNames([
-          "babel-plugin-transform-object-super",
-          "transform-parameters",
-        ]),
-        ["transform-object-super", "transform-parameters"],
-      );
     });
 
     it("should not throw if no duplicate names in both", function() {

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -63,6 +63,16 @@ describe("normalize-options", () => {
         "es6.math.log2",
       ]);
     });
+
+    it("should not allow the same modules in `include` and `exclude`", () => {
+      const normalizeWithNonExistingPlugin = () => {
+        normalizeOptions.default({
+          include: ["es6.math.log2"],
+          exclude: ["es6.math.log"],
+        });
+      };
+      assert.throws(normalizeWithNonExistingPlugin, Error);
+    });
   });
 
   describe("validateBoolOption", () => {


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6636  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | 
| Minor: New Feature?      | :+1:
| Tests Added + Pass?      | :+1:
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->

This PR adds support for regular expressions to includes/excludes list of plugins/builtins. Regular expressions can be passed as normal `RegExp` objects, or in `string` format.
We expand the regular expressions to get the list of plugins and then pass them around, therefore virtually none of the previous functions are affected.
Plugins can still be passed with full name or a partial name.

Examples:

- Full name: `"es6.math.sign"`
- Partial name: `"es6.math.*"`
- RegExp in string: `"es6.math.sin.?"`
- `RegExp` Object: `/^transform-.*$/` or `new RegExp("^transform-modules-.*")`

We still normalize the plugin names _before turning them into `RegExp`_, therefore patterns like `"^babel-plugin-transform-.*"` still work (, but `/^babel-plugin-transform-.*/`  doesn't).

**Note:** In all of the above examples `.` represents _a match for any character_ in a regular expression, and not the _dot_ character so for example  `"es6.math.sign"` would match  `es6-math-sign`.