### PR TITLE
Bump compat-table and regen preset-env data

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -1149,7 +1149,7 @@
   "es7.promise.finally": {
     "chrome": "63",
     "firefox": "58",
-    "safari": "tp",
+    "safari": "11.1",
     "opera": "50"
   }
 }

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -220,7 +220,7 @@
   },
   "transform-dotall-regex": {
     "chrome": "62",
-    "safari": "tp",
+    "safari": "11.1",
     "opera": "49"
   },
   "proposal-async-generator-functions": {
@@ -232,17 +232,19 @@
   "proposal-object-rest-spread": {
     "chrome": "60",
     "firefox": "55",
-    "safari": "tp",
+    "safari": "11.1",
     "node": "8.3",
     "opera": "47"
   },
   "proposal-optional-catch-binding": {
+    "chrome": "66",
     "firefox": "58",
-    "safari": "tp"
+    "safari": "11.1",
+    "opera": "53"
   },
   "proposal-unicode-property-regex": {
     "chrome": "64",
-    "safari": "tp",
+    "safari": "11.1",
     "opera": "51"
   }
 }

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -57,7 +57,7 @@
     "@babel/core": "7.0.0-beta.40",
     "@babel/helper-fixtures": "7.0.0-beta.40",
     "@babel/helper-plugin-test-runner": "7.0.0-beta.40",
-    "compat-table": "kangax/compat-table#3e30cd67a5d3d853caf8424d00ca66d100674d4f",
+    "compat-table": "kangax/compat-table#7c202e2da648fbd9d223d48d1680ec8f15147044",
     "electron-to-chromium": "^1.3.27",
     "request": "^2.83.0"
   }

--- a/packages/babel-preset-env/scripts/build-modules-support.js
+++ b/packages/babel-preset-env/scripts/build-modules-support.js
@@ -8,10 +8,14 @@ const request = require("request");
 // * https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type
 const lastKnown = {
   chrome: 61,
-  firefox: 59,
   safari: 10.1,
   ios_saf: 10.3,
   edge: 16,
+};
+
+const acceptedWithCaveats = {
+  safari: true,
+  ios_saf: true,
 };
 
 function input() {
@@ -38,12 +42,15 @@ function input() {
               const browserVersions = stats[browser];
               const allowedVersions = Object.keys(browserVersions)
                 .filter(value => {
-                  return browserVersions[value] === "y";
+                  return acceptedWithCaveats[browser]
+                    ? browserVersions[value][0] === "a"
+                    : browserVersions[value] === "y";
                 })
                 .sort((a, b) => a - b);
 
               if (allowedVersions[0] !== undefined) {
-                allowedBrowsers[browser] = allowedVersions[0];
+                // Handle cases where caniuse specifies version as: "11.0-11.2"
+                allowedBrowsers[browser] = allowedVersions[0].split("-")[0];
               }
             }
           });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Precursor to updating preset-env with es2018 stuff.

~~~Note, this actually changes `esmodules: true` a bit, since `caniuse` [updated `es6.modules`](https://github.com/Fyrd/caniuse/blob/master/features-json/es6-module.json), unless we don't care about the `nomodules` attribute?~~~

/cc: @kristoferbaxter

EDIT: Adds a workaround in `scripts/build-modules-support` to allow Safari 10.1/iOS 10.3