### PR TITLE
[Typescript] - Fix SyntaxError in async arrow functions with rest params

### DIFF
--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -1683,7 +1683,13 @@ export default class ExpressionParser extends LValParser {
     if (allowEmpty && this.match(tt.comma)) {
       elt = null;
     } else if (this.match(tt.ellipsis)) {
-      elt = this.parseSpread(refShorthandDefaultPos);
+      const spreadNodeStartPos = this.state.start;
+      const spreadNodeStartLoc = this.state.startLoc;
+      elt = this.parseParenItem(
+        this.parseSpread(refShorthandDefaultPos),
+        spreadNodeStartPos,
+        spreadNodeStartLoc,
+      );
 
       if (refTrailingCommaPos && this.match(tt.comma)) {
         refTrailingCommaPos.start = this.state.start;

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -1686,7 +1686,7 @@ export default class ExpressionParser extends LValParser {
       const spreadNodeStartPos = this.state.start;
       const spreadNodeStartLoc = this.state.startLoc;
       elt = this.parseParenItem(
-        this.parseSpread(refShorthandDefaultPos),
+        this.parseSpread(refShorthandDefaultPos, refNeedsArrowPos),
         spreadNodeStartPos,
         spreadNodeStartLoc,
       );

--- a/packages/babylon/src/parser/lval.js
+++ b/packages/babylon/src/parser/lval.js
@@ -183,10 +183,18 @@ export default class LValParser extends NodeUtils {
 
   // Parses spread element.
 
-  parseSpread<T: RestElement | SpreadElement>(refShorthandDefaultPos: ?Pos): T {
+  parseSpread<T: RestElement | SpreadElement>(
+    refShorthandDefaultPos: ?Pos,
+    refNeedsArrowPos?: ?Pos,
+  ): T {
     const node = this.startNode();
     this.next();
-    node.argument = this.parseMaybeAssign(false, refShorthandDefaultPos);
+    node.argument = this.parseMaybeAssign(
+      false,
+      refShorthandDefaultPos,
+      undefined,
+      refNeedsArrowPos,
+    );
     return this.finishNode(node, "SpreadElement");
   }
 

--- a/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest-optional-parameters/input.js
+++ b/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest-optional-parameters/input.js
@@ -1,0 +1,1 @@
+async (...args?: any) => {};

--- a/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest-optional-parameters/output.json
+++ b/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest-optional-parameters/output.json
@@ -1,0 +1,149 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 28
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 28,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 28
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 27
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [
+            {
+              "type": "RestElement",
+              "start": 7,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 7
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                }
+              },
+              "argument": {
+                "type": "Identifier",
+                "start": 10,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "identifierName": "args"
+                },
+                "name": "args"
+              },
+              "optional": true,
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 15,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "AnyTypeAnnotation",
+                  "start": 17,
+                  "end": 20,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 20
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 25,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 25
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest/input.js
+++ b/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest/input.js
@@ -1,0 +1,1 @@
+async (...args: any) => {};

--- a/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest/output.json
+++ b/packages/babylon/test/fixtures/flow/type-generics/async-arrow-rest/output.json
@@ -1,0 +1,148 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 27
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 27,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 27
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 26,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 26
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [
+            {
+              "type": "RestElement",
+              "start": 7,
+              "end": 19,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 7
+                },
+                "end": {
+                  "line": 1,
+                  "column": 19
+                }
+              },
+              "argument": {
+                "type": "Identifier",
+                "start": 10,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "identifierName": "args"
+                },
+                "name": "args"
+              },
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 14,
+                "end": 19,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 19
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "AnyTypeAnnotation",
+                  "start": 16,
+                  "end": 19,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 19
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 24,
+            "end": 26,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 26
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/typescript/arrow-function/async-rest-optional-parameter/input.js
+++ b/packages/babylon/test/fixtures/typescript/arrow-function/async-rest-optional-parameter/input.js
@@ -1,0 +1,1 @@
+async(...args?: any[]) : any => {}

--- a/packages/babylon/test/fixtures/typescript/arrow-function/async-rest-optional-parameter/output.json
+++ b/packages/babylon/test/fixtures/typescript/arrow-function/async-rest-optional-parameter/output.json
@@ -1,0 +1,194 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 34
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 34
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 34
+            }
+          },
+          "returnType": {
+            "type": "TSTypeAnnotation",
+            "start": 23,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 23
+              },
+              "end": {
+                "line": 1,
+                "column": 28
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSAnyKeyword",
+              "start": 25,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 25
+                },
+                "end": {
+                  "line": 1,
+                  "column": 28
+                }
+              }
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [
+            {
+              "type": "RestElement",
+              "start": 6,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                }
+              },
+              "argument": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 13,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 13
+                  },
+                  "identifierName": "args"
+                },
+                "name": "args"
+              },
+              "optional": true,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 14,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSArrayType",
+                  "start": 16,
+                  "end": 21,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 21
+                    }
+                  },
+                  "elementType": {
+                    "type": "TSAnyKeyword",
+                    "start": 16,
+                    "end": 19,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 19
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 32,
+            "end": 34,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 32
+              },
+              "end": {
+                "line": 1,
+                "column": 34
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/typescript/arrow-function/async-rest/input.js
+++ b/packages/babylon/test/fixtures/typescript/arrow-function/async-rest/input.js
@@ -1,0 +1,1 @@
+async (...args: any[]) : any => {}

--- a/packages/babylon/test/fixtures/typescript/arrow-function/async-rest/output.json
+++ b/packages/babylon/test/fixtures/typescript/arrow-function/async-rest/output.json
@@ -1,0 +1,193 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 34
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 34
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 34
+            }
+          },
+          "returnType": {
+            "type": "TSTypeAnnotation",
+            "start": 23,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 23
+              },
+              "end": {
+                "line": 1,
+                "column": 28
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSAnyKeyword",
+              "start": 25,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 25
+                },
+                "end": {
+                  "line": 1,
+                  "column": 28
+                }
+              }
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [
+            {
+              "type": "RestElement",
+              "start": 7,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 7
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                }
+              },
+              "argument": {
+                "type": "Identifier",
+                "start": 10,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "identifierName": "args"
+                },
+                "name": "args"
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 14,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSArrayType",
+                  "start": 16,
+                  "end": 21,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 21
+                    }
+                  },
+                  "elementType": {
+                    "type": "TSAnyKeyword",
+                    "start": 16,
+                    "end": 19,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 19
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 32,
+            "end": 34,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 32
+              },
+              "end": {
+                "line": 1,
+                "column": 34
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7253 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`parseSpread` in `parseExprListItem` should be called with `parseParenItem`