### PR TITLE
Add core-js as valid polyfill source

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -342,6 +342,8 @@ import "core-js/modules/es7.string.pad-start";
 import "core-js/modules/es7.string.pad-end";
 ```
 
+This will also work for `core-js` directly (`import "core-js";` or `require('core-js');`)
+
 #### `useBuiltIns: false`
 
 Don't add polyfills automatically per file, or transform `import "@babel/polyfill"` to individual polyfills.

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -86,7 +86,7 @@ export const filterStageFromList = (list: any, stageList: any) => {
 };
 
 export const isPolyfillSource = (source: string): boolean =>
-  source === "@babel/polyfill";
+  source === "@babel/polyfill" || source === "core-js";
 
 export const isRequire = (t: Object, path: Object): boolean =>
   t.isExpressionStatement(path.node) &&

--- a/packages/babel-preset-env/test/fixtures/preset-options/core-js/input.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/core-js/input.js
@@ -1,0 +1,1 @@
+import "core-js";

--- a/packages/babel-preset-env/test/fixtures/preset-options/core-js/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/core-js/options.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    ["../../../../lib", {
+      "targets": {
+        "chrome": 55
+      },
+      "modules": false,
+      "useBuiltIns": "entry"
+    }]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/core-js/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/core-js/output.js
@@ -1,0 +1,6 @@
+import "core-js/modules/es6.array.sort";
+import "core-js/modules/es7.string.pad-start";
+import "core-js/modules/es7.string.pad-end";
+import "core-js/modules/web.timers";
+import "core-js/modules/web.immediate";
+import "core-js/modules/web.dom.iterable";

--- a/packages/babel-preset-env/test/fixtures/preset-options/ios-6/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/ios-6/output.js
@@ -1,1 +1,0 @@
-import "core-js";


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | ?
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

I brought that up a while ago, but wanted to finally start the discussion. I'm not sure why it was removed in v7.x. I found it very useful to be able to use `import "core-js"` with babel-preset-env builtIn option. Especially to mitigate the problem that the wrong version of core-js could be installed on toplevel, so that the generated imports from core-js do fail.

Would also be interested why it was removed?
