### PR TITLE
Preserve import binding locations during module rewriting

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -180,7 +180,10 @@ const rewriteReferencesVisitor = {
     if (importData) {
       const ref = buildImportReference(importData, path.node);
 
-      if (path.parentPath.isCallExpression({ callee: path.node })) {
+      if (
+        path.parentPath.isCallExpression({ callee: path.node }) &&
+        t.isMemberExpression(ref)
+      ) {
         path.replaceWith(t.sequenceExpression([t.numericLiteral(0), ref]));
       } else if (path.isJSXIdentifier() && t.isMemberExpression(ref)) {
         const { object, property } = ref;

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -180,6 +180,9 @@ const rewriteReferencesVisitor = {
     if (importData) {
       const ref = buildImportReference(importData, path.node);
 
+      // Preserve the binding location so that sourcemaps are nicer.
+      ref.loc = path.node.loc;
+
       if (
         path.parentPath.isCallExpression({ callee: path.node }) &&
         t.isMemberExpression(ref)

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/auxiliary-comment/overview/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/auxiliary-comment/overview/output.js
@@ -61,25 +61,49 @@ exports.test2 = test2;
 /*after*/
 
 /*before*/
-(0, _foo4.bar)
+(0,
+/*after*/
+
+/*before*/
+_foo4
+/*after*/
+.
+/*before*/
+bar)
 /*after*/
 (
 /*before*/
-_foo2.default
+_foo2
+/*after*/
+.
+/*before*/
+default
 /*after*/
 ,
 /*before*/
-_foo5.foo
+_foo5
+/*after*/
+.
+/*before*/
+foo
 /*after*/
 );
 /* my comment */
 
 /*before*/
-_foo5.foo
+_foo5
+/*after*/
+.
+/*before*/
+foo
 /*after*/
 ;
 
 /*before*/
-_foo2.default
+_foo2
+/*after*/
+.
+/*before*/
+default
 /*after*/
 ;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/input.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/input.js
@@ -1,0 +1,14 @@
+import aDefault from "one";
+import { aNamed } from "two";
+import { orig as anAliased } from "three";
+import * as aNamespace from "four";
+
+console.log(aDefault);
+console.log(aNamed);
+console.log(anAliased);
+console.log(aNamespace);
+
+console.log(aDefault());
+console.log(aNamed());
+console.log(anAliased());
+console.log(aNamespace());

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/output.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var _one = babelHelpers.interopRequireDefault(require("one"));
+
+var _two = require("two");
+
+var _three = require("three");
+
+var aNamespace = babelHelpers.interopRequireWildcard(require("four"));
+console.log(_one.default);
+console.log(_two.aNamed);
+console.log(_three.orig);
+console.log(aNamespace);
+console.log((0, _one.default)());
+console.log((0, _two.aNamed)());
+console.log((0, _three.orig)());
+console.log(aNamespace());

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/source-mappings.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/reference-source-map/source-mappings.json
@@ -1,0 +1,162 @@
+[
+  {
+    "generated": {
+      "line": 10,
+      "column": 12
+    },
+    "original": {
+      "line": 6,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 10,
+      "column": 23
+    },
+    "original": {
+      "line": 6,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 11,
+      "column": 12
+    },
+    "original": {
+      "line": 7,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 11,
+      "column": 22
+    },
+    "original": {
+      "line": 7,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 12,
+      "column": 12
+    },
+    "original": {
+      "line": 8,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 12,
+      "column": 22
+    },
+    "original": {
+      "line": 8,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 13,
+      "column": 12
+    },
+    "original": {
+      "line": 9,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 13,
+      "column": 21
+    },
+    "original": {
+      "line": 9,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 14,
+      "column": 16
+    },
+    "original": {
+      "line": 11,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 14,
+      "column": 27
+    },
+    "original": {
+      "line": 11,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 15,
+      "column": 16
+    },
+    "original": {
+      "line": 12,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 15,
+      "column": 26
+    },
+    "original": {
+      "line": 12,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 16,
+      "column": 16
+    },
+    "original": {
+      "line": 13,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 16,
+      "column": 26
+    },
+    "original": {
+      "line": 13,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 17,
+      "column": 12
+    },
+    "original": {
+      "line": 14,
+      "column": 12
+    }
+  },
+  {
+    "generated": {
+      "line": 17,
+      "column": 21
+    },
+    "original": {
+      "line": 14,
+      "column": 12
+    }
+  }
+]


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Similar to https://github.com/babel/babel/pull/7312, but for import variables.