### PR TITLE
Fixes issues regarding super in optionalChain

### DIFF
--- a/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property-class/input.js
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property-class/input.js
@@ -1,0 +1,5 @@
+class A{
+    b(){
+        return super?.b;
+    }
+}

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property-class/options.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property-class/options.json
@@ -1,0 +1,4 @@
+{
+    "plugins":["optionalChaining"],
+    "throws": "Unexpected token (3:20)"
+}

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property/input.js
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property/input.js
@@ -1,0 +1,5 @@
+const a = {
+    b(){
+        return super?.c;
+    }
+}

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property/options.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/optional-super-property/options.json
@@ -1,0 +1,4 @@
+{
+    "plugins":["optionalChaining"],
+    "throws": "Unexpected token (3:20)"
+}

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/super-method-class/input.js
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/super-method-class/input.js
@@ -1,0 +1,5 @@
+class A{
+    constructor(){
+        super()?.b;
+    }
+}

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/super-method-class/options.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/super-method-class/options.json
@@ -1,0 +1,3 @@
+{
+    "plugins":["optionalChaining"]
+}

--- a/packages/babylon/test/fixtures/experimental/optional-chaining/super-method-class/output.json
+++ b/packages/babylon/test/fixtures/experimental/optional-chaining/super-method-class/output.json
@@ -1,0 +1,221 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 55,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 55,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 55,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 7,
+          "end": 55,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 5,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 13,
+              "end": 53,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 4,
+                  "column": 5
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 13,
+                "end": 24,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 15
+                  },
+                  "identifierName": "constructor"
+                },
+                "name": "constructor"
+              },
+              "computed": false,
+              "kind": "constructor",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 26,
+                "end": 53,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 5
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ExpressionStatement",
+                    "start": 36,
+                    "end": 47,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 19
+                      }
+                    },
+                    "expression": {
+                      "type": "OptionalMemberExpression",
+                      "start": 36,
+                      "end": 46,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 18
+                        }
+                      },
+                      "object": {
+                        "type": "CallExpression",
+                        "start": 36,
+                        "end": 43,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 15
+                          }
+                        },
+                        "callee": {
+                          "type": "Super",
+                          "start": 36,
+                          "end": 41,
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 13
+                            }
+                          }
+                        },
+                        "arguments": []
+                      },
+                      "property": {
+                        "type": "Identifier",
+                        "start": 45,
+                        "end": 46,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 17
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 18
+                          },
+                          "identifierName": "b"
+                        },
+                        "name": "b"
+                      },
+                      "computed": false,
+                      "optional": true
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7256 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixes issues regarding super in optionalChain, Now can't use super object/method with optionalChain.