### PR TITLE
Make comment props more consistent

### DIFF
--- a/packages/babylon/src/parser/comments.js
+++ b/packages/babylon/src/parser/comments.js
@@ -64,16 +64,14 @@ export default class CommentsParser extends BaseParser {
         // later.
         this.state.trailingComments.length = 0;
       }
-    } else {
-      if (stack.length > 0) {
-        const lastInStack = last(stack);
-        if (
-          lastInStack.trailingComments &&
-          lastInStack.trailingComments[0].start >= node.end
-        ) {
-          trailingComments = lastInStack.trailingComments;
-          lastInStack.trailingComments = null;
-        }
+    } else if (stack.length > 0) {
+      const lastInStack = last(stack);
+      if (
+        lastInStack.trailingComments &&
+        lastInStack.trailingComments[0].start >= node.end
+      ) {
+        trailingComments = lastInStack.trailingComments;
+        delete lastInStack.trailingComments;
       }
     }
 
@@ -143,7 +141,7 @@ export default class CommentsParser extends BaseParser {
           last(lastChild.leadingComments).end <= node.start
         ) {
           node.leadingComments = lastChild.leadingComments;
-          lastChild.leadingComments = null;
+          delete lastChild.leadingComments;
         } else {
           // A leading comment for an anonymous class had been stolen by its first ClassMethod,
           // so this takes back the leading comment.
@@ -196,8 +194,10 @@ export default class CommentsParser extends BaseParser {
         // result in an empty array, and if so, the array must be
         // deleted.
         const leadingComments = this.state.leadingComments.slice(0, i);
-        node.leadingComments =
-          leadingComments.length === 0 ? null : leadingComments;
+
+        if (leadingComments.length) {
+          node.leadingComments = leadingComments;
+        }
 
         // Similarly, trailing comments are attached later. The variable
         // must be reset to null if there are no trailing comments.

--- a/packages/babylon/src/parser/node.js
+++ b/packages/babylon/src/parser/node.js
@@ -24,9 +24,9 @@ class Node implements NodeBase {
   end: number;
   loc: SourceLocation;
   range: [number, number];
-  leadingComments: ?Array<Comment>;
-  trailingComments: ?Array<Comment>;
-  innerComments: ?Array<Comment>;
+  leadingComments: Array<Comment>;
+  trailingComments: Array<Comment>;
+  innerComments: Array<Comment>;
   extra: { [key: string]: any };
 
   __clone(): this {

--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -26,9 +26,9 @@ export interface NodeBase {
   end: number;
   loc: SourceLocation;
   range: [number, number];
-  leadingComments?: ?Array<Comment>;
-  trailingComments?: ?Array<Comment>;
-  innerComments?: ?Array<Comment>;
+  leadingComments?: Array<Comment>;
+  trailingComments?: Array<Comment>;
+  innerComments?: Array<Comment>;
 
   extra: { [key: string]: any };
 }

--- a/packages/babylon/test/expressions/is-expression-babylon/pass/5/output.json
+++ b/packages/babylon/test/expressions/is-expression-babylon/pass/5/output.json
@@ -14,7 +14,6 @@
     "identifierName": "abc"
   },
   "name": "abc",
-  "leadingComments": null,
   "trailingComments": [
     {
       "type": "CommentLine",

--- a/packages/babylon/test/fixtures/comments/basic/export-default-anonymous-class/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/export-default-anonymous-class/output.json
@@ -103,8 +103,7 @@
                     },
                     "identifierName": "method1"
                   },
-                  "name": "method1",
-                  "leadingComments": null
+                  "name": "method1"
                 },
                 "computed": false,
                 "kind": "method",
@@ -148,10 +147,8 @@
                   }
                 ]
               }
-            ],
-            "leadingComments": null
-          },
-          "leadingComments": null
+            ]
+          }
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/comments/basic/object-property-trailing-comma/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/object-property-trailing-comma/output.json
@@ -174,8 +174,7 @@
                       },
                       "identifierName": "b"
                     },
