### PR TITLE
Fix default descriptor setting for class properties with decorators

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -953,9 +953,7 @@ helpers.applyDecoratedDescriptor = () => template.program.ast`
         });
         desc.enumerable = !!desc.enumerable;
         desc.configurable = !!desc.configurable;
-        if ('value' in desc || desc.initializer){
-            desc.writable = true;
-        }
+        desc.writable = !!desc.writable;
 
         desc = decorators.slice().reverse().reduce(function(desc, decorator){
             return decorator(target, property, desc) || desc;

--- a/packages/babel-plugin-proposal-decorators/src/transformer-legacy.js
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-legacy.js
@@ -169,7 +169,15 @@ function applyTargetDecorators(path, state, decoratedProps) {
             ),
             t.objectExpression([
               t.objectProperty(
+                t.identifier("configurable"),
+                t.booleanLiteral(true),
+              ),
+              t.objectProperty(
                 t.identifier("enumerable"),
+                t.booleanLiteral(true),
+              ),
+              t.objectProperty(
+                t.identifier("writable"),
                 t.booleanLiteral(true),
               ),
               t.objectProperty(t.identifier("initializer"), initializer),

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/mutate-descriptor/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/mutate-descriptor/exec.js
@@ -16,6 +16,16 @@ function dec(target, name, descriptor) {
   });
 }
 
+function plainDec(target, name, descriptor) {
+  expect(target).toBeTruthy();
+  expect(typeof name).toBe("string");
+  expect(typeof descriptor).toBe("object");
+
+  target.decoratedProps = (target.decoratedProps || []).concat([name]);
+
+  return descriptor;
+}
+
 class Example {
   @dec
   enumconfwrite = 1;
@@ -40,6 +50,9 @@ class Example {
 
   @dec
   _ = 8;
+
+  @plainDec
+  plain = 9;
 }
 
 const inst = new Example();
@@ -54,6 +67,7 @@ expect(inst.decoratedProps).toEqual([
   "conf",
   "write",
   "_",
+  "plain",
 ]);
 
 const descs = Object.getOwnPropertyDescriptors(inst);
@@ -97,3 +111,8 @@ expect(descs._.enumerable).toBe(false);
 expect(descs._.writable).toBe(false);
 expect(descs._.configurable).toBe(false);
 expect(inst._).toBe("__8__");
+
+expect(descs.plain.enumerable).toBeTruthy();
+expect(descs.plain.writable).toBeTruthy();
+expect(descs.plain.configurable).toBeTruthy();
+expect(inst.plain).toBe(9);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/properties-without-initializer/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/properties-without-initializer/exec.js
@@ -1,5 +1,11 @@
 function dec(target, name, descriptor) {
+  expect(target).toBeTruthy();
+  expect(typeof name).toBe("string");
+  expect(typeof descriptor).toBe("object");
 
+  target.decoratedProps = (target.decoratedProps || []).concat([name]);
+
+  return descriptor;
 }
 
 class Example {
@@ -7,5 +13,17 @@ class Example {
 }
 
 let inst = new Example();
+
+expect(Example.prototype).toHaveProperty("decoratedProps");
+expect(inst.decoratedProps).toEqual([
+  "prop",
+]);
+
 expect(inst).toHaveProperty("prop");
 expect(inst.prop).toBeUndefined();
+
+const descs = Object.getOwnPropertyDescriptors(inst);
+
+expect(descs.prop.enumerable).toBeTruthy();
+expect(descs.prop.writable).toBeTruthy();
+expect(descs.prop.configurable).toBeTruthy();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-decl-to-expression/method-decorators/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-decl-to-expression/method-decorators/output.mjs
@@ -1,6 +1,6 @@
 var _class, _class2;
 
-function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; desc.writable = !!desc.writable; desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
 
 let A = (_class2 = class A {
   foo() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8041/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8041/output.mjs
@@ -1,6 +1,6 @@
 var _class2;
 
-function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; desc.writable = !!desc.writable; desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
 
 let _class = (_class2 = class {
   bar() {}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7391, Fixes #5519, Fixes https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy/issues/57, Fixes https://github.com/typeorm/typeorm/issues/1458 and probably more <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | No <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As described in #7391, class properties **with decorators** are given a descriptor whose `writable` value is false by default, which created an issue that the value of a class property with decorators is **fixed as undefined value** when it doesn't have an initializer. This patch changes the behavior to be consistent with the class properties without decorators as handled by `proposal-class-properties` plugin, where a class property gets a base descriptor with `configurable: true, enumerable: true, writable: true` (https://github.com/babel/babel/blob/master/packages/babel-plugin-proposal-class-properties/src/index.js#L51-L53).

I also made a small change in `applyDecoratedDescriptor` helper that determines `desc.writable` value, since `desc.writable` is always set to either true or false after the above change is made.