### PR TITLE
add guard for cannot find decorator of undefined

### DIFF
--- a/packages/babel-plugin-transform-classes/src/vanilla.js
+++ b/packages/babel-plugin-transform-classes/src/vanilla.js
@@ -255,7 +255,7 @@ export default class ClassTransformer {
         throw path.buildCodeFrameError("Missing class properties transform.");
       }
 
-      if (node.decorators) {
+      if (node && node.decorators) {
         throw path.buildCodeFrameError(
           "Method has decorators, put the decorator plugin before the classes one.",
         );


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/A
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

could get error `cannot find decorators of undefined` in case node is undefined. Could happen if node is deleted, therefore added guard for that.