-                    "name": "b",
-                    "leadingComments": null
+                    "name": "b"
                   },
                   "computed": false,
                   "shorthand": false,
@@ -248,8 +247,7 @@
                       },
                       "identifierName": "c"
                     },
-                    "name": "c",
-                    "leadingComments": null
+                    "name": "c"
                   },
                   "computed": false,
                   "shorthand": false,

--- a/packages/babylon/test/fixtures/comments/basic/shebang-import/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/shebang-import/output.json
@@ -72,8 +72,7 @@
                 },
                 "identifierName": "spawn"
               },
-              "name": "spawn",
-              "leadingComments": null
+              "name": "spawn"
             },
             "local": {
               "type": "Identifier",
@@ -91,8 +90,7 @@
                 "identifierName": "spawn"
               },
               "name": "spawn"
-            },
-            "leadingComments": null
+            }
           }
         ],
         "source": {

--- a/packages/babylon/test/fixtures/comments/basic/shebang-object/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/shebang-object/output.json
@@ -102,8 +102,7 @@
                       },
                       "identifierName": "spawn"
                     },
-                    "name": "spawn",
-                    "leadingComments": null
+                    "name": "spawn"
                   },
                   "computed": false,
                   "shorthand": true,
@@ -124,13 +123,11 @@
                     },
                     "name": "spawn"
                   },
-                  "leadingComments": null,
                   "extra": {
                     "shorthand": true
                   }
                 }
-              ],
-              "leadingComments": null
+              ]
             },
             "init": {
               "type": "Identifier",
@@ -148,8 +145,7 @@
                 "identifierName": "x"
               },
               "name": "x"
-            },
-            "leadingComments": null
+            }
           }
         ],
         "kind": "var",

--- a/packages/babylon/test/fixtures/comments/basic/surrounding-call-comments/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/surrounding-call-comments/output.json
@@ -120,11 +120,9 @@
                     },
                     "identifierName": "foo"
                   },
-                  "name": "foo",
-                  "leadingComments": null
+                  "name": "foo"
                 },
-                "arguments": [],
-                "leadingComments": null
+                "arguments": []
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/comments/basic/surrounding-throw-comments/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/surrounding-throw-comments/output.json
@@ -109,8 +109,7 @@
                   "rawValue": 55,
                   "raw": "55"
                 },
-                "value": 55,
-                "leadingComments": null
+                "value": 55
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/comments/basic/surrounding-while-loop-comments/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/surrounding-while-loop-comments/output.json
@@ -105,8 +105,7 @@
                     "column": 41
                   }
                 },
-                "value": true,
-                "leadingComments": null
+                "value": true
               },
               "body": {
                 "type": "BlockStatement",
@@ -123,9 +122,7 @@
                   }
                 },
                 "body": [],
-                "directives": [],
-                "leadingComments": null,
-                "trailingComments": null
+                "directives": []
               },
               "leadingComments": [
                 {
@@ -208,11 +205,9 @@
                       },
                       "identifierName": "each"
                     },
-                    "name": "each",
-                    "leadingComments": null
+                    "name": "each"
                   },
-                  "init": null,
-                  "leadingComments": null
+                  "init": null
                 }
               ],
               "kind": "var",

--- a/packages/babylon/test/fixtures/comments/basic/switch-fallthrough-comment-in-function/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-fallthrough-comment-in-function/output.json
@@ -160,8 +160,7 @@
                       "rawValue": 1,
                       "raw": "1"
                     },
