### PR TITLE
[BugFix] Compile export default from

### DIFF
--- a/packages/babylon/test/fixtures/esprima/es2015-export-declaration/invalid-export-default/options.json
+++ b/packages/babylon/test/fixtures/esprima/es2015-export-declaration/invalid-export-default/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:7)"
+  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:15)"
 }

--- a/packages/babylon/test/fixtures/experimental/_no-plugin/export-default/options.json
+++ b/packages/babylon/test/fixtures/experimental/_no-plugin/export-default/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:7)",
+  "throws": "This experimental syntax requires enabling the parser plugin: 'exportDefaultFrom' (1:9)",
   "plugins": []
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7293 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | NO
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Now we check in export default statements that if from is either an assignment or  from is exported then valid AST are generated, which doesn't require any sort of plugin.