### PR TITLE
Allow falsey, yet valid options for codeFrameColumns()

### DIFF
--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -127,10 +127,7 @@ function getMarkerLines(
     loc.start,
   );
   const endLoc: Location = Object.assign({}, startLoc, loc.end);
-  const {
-    linesAbove = 2,
-    linesBelow = 3,
-  } = opts || {};
+  const { linesAbove = 2, linesBelow = 3 } = opts || {};
   const startLine = startLoc.line;
   const startColumn = startLoc.column;
   const endLine = endLoc.line;

--- a/packages/babel-code-frame/src/index.js
+++ b/packages/babel-code-frame/src/index.js
@@ -127,9 +127,10 @@ function getMarkerLines(
     loc.start,
   );
   const endLoc: Location = Object.assign({}, startLoc, loc.end);
-  const linesAbove = opts.linesAbove || 2;
-  const linesBelow = opts.linesBelow || 3;
-
+  const {
+    linesAbove = 2,
+    linesBelow = 3,
+  } = opts || {};
   const startLine = startLoc.line;
   const startColumn = startLoc.column;
   const endLine = endLoc.line;

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -184,6 +184,57 @@ describe("@babel/code-frame", function() {
     );
   });
 
+  it("opts.linesAbove no lines above", function() {
+    const rawLines = [
+      "class Foo {",
+      "  constructor() {",
+      "    console.log(arguments);",
+      "  }",
+      "};",
+    ].join("\n");
+    assert.equal(
+      codeFrameColumns(rawLines, { start: { line: 2 } }, { linesAbove: 0 }),
+      [
+        "> 2 |   constructor() {",
+        "  3 |     console.log(arguments);",
+        "  4 |   }",
+        "  5 | };",
+      ].join("\n"),
+    );
+  });
+
+  it("opts.linesBelow no lines below", function() {
+    const rawLines = [
+      "class Foo {",
+      "  constructor() {",
+      "    console.log(arguments);",
+      "  }",
+      "};",
+    ].join("\n");
+    assert.equal(
+      codeFrameColumns(rawLines, { start: { line: 2 } }, { linesBelow: 0 }),
+      ["  1 | class Foo {", "> 2 |   constructor() {"].join("\n"),
+    );
+  });
+
+  it("opts.linesBelow single line", function() {
+    const rawLines = [
+      "class Foo {",
+      "  constructor() {",
+      "    console.log(arguments);",
+      "  }",
+      "};",
+    ].join("\n");
+    assert.equal(
+      codeFrameColumns(
+        rawLines,
+        { start: { line: 2 } },
+        { linesAbove: 0, linesBelow: 0 },
+      ),
+      ["> 2 |   constructor() {"].join("\n"),
+    );
+  });
+
   it("opts.forceColor", function() {
     const marker = chalk.red.bold;
     const gutter = chalk.grey;


### PR DESCRIPTION
Allow for overriding default linesAbove/linesBelow values.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7340
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes + Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Improved option defaulting logic, small change.