-                    "value": 1,
-                    "leadingComments": null
+                    "value": 1
                   },
                   "leadingComments": [
                     {
@@ -282,8 +281,7 @@
                       "rawValue": 2,
                       "raw": "2"
                     },
-                    "value": 2,
-                    "leadingComments": null
+                    "value": 2
                   },
                   "leadingComments": [
                     {

--- a/packages/babylon/test/fixtures/comments/basic/switch-fallthrough-comment/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-fallthrough-comment/output.json
@@ -93,8 +93,7 @@
                 "rawValue": 1,
                 "raw": "1"
               },
-              "value": 1,
-              "leadingComments": null
+              "value": 1
             },
             "leadingComments": [
               {
@@ -215,8 +214,7 @@
                 "rawValue": 2,
                 "raw": "2"
               },
-              "value": 2,
-              "leadingComments": null
+              "value": 2
             },
             "leadingComments": [
               {

--- a/packages/babylon/test/fixtures/comments/basic/switch-function-call-no-semicolon-no-default/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-function-call-no-semicolon-no-default/output.json
@@ -174,10 +174,8 @@
                       },
                       "value": "1"
                     }
-                  ],
-                  "trailingComments": null
-                },
-                "trailingComments": null
+                  ]
+                }
               }
             ],
             "test": {

--- a/packages/babylon/test/fixtures/comments/basic/switch-function-call-no-semicolon/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-function-call-no-semicolon/output.json
@@ -174,10 +174,8 @@
                       },
                       "value": "1"
                     }
-                  ],
-                  "trailingComments": null
-                },
-                "trailingComments": null
+                  ]
+                }
               }
             ],
             "test": {
@@ -248,8 +246,7 @@
                     "column": 10
                   }
                 },
-                "label": null,
-                "leadingComments": null
+                "label": null
               }
             ],
             "test": null,

--- a/packages/babylon/test/fixtures/comments/basic/switch-no-default-comment-in-function/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-no-default-comment-in-function/output.json
@@ -209,9 +209,7 @@
                           "column": 18
                         }
                       },
-                      "label": null,
-                      "leadingComments": null,
-                      "trailingComments": null
+                      "label": null
                     }
                   ],
                   "test": {

--- a/packages/babylon/test/fixtures/comments/basic/switch-no-default-comment-in-nested-functions/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-no-default-comment-in-nested-functions/output.json
@@ -537,8 +537,7 @@
                                       "computed": true
                                     }
                                   ]
-                                },
-                                "trailingComments": null
+                                }
                               }
                             ],
                             "test": {

--- a/packages/babylon/test/fixtures/comments/basic/switch-no-default-comment/output.json
+++ b/packages/babylon/test/fixtures/comments/basic/switch-no-default-comment/output.json
@@ -89,9 +89,7 @@
                     "column": 14
                   }
                 },
-                "label": null,
-                "leadingComments": null,
-                "trailingComments": null
+                "label": null
               }
             ],
             "test": {

--- a/packages/babylon/test/fixtures/core/categorized/filename-specified/output.json
+++ b/packages/babylon/test/fixtures/core/categorized/filename-specified/output.json
@@ -77,8 +77,7 @@
                 "filename": "path/to/input-file.js",
                 "identifierName": "node"
               },
-              "name": "node",
-              "leadingComments": null
+              "name": "node"
             },
             "init": {
               "type": "StringLiteral",
@@ -100,8 +99,7 @@
                 "raw": "\"shouldHaveFilenameLocProp\""
               },
               "value": "shouldHaveFilenameLocProp"
-            },
-            "leadingComments": null
+            }
           }
         ],
         "kind": "var",

--- a/packages/babylon/test/fixtures/core/uncategorised/302/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/302/output.json
@@ -72,9 +72,7 @@
                 },
                 "identifierName": "x"
               },
-              "name": "x",
-              "leadingComments": null,
-              "trailingComments": null
+              "name": "x"
             },
             "init": null,
             "trailingComments": [

--- a/packages/babylon/test/fixtures/core/uncategorised/305/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/305/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentLine",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/core/uncategorised/306/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/306/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentBlock",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/core/uncategorised/308/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/308/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentLine",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/core/uncategorised/309/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/309/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentBlock",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/core/uncategorised/311/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/311/output.json
@@ -90,7 +90,6 @@
                   }
                 },
                 "argument": null,
-                "leadingComments": null,
                 "trailingComments": [
                   {
                     "type": "CommentLine",
@@ -139,8 +138,7 @@
                     },
                     "identifierName": "x"
                   },
