### PR TITLE
Replace instead of merging babel-register options, and resolve cwd up front

### DIFF
--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -115,16 +115,22 @@ export default function register(opts?: Object = {}) {
 
   transformOpts = Object.assign({}, opts);
 
+  let { cwd = "." } = transformOpts;
+
+  // Ensure that the working directory is resolved up front so that
+  // things don't break if it changes later.
+  cwd = transformOpts.cwd = path.resolve(cwd);
+
   if (transformOpts.ignore === undefined && transformOpts.only === undefined) {
     transformOpts.only = [
       // Only compile things inside the current working directory.
-      new RegExp("^" + escapeRegExp(process.cwd()), "i"),
+      new RegExp("^" + escapeRegExp(cwd), "i"),
     ];
     transformOpts.ignore = [
       // Ignore any node_modules inside the current working directory.
       new RegExp(
         "^" +
-          escapeRegExp(process.cwd()) +
+          escapeRegExp(cwd) +
           "(?:" +
           path.sep +
           ".*)?" +

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -9,7 +9,7 @@ import fs from "fs";
 import path from "path";
 
 const maps = {};
-const transformOpts = {};
+let transformOpts = {};
 let piratesRevert = null;
 
 function installSourceMapSupport() {
@@ -113,9 +113,9 @@ export default function register(opts?: Object = {}) {
   delete opts.extensions;
   delete opts.cache;
 
-  Object.assign(transformOpts, opts);
+  transformOpts = Object.assign({}, opts);
 
-  if (!transformOpts.ignore && !transformOpts.only) {
+  if (transformOpts.ignore === undefined && transformOpts.only === undefined) {
     transformOpts.only = [
       // Only compile things inside the current working directory.
       new RegExp("^" + escapeRegExp(process.cwd()), "i"),


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y, 
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

The current behavior of merging the configs is likely not what people expect, if they even think about the fact that it is a global singleton.

For the cwd, just something I've been meaning to do to make things a little less reliant on global state during the actual compilation steps later.