### PR TITLE
Allow more flexible file-based configuration while preventing .babelrcs from breaking things

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -238,10 +238,6 @@ if (errors.length) {
 //
 
 const opts = commander.opts();
-//the configFile CLI option maps to the extends option in the node API
-if (opts.configFile) {
-  opts.extends = opts.configFile;
-}
 
 // Delete options that are specific to @babel/cli and shouldn't be passed to @babel/core.
 delete opts.version;
@@ -253,7 +249,6 @@ delete opts.outDir;
 delete opts.copyFiles;
 delete opts.includeDotfiles;
 delete opts.verbose;
-delete opts.configFile;
 delete opts.deleteDirOnStart;
 delete opts.keepFileExtension;
 delete opts.relative;

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -218,7 +218,8 @@ Following is a table of the options you can use:
 | `auxiliaryCommentBefore` | `null`               | Attach a comment before all non-user injected code |
 | `root`                   | `"."`                | Specify the "root" folder that defines the location to search for "babel.config.js", and the default folder to allow `.babelrc` files inside of.|
 | `configFile`             | `undefined`          | The config file to load Babel's config from. Defaults to searching for "babel.config.js" inside the "root" folder. `false` will disable searching for config files.|
-| `babelrc`                | `(root)`             | Specify whether or not to use .babelrc and .babelignore files. Not available when using the CLI, [use `--no-babelrc` instead](https://babeljs.io/docs/usage/cli/#babel-ignoring-babelrc). `false` to disable searching, and `true` to always search, a string path of the package to search inside of, or an array of paths to packages to search inside of. |
+| `babelrc`                | `true`               | Specify whether or not to use .babelrc and .babelignore files. Not available when using the CLI, [use `--no-babelrc` instead](https://babeljs.io/docs/usage/cli/#babel-ignoring-babelrc) |
+| `babelrcRoots`           | `(root)`             | Specify which packages should be search for .babelrc files when they are being compiled. `true` to _always_ search, or a path string or an array of paths to packages to search inside of. Defaults to only searching the "root" package. |
 | `envName`                | env vars             | Defaults to environment variable `BABEL_ENV` if set, or else `NODE_ENV` if set, or else it defaults to `"development"` |
 | `code`                   | `true`               | Enable code generation |
 | `comments`               | `true`               | Output comments in generated output |

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -216,7 +216,9 @@ Following is a table of the options you can use:
 | `ast`                    | `false`              | Include the AST in the returned object |
 | `auxiliaryCommentAfter`  | `null`               | Attach a comment after all non-user injected code |
 | `auxiliaryCommentBefore` | `null`               | Attach a comment before all non-user injected code |
-| `babelrc`                | `true`               | Specify whether or not to use .babelrc and .babelignore files. Not available when using the CLI, [use `--no-babelrc` instead](https://babeljs.io/docs/usage/cli/#babel-ignoring-babelrc) |
+| `root`                   | `"."`                | Specify the "root" folder that defines the location to search for "babel.config.js", and the default folder to allow `.babelrc` files inside of.|
+| `configFile`             | `undefined`          | The config file to load Babel's config from. Defaults to searching for "babel.config.js" inside the "root" folder. `false` will disable searching for config files.|
+| `babelrc`                | `(root)`             | Specify whether or not to use .babelrc and .babelignore files. Not available when using the CLI, [use `--no-babelrc` instead](https://babeljs.io/docs/usage/cli/#babel-ignoring-babelrc). `false` to disable searching, and `true` to always search, a string path of the package to search inside of, or an array of paths to packages to search inside of. |
 | `envName`                | env vars             | Defaults to environment variable `BABEL_ENV` if set, or else `NODE_ENV` if set, or else it defaults to `"development"` |
 | `code`                   | `true`               | Enable code generation |
 | `comments`               | `true`               | Output comments in generated output |

--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -13,6 +13,7 @@ import {
 const debug = buildDebug("babel:config:config-chain");
 
 import {
+  findPackageData,
   findRelativeConfig,
   loadConfig,
   type ConfigFile,
@@ -125,15 +126,17 @@ export function buildRootChain(
   );
   if (!programmaticChain) return null;
 
-  let ignore, babelrc;
+  const pkgData =
+    typeof context.filename === "string"
+      ? findPackageData(context.filename)
+      : null;
 
+  let ignore, babelrc;
   const fileChain = emptyChain();
   // resolve all .babelrc files
-  if (opts.babelrc !== false && context.filename !== null) {
-    const filename = context.filename;
-
+  if (opts.babelrc !== false && pkgData) {
     ({ ignore, config: babelrc } = findRelativeConfig(
-      filename,
+      pkgData,
       context.envName,
     ));
 

--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -16,6 +16,8 @@ import type { FilePackageData, RelativeConfig, ConfigFile } from "./types";
 
 const debug = buildDebug("babel:config:loading:files:configuration");
 
+const BABEL_CONFIG_JS_FILENAME = "babel.config.js";
+
 const BABELRC_FILENAME = ".babelrc";
 const BABELRC_JS_FILENAME = ".babelrc.js";
 const BABELIGNORE_FILENAME = ".babelignore";
@@ -83,6 +85,19 @@ export function findRelativeConfig(
   }
 
   return { config, ignore };
+}
+
+export function findRootConfig(
+  dirname: string,
+  envName: string,
+): ConfigFile | null {
+  const filepath = path.resolve(dirname, BABEL_CONFIG_JS_FILENAME);
+
+  const conf = readConfig(filepath, envName);
+  if (conf) {
+    debug("Found root config %o in $o.", BABEL_CONFIG_JS_FILENAME, dirname);
+  }
+  return conf;
 }
 
 export function loadConfig(

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -1,17 +1,35 @@
 // @flow
 
-import type { ConfigFile, IgnoreFile, RelativeConfig } from "./configuration";
+import type {
+  ConfigFile,
+  IgnoreFile,
+  RelativeConfig,
+  FilePackageData,
+} from "./types";
 
-export type { ConfigFile, IgnoreFile, RelativeConfig };
+export type { ConfigFile, IgnoreFile, RelativeConfig, FilePackageData };
 
-export function findRelativeConfig(
-  filepath: string,
-  envName: string, // eslint-disable-line no-unused-vars
-): RelativeConfig {
-  return { config: null, ignore: null };
+export function findPackageData(filepath: string): FilePackageData {
+  return {
+    filepath,
+    directories: [],
+    pkg: null,
+    isPackage: false,
+  };
 }
 
-export function loadConfig(name: string, dirname: string): ConfigFile {
+export function findRelativeConfig(
+  pkgData: FilePackageData,
+  envName: string, // eslint-disable-line no-unused-vars
+): RelativeConfig {
+  return { pkg: null, config: null, ignore: null };
+}
+
+export function loadConfig(
+  name: string,
+  dirname: string,
+  envName: string, // eslint-disable-line no-unused-vars
+): ConfigFile {
   throw new Error(`Cannot load ${name} relative to ${dirname} in a browser`);
 }
 

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -25,6 +25,13 @@ export function findRelativeConfig(
   return { pkg: null, config: null, ignore: null };
 }
 
+export function findRootConfig(
+  dirname: string,
+  envName: string, // eslint-disable-line no-unused-vars
+): ConfigFile | null {
+  return null;
+}
+
 export function loadConfig(
   name: string,
   dirname: string,

--- a/packages/babel-core/src/config/files/index.js
+++ b/packages/babel-core/src/config/files/index.js
@@ -7,5 +7,18 @@ import typeof * as indexType from "./index";
 // exports of index-browser, since this file may be replaced at bundle time with index-browser.
 ((({}: any): $Exact<indexBrowserType>): $Exact<indexType>);
 
-export * from "./configuration";
-export * from "./plugins";
+export { findPackageData } from "./package";
+
+export { findRelativeConfig, loadConfig } from "./configuration";
+export type {
+  ConfigFile,
+  IgnoreFile,
+  RelativeConfig,
+  FilePackageData,
+} from "./types";
+export {
+  resolvePlugin,
+  resolvePreset,
+  loadPlugin,
+  loadPreset,
+} from "./plugins";

--- a/packages/babel-core/src/config/files/index.js
+++ b/packages/babel-core/src/config/files/index.js
@@ -9,7 +9,11 @@ import typeof * as indexType from "./index";
 
 export { findPackageData } from "./package";
 
-export { findRelativeConfig, loadConfig } from "./configuration";
+export {
+  findRelativeConfig,
+  findRootConfig,
+  loadConfig,
+} from "./configuration";
 export type {
   ConfigFile,
   IgnoreFile,

--- a/packages/babel-core/src/config/files/package.js
+++ b/packages/babel-core/src/config/files/package.js
@@ -1,0 +1,60 @@
+// @flow
+
+import path from "path";
+import { makeStaticFileCache } from "./utils";
+
+import type { ConfigFile, FilePackageData } from "./types";
+
+const PACKAGE_FILENAME = "package.json";
+
+/**
+ * Find metadata about the package that this file is inside of. Resolution
+ * of Babel's config requires general package information to decide when to
+ * search for .babelrc files
+ */
+export function findPackageData(filepath: string): FilePackageData {
+  let pkg = null;
+  const directories = [];
+  let isPackage = true;
+
+  let dirname = path.dirname(filepath);
+  while (!pkg && path.basename(dirname) !== "node_modules") {
+    directories.push(dirname);
+
+    pkg = readConfigPackage(path.join(dirname, PACKAGE_FILENAME));
+
+    const nextLoc = path.dirname(dirname);
+    if (dirname === nextLoc) {
+      isPackage = false;
+      break;
+    }
+    dirname = nextLoc;
+  }
+
+  return { filepath, directories, pkg, isPackage };
+}
+
+const readConfigPackage = makeStaticFileCache(
+  (filepath, content): ConfigFile => {
+    let options;
+    try {
+      options = JSON.parse(content);
+    } catch (err) {
+      err.message = `${filepath}: Error while parsing JSON - ${err.message}`;
+      throw err;
+    }
+
+    if (typeof options !== "object") {
+      throw new Error(`${filepath}: Config returned typeof ${typeof options}`);
+    }
+    if (Array.isArray(options)) {
+      throw new Error(`${filepath}: Expected config object but found array`);
+    }
+
+    return {
+      filepath,
+      dirname: path.dirname(filepath),
+      options,
+    };
+  },
+);

--- a/packages/babel-core/src/config/files/types.js
+++ b/packages/babel-core/src/config/files/types.js
@@ -1,0 +1,38 @@
+// @flow
+
+export type ConfigFile = {
+  filepath: string,
+  dirname: string,
+  options: {},
+};
+
+export type IgnoreFile = {
+  filepath: string,
+  dirname: string,
+  ignore: Array<string>,
+};
+
+export type RelativeConfig = {
+  // The actual config, either from package.json#babel, .babelrc, or
+  // .babelrc.js, if there was one.
+  config: ConfigFile | null,
+
+  // The .babelignore, if there was one.
+  ignore: IgnoreFile | null,
+};
+
+export type FilePackageData = {
+  // The file in the package.
+  filepath: string,
+
+  // Any ancestor directories of the file that are within the package.
+  directories: Array<string>,
+
+  // The contents of the package.json. May not be found if the package just
+  // terminated at a node_modules folder without finding one.
+  pkg: ConfigFile | null,
+
+  // True if a package.json or node_modules folder was found while traversing
+  // the directory structure.
+  isPackage: boolean,
+};

--- a/packages/babel-core/src/config/files/utils.js
+++ b/packages/babel-core/src/config/files/utils.js
@@ -1,0 +1,27 @@
+// @flow
+
+import fs from "fs";
+import { makeStrongCache } from "../caching";
+
+export function makeStaticFileCache<T>(
+  fn: (string, string) => T,
+): string => T | null {
+  return makeStrongCache((filepath, cache) => {
+    if (cache.invalidate(() => fileMtime(filepath)) === null) {
+      cache.forever();
+      return null;
+    }
+
+    return fn(filepath, fs.readFileSync(filepath, "utf8"));
+  });
+}
+
+function fileMtime(filepath: string): number | null {
+  try {
+    return +fs.statSync(filepath).mtime;
+  } catch (e) {
+    if (e.code !== "ENOENT" && e.code !== "ENOTDIR") throw e;
+  }
+
+  return null;
+}

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -17,6 +17,7 @@ export default function loadPrivatePartialConfig(
   context: ConfigContext,
   ignore: IgnoreFile | void,
   babelrc: ConfigFile | void,
+  config: ConfigFile | void,
 } | null {
   if (
     inputOpts != null &&
@@ -64,6 +65,7 @@ export default function loadPrivatePartialConfig(
     context,
     ignore: configChain.ignore,
     babelrc: configChain.babelrc,
+    config: configChain.config,
   };
 }
 
@@ -71,7 +73,7 @@ export function loadPartialConfig(inputOpts: mixed): PartialConfig | null {
   const result = loadPrivatePartialConfig(inputOpts);
   if (!result) return null;
 
-  const { options, babelrc, ignore } = result;
+  const { options, babelrc, ignore, config } = result;
 
   (options.plugins || []).forEach(item => {
     if (item.value instanceof Plugin) {
@@ -86,6 +88,7 @@ export function loadPartialConfig(inputOpts: mixed): PartialConfig | null {
     options,
     babelrc ? babelrc.filepath : undefined,
     ignore ? ignore.filepath : undefined,
+    config ? config.filepath : undefined,
   );
 }
 
@@ -99,15 +102,18 @@ class PartialConfig {
   options: ValidatedOptions;
   babelrc: string | void;
   babelignore: string | void;
+  config: string | void;
 
   constructor(
     options: ValidatedOptions,
     babelrc: string | void,
     ignore: string | void,
+    config: string | void,
   ) {
     this.options = options;
     this.babelignore = ignore;
     this.babelrc = babelrc;
+    this.config = config;
 
     // Freeze since this is a public API and it should be extremely obvious that
     // reassigning properties on here does nothing.

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -128,7 +128,7 @@ class PartialConfig {
    * this.babelrc directly.
    */
   hasFilesystemConfig(): boolean {
-    return this.babelrc !== undefined;
+    return this.babelrc !== undefined || this.config !== undefined;
   }
 }
 Object.freeze(PartialConfig.prototype);

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type {
+  ConfigFileSearch,
   IgnoreList,
   IgnoreItem,
   PluginList,
@@ -162,6 +163,24 @@ function checkValidTest(value: mixed): boolean {
     typeof value === "function" ||
     value instanceof RegExp
   );
+}
+
+export function assertConfigFileSearch(
+  key: string,
+  value: mixed,
+): ConfigFileSearch | void {
+  if (
+    value !== undefined &&
+    typeof value !== "boolean" &&
+    typeof value !== "string"
+  ) {
+    throw new Error(
+      `.${key} must be a undefined, a boolean, a string, ` +
+        `got ${JSON.stringify(value)}`,
+    );
+  }
+
+  return value;
 }
 
 export function assertPluginList(key: string, value: mixed): PluginList | void {

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -2,6 +2,7 @@
 
 import type {
   ConfigFileSearch,
+  BabelrcSearch,
   IgnoreList,
   IgnoreItem,
   PluginList,
@@ -181,6 +182,27 @@ export function assertConfigFileSearch(
   }
 
   return value;
+}
+
+export function assertBabelrcSearch(
+  key: string,
+  value: mixed,
+): BabelrcSearch | void {
+  if (value === undefined || typeof value === "boolean") return value;
+
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => {
+      if (typeof item !== "string") {
+        throw new Error(`.${key}[${i}] must be a string.`);
+      }
+    });
+  } else if (typeof value !== "string") {
+    throw new Error(
+      `.${key} must be a undefined, a boolean, a string, ` +
+        `or an array of strings, got ${JSON.stringify(value)}`,
+    );
+  }
+  return (value: any);
 }
 
 export function assertPluginList(key: string, value: mixed): PluginList | void {

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -14,6 +14,7 @@ import {
   assertPluginList,
   assertConfigApplicableTest,
   assertConfigFileSearch,
+  assertBabelrcSearch,
   assertFunction,
   assertSourceMaps,
   assertCompact,
@@ -35,7 +36,7 @@ const ROOT_VALIDATORS: ValidatorSet = {
   filenameRelative: (assertString: Validator<
     $PropertyType<ValidatedOptions, "filenameRelative">,
   >),
-  babelrc: (assertBoolean: Validator<
+  babelrc: (assertBabelrcSearch: Validator<
     $PropertyType<ValidatedOptions, "babelrc">,
   >),
   code: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "code">>),
@@ -156,7 +157,7 @@ export type ValidatedOptions = {
   cwd?: string,
   filename?: string,
   filenameRelative?: string,
-  babelrc?: boolean,
+  babelrc?: BabelrcSearch,
   code?: boolean,
   configFile?: ConfigFileSearch,
   root?: string,
@@ -232,6 +233,7 @@ export type OverridesList = Array<ValidatedOptions>;
 export type ConfigApplicableTest = IgnoreItem | Array<IgnoreItem>;
 
 export type ConfigFileSearch = string | boolean;
+export type BabelrcSearch = boolean | string | Array<string>;
 export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -36,8 +36,11 @@ const ROOT_VALIDATORS: ValidatorSet = {
   filenameRelative: (assertString: Validator<
     $PropertyType<ValidatedOptions, "filenameRelative">,
   >),
-  babelrc: (assertBabelrcSearch: Validator<
+  babelrc: (assertBoolean: Validator<
     $PropertyType<ValidatedOptions, "babelrc">,
+  >),
+  babelrcRoots: (assertBabelrcSearch: Validator<
+    $PropertyType<ValidatedOptions, "babelrcRoots">,
   >),
   code: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "code">>),
   ast: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "ast">>),
@@ -157,10 +160,11 @@ export type ValidatedOptions = {
   cwd?: string,
   filename?: string,
   filenameRelative?: string,
-  babelrc?: BabelrcSearch,
-  code?: boolean,
+  babelrc?: boolean,
+  babelrcRoots?: BabelrcSearch,
   configFile?: ConfigFileSearch,
   root?: string,
+  code?: boolean,
   ast?: boolean,
   inputSourceMap?: RootInputSourceMapOption,
   envName?: string,

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -13,6 +13,7 @@ import {
   assertIgnoreList,
   assertPluginList,
   assertConfigApplicableTest,
+  assertConfigFileSearch,
   assertFunction,
   assertSourceMaps,
   assertCompact,
@@ -23,6 +24,11 @@ import {
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
+  root: (assertString: Validator<$PropertyType<ValidatedOptions, "root">>),
+  configFile: (assertConfigFileSearch: Validator<
+    $PropertyType<ValidatedOptions, "configFile">,
+  >),
+
   filename: (assertString: Validator<
     $PropertyType<ValidatedOptions, "filename">,
   >),
@@ -152,6 +158,8 @@ export type ValidatedOptions = {
   filenameRelative?: string,
   babelrc?: boolean,
   code?: boolean,
+  configFile?: ConfigFileSearch,
+  root?: string,
   ast?: boolean,
   inputSourceMap?: RootInputSourceMapOption,
   envName?: string,
@@ -223,6 +231,7 @@ export type PluginList = $ReadOnlyArray<PluginItem>;
 export type OverridesList = Array<ValidatedOptions>;
 export type ConfigApplicableTest = IgnoreItem | Array<IgnoreItem>;
 
+export type ConfigFileSearch = string | boolean;
 export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -294,6 +294,7 @@ describe("api", function() {
     process.env.BABEL_ENV = "development";
 
     const result = babel.transform("", {
+      cwd: path.join(__dirname, "fixtures", "config", "complex-plugin-config"),
       filename: path.join(
         __dirname,
         "fixtures",

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -11,6 +11,7 @@ describe("buildConfigChain", function() {
     describe("single", () => {
       it("should process matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: fixture("nonexistant-fake"),
@@ -22,6 +23,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: new RegExp(fixture("nonexistant-fake")),
@@ -33,6 +35,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: p => p.indexOf(fixture("nonexistant-fake")) === 0,
@@ -44,6 +47,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: fixture("nonexistant-fake-unknown"),
@@ -55,6 +59,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: new RegExp(fixture("nonexistant-unknown")),
@@ -66,6 +71,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: p => p.indexOf(fixture("nonexistant-unknown")) === 0,
@@ -79,6 +85,7 @@ describe("buildConfigChain", function() {
     describe("array", () => {
       it("should process matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: [fixture("nonexistant-fake")],
@@ -90,6 +97,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: [new RegExp(fixture("nonexistant-fake"))],
@@ -101,6 +109,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: [p => p.indexOf(fixture("nonexistant-fake")) === 0],
@@ -112,6 +121,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: [fixture("nonexistant-fake-unknown")],
@@ -123,6 +133,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: [new RegExp(fixture("nonexistant-unknown"))],
@@ -134,6 +145,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           test: [p => p.indexOf(fixture("nonexistant-unknown")) === 0],
@@ -149,6 +161,7 @@ describe("buildConfigChain", function() {
     describe("single", () => {
       it("should process matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: fixture("nonexistant-fake"),
@@ -160,6 +173,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: new RegExp(fixture("nonexistant-fake")),
@@ -171,6 +185,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: p => p.indexOf(fixture("nonexistant-fake")) === 0,
@@ -182,6 +197,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: fixture("nonexistant-fake-unknown"),
@@ -193,6 +209,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: new RegExp(fixture("nonexistant-unknown")),
@@ -204,6 +221,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: p => p.indexOf(fixture("nonexistant-unknown")) === 0,
@@ -217,6 +235,7 @@ describe("buildConfigChain", function() {
     describe("array", () => {
       it("should process matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: [fixture("nonexistant-fake")],
@@ -228,6 +247,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: [new RegExp(fixture("nonexistant-fake"))],
@@ -239,6 +259,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: [p => p.indexOf(fixture("nonexistant-fake")) === 0],
@@ -250,6 +271,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: [fixture("nonexistant-fake-unknown")],
@@ -261,6 +283,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: [new RegExp(fixture("nonexistant-unknown"))],
@@ -272,6 +295,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           include: [p => p.indexOf(fixture("nonexistant-unknown")) === 0],
@@ -287,6 +311,7 @@ describe("buildConfigChain", function() {
     describe("single", () => {
       it("should process matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: fixture("nonexistant-fake"),
@@ -298,6 +323,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: new RegExp(fixture("nonexistant-fake")),
@@ -309,6 +335,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: p => p.indexOf(fixture("nonexistant-fake")) === 0,
@@ -320,6 +347,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: fixture("nonexistant-fake-unknown"),
@@ -331,6 +359,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: new RegExp(fixture("nonexistant-unknown")),
@@ -342,6 +371,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: p => p.indexOf(fixture("nonexistant-unknown")) === 0,
@@ -355,6 +385,7 @@ describe("buildConfigChain", function() {
     describe("array", () => {
       it("should process matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: [fixture("nonexistant-fake")],
@@ -366,6 +397,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: [new RegExp(fixture("nonexistant-fake"))],
@@ -377,6 +409,7 @@ describe("buildConfigChain", function() {
 
       it("should process matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: [p => p.indexOf(fixture("nonexistant-fake")) === 0],
@@ -388,6 +421,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching string values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: [fixture("nonexistant-fake-unknown")],
@@ -399,6 +433,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching RegExp values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: [new RegExp(fixture("nonexistant-unknown"))],
@@ -410,6 +445,7 @@ describe("buildConfigChain", function() {
 
       it("should process non-matching function values", () => {
         const opts = loadOptions({
+          cwd: fixture("nonexistant-fake"),
           filename: fixture("nonexistant-fake", "src.js"),
           babelrc: false,
           exclude: [p => p.indexOf(fixture("nonexistant-unknown")) === 0],
@@ -424,6 +460,7 @@ describe("buildConfigChain", function() {
   describe("ignore", () => {
     it("should ignore files that match", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         ignore: [
@@ -441,6 +478,7 @@ describe("buildConfigChain", function() {
 
     it("should not ignore files that don't match", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         ignore: [
@@ -456,6 +494,7 @@ describe("buildConfigChain", function() {
   describe("only", () => {
     it("should ignore files that don't match", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         only: [
@@ -469,6 +508,7 @@ describe("buildConfigChain", function() {
 
     it("should not ignore files that match", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         only: [
@@ -484,6 +524,7 @@ describe("buildConfigChain", function() {
   describe("ignore/only", () => {
     it("should ignore files that match ignore and don't match only", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         ignore: [fixture("nonexistant-fake", "src.js")],
@@ -495,6 +536,7 @@ describe("buildConfigChain", function() {
 
     it("should ignore files that match ignore and also only", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         ignore: [fixture("nonexistant-fake", "src.js")],
@@ -506,6 +548,7 @@ describe("buildConfigChain", function() {
 
     it("should not ignore files that match only and not ignore", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         only: [fixture("nonexistant-fake", "src.js")],
@@ -516,6 +559,7 @@ describe("buildConfigChain", function() {
 
     it("should not ignore files when no ignore/only are specified", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
       });
@@ -525,6 +569,7 @@ describe("buildConfigChain", function() {
 
     it("should allow negation of only", () => {
       const opts1 = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         only: [
@@ -535,6 +580,7 @@ describe("buildConfigChain", function() {
       expect(opts1).toBeNull();
 
       const opts2 = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         only: [
@@ -545,6 +591,7 @@ describe("buildConfigChain", function() {
       expect(opts2).not.toBeNull();
 
       const opts3 = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "folder", "src.js"),
         babelrc: false,
         only: [
@@ -557,6 +604,7 @@ describe("buildConfigChain", function() {
 
     it("should allow negation of ignore", () => {
       const opts1 = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         ignore: [
@@ -568,6 +616,7 @@ describe("buildConfigChain", function() {
 
       // Tests disabled pending https://github.com/babel/babel/issues/6907
       // const opts2 = loadOptions({
+      //   cwd: fixture("nonexistant-fake"),
       //   filename: fixture("nonexistant-fake", "src.js"),
       //   babelrc: false,
       //   ignore: [
@@ -578,6 +627,7 @@ describe("buildConfigChain", function() {
       // expect(opts2).not.toBeNull();
       //
       // const opts3 = loadOptions({
+      //   cwd: fixture("nonexistant-fake"),
       //   filename: fixture("nonexistant-fake", "folder", "src.js"),
       //   babelrc: false,
       //   ignore: [
@@ -718,13 +768,13 @@ describe("buildConfigChain", function() {
           "package.json",
         );
 
-        const opts1 = loadOptions({ filename });
-        const opts2 = loadOptions({ filename });
+        const opts1 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts2 = loadOptions({ filename, cwd: path.dirname(filename) });
 
         touch(pkgJSON);
 
-        const opts3 = loadOptions({ filename });
-        const opts4 = loadOptions({ filename });
+        const opts3 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts4 = loadOptions({ filename, cwd: path.dirname(filename) });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -752,13 +802,13 @@ describe("buildConfigChain", function() {
           ".babelrc",
         );
 
-        const opts1 = loadOptions({ filename });
-        const opts2 = loadOptions({ filename });
+        const opts1 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts2 = loadOptions({ filename, cwd: path.dirname(filename) });
 
         touch(babelrcFile);
 
-        const opts3 = loadOptions({ filename });
-        const opts4 = loadOptions({ filename });
+        const opts3 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts4 = loadOptions({ filename, cwd: path.dirname(filename) });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -780,11 +830,19 @@ describe("buildConfigChain", function() {
           "src.js",
         );
 
-        const opts1 = loadOptions({ filename });
-        const opts2 = loadOptions({ filename });
+        const opts1 = loadOptions({ filename, cwd: path.dirname(filename) });
+        const opts2 = loadOptions({ filename, cwd: path.dirname(filename) });
 
-        const opts3 = loadOptions({ filename, envName: "new-env" });
-        const opts4 = loadOptions({ filename, envName: "new-env" });
+        const opts3 = loadOptions({
+          filename,
+          envName: "new-env",
+          cwd: path.dirname(filename),
+        });
+        const opts4 = loadOptions({
+          filename,
+          envName: "new-env",
+          cwd: path.dirname(filename),
+        });
 
         expect(opts1.plugins).toHaveLength(1);
         expect(opts2.plugins).toHaveLength(1);
@@ -803,6 +861,7 @@ describe("buildConfigChain", function() {
   describe("overrides merging", () => {
     it("should apply matching overrides over base configs", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         comments: true,
@@ -819,6 +878,7 @@ describe("buildConfigChain", function() {
 
     it("should not apply non-matching overrides over base configs", () => {
       const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
         filename: fixture("nonexistant-fake", "src.js"),
         babelrc: false,
         comments: true,
@@ -860,9 +920,15 @@ describe("buildConfigChain", function() {
     it("should load .babelrc", () => {
       const filename = fixture("config-files", "babelrc", "src.js");
 
-      expect(loadOptions({ filename })).toEqual({
+      expect(
+        loadOptions({
+          filename,
+          cwd: path.dirname(filename),
+        }),
+      ).toEqual({
         ...getDefaults(),
         filename,
+        cwd: path.dirname(filename),
         comments: true,
       });
     });
@@ -870,9 +936,10 @@ describe("buildConfigChain", function() {
     it("should load .babelrc.js", () => {
       const filename = fixture("config-files", "babelrc-js", "src.js");
 
-      expect(loadOptions({ filename })).toEqual({
+      expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
         ...getDefaults(),
         filename,
+        cwd: path.dirname(filename),
         comments: true,
       });
     });
@@ -880,9 +947,10 @@ describe("buildConfigChain", function() {
     it("should load package.json#babel", () => {
       const filename = fixture("config-files", "pkg", "src.js");
 
-      expect(loadOptions({ filename })).toEqual({
+      expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
         ...getDefaults(),
         filename,
+        cwd: path.dirname(filename),
         comments: true,
       });
     });
@@ -890,39 +958,40 @@ describe("buildConfigChain", function() {
     it("should load .babelignore", () => {
       const filename = fixture("config-files", "babelignore", "src.js");
 
-      expect(loadOptions({ filename })).toBeNull();
+      expect(loadOptions({ filename, cwd: path.dirname(filename) })).toBeNull();
     });
 
     it("should throw if there are both .babelrc and .babelrc.js", () => {
       const filename = fixture("config-files", "both-babelrc", "src.js");
 
-      expect(() => loadOptions({ filename })).toThrow(
-        /Multiple configuration files found/,
-      );
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Multiple configuration files found/);
     });
 
     it("should throw if there are both .babelrc and package.json", () => {
       const filename = fixture("config-files", "pkg-babelrc", "src.js");
 
-      expect(() => loadOptions({ filename })).toThrow(
-        /Multiple configuration files found/,
-      );
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Multiple configuration files found/);
     });
 
     it("should throw if there are both .babelrc.js and package.json", () => {
       const filename = fixture("config-files", "pkg-babelrc-js", "src.js");
 
-      expect(() => loadOptions({ filename })).toThrow(
-        /Multiple configuration files found/,
-      );
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Multiple configuration files found/);
     });
 
     it("should ignore package.json without a 'babel' property", () => {
       const filename = fixture("config-files", "pkg-ignored", "src.js");
 
-      expect(loadOptions({ filename })).toEqual({
+      expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
         ...getDefaults(),
         filename,
+        cwd: path.dirname(filename),
         comments: true,
       });
     });
@@ -930,23 +999,25 @@ describe("buildConfigChain", function() {
     it("should show helpful errors for .babelrc", () => {
       const filename = fixture("config-files", "babelrc-error", "src.js");
 
-      expect(() => loadOptions({ filename })).toThrow(
-        /Error while parsing config - /,
-      );
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Error while parsing config - /);
     });
 
     it("should show helpful errors for .babelrc.js", () => {
       const filename = fixture("config-files", "babelrc-js-error", "src.js");
 
-      expect(() => loadOptions({ filename })).toThrow(/Babelrc threw an error/);
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Babelrc threw an error/);
     });
 
     it("should show helpful errors for package.json", () => {
       const filename = fixture("config-files", "pkg-error", "src.js");
 
-      expect(() => loadOptions({ filename })).toThrow(
-        /Error while parsing JSON - /,
-      );
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Error while parsing JSON - /);
     });
   });
 });

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -25,6 +25,7 @@ describe("@babel/core config loading", () => {
 
   function makeOpts(skipProgrammatic = false) {
     return {
+      cwd: path.dirname(FILEPATH),
       filename: FILEPATH,
       presets: skipProgrammatic
         ? null

--- a/packages/babel-preset-env/test/debug-fixtures.js
+++ b/packages/babel-preset-env/test/debug-fixtures.js
@@ -52,7 +52,9 @@ const buildTest = opts => {
     let args = [binLoc];
     args = args.concat(opts.args);
 
-    const spawn = child.spawn(process.execPath, args);
+    const spawn = child.spawn(process.execPath, args, {
+      cwd: tmpLoc,
+    });
 
     let stdout = "";
     let stderr = "";

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 
 let currentHook;
 let currentOptions;
@@ -39,6 +40,11 @@ describe("@babel/register", function() {
   let babelRegister;
 
   function setupRegister(config = { babelrc: false }) {
+    config = {
+      cwd: path.dirname(testFile),
+      ...config,
+    };
+
     babelRegister = require(registerFile);
     babelRegister.default(config);
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6766
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y
| Minor: New Feature?      | Y
| Tests Added + Pass?      |
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Alright! Let's do this. This is my proposal for fixing the issues spelled out in #6766. This PR does the following:

### When searching for `.babelrc` files for a given file, stop at package.json

Currently, Babel will look all the way up the directory hierarchy. This change prevents config files outside of a given package from potentially breaking your project's builds, which has been a problem occasionally. Also potentially frustrating for projects that integrate Babel, because they often allow users can _optionally_ create .babelrc files, and if they haven't created one, but have one in a parent folder, it might find a bad config.

The downside here is that monorepos like

```
.babelrc
packages/
  one/
    package.json
    index.js
  two/
    package.json
    index.js
```
will fail to find the `.babelrc`. I think that is acceptable because there are alternatives:

1. Have each module have their own `.babelrc` doing `{ extends: "../../.babelrc" }` to explicitly load the config from a parent directory.
2. See the next point.


### Adds support for a `babel.config.js` file along the lines of what Webpack does

This PR adds a `root` option (that defaults to the working directory), that defines the conceptual "root" of your project. This location is used to automatically search for the config file `babel.config.js`. Optionally instead the user can specify `configFile: "./foo.js"` or whatever they'd like.

The file itself behaves just like a `.babelrc.js` file would, but is not loaded relative to the individual file being compiled, and thus has more flexibility in what files it applies to. For instance, if users are symlinking in `node_modules` or something, it is currently impossible for a `.babelrc` to configure their builds any way other than by hard-coding their config into webpack.config.js, which is not great.

With our new support for `overrides` it's now easy for users to have a single `babel.config.js` which could define the full build process for their project, when used alongside `env`.


### Only search for a `.babelrc` for files inside the `root` (which defaults to cwd) (unless the user opts out)

Specifically excluding `node_modules` folders. Given the path of the file being compiled, if the path relative to the root contains `node_modules`, do not attempt to search for `.babelrc` files. This essentially has the effect of making `.babelrc` files only useful by default in a "root" package, which is essentially how most people used them.

This (potentially combined with the previous `babel.config.js`) allows users to _safely_ do
```
test: /\.js$/,
loader: "babel-loader",
```
without risking loading a `.babelrc` from a node_modules that was not intented to apply to the current project. There _are_ still other edge cases to compiling `node_modules`, but this was a particularly dangerous edge case, especially for things like `babel-register` that don't have a nice `rules` list like Webpack does.

To allow people to opt into `.babelrc` usage, potentially for local development, this PR allows Babel's `babelrc` option to be an array, so users could do

```
test: /\.js$/,
loader: "babel-loader",
options: {
  babelrc: [
    ".",
    "../some-linked-package"
  ]
}
```
which would also attempt to load `.babelrc` files for anything within that package. Alternatively

```
options: {
  babelrc: [
    ".",
    "node_modules/foo"
  ]
}
```
if there was a specific package you wanted to load a config for, and were confident in its installation location.


### What this PR does _not_ do

Part of the reason I personally had so much back and forth on this issue is because it wasn't necessarily obvious what `root` should actually be responsible for. For instance, if Babel is passed a file that is not in the `root`, should it compile it at all? As is hopefully clear, my answer there was yes.

One core thing that this PR does is that it leaves it up to the individual _callers_ of Babel to decide what files should actually be passed to Babel in the first place. Alongside that, if you configure Babel with a custom `root` or `configFile` or `babelrc` array, the user will have to decide if those need to be replicated between Babel callers, because they are top-level Babel options, not ones that can be included inside a config file (for obvious reasons).

### What is left

This PR has no tests, and an unoptimized implementation of a lot of stuff. It will need more work before it can land, but I want to post it now to get a feel for what everyone thinks.