### PR TITLE
turn optional into a tri-state boolean in OptionalChaining for babylon

### DIFF
--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -506,6 +506,7 @@ export type MemberExpression = NodeBase & {
   type: "MemberExpression",
   object: Expression | Super,
   property: Expression,
+  optional?: boolean,
   computed: boolean,
 };
 

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/function-call/input.js
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/function-call/input.js
@@ -5,3 +5,5 @@ func?.(a, b)
 a?.func?.()
 
 a?.func?.(a, b)
+
+(a?.b).func()

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/function-call/output.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/function-call/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 52,
+  "end": 67,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 7,
-      "column": 15
+      "line": 9,
+      "column": 13
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 52,
+    "end": 67,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 7,
-        "column": 15
+        "line": 9,
+        "column": 13
       }
     },
     "sourceType": "script",
@@ -247,119 +247,237 @@
       {
         "type": "ExpressionStatement",
         "start": 37,
-        "end": 52,
+        "end": 67,
         "loc": {
           "start": {
             "line": 7,
             "column": 0
           },
           "end": {
-            "line": 7,
-            "column": 15
+            "line": 9,
+            "column": 13
           }
         },
         "expression": {
           "type": "CallExpression",
           "start": 37,
-          "end": 52,
+          "end": 67,
           "loc": {
             "start": {
               "line": 7,
               "column": 0
             },
             "end": {
-              "line": 7,
-              "column": 15
+              "line": 9,
+              "column": 13
             }
           },
           "callee": {
             "type": "MemberExpression",
             "start": 37,
-            "end": 44,
+            "end": 65,
             "loc": {
               "start": {
                 "line": 7,
                 "column": 0
               },
               "end": {
-                "line": 7,
-                "column": 7
+                "line": 9,
+                "column": 11
               }
             },
             "object": {
-              "type": "Identifier",
+              "type": "CallExpression",
               "start": 37,
-              "end": 38,
+              "end": 60,
               "loc": {
                 "start": {
                   "line": 7,
                   "column": 0
                 },
                 "end": {
-                  "line": 7,
-                  "column": 1
-                },
-                "identifierName": "a"
+                  "line": 9,
+                  "column": 6
+                }
               },
-              "name": "a"
+              "callee": {
+                "type": "CallExpression",
+                "start": 37,
+                "end": 52,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 15
+                  }
+                },
+                "callee": {
+                  "type": "MemberExpression",
+                  "start": 37,
+                  "end": 44,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 7
+                    }
+                  },
+                  "object": {
+                    "type": "Identifier",
+                    "start": 37,
+                    "end": 38,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 1
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "property": {
+                    "type": "Identifier",
+                    "start": 40,
+                    "end": 44,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 7
+                      },
+                      "identifierName": "func"
+                    },
+                    "name": "func"
+                  },
+                  "computed": false,
+                  "optional": true
+                },
+                "arguments": [
+                  {
+                    "type": "Identifier",
+                    "start": 47,
+                    "end": 48,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 11
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  {
+                    "type": "Identifier",
+                    "start": 50,
+                    "end": 51,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 14
+                      },
+                      "identifierName": "b"
+                    },
+                    "name": "b"
+                  }
+                ],
+                "optional": true
+              },
+              "arguments": [
+                {
+                  "type": "MemberExpression",
+                  "start": 55,
+                  "end": 59,
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 5
+                    }
+                  },
+                  "object": {
+                    "type": "Identifier",
+                    "start": 55,
+                    "end": 56,
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 1
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 2
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "property": {
+                    "type": "Identifier",
+                    "start": 58,
+                    "end": 59,
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 5
+                      },
+                      "identifierName": "b"
+                    },
+                    "name": "b"
+                  },
+                  "computed": false,
+                  "optional": true
+                }
+              ]
             },
             "property": {
               "type": "Identifier",
-              "start": 40,
-              "end": 44,
+              "start": 61,
+              "end": 65,
               "loc": {
                 "start": {
-                  "line": 7,
-                  "column": 3
+                  "line": 9,
+                  "column": 7
                 },
                 "end": {
-                  "line": 7,
-                  "column": 7
+                  "line": 9,
+                  "column": 11
                 },
                 "identifierName": "func"
               },
               "name": "func"
             },
             "computed": false,
-            "optional": true
+            "optional": false
           },
-          "arguments": [
-            {
-              "type": "Identifier",
-              "start": 47,
-              "end": 48,
-              "loc": {
-                "start": {
-                  "line": 7,
-                  "column": 10
-                },
-                "end": {
-                  "line": 7,
-                  "column": 11
-                },
-                "identifierName": "a"
-              },
-              "name": "a"
-            },
-            {
-              "type": "Identifier",
-              "start": 50,
-              "end": 51,
-              "loc": {
-                "start": {
-                  "line": 7,
-                  "column": 13
-                },
-                "end": {
-                  "line": 7,
-                  "column": 14
-                },
-                "identifierName": "b"
-              },
-              "name": "b"
-            }
-          ],
-          "optional": true
+          "arguments": []
         }
       }
     ],

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/member-access/input.js
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/member-access/input.js
@@ -1,3 +1,7 @@
 foo?.bar
 
 foo?.bar?.baz
+
+(foo?.bar).baz
+
+foo?.bar.baz

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/member-access/output.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/member-access/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 23,
+  "end": 53,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 3,
-      "column": 13
+      "line": 7,
+      "column": 12
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 23,
+    "end": 53,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 3,
-        "column": 13
+        "line": 7,
+        "column": 12
       }
     },
     "sourceType": "script",
