### PR TITLE
Favour extends helper over objectWithoutProperties when whole object …

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/README.md
+++ b/packages/babel-plugin-proposal-object-rest-spread/README.md
@@ -71,8 +71,7 @@ For detailed information please check out [Spread VS. Object.assign](http://2ali
 
 `boolean`, defaults to `false`.
 
-Enabling this option will use `Object.assign` directly instead of the Babel's `extends` helper. Keep in mind that this flag only applies when `loose: true`.
-
+Enabling this option will use `Object.assign` directly instead of the Babel's `extends` helper. 
 
 ##### Example
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/catch-clause/output.js
@@ -1,5 +1,5 @@
 try {} catch (_ref) {
-  let a34 = babelHelpers.objectWithoutProperties(_ref, []);
+  let a34 = babelHelpers.extends({}, _ref);
 }
 
 try {} catch (_ref2) {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/duplicate-decl-bug/output.js
@@ -3,5 +3,5 @@ it("es7.objectRestSpread", () => {
     a: 1,
     b: 2
   };
-  let copy = babelHelpers.objectWithoutProperties(original, []);
+  let copy = babelHelpers.extends({}, original);
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-computed-key/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-computed-key/output.js
@@ -2,8 +2,8 @@ var _ref2;
 
 const {
   [(_ref) => {
-    let rest = babelHelpers.objectWithoutProperties(_ref, []);
-    let b = babelHelpers.objectWithoutProperties({}, []);
+    let rest = babelHelpers.extends({}, _ref);
+    let b = babelHelpers.extends({}, {});
   }]: a,
-  [(_ref2 = {}, ({} = _ref2), d = babelHelpers.objectWithoutProperties(_ref2, []), _ref2)]: c
+  [(_ref2 = {}, ({} = _ref2), d = babelHelpers.extends({}, _ref2), _ref2)]: c
 } = {};

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-default-value/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-default-value/output.js
@@ -2,8 +2,8 @@ var _ref2;
 
 const {
   a = (_ref) => {
-    let rest = babelHelpers.objectWithoutProperties(_ref, []);
-    let b = babelHelpers.objectWithoutProperties({}, []);
+    let rest = babelHelpers.extends({}, _ref);
+    let b = babelHelpers.extends({}, {});
   },
-  c = (_ref2 = {}, ({} = _ref2), d = babelHelpers.objectWithoutProperties(_ref2, []), _ref2)
+  c = (_ref2 = {}, ({} = _ref2), d = babelHelpers.extends({}, _ref2), _ref2)
 } = {};

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-order/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/nested-order/output.js
@@ -1,3 +1,3 @@
-const bar = babelHelpers.objectWithoutProperties(obj.a, []),
-      baz = babelHelpers.objectWithoutProperties(obj.b, []),
-      foo = babelHelpers.objectWithoutProperties(obj, []);
+const bar = babelHelpers.extends({}, obj.a),
+      baz = babelHelpers.extends({}, obj.b),
+      foo = babelHelpers.extends({}, obj);

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters/output.js
@@ -1,5 +1,5 @@
 function a(_ref) {
-  let a34 = babelHelpers.objectWithoutProperties(_ref, []);
+  let a34 = babelHelpers.extends({}, _ref);
 }
 
 function a2(_ref2) {
@@ -57,7 +57,7 @@ function a7(_ref8 = {}) {
 }
 
 function a8([_ref9]) {
-  let a1 = babelHelpers.objectWithoutProperties(_ref9, []);
+  let a1 = babelHelpers.extends({}, _ref9);
 }
 
 function a9([_ref10]) {
@@ -68,7 +68,7 @@ function a9([_ref10]) {
 }
 
 function a10([a1, _ref11]) {
-  let a2 = babelHelpers.objectWithoutProperties(_ref11, []);
+  let a2 = babelHelpers.extends({}, _ref11);
 } // Unchanged
 
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/variable-destructuring/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/variable-destructuring/output.js
@@ -1,10 +1,10 @@
 var z = {};
-var x = babelHelpers.objectWithoutProperties(z, []);
-var a = babelHelpers.objectWithoutProperties({
+var x = babelHelpers.extends({}, z);
+var a = babelHelpers.extends({}, {
   a: 1
-}, []);
-var x = babelHelpers.objectWithoutProperties(a.b, []);
-var x = babelHelpers.objectWithoutProperties(a(), []);
+});
+var x = babelHelpers.extends({}, a.b);
+var x = babelHelpers.extends({}, a());
 var {
   x1
 } = z,
@@ -36,7 +36,7 @@ let {
   }
 } = complex,
     asdf = babelHelpers.objectWithoutProperties(complex.x, ["a", d].map(babelHelpers.toPropertyKey)),
-    d = babelHelpers.objectWithoutProperties(complex.y, []),
+    d = babelHelpers.extends({}, complex.y),
     g = babelHelpers.objectWithoutProperties(complex, ["x"]);
 let {} = z,
-    y4 = babelHelpers.objectWithoutProperties(z.x4, []);
+    y4 = babelHelpers.extends({}, z.x4);

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/T7178/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/T7178/output.js
@@ -5,6 +5,6 @@ var _props = babelHelpers.interopRequireDefault(require("props"));
 console.log(_props.default);
 
 (function () {
-  const props = babelHelpers.objectWithoutProperties(this.props, []);
+  const props = babelHelpers.extends({}, this.props);
   console.log(props);
 })();

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-5151/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-5151/output.js
@@ -3,7 +3,7 @@ const {
 } = a,
       y = babelHelpers.objectWithoutProperties(a, ["x"]),
       z = foo(y);
-const s = babelHelpers.objectWithoutProperties(r, []),
+const s = babelHelpers.extends({}, r),
       t = foo(s); // ordering is preserved
 
 var l = foo(),

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7304/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/regression/gh-7304/output.js
@@ -7,7 +7,7 @@ exports.default = void 0;
 
 class _default {
   method(_ref) {
-    let object = babelHelpers.objectWithoutProperties(_ref, []);
+    let object = Object.assign({}, _ref);
   }
 
 }

--- a/packages/babel-plugin-transform-destructuring/README.md
+++ b/packages/babel-plugin-transform-destructuring/README.md
@@ -51,3 +51,42 @@ require("@babel/core").transform("code", {
   plugins: ["@babel/plugin-transform-destructuring"]
 });
 ```
+
+## Options
+
+### `loose`
+
+`boolean`, defaults to `false`.
+
+Enabling this option will assume that what you want to destructure is an array and won't use `Array.from` on other iterables.
+
+### `useBuiltIns`
+
+`boolean`, defaults to `false`.
+
+Enabling this option will use `Object.assign` directly instead of the Babel's `extends` helper. 
+
+##### Example
+
+**.babelrc**
+
+```json
+{
+  "plugins": [
+    ["@babel/plugin-transform-destructuring", { "useBuiltIns": true }]
+  ]
+}
+```
+
+**In**
+
+```js
+var { ...x } = z;
+```
+
+**Out**
+
+```js
+var _z = z,
+    x = Object.assign({}, _z);
+```

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/input.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/input.js
@@ -1,0 +1,7 @@
+var z = {};
+var { ...x } = z;
+var { x, ...y } = z;
+var { [x]: x, ...y } = z;
+(function({ x, ...y }) { });
+
+({ x, y, ...z } = o);

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["transform-destructuring", { "useBuiltIns": true }],
+    "transform-spread",
+    "transform-parameters",
+    "transform-block-scoping",
+    "proposal-object-rest-spread",
+    "transform-regenerator"
+  ]
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/output.js
@@ -1,6 +1,6 @@
 var z = {};
 var _z = z,
-    x = babelHelpers.extends({}, _z);
+    x = Object.assign({}, _z);
 var _z2 = z,
     x = _z2.x,
     y = babelHelpers.objectWithoutProperties(_z2, ["x"]);


### PR DESCRIPTION
…gets copied anyway

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | yes
| Tests Added + Pass?      | Yes
| Documentation PR         | docs included
| Any Dependency Changes?  |
| License                  | MIT

Simple polish/perf PR, if we do not actually exclude any properties we can just make a shallow copy of the object which is nice because we do not need filtering logic & and do not need to allocate extra temp array.
