### PR TITLE
Ensure babel-preset-env targets input object is not mutated

### DIFF
--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -169,7 +169,7 @@ export default function normalizeOptions(opts: Options) {
       false,
     ),
     spec: validateBoolOption("loose", opts.spec, false),
-    targets: opts.targets,
+    targets: Object.assign({}, opts.targets),
     useBuiltIns: validateUseBuiltInsOption(opts.useBuiltIns),
   };
 }


### PR DESCRIPTION
Currently the `opts.target` object is being passed through and mutated. This caught me up in a workflow where I was passing `{ esmodules: true }` which was being mutated into `{ esmodules: true, browsers: ... browser list... }` and then giving a warning for future transforms using the same input object that both browsers and esmodules were being provided.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N-->
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | N
| Documentation PR         | N <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | N
| License                  | MIT
