### PR TITLE
Added support for passing-through modules transform plugin options

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -231,7 +231,7 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 ### `modules`
 
-`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false | [<module type>, <plugin options>]`, defaults to `"commonjs"`.
+`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false | [<module type>, <plugin options>]`, defaults to `"commonjs" (which resolves to ["commonjs", { "loose": false }])`.
 
 Enable transformation of ES6 module syntax to another module type.
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -231,7 +231,7 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 ### `modules`
 
-`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false`, defaults to `"commonjs"`.
+`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false | [<module type>, <plugin options>]`, defaults to `"commonjs"`.
 
 Enable transformation of ES6 module syntax to another module type.
 
@@ -580,6 +580,25 @@ Using polyfills:
       },
       "include": ["@babel/plugin-transform-arrow-functions", "es6.map"],
       "exclude": ["@babel/plugin-transform-regenerator", "es6.set"]
+    }]
+  ]
+}
+```
+
+### Pass-through plugin options when using [`modules`](#modules) option.
+
+> always include arrow functions, explicitly exclude generators
+
+```json
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "browsers": ["last 2 versions", "safari >= 7"]
+      },
+      "modules": ["commonjs", {
+        "noInterop": true
+      }]
     }]
   ]
 }

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -172,6 +172,7 @@ export default function buildPreset(
   } = normalizeOptions(opts);
   // TODO: remove this in next major
   let hasUglifyTarget = false;
