### PR TITLE
Tweak and add tests to babel-helper-annotate-as-pure

### DIFF
--- a/packages/babel-helper-annotate-as-pure/src/index.js
+++ b/packages/babel-helper-annotate-as-pure/src/index.js
@@ -2,13 +2,9 @@ import * as t from "@babel/types";
 
 const PURE_ANNOTATION = "#__PURE__";
 
-const isPureAnnotated = node => {
-  const { leadingComments } = node;
-  if (leadingComments === undefined) {
-    return false;
-  }
-  return leadingComments.some(comment => /[@#]__PURE__/.test(comment.value));
-};
+const isPureAnnotated = ({ leadingComments }) =>
+  leadingComments &&
+  leadingComments.some(comment => /[@#]__PURE__/.test(comment.value));
 
 export default function annotateAsPure(pathOrNode) {
   const node = pathOrNode.node || pathOrNode;

--- a/packages/babel-helper-annotate-as-pure/test/index.js
+++ b/packages/babel-helper-annotate-as-pure/test/index.js
@@ -1,0 +1,36 @@
+import annotateAsPure from "../";
+import assert from "assert";
+
+describe("@babel/helper-annotate-as-pure", () => {
+  it("will add leading comment", () => {
+    const node = {};
+    annotateAsPure(node);
+
+    assert.deepEqual(node.leadingComments, [
+      {
+        type: "CommentBlock",
+        value: "#__PURE__",
+      },
+    ]);
+  });
+
+  it("will not add an extra leading comment", () => {
+    const node = {
+      leadingComments: [
+        {
+          type: "CommentBlock",
+          value: "#__PURE__",
+        },
+      ],
+    };
+
+    annotateAsPure(node);
+
+    assert.deepEqual(node.leadingComments, [
+      {
+        type: "CommentBlock",
+        value: "#__PURE__",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7026
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | y/y
| Documentation PR         |
| Any Dependency Changes?  |
| License                  | MIT

Trying to clear through a big backlog of PRs I've been too busy to get done :(

This was originally part of a larger PR that normalizes comment props on nodes, but figured we could land this while bikeshedding that.