### PR TITLE
Preserve identifier location information when mapping this and arguments.

### DIFF
--- a/packages/babel-traverse/src/path/conversion.js
+++ b/packages/babel-traverse/src/path/conversion.js
@@ -208,9 +208,12 @@ function hoistFunctionEnvironment(
       },
     });
     const superBinding = getSuperBinding(thisEnvFn);
-    allSuperCalls.forEach(superCall =>
-      superCall.get("callee").replaceWith(t.identifier(superBinding)),
-    );
+    allSuperCalls.forEach(superCall => {
+      const callee = t.identifier(superBinding);
+      callee.loc = superCall.node.callee.loc;
+
+      superCall.get("callee").replaceWith(callee);
+    });
   }
 
   // Convert all "this" references in the arrow to point at the alias.
@@ -225,11 +228,12 @@ function hoistFunctionEnvironment(
       (inConstructor && hasSuperClass(thisEnvFn))
     ) {
       thisPaths.forEach(thisChild => {
-        thisChild.replaceWith(
-          thisChild.isJSX()
-            ? t.jsxIdentifier(thisBinding)
-            : t.identifier(thisBinding),
-        );
+        const thisRef = thisChild.isJSX()
+          ? t.jsxIdentifier(thisBinding)
+          : t.identifier(thisBinding);
+
+        thisRef.loc = thisChild.node.loc;
+        thisChild.replaceWith(thisRef);
       });
 
       if (specCompliant) thisBinding = null;
@@ -243,7 +247,10 @@ function hoistFunctionEnvironment(
     );
 
     argumentsPaths.forEach(argumentsChild => {
-      argumentsChild.replaceWith(t.identifier(argumentsBinding));
+      const argsRef = t.identifier(argumentsBinding);
+      argsRef.loc = argumentsChild.node.loc;
+
+      argumentsChild.replaceWith(argsRef);
     });
   }
 
@@ -253,8 +260,11 @@ function hoistFunctionEnvironment(
       t.metaProperty(t.identifier("new"), t.identifier("target")),
     );
 
-    newTargetPaths.forEach(argumentsChild => {
-      argumentsChild.replaceWith(t.identifier(newTargetBinding));
+    newTargetPaths.forEach(targetChild => {
+      const targetRef = t.identifier(newTargetBinding);
+      targetRef.loc = targetChild.node.loc;
+
+      targetChild.replaceWith(targetRef);
     });
   }
 

--- a/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/input.js
+++ b/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/input.js
@@ -1,0 +1,5 @@
+function fn() {
+  var inner = () => {
+    console.log(arguments);
+  };
+}

--- a/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/options.json
+++ b/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-arrow-functions"]
+}

--- a/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/output.js
+++ b/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/output.js
@@ -1,0 +1,7 @@
+function fn() {
+  var _arguments = arguments;
+
+  var inner = function () {
+    console.log(_arguments);
+  };
+}

--- a/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/source-mappings.json
+++ b/packages/babel-traverse/test/fixtures/conversion/arguments-source-maps/source-mappings.json
@@ -1,0 +1,8 @@
+[{
+  "generated": {
+    "line": 5, "column": 16
+  },
+  "original": {
+    "line": 3, "column": 16
+  }
+}]

--- a/packages/babel-traverse/test/fixtures/conversion/this-source-maps/input.js
+++ b/packages/babel-traverse/test/fixtures/conversion/this-source-maps/input.js
@@ -1,0 +1,5 @@
+function fn() {
+  var inner = () => {
+    console.log(this);
+  };
+}

--- a/packages/babel-traverse/test/fixtures/conversion/this-source-maps/options.json
+++ b/packages/babel-traverse/test/fixtures/conversion/this-source-maps/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-arrow-functions"]
+}

--- a/packages/babel-traverse/test/fixtures/conversion/this-source-maps/output.js
+++ b/packages/babel-traverse/test/fixtures/conversion/this-source-maps/output.js
@@ -1,0 +1,7 @@
+function fn() {
+  var _this = this;
+
+  var inner = function () {
+    console.log(_this);
+  };
+}

--- a/packages/babel-traverse/test/fixtures/conversion/this-source-maps/source-mappings.json
+++ b/packages/babel-traverse/test/fixtures/conversion/this-source-maps/source-mappings.json
@@ -1,0 +1,8 @@
+[{
+  "generated": {
+    "line": 5, "column": 16
+  },
+  "original": {
+    "line": 3, "column": 16
+  }
+}]


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

A bug I came across while working on some sourcemapping stuff. Preserving the `.loc` on the nodes means that you can actually map back and forth properly.