@@ -97,49 +97,49 @@
       {
         "type": "ExpressionStatement",
         "start": 10,
-        "end": 23,
+        "end": 39,
         "loc": {
           "start": {
             "line": 3,
             "column": 0
           },
           "end": {
-            "line": 3,
-            "column": 13
+            "line": 5,
+            "column": 14
           }
         },
         "expression": {
           "type": "MemberExpression",
           "start": 10,
-          "end": 23,
+          "end": 39,
           "loc": {
             "start": {
               "line": 3,
               "column": 0
             },
             "end": {
-              "line": 3,
-              "column": 13
+              "line": 5,
+              "column": 14
             }
           },
           "object": {
-            "type": "MemberExpression",
+            "type": "CallExpression",
             "start": 10,
-            "end": 18,
+            "end": 35,
             "loc": {
               "start": {
                 "line": 3,
                 "column": 0
               },
               "end": {
-                "line": 3,
-                "column": 8
+                "line": 5,
+                "column": 10
               }
             },
-            "object": {
-              "type": "Identifier",
+            "callee": {
+              "type": "MemberExpression",
               "start": 10,
-              "end": 13,
+              "end": 23,
               "loc": {
                 "start": {
                   "line": 3,
@@ -147,6 +147,208 @@
                 },
                 "end": {
                   "line": 3,
+                  "column": 13
+                }
+              },
+              "object": {
+                "type": "MemberExpression",
+                "start": 10,
+                "end": 18,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  }
+                },
+                "object": {
+                  "type": "Identifier",
+                  "start": 10,
+                  "end": 13,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 3
+                    },
+                    "identifierName": "foo"
+                  },
+                  "name": "foo"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "start": 15,
+                  "end": 18,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 8
+                    },
+                    "identifierName": "bar"
+                  },
+                  "name": "bar"
+                },
+                "computed": false,
+                "optional": true
+              },
+              "property": {
+                "type": "Identifier",
+                "start": 20,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 13
+                  },
+                  "identifierName": "baz"
+                },
+                "name": "baz"
+              },
+              "computed": false,
+              "optional": true
+            },
+            "arguments": [
+              {
+                "type": "MemberExpression",
+                "start": 26,
+                "end": 34,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 9
+                  }
+                },
+                "object": {
+                  "type": "Identifier",
+                  "start": 26,
+                  "end": 29,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "identifierName": "foo"
+                  },
+                  "name": "foo"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "start": 31,
+                  "end": 34,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 6
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 9
+                    },
+                    "identifierName": "bar"
+                  },
+                  "name": "bar"
+                },
+                "computed": false,
+                "optional": true
+              }
+            ]
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 36,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 11
+              },
+              "end": {
+                "line": 5,
+                "column": 14
+              },
+              "identifierName": "baz"
+            },
+            "name": "baz"
+          },
+          "computed": false,
+          "optional": false
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 41,
+        "end": 53,
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 12
+          }
+        },
+        "expression": {
+          "type": "MemberExpression",
+          "start": 41,
+          "end": 53,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 0
+            },
+            "end": {
+              "line": 7,
+              "column": 12
+            }
+          },
+          "object": {
+            "type": "MemberExpression",
+            "start": 41,
+            "end": 49,
+            "loc": {
+              "start": {
+                "line": 7,
+                "column": 0
+              },
+              "end": {
+                "line": 7,
+                "column": 8
+              }
+            },
+            "object": {
+              "type": "Identifier",
+              "start": 41,
+              "end": 44,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 0
+                },
+                "end": {
+                  "line": 7,
                   "column": 3
                 },
                 "identifierName": "foo"
@@ -155,15 +357,15 @@
             },
             "property": {
               "type": "Identifier",
-              "start": 15,
-              "end": 18,
+              "start": 46,
+              "end": 49,
               "loc": {
                 "start": {
-                  "line": 3,
+                  "line": 7,
                   "column": 5
                 },
                 "end": {
-                  "line": 3,
+                  "line": 7,
                   "column": 8
                 },
                 "identifierName": "bar"
@@ -175,23 +377,23 @@
           },
           "property": {
             "type": "Identifier",
-            "start": 20,
-            "end": 23,
+            "start": 50,
+            "end": 53,
             "loc": {
               "start": {
-                "line": 3,
-                "column": 10
+                "line": 7,
+                "column": 9
               },
               "end": {
-                "line": 3,
-                "column": 13
+                "line": 7,
+                "column": 12
               },
               "identifierName": "baz"
             },
             "name": "baz"
           },
           "computed": false,
-          "optional": true
+          "optional": false
         }
       }
     ],

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/separated-chaining/output.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/separated-chaining/output.json
@@ -166,7 +166,8 @@
                   },
                   "name": "c"
                 },
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "property": {
                 "type": "Identifier",
@@ -185,7 +186,8 @@
                 },
                 "name": "d"
               },
-              "computed": false
+              "computed": false,
+              "optional": false
             },
             "property": {
               "type": "Identifier",
@@ -204,7 +206,8 @@
               },
               "name": "e"
             },
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": {
             "type": "Identifier",
@@ -403,7 +406,8 @@
               },
               "name": "e"
             },
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": {
             "type": "Identifier",
@@ -422,7 +426,8 @@
             },
             "name": "f"
           },
-          "computed": false
+          "computed": false,
+          "optional": false
         }
       }
     ],


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7256 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->No
| Any Dependency Changes?  |No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As was decided, we can turn `optional` into tri-state, saving us from trouble of creating new nodes and breaking current transforms!