### PR TITLE
Prevent undefined function name for template literal computed property

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -167,7 +167,7 @@ export default function({ node, parent, scope, id }, localBinding = false) {
   }
 
   let name;
-  if (id && t.isLiteral(id)) {
+  if (id && t.isLiteral(id) && id.value) {
     name = id.value;
   } else if (id && t.isIdentifier(id)) {
     name = id.name;

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
@@ -1,0 +1,3 @@
+const x = {
+  [`y`]: function () {}
+};

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/options.json
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-function-name"]
+}

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
@@ -1,0 +1,3 @@
+const x = {
+  [`y`]: function () {}
+};


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #7199 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

This PR ensures that when inferring a function name from a literal, it will make sure that the literal has a truthy value to prevent having undefined as a function name.

I'm not sure this is the best way to address it, I added my thoughts on the issue.
https://github.com/babel/babel/issues/7199#issuecomment-368229625