-                  "name": "x",
-                  "leadingComments": null
+                  "name": "x"
                 },
                 "leadingComments": [
                   {

--- a/packages/babylon/test/fixtures/core/uncategorised/312/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/312/output.json
@@ -90,7 +90,6 @@
                   }
                 },
                 "argument": null,
-                "leadingComments": null,
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
@@ -139,8 +138,7 @@
                     },
                     "identifierName": "x"
                   },
-                  "name": "x",
-                  "leadingComments": null
+                  "name": "x"
                 },
                 "leadingComments": [
                   {

--- a/packages/babylon/test/fixtures/core/uncategorised/314/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/314/output.json
@@ -72,9 +72,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null,
-              "trailingComments": null
+              "name": "error"
             },
             "trailingComments": [
               {
@@ -124,8 +122,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null
+              "name": "error"
             },
             "leadingComments": [
               {

--- a/packages/babylon/test/fixtures/core/uncategorised/315/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/315/output.json
@@ -72,9 +72,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null,
-              "trailingComments": null
+              "name": "error"
             },
             "trailingComments": [
               {
@@ -124,8 +122,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null
+              "name": "error"
             },
             "leadingComments": [
               {

--- a/packages/babylon/test/fixtures/core/uncategorised/342/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/342/output.json
@@ -72,7 +72,6 @@
               "identifierName": "foo"
             },
             "name": "foo",
-            "leadingComments": null,
             "trailingComments": [
               {
                 "type": "CommentLine",

--- a/packages/babylon/test/fixtures/core/uncategorised/46/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/46/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/47/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/47/output.json
@@ -60,9 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null,
-          "trailingComments": null
+          "value": 42
         },
         "trailingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/48/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/48/output.json
@@ -60,9 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null,
-          "trailingComments": null
+          "value": 42
         },
         "trailingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/49/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/49/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/50/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/50/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/51/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/51/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/52/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/52/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/53/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/53/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/54/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/54/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/55/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/55/output.json
@@ -60,9 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null,
-          "trailingComments": null
+          "value": 42
         },
         "trailingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/56/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/56/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/57/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/57/output.json
@@ -29,7 +29,6 @@
     "sourceType": "script",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentLine",

--- a/packages/babylon/test/fixtures/core/uncategorised/58/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/58/output.json
@@ -29,7 +29,6 @@
     "sourceType": "script",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentLine",

--- a/packages/babylon/test/fixtures/core/uncategorised/59/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/59/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/60/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/60/output.json
@@ -29,7 +29,6 @@
     "sourceType": "script",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentLine",

--- a/packages/babylon/test/fixtures/core/uncategorised/61/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/61/output.json
@@ -29,7 +29,6 @@
     "sourceType": "script",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentLine",

--- a/packages/babylon/test/fixtures/core/uncategorised/62/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/62/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/63/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/63/output.json
@@ -60,8 +60,7 @@
             "rawValue": 42,
             "raw": "42"
           },
-          "value": 42,
-          "leadingComments": null
+          "value": 42
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/core/uncategorised/64/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/64/output.json
@@ -117,11 +117,9 @@
                     },
                     "identifierName": "doThat"
                   },
-                  "name": "doThat",
-                  "leadingComments": null
+                  "name": "doThat"
                 },
-                "arguments": [],
-                "leadingComments": null
+                "arguments": []
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/core/uncategorised/65/output.json
+++ b/packages/babylon/test/fixtures/core/uncategorised/65/output.json
@@ -118,11 +118,9 @@
                       },
                       "identifierName": "bingo"
                     },
-                    "name": "bingo",
-                    "leadingComments": null
+                    "name": "bingo"
                   },
-                  "arguments": [],
-                  "leadingComments": null
+                  "arguments": []
                 },
                 "leadingComments": [
                   {

--- a/packages/babylon/test/fixtures/es2015/modules/xml-comment-in-script/output.json
+++ b/packages/babylon/test/fixtures/es2015/modules/xml-comment-in-script/output.json
@@ -57,9 +57,7 @@
             },
             "identifierName": "foo"
           },
