### PR TITLE
eslint: Rename to .json, mark as root config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": "babel",
   "plugins": [
     "prettier"


### PR DESCRIPTION
This renames the file to have a .json suffix, as [.eslintrc is deprecated](https://eslint.org/docs/user-guide/configuring#configuration-file-formats), and [marks the file as the root config](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy) to prevent ESLint from looking for config files in parent directories.