### PR TITLE
Solves Tagged template literal size optimization

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -670,6 +670,7 @@ helpers.slicedToArrayLoose = defineHelper(`
 
 helpers.taggedTemplateLiteral = defineHelper(`
   export default function _taggedTemplateLiteral(strings, raw) {
+    if (!raw) { raw = strings.slice(0); }
     return Object.freeze(Object.defineProperties(strings, {
         raw: { value: Object.freeze(raw) }
     }));
@@ -678,6 +679,7 @@ helpers.taggedTemplateLiteral = defineHelper(`
 
 helpers.taggedTemplateLiteralLoose = defineHelper(`
   export default function _taggedTemplateLiteralLoose(strings, raw) {
+    if (!raw) { raw = strings.slice(0); }
     strings.raw = raw;
     return strings;
   }

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -1,5 +1,5 @@
 var _taggedTemplateLiteral = require("@babel/runtime/helpers/taggedTemplateLiteral");
 
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["foo"], ["foo"]);
+var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["foo"]);
 
 tag(_templateObject);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -1,5 +1,5 @@
 var _taggedTemplateLiteral = require("@babel/runtime/helpers/taggedTemplateLiteral");
 
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["foo"], ["foo"]);
+var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["foo"]);
 
 tag(_templateObject);

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -54,6 +54,9 @@ export default function(api, options) {
         const strings = [];
         const raws = [];
 
+        // Flag variable to check if contents of strings and raw are equal
+        let isStringsRawEqual = true;
+
         for (const elem of (quasi.quasis: Array)) {
           const { raw, cooked } = elem.value;
           const value =
@@ -63,6 +66,11 @@ export default function(api, options) {
 
           strings.push(value);
           raws.push(t.stringLiteral(raw));
+
+          if (raw !== cooked) {
+            // false even if one of raw and cooked are not equal
+            isStringsRawEqual = false;
+          }
         }
 
         // Generate a unique name based on the string literals so we dedupe
@@ -81,10 +89,15 @@ export default function(api, options) {
           this.templates.set(name, templateObject);
 
           const helperId = this.addHelper(helperName);
-          const init = t.callExpression(helperId, [
-            t.arrayExpression(strings),
-            t.arrayExpression(raws),
-          ]);
+
+          // only add raw arrayExpression if there is any difference between raws and strings
+          const init = t.callExpression(
+            helperId,
+            [
+              t.arrayExpression(strings),
+              !isStringsRawEqual ? t.arrayExpression(raws) : null,
+            ].filter(x => x),
+          );
           annotateAsPure(init);
           init._compact = true;
           programPath.scope.push({

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -89,15 +89,15 @@ export default function(api, options) {
           this.templates.set(name, templateObject);
 
           const helperId = this.addHelper(helperName);
+          const callExpressionInput = [];
+          callExpressionInput.push(t.arrayExpression(strings));
+
+          if (!isStringsRawEqual) {
+            callExpressionInput.push(t.arrayExpression(raws));
+          }
 
           // only add raw arrayExpression if there is any difference between raws and strings
-          const init = t.callExpression(
-            helperId,
-            [
-              t.arrayExpression(strings),
-              !isStringsRawEqual ? t.arrayExpression(raws) : null,
-            ].filter(x => x),
-          );
+          const init = t.callExpression(helperId, callExpressionInput);
           annotateAsPure(init);
           init._compact = true;
           programPath.scope.push({

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/input.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/input.js
@@ -1,1 +1,2 @@
 var foo = tag`wow`;
+var bar = tag`first${1}second`;

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/input.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/input.js
@@ -1,0 +1,1 @@
+var foo = tag`wow`;

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -1,5 +1,7 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow"]);
+var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow"]),
+    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"]);
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
 var foo = tag(_templateObject);
+var bar = tag(_templateObject2, 1);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -1,0 +1,5 @@
+var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow"]);
+
+function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
+
+var foo = tag(_templateObject);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
@@ -2,7 +2,7 @@ var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""],
     _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""]),
     _templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
 
-function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
+function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
 var foo = bar(_templateObject, 42, _.foobar());
 var bar = bar(_templateObject2, 42, _.foobar());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
@@ -6,7 +6,7 @@ var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode
     _templateObject6 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"]),
     _templateObject7 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"]);
 
-function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
+function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
 tag(_templateObject);
 tag(_templateObject2);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
@@ -2,7 +2,7 @@ var _templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ",
     _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""]),
     _templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
 
-function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
 var foo = bar(_templateObject, 42, _.foobar());
 var bar = bar(_templateObject2, 42, _.foobar());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
@@ -6,7 +6,7 @@ var _templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\un
     _templateObject6 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"]),
     _templateObject7 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"]);
 
-function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
 tag(_templateObject);
 tag(_templateObject2);


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues? | Fixes #7352 
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

1. Adds a check to see if strings and raw strings are equal
2. If they are equal doesn't pass raws to call expression
3. Modifies taggedTemplateHelpers to slice strings if raws is not passed