### PR TITLE
Assign another temp var when parsing assignment patterns in destructuring

### DIFF
--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -108,43 +108,40 @@ export default function(api, options) {
       }
     }
 
-    pushAssignmentPattern(pattern, valueRef) {
+    pushAssignmentPattern({ left, right }, valueRef) {
       // we need to assign the current value of the assignment to avoid evaluating
       // it more than once
+      const tempId = this.scope.generateUidIdentifierBasedOnNode(valueRef);
 
-      const tempValueRef = this.scope.generateUidBasedOnNode(valueRef);
-
-      const declar = t.variableDeclaration("var", [
-        t.variableDeclarator(t.identifier(tempValueRef), valueRef),
-      ]);
-      declar._blockHoist = this.blockHoist;
-      this.nodes.push(declar);
-
-      //
+      this.nodes.push(this.buildVariableDeclaration(tempId, valueRef));
 
       const tempConditional = t.conditionalExpression(
         t.binaryExpression(
           "===",
-          t.identifier(tempValueRef),
+          t.cloneNode(tempId),
           this.scope.buildUndefinedNode(),
         ),
-        pattern.right,
-        t.identifier(tempValueRef),
+        right,
+        t.cloneNode(tempId),
       );
 
-      const left = pattern.left;
       if (t.isPattern(left)) {
-        const tempValueDefault = t.expressionStatement(
-          t.assignmentExpression(
-            "=",
-            t.identifier(tempValueRef),
-            tempConditional,
-          ),
-        );
-        tempValueDefault._blockHoist = this.blockHoist;
+        let patternId;
+        let node;
 
-        this.nodes.push(tempValueDefault);
-        this.push(left, t.identifier(tempValueRef));
+        if (this.kind === "const") {
+          patternId = this.scope.generateUidIdentifier(tempId.name);
+          node = this.buildVariableDeclaration(patternId, tempConditional);
+        } else {
+          patternId = tempId;
+
+          node = t.expressionStatement(
+            t.assignmentExpression("=", t.cloneNode(tempId), tempConditional),
+          );
+        }
+
+        this.nodes.push(node);
+        this.push(left, patternId);
       } else {
         this.nodes.push(this.buildVariableAssignment(left, tempConditional));
       }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/exec.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/exec.js
@@ -1,0 +1,5 @@
+const getState = () => ({});
+
+const { data: { courses: oldCourses = [] } = {} } = getState();
+
+assert.deepEqual(oldCourses, []);

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/input.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/input.js
@@ -1,0 +1,1 @@
+const { data: { courses: oldCourses = [] } = {} } = getState();

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-destructuring"]
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/const/output.js
@@ -1,0 +1,5 @@
+const _getState = getState(),
+      _getState$data = _getState.data,
+      _getState$data2 = _getState$data === void 0 ? {} : _getState$data,
+      _getState$data2$cours = _getState$data2.courses,
+      oldCourses = _getState$data2$cours === void 0 ? [] : _getState$data2$cours;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7329
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | y/y
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Creates another `variableDeclaration ` instead of an `assignmentExpression` to prevent cases where we try to assign to a const.