-          "name": "foo",
-          "leadingComments": null,
-          "trailingComments": null
+          "name": "foo"
         },
         "trailingComments": [
           {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0002/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0002/output.json
@@ -72,9 +72,7 @@
                 },
                 "identifierName": "x"
               },
-              "name": "x",
-              "leadingComments": null,
-              "trailingComments": null
+              "name": "x"
             },
             "init": null,
             "trailingComments": [

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0005/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0005/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentLine",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0006/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0006/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentBlock",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0008/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0008/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentLine",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0009/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0009/output.json
@@ -88,7 +88,6 @@
                 }
               },
               "label": null,
-              "leadingComments": null,
               "trailingComments": [
                 {
                   "type": "CommentBlock",
@@ -137,8 +136,7 @@
                   },
                   "identifierName": "there"
                 },
-                "name": "there",
-                "leadingComments": null
+                "name": "there"
               },
               "leadingComments": [
                 {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0011/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0011/output.json
@@ -90,7 +90,6 @@
                   }
                 },
                 "argument": null,
-                "leadingComments": null,
                 "trailingComments": [
                   {
                     "type": "CommentLine",
@@ -139,8 +138,7 @@
                     },
                     "identifierName": "x"
                   },
-                  "name": "x",
-                  "leadingComments": null
+                  "name": "x"
                 },
                 "leadingComments": [
                   {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0012/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0012/output.json
@@ -90,7 +90,6 @@
                   }
                 },
                 "argument": null,
-                "leadingComments": null,
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
@@ -139,8 +138,7 @@
                     },
                     "identifierName": "x"
                   },
-                  "name": "x",
-                  "leadingComments": null
+                  "name": "x"
                 },
                 "leadingComments": [
                   {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0014/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0014/output.json
@@ -72,9 +72,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null,
-              "trailingComments": null
+              "name": "error"
             },
             "trailingComments": [
               {
@@ -124,8 +122,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null
+              "name": "error"
             },
             "leadingComments": [
               {

--- a/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0015/output.json
+++ b/packages/babylon/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0015/output.json
@@ -72,9 +72,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null,
-              "trailingComments": null
+              "name": "error"
             },
             "trailingComments": [
               {
@@ -124,8 +122,7 @@
                 },
                 "identifierName": "error"
               },
-              "name": "error",
-              "leadingComments": null
+              "name": "error"
             },
             "leadingComments": [
               {

--- a/packages/babylon/test/fixtures/flow/anonymous-function-types/good_02/output.json
+++ b/packages/babylon/test/fixtures/flow/anonymous-function-types/good_02/output.json
@@ -29,7 +29,6 @@
     "sourceType": "module",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentLine",

--- a/packages/babylon/test/fixtures/flow/comment-disabled/01-type-include/output.json
+++ b/packages/babylon/test/fixtures/flow/comment-disabled/01-type-include/output.json
@@ -75,7 +75,6 @@
             }
           },
           "body": [],
-          "leadingComments": null,
           "innerComments": [
             {
               "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/flow/comment-disabled/02-type-include/output.json
+++ b/packages/babylon/test/fixtures/flow/comment-disabled/02-type-include/output.json
@@ -29,7 +29,6 @@
     "sourceType": "module",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/flow/comment-disabled/03-type-flow-include/output.json
+++ b/packages/babylon/test/fixtures/flow/comment-disabled/03-type-flow-include/output.json
@@ -29,7 +29,6 @@
     "sourceType": "module",
     "body": [],
     "directives": [],
-    "leadingComments": null,
     "innerComments": [
       {
         "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/flow/comment-disabled/04-type-flow-include/output.json
+++ b/packages/babylon/test/fixtures/flow/comment-disabled/04-type-flow-include/output.json
@@ -75,7 +75,6 @@
             }
           },
           "body": [],
-          "leadingComments": null,
           "innerComments": [
             {
               "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/flow/comment-disabled/05-type-annotation/output.json
+++ b/packages/babylon/test/fixtures/flow/comment-disabled/05-type-annotation/output.json
@@ -78,7 +78,6 @@
               "identifierName": "param"
             },
             "name": "param",
-            "leadingComments": null,
             "trailingComments": [
               {
                 "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/flow/comment/04-type-flow-include/output.json
+++ b/packages/babylon/test/fixtures/flow/comment/04-type-flow-include/output.json
@@ -75,7 +75,6 @@
             }
           },
           "body": [],
-          "leadingComments": null,
           "innerComments": [
             {
               "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/flow/comment/spread/output.json
+++ b/packages/babylon/test/fixtures/flow/comment/spread/output.json
@@ -57,8 +57,7 @@
             },
             "identifierName": "commentsAttachedToIdentifier"
           },
-          "name": "commentsAttachedToIdentifier",
-          "leadingComments": null
+          "name": "commentsAttachedToIdentifier"
         },
         "generator": false,
         "async": false,

--- a/packages/babylon/test/fixtures/flow/regression/issue-58/output.json
+++ b/packages/babylon/test/fixtures/flow/regression/issue-58/output.json
@@ -71,8 +71,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "Identifier",
@@ -148,8 +147,7 @@
               },
               "name": "d"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -231,8 +229,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -353,8 +350,7 @@
               "identifierName": "e"
             },
             "name": "e"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -436,8 +432,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "Identifier",
@@ -562,8 +557,7 @@
               },
               "name": "e"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -661,8 +655,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "AssignmentExpression",
@@ -808,8 +801,7 @@
               },
               "name": "f"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -907,8 +899,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -1098,8 +1089,7 @@
               "identifierName": "g"
             },
             "name": "g"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -1197,8 +1187,7 @@
               },
               "identifierName": "b"
             },
