### PR TITLE
Failing test involving object rest/spread and clearScope().

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/input.js
@@ -1,0 +1,4 @@
+it("es7.objectRestSpread", () => {
+  let original = { a: 1, b: 2 };
+  let { ...copy } = original;
+});

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/options.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "./plugin-clear-scope",
+    "proposal-object-rest-spread",
+    "external-helpers"
+  ]
+}

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/output.js
@@ -1,0 +1,7 @@
+it("es7.objectRestSpread", () => {
+  let original = {
+    a: 1,
+    b: 2
+  };
+  let copy = babelHelpers.objectWithoutProperties(original, []);
+});

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/plugin-clear-scope.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/plugin-clear-scope.js
@@ -1,0 +1,11 @@
+"use strict";
+exports.__esModule = true;
+exports.default = function (api) {
+  return {
+    visitor: {
+      Program: function () {
+        api.traverse.cache.clearScope();
+      }
+    }
+  };
+};


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Possibly #7304, once this test passes
| Patch: Bug Fix?          | Not yet; I hope to push a fix if I can figure it out
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Added a failing test
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

This failing test case demonstrates a regression between `7.0.0-beta.38` and `7.0.0-beta.39` in the [`@babel/plugin-proposal-object-rest-spread`](https://github.com/babel/babel/tree/eb38ea2b10d07b3451e4f68b6505cb4730aa5311/packages/babel-plugin-proposal-object-rest-spread) package.

I distilled this test case from a larger configuration of plugins in my application, one of which calls `api.traverse.cache.clearScope()`. Although calling `clearScope()` is an uncommon thing for a plugin to do, it was a reliable way to reproduce the problem. If I can find other reliable reproductions, I'll push some additional failing tests to this PR.

Regardless of how common it is, clearing the scope cache should be a safe operation that only slows down the transform (because scopes have to be recreated and re-crawled). Crashing due to a spurious duplicate declaration seems like a bug worth fixing.

My hunch is that [these two lines](https://github.com/babel/babel/blob/eb38ea2b10d07b3451e4f68b6505cb4730aa5311/packages/babel-plugin-proposal-object-rest-spread/src/index.js#L75-L76) (which were changed in `7.0.0-beta.39`) are not actually removing the original rest element as a binding from the enclosing `Scope`, in certain circumstances, so the new variable declaration ends up colliding with the old (removed) binding.

cc @nicolo-ribaudo & @Andarist who worked on #7149

Possibly related: #7304 (reported by @julien-f)

Here's the error:
```
% TEST_GREP=object-rest-spread make test-only
./scripts/test.sh


  ․․!․․․․․․․․․․․․․․․․․․․․․․

  24 passing (312ms)
  1 failing

  1) babel-plugin-proposal-object-rest-spread/object rest duplicate decl bug:
     TypeError: /Users/ben/dev/babel/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/input.js: Duplicate declaration "copy"
  1 | it("es7.objectRestSpread", () => {
  2 |   let original = { a: 1, b: 2 };
> 3 |   let { ...copy } = original;
    |            ^
  4 | });
      at File.buildCodeFrameError (packages/babel-core/lib/transformation/file/file.js:207:12)
      at Scope.checkBlockScopedCollisions (packages/babel-traverse/lib/scope/index.js:303:27)
      at Scope.registerBinding (packages/babel-traverse/lib/scope/index.js:485:16)
      at Scope.registerDeclaration (packages/babel-traverse/lib/scope/index.js:404:14)
      at Object.BlockScoped (packages/babel-traverse/lib/scope/index.js:146:28)
      at Object.newFn (packages/babel-traverse/lib/visitors.js:266:17)
      at NodePath._call (packages/babel-traverse/lib/path/context.js:64:19)
      at NodePath.call (packages/babel-traverse/lib/path/context.js:34:14)
      at NodePath.visit (packages/babel-traverse/lib/path/context.js:99:12)
      ...
```