+  const [modulesType, modulePluginOptions] = modules;
 
   if (optionsTargets && optionsTargets.uglify) {
     hasUglifyTarget = true;
@@ -232,13 +233,13 @@ export default function buildPreset(
 
   // NOTE: not giving spec here yet to avoid compatibility issues when
   // transform-modules-commonjs gets its spec mode
-  if (Array.isArray(modules) && modules.length) {
-    const [modulesType, modulesTypeOpts] = modules;
+  if (modulesType !== false) {
+    const [modulesType, modulePluginOptions] = modules;
 
     if (moduleTransformations[modulesType]) {
       plugins.push([
-        getPlugin(moduleTransformations[modules]),
-        modulesTypeOpts,
+        getPlugin(moduleTransformations[modulesType]),
+        modulePluginOptions,
       ]);
     }
   }
@@ -256,7 +257,14 @@ export default function buildPreset(
     console.log("@babel/preset-env: `DEBUG` option");
     console.log("\nUsing targets:");
     console.log(JSON.stringify(prettifyTargets(targets), null, 2));
-    console.log(`\nUsing modules transform: ${modules.toString()}`);
+    if (modulePluginOptions) {
+      console.log(
+        `\nUsing modules transform: ${modulesType.toString()}, with options:`,
+      );
+      console.log(JSON.stringify(modules[1], null, 2));
+    } else {
+      console.log(`\nUsing modules transform: ${modulesType.toString()}`);
+    }
     console.log("\nUsing plugins:");
     transformations.forEach(transform => {
       logPlugin(transform, targets, pluginList);

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -7,8 +7,8 @@ import {
   getPlatformSpecificDefaultFor,
   getOptionSpecificExcludesFor,
 } from "./defaults";
-import moduleTransformations from "./module-transformations";
 import normalizeOptions from "./normalize-options.js";
+import moduleTransformations from "./module-transformations";
 import pluginList from "../data/plugins.json";
 import {
   builtIns as proposalBuiltIns,
@@ -232,8 +232,15 @@ export default function buildPreset(
 
   // NOTE: not giving spec here yet to avoid compatibility issues when
   // transform-modules-commonjs gets its spec mode
-  if (modules !== false && moduleTransformations[modules]) {
-    plugins.push([getPlugin(moduleTransformations[modules]), { loose }]);
+  if (Array.isArray(modules) && modules.length) {
+    const [modulesType, modulesTypeOpts] = modules;
+
+    if (moduleTransformations[modulesType]) {
+      plugins.push([
+        getPlugin(moduleTransformations[modules]),
+        modulesTypeOpts,
+      ]);
+    }
   }
 
   transformations.forEach(pluginName =>

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -123,7 +123,7 @@ export const normalizeModulesOption = (
   );
 
   if (modulesOpt === false) {
-    return false;
+    return [false];
   }
 
   const [

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -5,10 +5,11 @@ export type Target = string;
 export type Targets = {
   [target: string]: Target,
 };
-
 // Options
 // Use explicit modules to prevent typo errors.
-export type ModuleOption = false | "amd" | "commonjs" | "systemjs" | "umd";
+export type KnownModuleFormat = "amd" | "commonjs" | "systemjs" | "umd";
+export type TransformModulesPlugin = [KnownModuleFormat, ?Object];
+export type ModulesOption = false | KnownModuleFormat | TransformModulesPlugin;
 export type BuiltInsOption = false | "entry" | "usage";
 
 export type Options = {
@@ -19,7 +20,7 @@ export type Options = {
   ignoreBrowserslistConfig: boolean,
   include: Array<string>,
   loose: boolean,
-  modules: ModuleOption,
+  modules: ModulesOption,
   shippedProposals: boolean,
   spec: boolean,
   targets: Targets,

--- a/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
@@ -5,7 +5,10 @@ Using targets:
   "android": "4"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "android":"4" }

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
@@ -5,7 +5,10 @@ Using targets:
   "node": "6"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-destructuring { "node":"6" }

--- a/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
@@ -7,7 +7,10 @@ Using targets:
   "node": "6"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "ie":"10" }

--- a/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
@@ -12,7 +12,10 @@ Using targets:
   "electron": "0.36"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-block-scoping { "electron":"0.36" }

--- a/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
@@ -13,7 +13,10 @@ Using targets:
   "node": "7.4"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-destructuring { "firefox":"52" }

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
@@ -5,7 +5,10 @@ Using targets:
   "chrome": "60"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-dotall-regex { "chrome":"60" }

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
@@ -3,7 +3,10 @@
 Using targets:
 {}
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions {}

--- a/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -10,7 +10,10 @@ Using targets:
   "safari": "7"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
@@ -7,7 +7,10 @@ Using targets:
   "ie": "11"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "ie":"11" }

--- a/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
@@ -5,7 +5,10 @@ Using targets:
   "chrome": "55"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-dotall-regex { "chrome":"55" }

--- a/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
@@ -7,7 +7,10 @@ Using targets:
   "ie": "11"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "ie":"11" }

--- a/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
@@ -16,7 +16,10 @@ Using targets:
   "node": "6.1"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "ie":"10" }

--- a/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
@@ -7,7 +7,10 @@ Using targets:
   "node": "6.10"
 }
 
-Using modules transform: commonjs
+Using modules transform: commonjs, with options:
+{
+  "loose": false
+}
 
 Using plugins:
   transform-arrow-functions { "ie":"10" }

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -36,7 +36,7 @@ describe("normalize-options", () => {
 
   describe("validateBoolOption", () => {
     it("`undefined` option returns false", () => {
-      assert(validateBoolOption("test", undefined, false) === [false]);
+      assert(validateBoolOption("test", undefined, false) === false);
     });
 
     it("`false` option returns false", () => {
@@ -95,7 +95,7 @@ describe("normalize-options", () => {
     });
 
     it("`false` option returns false", () => {
-      assert(normalizeModulesOption(false) === false);
+      assert(normalizeModulesOption(false)[0] === false);
     });
 
     it("commonjs option is valid", () => {

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -36,7 +36,7 @@ describe("normalize-options", () => {
 
   describe("validateBoolOption", () => {
     it("`undefined` option returns false", () => {
-      assert(validateBoolOption("test", undefined, false) === false);
+      assert(validateBoolOption("test", undefined, false) === [false]);
     });
 
     it("`false` option returns false", () => {

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -8,7 +8,7 @@ const {
   normalizePluginNames,
   validateBoolOption,
   validateIncludesAndExcludes,
-  validateModulesOption,
+  normalizeModulesOption,
 } = normalizeOptions;
 
 describe("normalize-options", () => {
@@ -89,40 +89,68 @@ describe("normalize-options", () => {
     });
   });
 
-  describe("validateModulesOption", () => {
+  describe("normalizeModulesOption", () => {
     it("`undefined` option returns commonjs", () => {
-      assert(validateModulesOption() === "commonjs");
+      assert(normalizeModulesOption()[0] === "commonjs");
     });
 
-    it("`false` option returns commonjs", () => {
-      assert(validateModulesOption(false) === false);
+    it("`false` option returns false", () => {
+      assert(normalizeModulesOption(false) === false);
     });
 
     it("commonjs option is valid", () => {
-      assert(validateModulesOption("commonjs") === "commonjs");
+      assert(normalizeModulesOption("commonjs")[0] === "commonjs");
     });
 
     it("systemjs option is valid", () => {
-      assert(validateModulesOption("systemjs") === "systemjs");
+      assert(normalizeModulesOption("systemjs")[0] === "systemjs");
     });
 
     it("amd option is valid", () => {
-      assert(validateModulesOption("amd") === "amd");
+      assert(normalizeModulesOption("amd")[0] === "amd");
     });
 
     it("umd option is valid", () => {
-      assert(validateModulesOption("umd") === "umd");
+      assert(normalizeModulesOption("umd")[0] === "umd");
+    });
+
+    it("commonjs option with options is valid", () => {
+      const [format, options] = normalizeModulesOption("commonjs", {
+        strictMode: true,
+      });
+      assert(format === "commonjs");
+      assert.deepStrictEqual(options, { strictMode: true });
+    });
+
+    it("systemjs option with options is valid", () => {
+      const [format, options] = normalizeModulesOption("systemjs", {
+        strictMode: true,
+        loose: true,
+      });
+      assert(format === "systemjs");
+      assert.deepStrictEqual(options, { loose: true, strictMode: true });
+    });
+
+    it("amd option with options is valid", () => {
+      const [format, options] = normalizeModulesOption("amd", {
+        strictMode: true,
+        loose: false,
+      });
+      assert(format === "amd");
+      assert.deepStrictEqual(options, { loose: false, strictMode: true });
+    });
+
+    it("umd option with options is valid", () => {
+      const [format, options] = normalizeModulesOption("umd", {
+        strictMode: true,
+      });
+      assert(format === "umd");
+      assert.deepStrictEqual(options, { strictMode: true });
     });
 
     it("`true` option is invalid", () => {
       assert.throws(() => {
-        validateModulesOption(true);
-      }, Error);
-    });
-
-    it("array option is invalid", () => {
-      assert.throws(() => {
-        assert(validateModulesOption([]));
+        normalizeModulesOption(true);
       }, Error);
     });
   });


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #6624 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes + Yes
| Documentation PR         | No, but includes docs
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Added support to allow passing through modules transform plugin options via the `@babel/preset-env` `modules` option.
