### PR TITLE
Rely entirely on sourceType for module vs script differentiation.

### DIFF
--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -206,6 +206,7 @@ describe("api", function() {
 
     function execTest(passPerPreset) {
       return babel.transform("type Foo = number; let x = (y): Foo => y;", {
+        sourceType: "script",
         passPerPreset: passPerPreset,
         presets: [
           // First preset with our plugin, "before"

--- a/packages/babel-helper-module-imports/src/import-injector.js
+++ b/packages/babel-helper-module-imports/src/import-injector.js
@@ -209,7 +209,7 @@ export default class ImportInjector {
     // to a variable.
     let name = nameHint || importName;
 
-    const isMod = isModule(this._programPath, true);
+    const isMod = isModule(this._programPath);
     const isModuleForNode = isMod && importingInterop === "node";
     const isModuleForBabel = isMod && importingInterop === "babel";
 

--- a/packages/babel-helper-module-imports/src/is-module.js
+++ b/packages/babel-helper-module-imports/src/is-module.js
@@ -1,11 +1,7 @@
 /**
- * A small utility to check if a file qualifies as a module, based on a few
- * possible conditions.
+ * A small utility to check if a file qualifies as a module.
  */
-export default function isModule(
-  path: NodePath,
-  requireUnambiguous: boolean = false,
-) {
+export default function isModule(path: NodePath) {
   const { sourceType } = path.node;
   if (sourceType !== "module" && sourceType !== "script") {
     throw path.buildCodeFrameError(
@@ -13,19 +9,5 @@ export default function isModule(
     );
   }
 
-  const filename = path.hub.file.opts.filename;
-  if (/\.mjs$/.test(filename)) {
-    requireUnambiguous = false;
-  }
-
-  return (
-    path.node.sourceType === "module" &&
-    (!requireUnambiguous || isUnambiguousModule(path))
-  );
-}
-
-// This approach is not ideal. It is here to preserve compatibility for now,
-// but really this should just return true or be deleted.
-function isUnambiguousModule(path) {
-  return path.get("body").some(p => p.isModuleDeclaration());
+  return path.node.sourceType === "module";
 }

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -330,6 +330,7 @@ function run(task) {
     const newOpts = merge(
       {
         filename: self.loc,
+        sourceType: "unambiguous",
       },
       opts,
     );

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/get-module-name-option/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/get-module-name-option/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name"
 }

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name/options.json
@@ -1,3 +1,4 @@
 {
+  "sourceType": "module",
   "moduleIds": true
 }

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/get-module-name-option/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/get-module-name-option/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name",
   "plugins": [

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/module-name/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/loose/module-name/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleIds": true,
   "plugins": [
     "external-helpers",

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -98,9 +98,7 @@ export default function(api, options) {
     visitor: {
       Program: {
         exit(path) {
-          // For now this requires unambiguous rather that just sourceType
-          // because Babel currently parses all files as sourceType:module.
-          if (!isModule(path, true /* requireUnambiguous */)) return;
+          if (!isModule(path)) return;
 
           // Rename the bindings auto-injected into the scope so there is no
           // risk of conflict between the bindings.

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/get-module-name-option/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/get-module-name-option/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name",
   "plugins": [

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleId": "MyLib",
   "plugins": [
     "external-helpers",

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleIds": true,
   "plugins": [
     "external-helpers",

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/get-module-name-option/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/get-module-name-option/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "moduleIds": true,
   "moduleId": "my custom module name"
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/options.json
@@ -1,3 +1,4 @@
 {
+  "sourceType": "module",
   "moduleId": "MyLib"
 }

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name/options.json
@@ -1,3 +1,4 @@
 {
+  "sourceType": "module",
   "moduleIds": true
 }

--- a/packages/babel-preset-env-standalone/test/babel-preset-env.js
+++ b/packages/babel-preset-env-standalone/test/babel-preset-env.js
@@ -7,6 +7,7 @@ require("../babel-preset-env");
 describe("babel-preset-env-standalone", () => {
   it("works w/o targets", () => {
     const output = Babel.transform("const a = 1;", {
+      sourceType: "script",
       presets: ["env"],
     }).code;
     assert.equal(output, "var a = 1;");
@@ -14,6 +15,7 @@ describe("babel-preset-env-standalone", () => {
 
   it("doesn't transpile `const` with chrome 60", () => {
     const output = Babel.transform("const a = 1;", {
+      sourceType: "script",
       presets: [
         [
           "env",
@@ -30,6 +32,7 @@ describe("babel-preset-env-standalone", () => {
 
   it("transpiles `const` with chrome 60 and preset-es2015", () => {
     const output = Babel.transform("const a = 1;", {
+      sourceType: "script",
       presets: [
         [
           "env",
@@ -47,6 +50,7 @@ describe("babel-preset-env-standalone", () => {
 
   it("uses transform-new-targets plugin", () => {
     const output = Babel.transform("function Foo() {new.target}", {
+      sourceType: "script",
       presets: ["env"],
     }).code;
     assert.equal(

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/test-modules-tranform/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/test-modules-tranform/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "presets": [
     ["../../../../lib", {
       "useBuiltIns": "usage"

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/options.json
@@ -1,4 +1,5 @@
 {
+  "sourceType": "module",
   "presets": [
     ["../../../../lib", {
       "shippedProposals": true,

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -16,6 +16,7 @@ describe("@babel/standalone", () => {
   });
   it("handles the es2015-loose preset", () => {
     const output = Babel.transform("class A {}", {
+      sourceType: "script",
       presets: ["es2015-loose"],
     }).code;
     assert.equal(output, "var A = function A() {};");
@@ -52,7 +53,7 @@ describe("@babel/standalone", () => {
           },
         },
       ],
-      sourceType: "module",
+      sourceType: "script",
     };
     const output = Babel.transformFromAst(ast, "42", { presets: ["es2015"] })
       .code;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7416
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | Yes (Within 7 yes, from 6 it depends on if we disable `allowCommonJSExports` by default)
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Per #7416, we're in a weird place right now in Babel 7 because we've landed some logic that tries to be smart about whether something is a module or a script. The two points that affect this issue are:

* If something is a ES6 module, we automatically add `use strict` and convert `this` to `undefined`.
* In `transform-runtime` (and `transform-async-to-generator` when using `module` and `method` options), we try to insert either `require` or `import` based on the type of file.

So this puts us in a weird place. 

In Babel 6, we just assumed it was _always_ an ES6 module, which leads to breakage with Webpack because if `transform-runtime` inserts an import, but the user's file was CommonJS, Webpack will consider the whole file an ES6 module and the CommonJS stuff will break.

In Babel 7 we rectified that in the short term by basically saying it's an ES6 module if __both__:

* It has `sourceType: module`
* It has at least one `import` or `export`.

Unfortunately this means that if you want something to be an ES6 module and it _doesn't_ have an import or export, it's actually impossible, hence #7416.

To resolve this, we've introduced `sourceType: "unambiguous"` that performs the above logic at the _parser_ level, so instead of checking those 2 states during transformation, the parser produces either a `script` or `module`, which means that Babel itself can respect the `sourceType` as a source of truth.

With that work landed in the parser, this PR removes the logic from the transformation system. The downside here being that we don't want to default to `sourceType: unambiguous` because it isn't a formal specification and isn't backed by anything in particular. Instead we'd like to leave that up to the user to opt into.

This means that with this PR, Babel will revert to it's Babel 6 behavior as mentioned above for `use strict` and `this` rewriting.

I personally think that is fine. The main question I have is, should we try to make it more painful to treat a CommonJS module this way (auto-injecting use-strict and this->undefined) to encourage people to explicitly set `sourceType` based on what they actually want? 

This could easily amount to us injecting code to throw a nice error saying "please set `sourceType:script` or `sourceType:unambiguous` in your Babel config". We already have an `allowCommonJSExports` option on the CommonJS transform that we could easily disable by default, though the message will need updating to be more helpful. If we _don't_, it'll just be like Babel 6 if someone runs `transform-runtime` on a CommonJS module, with `modules:false` for Webpack they'll get unhelpful error messages about `module` and `exports` being undeclared.