### PR TITLE
Adds function injectExternalHelpers to inject babelHelpers in global

### DIFF
--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -3,6 +3,7 @@
 export { default as File } from "./transformation/file/file";
 export {
   default as buildExternalHelpers,
+  injectExternalHelpers,
 } from "./tools/build-external-helpers";
 export { resolvePlugin, resolvePreset } from "./config/files";
 

--- a/packages/babel-core/src/tools/build-external-helpers.js
+++ b/packages/babel-core/src/tools/build-external-helpers.js
@@ -139,7 +139,10 @@ function buildHelpers(body, namespace, whitelist) {
   });
   return refs;
 }
-export default function(
+export function injectExternalHelpers() {
+  eval(buildExternalHelpers());
+}
+export default function buildExternalHelpers(
   whitelist?: Array<string>,
   outputType: "global" | "module" | "umd" | "var" = "global",
 ) {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -574,11 +574,6 @@ describe("api", function() {
       it("builds external helpers in var output type", function() {
         babel.buildExternalHelpers(null, "var");
       });
-
-      it("injects external helpers in global context", function() {
-        babel.injectExternalHelpers();
-        assert.ok(global.babelHelpers);
-      });
     });
 
     it("all", function() {

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -574,6 +574,11 @@ describe("api", function() {
       it("builds external helpers in var output type", function() {
         babel.buildExternalHelpers(null, "var");
       });
+
+      it("injects external helpers in global context", function() {
+        babel.injectExternalHelpers();
+        assert.ok(global.babelHelpers);
+      });
     });
 
     it("all", function() {

--- a/packages/babel-core/test/inject-external-helpers.js
+++ b/packages/babel-core/test/inject-external-helpers.js
@@ -1,0 +1,9 @@
+import * as babel from "../lib/index";
+import assert from "assert";
+
+describe("buildExternalHelpers", function() {
+  it("injects external helpers in global context", function() {
+    babel.injectExternalHelpers();
+    assert.ok(global.babelHelpers);
+  });
+});


### PR DESCRIPTION
global context
Solves #7357

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #7357` <!-- remove the (`) quotes to link the issues -->
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Adds a new function `injectExternalHelpers ` in `build-external-helpers` which automatically inject `buildHelpers` global context when called.