-            "name": "b",
-            "leadingComments": null
+            "name": "b"
           },
           "consequent": {
             "type": "ConditionalExpression",
@@ -1372,8 +1361,7 @@
               "identifierName": "h"
             },
             "name": "h"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -1471,8 +1459,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ConditionalExpression",
@@ -1650,8 +1637,7 @@
               "identifierName": "h"
             },
             "name": "h"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -1733,8 +1719,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ConditionalExpression",
@@ -1908,8 +1893,7 @@
               "identifierName": "g"
             },
             "name": "g"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -2007,8 +1991,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -2215,8 +2198,7 @@
               },
               "name": "g"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -2330,8 +2312,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -2538,8 +2519,7 @@
               "identifierName": "g"
             },
             "name": "g"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -2637,8 +2617,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "Identifier",
@@ -2834,8 +2813,7 @@
                 ]
               }
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -2917,8 +2895,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -3114,8 +3091,7 @@
               },
               "name": "f"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -3213,8 +3189,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -3327,8 +3302,7 @@
               },
               "name": "e"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -3426,8 +3400,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ConditionalExpression",
@@ -3589,8 +3562,7 @@
               "identifierName": "g"
             },
             "name": "g"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -3688,8 +3660,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -3888,8 +3859,7 @@
               },
               "name": "g"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -3987,8 +3957,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ConditionalExpression",
@@ -4228,8 +4197,7 @@
               },
               "name": "i"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -4327,8 +4295,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -4518,8 +4485,7 @@
               "identifierName": "f"
             },
             "name": "f"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -4633,8 +4599,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "CallExpression",
@@ -4740,8 +4705,7 @@
               },
               "name": "d"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -4839,8 +4803,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -4960,8 +4923,7 @@
               "identifierName": "e"
             },
             "name": "e"
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -5043,8 +5005,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "CallExpression",
@@ -5187,8 +5148,7 @@
               },
               "name": "e"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -5270,8 +5230,7 @@
               },
               "identifierName": "a"
             },
