### PR TITLE
Fix function name computation for literal values

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -47,13 +47,15 @@ const visitor = {
 
 function getNameFromLiteralId(id) {
   if (t.isNullLiteral(id)) {
-    return null;
+    return "null";
   } else if (t.isRegExpLiteral(id)) {
     return `_${id.pattern}_${id.flags}`;
-  } else if (t.isTemplateLiteral(id) && id.expressions.length === 0) {
-    return id.quasis[0].value.raw;
+  } else if (t.isTemplateLiteral(id)) {
+    return id.quasis.map(quasi => quasi.value.raw).join("");
+  } else if (id.value !== undefined) {
+    return id.value + "";
   } else {
-    return id.value;
+    return "";
   }
 }
 

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -45,6 +45,18 @@ const visitor = {
   },
 };
 
+function getNameFromLiteralId(id) {
+  if (t.isNullLiteral(id)) {
+    return null;
+  } else if (t.isRegExpLiteral(id)) {
+    return `_${id.pattern}_${id.flags}`;
+  } else if (t.isTemplateLiteral(id) && id.expressions.length === 0) {
+    return id.quasis[0].value.raw;
+  } else {
+    return id.value;
+  }
+}
+
 function wrap(state, method, id, scope) {
   if (state.selfReference) {
     if (scope.hasBinding(id.name) && !scope.hasGlobal(id.name)) {
@@ -168,10 +180,12 @@ export default function({ node, parent, scope, id }, localBinding = false) {
 
   let name;
   if (id && t.isLiteral(id)) {
-    name = id.value;
+    name = getNameFromLiteralId(id);
   } else if (id && t.isIdentifier(id)) {
     name = id.name;
-  } else {
+  }
+
+  if (name === undefined) {
     return;
   }
 

--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -48,15 +48,21 @@ const visitor = {
 function getNameFromLiteralId(id) {
   if (t.isNullLiteral(id)) {
     return "null";
-  } else if (t.isRegExpLiteral(id)) {
-    return `_${id.pattern}_${id.flags}`;
-  } else if (t.isTemplateLiteral(id)) {
-    return id.quasis.map(quasi => quasi.value.raw).join("");
-  } else if (id.value !== undefined) {
-    return id.value + "";
-  } else {
-    return "";
   }
+
+  if (t.isRegExpLiteral(id)) {
+    return `_${id.pattern}_${id.flags}`;
+  }
+
+  if (t.isTemplateLiteral(id)) {
+    return id.quasis.map(quasi => quasi.value.raw).join("");
+  }
+
+  if (id.value !== undefined) {
+    return id.value + "";
+  }
+
+  return "";
 }
 
 function wrap(state, method, id, scope) {

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
@@ -1,0 +1,6 @@
+const x = {
+  [null]: function () {},
+  [/regex/gi]: function () {},
+  [`y`]: function () {},
+  [`${y}`]: function () {}
+};

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
@@ -2,7 +2,7 @@ const x = {
   [null]: function () {},
   [/regex/gi]: function () {},
   [`y`]: function () {},
-  [`${y}`]: function () {},
+  [`abc${y}def`]: function () {},
   [0]: function () {},
   [false]: function () {},
 };

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/input.js
@@ -2,5 +2,7 @@ const x = {
   [null]: function () {},
   [/regex/gi]: function () {},
   [`y`]: function () {},
-  [`${y}`]: function () {}
+  [`${y}`]: function () {},
+  [0]: function () {},
+  [false]: function () {},
 };

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/options.json
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "transform-function-name"]
+}

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
@@ -2,7 +2,7 @@ const x = {
   [null]: function _null() {},
   [/regex/gi]: function _regex_gi() {},
   [`y`]: function y() {},
-  [`${y}`]: function _() {},
+  [`abc${y}def`]: function abcdef() {},
   [0]: function _() {},
   [false]: function _false() {}
 };

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
@@ -2,7 +2,7 @@ const x = {
   [null]: function _null() {},
   [/regex/gi]: function _regex_gi() {},
   [`y`]: function y() {},
-  [`${y}`]: function () {},
+  [`${y}`]: function _() {},
   [0]: function _() {},
   [false]: function _false() {}
 };

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
@@ -1,0 +1,6 @@
+const x = {
+  [null]: function _null() {},
+  [/regex/gi]: function _regex_gi() {},
+  [`y`]: function y() {},
+  [`${y}`]: function () {}
+};

--- a/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/issues/7199/output.js
@@ -2,5 +2,7 @@ const x = {
   [null]: function _null() {},
   [/regex/gi]: function _regex_gi() {},
   [`y`]: function y() {},
-  [`${y}`]: function () {}
+  [`${y}`]: function () {},
+  [0]: function _() {},
+  [false]: function _false() {}
 };


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7199 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No 
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I made a first PR [here](https://github.com/babel/babel/pull/7428) but I realized it broke some existing functionalities and I also discovered some other bugs in the way.
Currently,
``    const x = {
        [null]: function(){},
        [/regex/]: function(){},
        [`test`]: function(){}  
};``  

will all create a function with a name of undefined.

My PR correctly creates for null: _null, /regex/: _regex_ and for simple template literals ( which don't have any expressions).
It will not generate a name for more complicated template literals.




