### PR TITLE
build types as part of ci, to re-enable flow checks (also see #7227)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,8 +13,8 @@ codemods/*/src
 [libs]
 lib/file.js
 lib/parser.js
-lib/packages/babel-types/lib/index.js.flow
 lib/third-party-libs.js.flow
+packages/babel-types/lib/index.js.flow
 
 [options]
 include_warnings=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,12 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
 
 before_script:
+  - 'make bootstrap'
   - 'if [ "$JOB" = "babylon-flow-tests" ]; then make bootstrap-flow; fi'
   - 'if [ "$JOB" = "babylon-test262-tests" ]; then make bootstrap-test262; fi'
 
 script:
-  - 'if [ "$JOB" = "test" ]; then make test-ci; fi'
+  - 'if [ "$JOB" = "test" ]; then make test-only; fi'
   - 'if [ "$JOB" = "lint" ]; then make lint && make flow; fi'
   - 'if [ "$JOB" = "babylon-flow-tests" ]; then make test-flow-ci; fi'
   - 'if [ "$JOB" = "babylon-test262-tests" ]; then make test-test262-ci; fi'

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export FORCE_COLOR = true
 
 SOURCES = packages codemods
 
-.PHONY: build build-dist watch lint fix clean test-clean test-only test test-ci publish bootstrap
+.PHONY: build build-dist watch lint fix clean test-clean test-only test publish bootstrap
 
 build: clean
 	make clean-lib
@@ -67,10 +67,6 @@ test-only:
 	make test-clean
 
 test: lint test-only
-
-test-ci:
-	make bootstrap
-	make test-only
 
 test-ci-coverage: SHELL:=/bin/bash
 test-ci-coverage:


### PR DESCRIPTION
See https://github.com/babel/babel/pull/7101#issuecomment-363682345