-            "name": "a",
-            "leadingComments": null
+            "name": "a"
           },
           "consequent": {
             "type": "ArrowFunctionExpression",
@@ -5421,8 +5380,7 @@
               },
               "name": "f"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -5521,8 +5479,7 @@
                 },
                 "identifierName": "icecream"
               },
-              "name": "icecream",
-              "leadingComments": null
+              "name": "icecream"
             },
             "init": {
               "type": "ConditionalExpression",
@@ -5968,8 +5925,7 @@
                   ]
                 }
               }
-            },
-            "leadingComments": null
+            }
           }
         ],
         "kind": "let",

--- a/packages/babylon/test/fixtures/flow/type-generics/async-arrow-like/output.json
+++ b/packages/babylon/test/fixtures/flow/type-generics/async-arrow-like/output.json
@@ -316,8 +316,7 @@
                   },
                   "identifierName": "async"
                 },
-                "name": "async",
-                "leadingComments": null
+                "name": "async"
               },
               "operator": "<",
               "right": {
@@ -369,8 +368,7 @@
                   },
                   "name": "U"
                 }
-              },
-              "leadingComments": null
+              }
             },
             "operator": ">",
             "right": {
@@ -456,8 +454,7 @@
                 "parenthesized": true,
                 "parenStart": 149
               }
-            },
-            "leadingComments": null
+            }
           },
           "typeAnnotation": {
             "type": "TypeAnnotation",
@@ -576,7 +573,6 @@
               "typeParameters": null
             }
           },
-          "leadingComments": null,
           "extra": {
             "parenthesized": true,
             "parenStart": 135

--- a/packages/babylon/test/fixtures/jsx/basic/10/output.json
+++ b/packages/babylon/test/fixtures/jsx/basic/10/output.json
@@ -149,7 +149,6 @@
                     "column": 27
                   }
                 },
-                "leadingComments": null,
                 "innerComments": [
                   {
                     "type": "CommentBlock",

--- a/packages/babylon/test/fixtures/jsx/basic/fragment-5/output.json
+++ b/packages/babylon/test/fixtures/jsx/basic/fragment-5/output.json
@@ -70,7 +70,6 @@
                 "column": 1
               }
             },
-            "leadingComments": null,
             "innerComments": [
               {
                 "type": "CommentLine",

--- a/packages/babylon/test/fixtures/typescript/arrow-function/generic-tsx/output.json
+++ b/packages/babylon/test/fixtures/typescript/arrow-function/generic-tsx/output.json
@@ -218,11 +218,9 @@
                     "column": 2
                   }
                 },
-                "name": "T",
-                "leadingComments": null
+                "name": "T"
               }
-            ],
-            "leadingComments": null
+            ]
           }
         },
         "leadingComments": [

--- a/packages/babylon/test/fixtures/typescript/cast/as/output.json
+++ b/packages/babylon/test/fixtures/typescript/cast/as/output.json
@@ -263,8 +263,7 @@
               },
               "identifierName": "x"
             },
-            "name": "x",
-            "leadingComments": null
+            "name": "x"
           },
           "operator": "===",
           "right": {
@@ -316,8 +315,7 @@
                 }
               }
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {
@@ -413,8 +411,7 @@
                 },
                 "identifierName": "x"
               },
-              "name": "x",
-              "leadingComments": null
+              "name": "x"
             },
             "typeAnnotation": {
               "type": "TSAnyKeyword",
@@ -430,8 +427,7 @@
                   "column": 8
                 }
               }
-            },
-            "leadingComments": null
+            }
           },
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -464,8 +460,7 @@
               },
               "name": "T"
             }
-          },
-          "leadingComments": null
+          }
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/typescript/class/abstract-false-positive/output.json
+++ b/packages/babylon/test/fixtures/typescript/class/abstract-false-positive/output.json
@@ -57,8 +57,7 @@
             },
             "identifierName": "abstract"
           },
