### PR TITLE
Reinstate `--inspect-brk`, lost when making babel-node standalone

### DIFF
--- a/packages/babel-node/src/babel-node.js
+++ b/packages/babel-node/src/babel-node.js
@@ -46,6 +46,7 @@ getV8Flags(function(err, v8Flags) {
       case "--debug":
       case "--debug-brk":
       case "--inspect":
+      case "--inspect-brk":
         args.unshift(arg);
         break;
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #7422
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | n/a regression
| Documentation PR         | n/a regression
| Any Dependency Changes?  | No
| License                  | MIT

Fix regression issue: `--inspect-brk` no longer works