### PR TITLE
Update browserslist for babel-preset-env.

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -45,7 +45,7 @@
     "@babel/plugin-transform-template-literals": "7.0.0-beta.39",
     "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.39",
     "@babel/plugin-transform-unicode-regex": "7.0.0-beta.39",
-    "browserslist": "^2.4.0",
+    "browserslist": "^3.0.0",
     "invariant": "^2.2.2",
     "semver": "^5.3.0"
   },


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N
| Patch: Bug Fix?          | Y?
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Y
| Documentation PR         | N
| Any Dependency Changes?  | Y
| License                  | MIT

Not sure if this qualifies as a breaking change due to the fact that `browserslist` had a major version bump, but it should be updated to the latest version to accept the new syntax.