-          "name": "abstract",
-          "leadingComments": null
+          "name": "abstract"
         },
         "leadingComments": [
           {

--- a/packages/babylon/test/fixtures/typescript/class/abstract/output.json
+++ b/packages/babylon/test/fixtures/typescript/class/abstract/output.json
@@ -192,11 +192,8 @@
                 "column": 26
               }
             },
-            "body": [],
-            "leadingComments": null,
-            "trailingComments": null
-          },
-          "trailingComments": null
+            "body": []
+          }
         },
         "trailingComments": [
           {
@@ -261,10 +258,8 @@
                 "column": 33
               }
             },
-            "body": [],
-            "leadingComments": null
+            "body": []
           },
-          "leadingComments": null,
           "abstract": true
         },
         "leadingComments": [
@@ -346,11 +341,8 @@
                 "column": 35
               }
             },
-            "body": [],
-            "leadingComments": null,
-            "trailingComments": null
+            "body": []
           },
-          "trailingComments": null,
           "abstract": true
         },
         "trailingComments": [

--- a/packages/babylon/test/fixtures/typescript/class/parameter-properties/output.json
+++ b/packages/babylon/test/fixtures/typescript/class/parameter-properties/output.json
@@ -385,8 +385,7 @@
                         },
                         "identifierName": "x"
                       },
-                      "name": "x",
-                      "leadingComments": null
+                      "name": "x"
                     },
                     "right": {
                       "type": "NumericLiteral",
@@ -407,8 +406,7 @@
                         "raw": "0"
                       },
                       "value": 0
-                    },
-                    "leadingComments": null
+                    }
                   },
                   "leadingComments": [
                     {

--- a/packages/babylon/test/fixtures/typescript/interface/export/output.json
+++ b/packages/babylon/test/fixtures/typescript/interface/export/output.json
@@ -89,11 +89,8 @@
                 "column": 21
               }
             },
-            "body": [],
-            "leadingComments": null,
-            "trailingComments": null
-          },
-          "trailingComments": null
+            "body": []
+          }
         },
         "trailingComments": [
           {

--- a/packages/babylon/test/fixtures/typescript/tsx/brace-is-block/output.json
+++ b/packages/babylon/test/fixtures/typescript/tsx/brace-is-block/output.json
@@ -57,8 +57,7 @@
             },
             "identifierName": "C"
           },
-          "name": "C",
-          "leadingComments": null
+          "name": "C"
         },
         "superClass": {
           "type": "Identifier",

--- a/packages/babylon/test/fixtures/typescript/type-alias/export/output.json
+++ b/packages/babylon/test/fixtures/typescript/type-alias/export/output.json
@@ -89,8 +89,7 @@
                 "column": 22
               }
             }
-          },
-          "trailingComments": null
+          }
         },
         "trailingComments": [
           {

--- a/scripts/generators/flow.js
+++ b/scripts/generators/flow.js
@@ -36,9 +36,9 @@ declare class ${NODE_PREFIX}SourceLocation {
 }
 
 declare class ${NODE_PREFIX} {
-  leadingComments: ?Array<${NODE_PREFIX}Comment>;
-  innerComments: ?Array<${NODE_PREFIX}Comment>;
-  trailingComments: ?Array<${NODE_PREFIX}Comment>;
+  leadingComments?: Array<${NODE_PREFIX}Comment>;
+  innerComments?: Array<${NODE_PREFIX}Comment>;
+  trailingComments?: Array<${NODE_PREFIX}Comment>;
   start: ?number;
   end: ?number;
   loc: ?${NODE_PREFIX}SourceLocation;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | maybe?
| Minor: New Feature?      | n
| Tests Added + Pass?      | n/y
| Documentation PR         |
| Any Dependency Changes?  |
| License                  | MIT

As mentioned in https://github.com/babel/babel/pull/7245 and some slack convos, this PR makes `leadingComments`, `trailingComments` and `innerComments` more consistent by not allowing them to be set to `null`.

I ran this through https://github.com/babel/babylon_performance a number of times and noticed no real impact.

Conditionally setting them seemed better than instantiating them as empty arrays, but def open to discussing alternatives as well.


