### PR TITLE
Add missing promise polyfill deps for preset-env's useBuiltIns: usage

### DIFF
--- a/packages/babel-preset-env/src/built-in-definitions.js
+++ b/packages/babel-preset-env/src/built-in-definitions.js
@@ -15,7 +15,7 @@ export const definitions = {
     Set: "es6.set",
     WeakMap: "es6.weak-map",
     WeakSet: "es6.weak-set",
-    Promise: "es6.promise",
+    Promise: ["es6.object.to-string", "es6.promise"],
     Symbol: "es6.symbol",
   },
 
@@ -112,6 +112,11 @@ export const definitions = {
       EPSILON: "es6.number.epsilon",
       MIN_SAFE_INTEGER: "es6.number.min-safe-integer",
       MAX_SAFE_INTEGER: "es6.number.max-safe-integer",
+    },
+
+    Promise: {
+      all: ["es6.string.iterator", "web.dom.iterable"],
+      race: ["es6.string.iterator", "web.dom.iterable"],
     },
 
     Reflect: {

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/input.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/input.js
@@ -1,0 +1,4 @@
+var p = Promise.resolve(0);
+Promise.all([p]).then(outcome => {
+  alert("OK");
+});

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/options.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": {
+          "browsers": ["ie > 10"]
+        },
+        "useBuiltIns": "usage",
+        "modules": false
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/output.js
@@ -1,0 +1,6 @@
+import "core-js/modules/web.dom.iterable";
+import "core-js/modules/es6.promise";
+var p = Promise.resolve(0);
+Promise.all([p]).then(function (outcome) {
+  alert("OK");
+});

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/input.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/input.js
@@ -1,0 +1,4 @@
+var p = Promise.resolve(0);
+Promise.race([p]).then(outcome => {
+  alert("OK");
+});

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/options.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": {
+          "browsers": ["ie > 10"]
+        },
+        "useBuiltIns": "usage",
+        "modules": false
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/output.js
@@ -1,0 +1,6 @@
+import "core-js/modules/web.dom.iterable";
+import "core-js/modules/es6.promise";
+var p = Promise.resolve(0);
+Promise.race([p]).then(function (outcome) {
+  alert("OK");
+});


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7395 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
