### PR TITLE
Add location information to parsing errors

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -91,7 +91,6 @@ function parser(pluginPasses, options, code) {
   } catch (err) {
     const { loc, missingPlugin } = err;
     if (loc) {
-      err.loc = null;
       const codeFrame = codeFrameColumns(
         code,
         {
@@ -110,6 +109,7 @@ function parser(pluginPasses, options, code) {
         err.message =
           `${options.filename || "unknown"}: ${err.message}\n\n` + codeFrame;
       }
+      err.code = "BABEL_PARSE_ERROR";
     }
     throw err;
   }

--- a/packages/babel-template/src/parse.js
+++ b/packages/babel-template/src/parse.js
@@ -148,8 +148,8 @@ function parseWithCodeFrame(code: string, parserOpts: {}): BabelNodeFile {
   } catch (err) {
     const loc = err.loc;
     if (loc) {
-      err.loc = null;
       err.message += "\n" + codeFrameColumns(code, { start: loc });
+      err.code = "BABEL_TEMPLATE_PARSE_ERROR";
     }
     throw err;
   }

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -77,10 +77,6 @@ export function replaceWithSourceString(replacement) {
   } catch (err) {
     const loc = err.loc;
     if (loc) {
-      // Set the location to null or else the re-thrown exception could
-      // incorrectly interpret the location as referencing the file being
-      // transformed.
-      err.loc = null;
       err.message +=
         " - make sure this is an expression.\n" +
         codeFrameColumns(replacement, {
@@ -89,6 +85,7 @@ export function replaceWithSourceString(replacement) {
             column: loc.column + 1,
           },
         });
+      err.code = "BABEL_REPLACE_SOURCE_ERROR";
     }
     throw err;
   }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | refs https://github.com/babel/babel-eslint/issues/573#issuecomment-362142343
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As discussed in [Slack](https://babeljs.slack.com/archives/C062RC35M/p1517507859000347), this PR retains location information for errors thrown by the parser and adds error codes so that the consumer can distinguish between errors easily.

A few questions I have:
1. Did I miss any spots?
2. Should we be exposing these error codes as constants that a consumer can import so they don't have to care about Babel changing these strings? With only two errors codes, maybe this isn't necessary. They're also shared across packages, so I'm not sure how the team would want to go about that.
3. I didn't update any tests - should I have?