### PR TITLE
Fix failing test

### DIFF
--- a/packages/babel-preset-env/test/fixtures/preset-options/use-builtins-chromeandroid/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/use-builtins-chromeandroid/output.js
@@ -1,4 +1,3 @@
-import "core-js/modules/es6.array.sort";
 import "core-js/modules/web.timers";
 import "core-js/modules/web.immediate";
 import "core-js/modules/web.dom.iterable";


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The problem is that CanIUse doesn't track old mobile browsers versions, so `browsers: ["ChromeAndroid 59"]` actually resolves to the lastest chrome version. Thanks @existentialism for explaining it to me :wink:
https://github.com/Fyrd/caniuse/issues/3518

This PR doesn't fix this problem (which can't be fixed by Babel anyway), but it updates the test to make it pass.