### PR TITLE
Remove outdated sentence from README

### DIFF
--- a/packages/babel-plugin-proposal-unicode-property-regex/README.md
+++ b/packages/babel-plugin-proposal-unicode-property-regex/README.md
@@ -2,8 +2,6 @@
 
 Compile [Unicode property escapes](https://github.com/mathiasbynens/regexpu-core/blob/master/property-escapes.md) (`\p{…}` and `\P{…}`) in Unicode regular expressions to ES5 or ES6 that works in today’s environments.
 
-**Note:** the Unicode property escape syntax is non-standard and may or may not reflect what eventually gets specified.
-
 [Here’s an online demo.](https://mothereff.in/regexpu#input=var+regex+%3D+/%5Cp%7BScript_Extensions%3DGreek%7D/u%3B&unicodePropertyEscape=1)
 
 ## Installation


### PR DESCRIPTION
Unicode property escapes are now part of ECMAScript proper, so we can get rid of this sentence. 🎉