### PR TITLE
TypeScript: support mapped type modifiers syntax

### DIFF
--- a/packages/babel-generator/src/generators/typescript.js
+++ b/packages/babel-generator/src/generators/typescript.js
@@ -280,6 +280,7 @@ export function TSMappedType(node) {
   this.token("{");
   this.space();
   if (readonly) {
+    tokenIfPlusMinus(this, readonly);
     this.word("readonly");
     this.space();
   }
@@ -293,6 +294,7 @@ export function TSMappedType(node) {
   this.token("]");
 
   if (optional) {
+    tokenIfPlusMinus(this, optional);
     this.token("?");
   }
   this.token(":");
@@ -300,6 +302,12 @@ export function TSMappedType(node) {
   this.print(node.typeAnnotation, node);
   this.space();
   this.token("}");
+}
+
+function tokenIfPlusMinus(self, tok) {
+  if (tok !== true) {
+    self.token(tok);
+  }
 }
 
 export function TSLiteralType(node) {

--- a/packages/babel-generator/test/fixtures/typescript/types-mapped/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-mapped/input.js
@@ -1,2 +1,4 @@
-let map: { [P in string]: number; };
-let map: { readonly [P in string]?: number; };
+let map: { [P in string]: number };
+let map: { readonly [P in string]?: number };
+let map: { +readonly [P in string]+?: number };
+let map: { -readonly [P in string]-?: number };

--- a/packages/babel-generator/test/fixtures/typescript/types-mapped/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-mapped/output.js
@@ -1,2 +1,4 @@
 let map: { [P in string]: number };
 let map: { readonly [P in string]?: number };
+let map: { +readonly [P in string]+?: number };
+let map: { -readonly [P in string]-?: number };

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -446,6 +446,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     tsIsStartOfMappedType(): boolean {
       this.next();
+      if (this.eat(tt.plusMin)) {
+        return this.isContextual("readonly");
+      }
       if (this.isContextual("readonly")) {
         this.next();
       }
@@ -472,15 +475,27 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const node: N.TsMappedType = this.startNode();
 
       this.expect(tt.braceL);
-      if (this.eatContextual("readonly")) {
+
+      if (this.match(tt.plusMin)) {
+        node.readonly = this.state.value;
+        this.next();
+        this.expectContextual("readonly");
+      } else if (this.eatContextual("readonly")) {
         node.readonly = true;
       }
+
       this.expect(tt.bracketL);
       node.typeParameter = this.tsParseMappedTypeParameter();
       this.expect(tt.bracketR);
-      if (this.eat(tt.question)) {
+
+      if (this.match(tt.plusMin)) {
+        node.optional = this.state.value;
+        this.next();
+        this.expect(tt.question);
+      } else if (this.eat(tt.question)) {
         node.optional = true;
       }
+
       node.typeAnnotation = this.tsTryParseType();
       this.semicolon();
       this.expect(tt.braceR);

--- a/packages/babylon/src/types.js
+++ b/packages/babylon/src/types.js
@@ -1161,9 +1161,9 @@ export type TsIndexedAccessType = TsTypeBase & {
 
 export type TsMappedType = TsTypeBase & {
   type: "TSMappedType",
-  readonly?: true,
+  readonly?: true | "+" | "-",
   typeParameter: TsTypeParameter,
-  optional?: true,
+  optional?: true | "+" | "-",
   typeAnnotation: ?TsType,
 };
 

--- a/packages/babylon/test/fixtures/typescript/types/mapped/input.js
+++ b/packages/babylon/test/fixtures/typescript/types/mapped/input.js
@@ -1,2 +1,4 @@
 let map: { [P in string]: number; };
 let map: { readonly [P in string]?: number; };
+let map: { +readonly [P in string]+?: number; };
+let map: { -readonly [P in string]-?: number };

--- a/packages/babylon/test/fixtures/typescript/types/mapped/output.json
+++ b/packages/babylon/test/fixtures/typescript/types/mapped/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 83,
+  "end": 180,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 2,
-      "column": 46
+      "line": 4,
+      "column": 47
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 83,
+    "end": 180,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 2,
-        "column": 46
+        "line": 4,
+        "column": 47
       }
     },
     "sourceType": "module",
@@ -273,6 +273,264 @@
                       "end": {
                         "line": 2,
                         "column": 42
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 84,
+        "end": 132,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 48
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 88,
+            "end": 131,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 4
+              },
+              "end": {
+                "line": 3,
+                "column": 47
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 88,
+              "end": 131,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 4
+                },
+                "end": {
+                  "line": 3,
+                  "column": 47
+                },
+                "identifierName": "map"
+              },
+              "name": "map",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 91,
+                "end": 131,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 47
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSMappedType",
+                  "start": 93,
+                  "end": 131,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 47
+                    }
+                  },
+                  "readonly": "+",
+                  "typeParameter": {
+                    "type": "TSTypeParameter",
+                    "start": 106,
+                    "end": 117,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 33
+                      }
+                    },
+                    "name": "P",
+                    "constraint": {
+                      "type": "TSStringKeyword",
+                      "start": 111,
+                      "end": 117,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 27
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 33
+                        }
+                      }
+                    }
+                  },
+                  "optional": "+",
+                  "typeAnnotation": {
+                    "type": "TSNumberKeyword",
+                    "start": 122,
+                    "end": 128,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 38
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 44
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 133,
+        "end": 180,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 47
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 137,
+            "end": 179,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 4
+              },
+              "end": {
+                "line": 4,
+                "column": 46
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 137,
+              "end": 179,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 4
+                },
+                "end": {
+                  "line": 4,
+                  "column": 46
+                },
+                "identifierName": "map"
+              },
+              "name": "map",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 140,
+                "end": 179,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 46
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSMappedType",
+                  "start": 142,
+                  "end": 179,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 46
+                    }
+                  },
+                  "readonly": "-",
+                  "typeParameter": {
+                    "type": "TSTypeParameter",
+                    "start": 155,
+                    "end": 166,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 33
+                      }
+                    },
+                    "name": "P",
+                    "constraint": {
+                      "type": "TSStringKeyword",
+                      "start": 160,
+                      "end": 166,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 27
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 33
+                        }
+                      }
+                    }
+                  },
+                  "optional": "-",
+                  "typeAnnotation": {
+                    "type": "TSNumberKeyword",
+                    "start": 171,
+                    "end": 177,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 38
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 44
                       }
                     }
                   }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         |
| Any Dependency Changes?  |
| License                  | MIT

Supports the syntax from Microsoft/TypeScript#21919. Now you can write `let x: { +readonly [P in string]-?: number };`.