### PR TITLE
make babel injectable in babel-register

### DIFF
--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -68,7 +68,10 @@ require("@babel/register")({
   extensions: [".es6", ".es", ".jsx", ".js", ".mjs"],
 
   // Setting this to false will disable the cache.
-  cache: true
+  cache: true,
+
+  // Specify the version of babel-core used for transformation. (Optional)
+  babel: require('babel-core')
 });
 ```
 

--- a/packages/babel-register/README.md
+++ b/packages/babel-register/README.md
@@ -71,7 +71,7 @@ require("@babel/register")({
   cache: true,
 
   // Specify the version of babel-core used for transformation. (Optional)
-  babel: require('babel-core')
+  babel: require('@babel/core')
 });
 ```
 

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -10,7 +10,7 @@ import path from "path";
 
 const maps = {};
 const transformOpts = {};
-let babel = babelCore;
+let babel = null;
 let piratesRevert = null;
 
 function installSourceMapSupport() {
@@ -102,7 +102,7 @@ export default function register(opts?: Object = {}) {
   // Clone to avoid mutating the arguments object with the 'delete's below.
   opts = Object.assign({}, opts);
 
-  if (opts.babel) babel = opts.babel;
+  babel = opts.babel ? opts.babel : babelCore;
 
   if (opts.extensions) hookExtensions(opts.extensions);
 

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -2,7 +2,7 @@ import deepClone from "lodash/cloneDeep";
 import sourceMapSupport from "source-map-support";
 import * as registerCache from "./cache";
 import escapeRegExp from "lodash/escapeRegExp";
-import * as babel from "@babel/core";
+import * as babelCore from "@babel/core";
 import { OptionManager, DEFAULT_EXTENSIONS } from "@babel/core";
 import { addHook } from "pirates";
 import fs from "fs";
@@ -10,6 +10,7 @@ import path from "path";
 
 const maps = {};
 const transformOpts = {};
+let babel = babelCore;
 let piratesRevert = null;
 
 function installSourceMapSupport() {
@@ -100,6 +101,9 @@ register({
 export default function register(opts?: Object = {}) {
   // Clone to avoid mutating the arguments object with the 'delete's below.
   opts = Object.assign({}, opts);
+
+  if (opts.babel) babel = opts.babel;
+
   if (opts.extensions) hookExtensions(opts.extensions);
 
   if (opts.cache === false && cache) {
@@ -110,6 +114,7 @@ export default function register(opts?: Object = {}) {
     cache = registerCache.get();
   }
 
+  delete opts.babel;
   delete opts.extensions;
   delete opts.cache;
 

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -103,4 +103,20 @@ describe("@babel/register", function() {
     chai.expect((gen_error = require(GEN_ERROR))).to.be.ok;
     chai.expect(gen_error()).to.match(/gen_error\.js:2:86/);
   });
+
+  it("uses custom babel when requested", () => {
+    setupRegister({
+      babel: {
+        transform() {
+          return { code: "module.exports = 'hello';" };
+        },
+        getEnv() {
+          return {};
+        },
+        version: "custom",
+      },
+    });
+
+    chai.expect(require(DATA_ES2015)).to.equal("hello");
+  });
 });

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -119,4 +119,20 @@ describe("@babel/register", function() {
 
     chai.expect(require(DATA_ES2015)).to.equal("hello");
   });
+
+  it("Resets babel next register", () => {
+    function crash() {
+      throw new Error("shouldn't be called");
+    }
+
+    setupRegister({
+      babel: {
+        transform: crash,
+        getEnv: crash,
+      },
+    });
+    setupRegister();
+
+    chai.expect(require(DATA_ES2015)).to.be.ok;
+  });
 });

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -120,7 +120,7 @@ describe("@babel/register", function() {
     chai.expect(require(DATA_ES2015)).to.equal("hello");
   });
 
-  it("Resets babel next register", () => {
+  it("resets babel on subsequent register calls", () => {
     function crash() {
       throw new Error("shouldn't be called");
     }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | closes #7263
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I made the babel instance used by `babel-register` configurable to allow for the use case in #7263.
