### PR TITLE
Allow plugins to assert that a specific babel version has loaded the plugin.

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -41,6 +41,7 @@
     "lodash": "^4.2.0",
     "micromatch": "^2.3.11",
     "resolve": "^1.3.2",
+    "semver": "^5.4.1",
     "source-map": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@babel/helper-plugin-utils",
+  "version": "7.0.0-beta.40",
+  "description": "General utilities for plugins to use",
+  "author": "Logan Smyth <loganfsmyth@gmail.com>",
+  "homepage": "https://babeljs.io/",
+  "license": "MIT",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils",
+  "main": "lib/index.js"
+}

--- a/packages/babel-helper-plugin-utils/src/README.md
+++ b/packages/babel-helper-plugin-utils/src/README.md
@@ -1,0 +1,41 @@
+# @babel/helper-plugin-utils
+
+The intention of this module is to provide a place for us to expose a
+standardized API layer over top of what Babel's core API provides on its own.
+
+This is not aiming to implement APIs that are missing on a given Babel version,
+but it is means to provide clear error messages if a plugin is run on a version
+of Babel that doesn't have the APIs that the plugin is trying to use.
+
+Every one of Babel's core plugins and presets will use this module, and ideally
+because of that its size should be kept to a miminum because this may or may
+not be deduplicated when installed.
+
+
+## Usage
+
+```js
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare((api, options, dirname) => {
+  return {};
+});
+```
+
+
+## What this does
+
+Currently, this plugin provides a few services to ensure that plugins function
+well-enough to throw useful errors.
+
+### `options` is always passed
+
+Babel 6 does not pass a second parameter. This frequently means that plugins
+written for Babel 7 that use `options` will attempt to destructure options
+out of an `undefined` value. By supplying the default, we avoid that risk.
+
+### `api.assertVersion` always exists
+
+Babel 6 and early betas of Babel 7 do not have `assertVersion`, so this
+wrapper ensures that it exists and throws a useful error message when not
+supplied by Babel itself.

--- a/packages/babel-helper-plugin-utils/src/index.js
+++ b/packages/babel-helper-plugin-utils/src/index.js
@@ -1,0 +1,65 @@
+export function declare(builder) {
+  return (api, options, dirname) => {
+    if (!api.assertVersion) {
+      // Inject a custom version of 'assertVersion' for Babel 6 and early
+      // versions of Babel 7's beta that didn't have it.
+      api = Object.assign({}, api, {
+        assertVersion(range) {
+          throwVersionError(range, api.version);
+        },
+      });
+    }
+
+    return builder(api, options || {}, dirname);
+  };
+}
+
+function throwVersionError(range, version) {
+  if (typeof range === "number") {
+    if (!Number.isInteger(range)) {
+      throw new Error("Expected string or integer value.");
+    }
+    range = `^${range}.0.0-0`;
+  }
+  if (typeof range !== "string") {
+    throw new Error("Expected string or integer value.");
+  }
+
+  const limit = Error.stackTraceLimit;
+
+  if (typeof limit === "number" && limit < 25) {
+    // Bump up the limit if needed so that users are more likely
+    // to be able to see what is calling Babel.
+    Error.stackTraceLimit = 25;
+  }
+
+  let err;
+  if (version.slice(0, 2) === "7.") {
+    err = new Error(
+      `Requires Babel "^7.0.0-beta.41", but was loaded with "${version}". ` +
+        `You'll need to update your @babel/core version.`,
+    );
+  } else {
+    err = new Error(
+      `Requires Babel "${range}", but was loaded with "${version}". ` +
+        `If you are sure you have a compatible version of @babel/core, ` +
+        `it is likely that something in your build process is loading the ` +
+        `wrong version. Inspect the stack trace of this error to look for ` +
+        `the first entry that doesn't mention "@babel/core" or "babel-core" ` +
+        `to see what is calling Babel.`,
+    );
+  }
+
+  if (typeof limit === "number") {
+    Error.stackTraceLimit = limit;
+  }
+
+  throw Object.assign(
+    err,
+    ({
+      code: "BABEL_VERSION_UNSUPPORTED",
+      version,
+      range,
+    }: any),
+  );
+}

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-external-helpers/src/index.js
+++ b/packages/babel-plugin-external-helpers/src/index.js
@@ -1,9 +1,12 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     pre(file) {
       file.set("helpersNamespace", t.identifier("babelHelpers"));
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-remap-async-to-generator": "7.0.0-beta.40",
     "@babel/plugin-syntax-async-generators": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-proposal-async-generator-functions/src/index.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/src/index.js
@@ -1,8 +1,11 @@
+import { declare } from "@babel/helper-plugin-utils";
 import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
 import syntaxAsyncGenerators from "@babel/plugin-syntax-async-generators";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   const yieldStarVisitor = {
     Function(path) {
       path.skip();
@@ -33,4 +36,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-function-name": "7.0.0-beta.40",
     "@babel/plugin-syntax-class-properties": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -1,8 +1,11 @@
+import { declare } from "@babel/helper-plugin-utils";
 import nameFunction from "@babel/helper-function-name";
 import syntaxClassProperties from "@babel/plugin-syntax-class-properties";
 import { template, types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose } = options;
 
   const findBareSupers = {
@@ -247,4 +250,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -12,6 +12,7 @@
     "decorators"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-decorators": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-decorators/src/index.js
+++ b/packages/babel-plugin-proposal-decorators/src/index.js
@@ -1,5 +1,6 @@
 // Fork of https://github.com/loganfsmyth/babel-plugin-proposal-decorators-legacy
 
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxDecorators from "@babel/plugin-syntax-decorators";
 import { template, types as t } from "@babel/core";
 
@@ -26,7 +27,9 @@ const buildGetObjectInitializer = template(`
     })
 `);
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   const WARNING_CALLS = new WeakSet();
 
   /**
@@ -276,4 +279,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-do-expressions": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-do-expressions/src/index.js
+++ b/packages/babel-plugin-proposal-do-expressions/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxDoExpressions from "@babel/plugin-syntax-do-expressions";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxDoExpressions,
 
@@ -17,4 +20,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-export-default-from": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-export-default-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxExportDefaultFrom from "@babel/plugin-syntax-export-default-from";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxExportDefaultFrom,
 
@@ -33,4 +36,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-export-namespace-from": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-export-namespace-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-namespace-from/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxExportNamespaceFrom from "@babel/plugin-syntax-export-namespace-from";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxExportNamespaceFrom,
 
@@ -43,4 +46,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-function-bind": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-function-bind/src/index.js
+++ b/packages/babel-plugin-proposal-function-bind/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxFunctionBind from "@babel/plugin-syntax-function-bind";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function getTempId(scope) {
     let id = scope.path.getData("functionBind");
     if (id) return id;
@@ -60,4 +63,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-wrap-function": "7.0.0-beta.40",
     "@babel/plugin-syntax-function-sent": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-proposal-function-sent/src/index.js
+++ b/packages/babel-plugin-proposal-function-sent/src/index.js
@@ -1,8 +1,11 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxFunctionSent from "@babel/plugin-syntax-function-sent";
 import wrapFunction from "@babel/helper-wrap-function";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   const isFunctionSent = node =>
     t.isIdentifier(node.meta, { name: "function" }) &&
     t.isIdentifier(node.property, { name: "sent" });
@@ -57,4 +60,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-logical-assignment-operators": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-logical-assignment-operators/src/index.js
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxLogicalAssignmentOperators from "@babel/plugin-syntax-logical-assignment-operators";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxLogicalAssignmentOperators,
 
@@ -39,4 +42,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-nullish-coalescing-operator": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxNullishCoalescingOperator from "@babel/plugin-syntax-nullish-coalescing-operator";
 import { types as t } from "@babel/core";
 
-export default function(api, { loose = false }) {
+export default declare((api, { loose = false }) => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxNullishCoalescingOperator,
 
@@ -43,4 +46,4 @@ export default function(api, { loose = false }) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-numeric-separator/src/index.js
+++ b/packages/babel-plugin-proposal-numeric-separator/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxNumericSeparator from "@babel/plugin-syntax-numeric-separator";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function replaceNumberArg({ node }) {
     if (node.callee.name !== "Number") {
       return;
@@ -29,4 +32,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxObjectRestSpread from "@babel/plugin-syntax-object-rest-spread";
 import { types as t } from "@babel/core";
 
-export default function(api, opts) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   const { useBuiltIns = false, loose = false } = opts;
 
   if (typeof loose !== "boolean") {
@@ -404,4 +407,4 @@ export default function(api, opts) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-optional-catch-binding/src/index.js
+++ b/packages/babel-plugin-proposal-optional-catch-binding/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxOptionalCatchBinding from "@babel/plugin-syntax-optional-catch-binding";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxOptionalCatchBinding,
 
@@ -14,4 +17,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-optional-chaining": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxOptionalChaining from "@babel/plugin-syntax-optional-chaining";
 import { types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose = false } = options;
 
   function optional(path, replacementPath) {
@@ -136,4 +139,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-pipeline-operator": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxPipelineOperator from "@babel/plugin-syntax-pipeline-operator";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxPipelineOperator,
 
@@ -57,4 +60,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-proposal-throw-expressions/src/index.js
+++ b/packages/babel-plugin-proposal-throw-expressions/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxThrowExpressions from "@babel/plugin-syntax-throw-expressions";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxThrowExpressions,
 
@@ -20,4 +23,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -19,6 +19,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex",
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-regex": "7.0.0-beta.40",
     "regexpu-core": "^4.1.3"
   },

--- a/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
+++ b/packages/babel-plugin-proposal-unicode-property-regex/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { useUnicodeFlag = true } = options;
   if (typeof useUnicodeFlag !== "boolean") {
     throw new Error(".useUnicodeFlag must be a boolean, or undefined");
@@ -24,4 +27,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-async-generators/src/index.js
+++ b/packages/babel-plugin-syntax-async-generators/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("asyncGenerators");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-class-properties/src/index.js
+++ b/packages/babel-plugin-syntax-class-properties/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("classProperties");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("decorators");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-do-expressions/src/index.js
+++ b/packages/babel-plugin-syntax-do-expressions/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("doExpressions");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-dynamic-import/package.json
+++ b/packages/babel-plugin-syntax-dynamic-import/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-dynamic-import/src/index.js
+++ b/packages/babel-plugin-syntax-dynamic-import/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("dynamicImport");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-export-default-from/src/index.js
+++ b/packages/babel-plugin-syntax-export-default-from/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("exportDefaultFrom");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-export-namespace-from/package.json
+++ b/packages/babel-plugin-syntax-export-namespace-from/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-export-namespace-from/src/index.js
+++ b/packages/babel-plugin-syntax-export-namespace-from/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("exportNamespaceFrom");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-flow/src/index.js
+++ b/packages/babel-plugin-syntax-flow/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("flow");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-function-bind/src/index.js
+++ b/packages/babel-plugin-syntax-function-bind/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("functionBind");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-function-sent/src/index.js
+++ b/packages/babel-plugin-syntax-function-sent/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("functionSent");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-import-meta/package.json
+++ b/packages/babel-plugin-syntax-import-meta/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-import-meta/src/index.js
+++ b/packages/babel-plugin-syntax-import-meta/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("importMeta");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-jsx/src/index.js
+++ b/packages/babel-plugin-syntax-jsx/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-logical-assignment-operators/src/index.js
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("logicalAssignment");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/src/index.js
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("nullishCoalescingOperator");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-numeric-separator/src/index.js
+++ b/packages/babel-plugin-syntax-numeric-separator/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("numericSeparator");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-syntax-object-rest-spread/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("objectRestSpread");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-optional-catch-binding/package.json
+++ b/packages/babel-plugin-syntax-optional-catch-binding/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-optional-catch-binding/src/index.js
+++ b/packages/babel-plugin-syntax-optional-catch-binding/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("optionalCatchBinding");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-optional-chaining/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-optional-chaining/src/index.js
+++ b/packages/babel-plugin-syntax-optional-chaining/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("optionalChaining");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-syntax-pipeline-operator/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("pipelineOperator");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-throw-expressions/src/index.js
+++ b/packages/babel-plugin-syntax-throw-expressions/src/index.js
@@ -1,7 +1,11 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("throwExpressions");
     },
   };
-}
+});

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -9,6 +9,9 @@
     "babel-plugin",
     "typescript"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-syntax-typescript/src/index.js
+++ b/packages/babel-plugin-syntax-typescript/src/index.js
@@ -1,4 +1,8 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push(
@@ -8,4 +12,4 @@ export default function() {
       );
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-arrow-functions/src/index.js
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import type NodePath from "@babel/traverse";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { spec } = options;
   return {
     visitor: {
@@ -20,4 +23,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-module-imports": "7.0.0-beta.40",
     "@babel/helper-remap-async-to-generator": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-async-to-generator/src/index.js
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.js
@@ -1,8 +1,11 @@
+import { declare } from "@babel/helper-plugin-utils";
 import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
 import { addNamed } from "@babel/helper-module-imports";
 import { types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { method, module } = options;
 
   if (method && module) {
@@ -37,4 +40,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-block-scoped-functions/src/index.js
+++ b/packages/babel-plugin-transform-block-scoped-functions/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function statementList(key, path) {
     const paths: Array = path.get(key);
 
@@ -41,4 +44,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "lodash": "^4.2.0"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import type NodePath from "@babel/traverse";
 import type Scope from "@babel/traverse";
 import { visitor as tdzVisitor } from "./tdz";
@@ -7,7 +8,9 @@ import { traverse, template, types as t } from "@babel/core";
 
 const DONE = new WeakSet();
 
-export default function(api, opts) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   const { throwIfClosureRequired = false, tdz: tdzEnabled = false } = opts;
   if (typeof throwIfClosureRequired !== "boolean") {
     throw new Error(`.throwIfClosureRequired must be a boolean, or undefined`);
@@ -94,7 +97,7 @@ export default function(api, opts) {
       },
     },
   };
-}
+});
 
 function ignoreBlock(path) {
   return t.isLoop(path.parent) || t.isCatchClause(path.parent);

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-annotate-as-pure": "7.0.0-beta.40",
     "@babel/helper-define-map": "7.0.0-beta.40",
     "@babel/helper-function-name": "7.0.0-beta.40",

--- a/packages/babel-plugin-transform-classes/src/index.js
+++ b/packages/babel-plugin-transform-classes/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import LooseTransformer from "./loose";
 import VanillaTransformer from "./vanilla";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
@@ -14,7 +15,9 @@ const builtinClasses = new Set([
   ...getBuiltinClasses("browser"),
 ]);
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose } = options;
   const Constructor = loose ? LooseTransformer : VanillaTransformer;
 
@@ -65,4 +68,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-computed-properties/src/index.js
+++ b/packages/babel-plugin-transform-computed-properties/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { template, types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose } = options;
   const pushComputedProps = loose
     ? pushComputedPropsLoose
@@ -199,4 +202,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose = false } = options;
   if (typeof loose !== "boolean") {
     throw new Error(`.loose must be a boolean or undefined`);
@@ -583,4 +586,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -21,6 +21,7 @@
   },
   "bugs": "https://github.com/babel/babel/issues",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-regex": "7.0.0-beta.40",
     "regexpu-core": "^4.1.3"
   },

--- a/packages/babel-plugin-transform-dotall-regex/src/index.js
+++ b/packages/babel-plugin-transform-dotall-regex/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       RegExpLiteral(path) {
@@ -17,4 +20,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-duplicate-keys/src/index.js
+++ b/packages/babel-plugin-transform-duplicate-keys/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 function getName(key) {
@@ -7,7 +8,9 @@ function getName(key) {
   return key.value.toString();
 }
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       ObjectExpression(path) {
@@ -65,4 +68,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-exponentiation-operator/src/index.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import build from "@babel/helper-builder-binary-assignment-operator-visitor";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: build({
       operator: "**",
@@ -14,4 +17,4 @@ export default function() {
       },
     }),
   };
-}
+});

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-flow": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-flow-comments/src/index.js
+++ b/packages/babel-plugin-transform-flow-comments/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxFlow from "@babel/plugin-syntax-flow";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function wrapInFlowComment(path, parent) {
     let attach = path.getPrevSibling();
     let where = "trailing";
@@ -143,4 +146,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-flow": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxFlow from "@babel/plugin-syntax-flow";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   const FLOW_DIRECTIVE = "@flow";
 
   let skipStrip = false;
@@ -107,4 +110,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { template, types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose, assumeArray } = options;
 
   if (loose === true && assumeArray === true) {
@@ -332,4 +335,4 @@ export default function(api, options) {
       node: template,
     };
   }
-}
+});

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-function-name": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-function-name/src/index.js
+++ b/packages/babel-plugin-transform-function-name/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import nameFunction from "@babel/helper-function-name";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       FunctionExpression: {
@@ -21,4 +24,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-instanceof/src/index.js
+++ b/packages/babel-plugin-transform-instanceof/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       BinaryExpression(path) {
@@ -25,4 +28,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-jscript/src/index.js
+++ b/packages/babel-plugin-transform-jscript/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       FunctionExpression: {
@@ -25,4 +28,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-literals/src/index.js
+++ b/packages/babel-plugin-transform-literals/src/index.js
@@ -1,4 +1,8 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       NumericLiteral({ node }) {
@@ -16,4 +20,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-member-expression-literals/src/index.js
+++ b/packages/babel-plugin-transform-member-expression-literals/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       MemberExpression: {
@@ -19,4 +22,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-module-transforms": "7.0.0-beta.40"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import {
   isModule,
   rewriteModuleStatementsAndPrepareHeader,
@@ -14,7 +15,9 @@ const buildWrapper = template(`
   })
 `);
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose, allowTopLevelThis, strict, strictMode, noInterop } = options;
   return {
     visitor: {
@@ -97,4 +100,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-module-transforms": "7.0.0-beta.40",
     "@babel/helper-simple-access": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import {
   isModule,
   rewriteModuleStatementsAndPrepareHeader,
@@ -9,7 +10,9 @@ import {
 import simplifyAccess from "@babel/helper-simple-access";
 import { template, types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const {
     loose,
     allowTopLevelThis,
@@ -176,4 +179,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-hoist-variables": "7.0.0-beta.40"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import hoistVariables from "@babel/helper-hoist-variables";
 import { template, types as t } from "@babel/core";
 
@@ -22,7 +23,9 @@ const buildExportAll = template(`
 
 const TYPE_IMPORT = "Import";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { systemGlobal = "System" } = options;
   const IGNORE_REASSIGNMENT_SYMBOL = Symbol();
 
@@ -407,4 +410,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-module-transforms": "7.0.0-beta.40"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { basename, extname } from "path";
 import {
   isModule,
@@ -30,7 +31,9 @@ const buildWrapper = template(`
   })
 `);
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const {
     globals,
     exactGlobals,
@@ -225,4 +228,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-new-target/src/index.js
+++ b/packages/babel-plugin-transform-new-target/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     name: "transform-new-target",
 
@@ -67,4 +70,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -9,6 +9,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-object-assign/src/index.js
+++ b/packages/babel-plugin-transform-object-assign/src/index.js
@@ -1,4 +1,8 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       CallExpression: function(path, file) {
@@ -8,4 +12,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.js
@@ -1,4 +1,8 @@
-export default function() {
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       CallExpression(path, file) {
@@ -8,4 +12,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-replace-supers": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-object-super/src/index.js
+++ b/packages/babel-plugin-transform-object-super/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import { types as t } from "@babel/core";
 
@@ -14,7 +15,9 @@ function replacePropertySuper(path, node, scope, getObjectRef, file) {
   replaceSupers.replace();
 }
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       ObjectExpression(path, state) {
@@ -47,4 +50,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-call-delegate": "7.0.0-beta.40",
     "@babel/helper-get-function-arity": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-parameters/src/index.js
+++ b/packages/babel-plugin-transform-parameters/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import convertFunctionParams from "./params";
 import convertFunctionRest from "./rest";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose } = options;
   return {
     visitor: {
@@ -26,4 +29,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-property-literals/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       ObjectProperty: {
@@ -18,4 +21,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-define-map": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-property-mutators/src/index.js
+++ b/packages/babel-plugin-transform-property-mutators/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import * as defineMap from "@babel/helper-define-map";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       ObjectExpression(path, file) {
@@ -38,4 +41,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "lodash": "^4.2.0"
   },
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-proto-to-assign/src/index.js
+++ b/packages/babel-plugin-transform-proto-to-assign/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import pull from "lodash/pull";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function isProtoKey(node) {
     return t.isLiteral(t.toComputedKey(node, node.key), { value: "__proto__" });
   }
@@ -76,4 +79,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-annotate-as-pure": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
-export default function transformReactConstantElement(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { allowMutablePropsOnTags } = options;
 
   if (
@@ -111,4 +114,4 @@ export default function transformReactConstantElement(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import path from "path";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function addDisplayName(id, call) {
     const props = call.arguments[0].properties;
     let safe = true;
@@ -104,4 +107,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-builder-react-jsx": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.js
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import helper from "@babel/helper-builder-react-jsx";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function hasRefOrSpread(attrs) {
     for (let i = 0; i < attrs.length; i++) {
       const attr = attrs[i];
@@ -62,4 +65,4 @@ export default function() {
     },
   });
   return { visitor };
-}
+});

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-builder-react-jsx": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-react-jsx-compat/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-compat/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import helper from "@babel/helper-builder-react-jsx";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     manipulateOptions(opts, parserOpts) {
       parserOpts.plugins.push("jsx");
@@ -27,4 +30,4 @@ export default function() {
       compat: true,
     }),
   };
-}
+});

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-jsx": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.js
@@ -11,11 +11,14 @@
  *
  * <sometag __self={this} />
  */
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 const TRACE_ID = "__self";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   const visitor = {
     JSXOpeningElement({ node }) {
       const id = t.jsxIdentifier(TRACE_ID);
@@ -28,4 +31,4 @@ export default function() {
   return {
     visitor,
   };
-}
+});

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-jsx": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-react-jsx-source/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx-source/src/index.js
@@ -12,12 +12,15 @@
  * var __jsxFileName = 'this/file.js';
  * <sometag __source={{fileName: __jsxFileName, lineNumber: 10}}/>
  */
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 const TRACE_ID = "__source";
 const FILE_NAME_VAR = "_jsxFileName";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   function makeTrace(fileNameIdentifier, lineNumber) {
     const fileLineLiteral =
       lineNumber != null ? t.numericLiteral(lineNumber) : t.nullLiteral();
@@ -71,4 +74,4 @@ export default function() {
   return {
     visitor,
   };
-}
+});

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-builder-react-jsx": "7.0.0-beta.40",
     "@babel/plugin-syntax-jsx": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -1,8 +1,11 @@
+import { declare } from "@babel/helper-plugin-utils";
 import jsx from "@babel/plugin-syntax-jsx";
 import helper from "@babel/helper-builder-react-jsx";
 import { types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const THROW_IF_NAMESPACE =
     options.throwIfNamespace === undefined ? true : !!options.throwIfNamespace;
 
@@ -91,4 +94,4 @@ export default function(api, options) {
     inherits: jsx,
     visitor,
   };
-}
+});

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-reserved-words/src/index.js
+++ b/packages/babel-plugin-transform-reserved-words/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       "BindingIdentifier|ReferencedIdentifier"(path) {
@@ -10,4 +13,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-module-imports": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -1,9 +1,12 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { addDefault, isModule } from "@babel/helper-module-imports";
 import { types as t } from "@babel/core";
 
 import definitions from "./definitions";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const {
     helpers,
     moduleName = "@babel/runtime",
@@ -212,6 +215,6 @@ export default function(api, options) {
       },
     },
   };
-}
+});
 
 export { definitions };

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-shorthand-properties/src/index.js
+++ b/packages/babel-plugin-transform-shorthand-properties/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       ObjectMethod(path) {
@@ -26,4 +29,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-spread/src/index.js
+++ b/packages/babel-plugin-transform-spread/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
+
   const { loose } = options;
 
   function getSpreadLiteral(spread, scope) {
@@ -156,4 +159,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-regex": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-sticky-regex/src/index.js
+++ b/packages/babel-plugin-transform-sticky-regex/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import * as regex from "@babel/helper-regex";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       RegExpLiteral(path) {
@@ -17,4 +20,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-strict-mode/src/index.js
+++ b/packages/babel-plugin-transform-strict-mode/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       Program(path) {
@@ -17,4 +20,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-annotate-as-pure": "7.0.0-beta.40"
   },
   "keywords": [

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -1,7 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import { types as t } from "@babel/core";
 
-export default function(api, options) {
+export default declare((api, options) => {
+  api.assertVersion(7);
   const { loose } = options;
 
   let helperName = "taggedTemplateLiteral";
@@ -155,4 +157,4 @@ export default function(api, options) {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -8,6 +8,9 @@
   "keywords": [
     "babel-plugin"
   ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40"
+  },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.40"
   },

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.js
@@ -1,6 +1,9 @@
+import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       Scope({ scope }) {
@@ -62,4 +65,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -10,6 +10,7 @@
     "typescript"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-typescript": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxTypeScript from "@babel/plugin-syntax-typescript";
 import { types as t } from "@babel/core";
 
@@ -19,7 +20,9 @@ interface State {
   programPath: any;
 }
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     inherits: syntaxTypeScript,
     visitor: {
@@ -276,4 +279,4 @@ export default function() {
     });
     return !sourceFileHasJsx;
   }
-}
+});

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -9,6 +9,7 @@
     "babel-plugin"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/helper-regex": "7.0.0-beta.40",
     "regexpu-core": "^4.1.3"
   },

--- a/packages/babel-plugin-transform-unicode-regex/src/index.js
+++ b/packages/babel-plugin-transform-unicode-regex/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import rewritePattern from "regexpu-core";
 import * as regex from "@babel/helper-regex";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     visitor: {
       RegExpLiteral({ node }) {
@@ -11,4 +14,4 @@ export default function() {
       },
     },
   };
-}
+});

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -11,6 +11,7 @@
     "build-data": "node ./scripts/build-data.js; node ./scripts/build-modules-support.js"
   },
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.40",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.40",
     "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.40",

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -25,7 +25,8 @@ import {
   semverify,
   isUnreleasedVersion,
 } from "./utils";
-import type { Plugin, Targets } from "./types";
+import type { Targets } from "./types";
+import { declare } from "@babel/helper-plugin-utils";
 
 const getPlugin = (pluginName: string) => {
   const plugin = availablePlugins[pluginName];
@@ -152,10 +153,9 @@ const filterItems = (
   return result;
 };
 
-export default function buildPreset(
-  api: Object,
-  opts: Object = {},
-): { plugins: Array<Plugin> } {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   const {
     configPath,
     debug,
@@ -288,4 +288,4 @@ Using polyfills with \`${useBuiltIns}\` option:`,
   return {
     plugins,
   };
-}
+});

--- a/packages/babel-preset-es2015/package.json
+++ b/packages/babel-preset-es2015/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2015",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-transform-arrow-functions": "7.0.0-beta.40",
     "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.40",
     "@babel/plugin-transform-block-scoping": "7.0.0-beta.40",

--- a/packages/babel-preset-es2015/src/index.js
+++ b/packages/babel-preset-es2015/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import transformES2015TemplateLiterals from "@babel/plugin-transform-template-literals";
 import transformES2015Literals from "@babel/plugin-transform-literals";
 import transformES2015FunctionName from "@babel/plugin-transform-function-name";
@@ -23,7 +24,9 @@ import transformES2015ModulesUMD from "@babel/plugin-transform-modules-umd";
 import transformES2015Instanceof from "@babel/plugin-transform-instanceof";
 import transformRegenerator from "@babel/plugin-transform-regenerator";
 
-export default function(api, opts = {}) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   const moduleTypes = ["commonjs", "cjs", "amd", "umd", "systemjs"];
   let loose = false;
   let modules = "commonjs";
@@ -82,4 +85,4 @@ export default function(api, opts = {}) {
       [transformRegenerator, { async: false, asyncGenerators: false }],
     ].filter(Boolean), // filter out falsy values
   };
-}
+});

--- a/packages/babel-preset-es2015/test/index.js
+++ b/packages/babel-preset-es2015/test/index.js
@@ -1,18 +1,19 @@
+import * as babel from "@babel/core";
 import es2015 from "../lib";
 import { expect } from "chai";
 
 describe("es2015 preset", function() {
-  it("doesn't throw with no options passed", function() {
+  it("does throw clear error when no options passed for Babel 6", () => {
     expect(function() {
-      es2015(null);
-    }).not.to.throw();
+      es2015({ version: "6.5.0" });
+    }).to.throw(Error, /Requires Babel "\^7.0.0-0"/);
   });
 
   describe("options", function() {
     describe("loose", function() {
       it("throws on non-boolean value", function() {
         expect(function() {
-          es2015(null, { loose: 1 });
+          babel.transform("", { presets: [[es2015, { loose: 1 }]] });
         }).to.throw(/must be a boolean/);
       });
     });
@@ -20,7 +21,7 @@ describe("es2015 preset", function() {
     describe("spec", function() {
       it("throws on non-boolean value", function() {
         expect(function() {
-          es2015(null, { spec: 1 });
+          babel.transform("", { presets: [[es2015, { spec: 1 }]] });
         }).to.throw(/must be a boolean/);
       });
     });
@@ -28,31 +29,31 @@ describe("es2015 preset", function() {
     describe("modules", function() {
       it("doesn't throw when passing one false", function() {
         expect(function() {
-          es2015(null, { modules: false });
+          babel.transform("", { presets: [[es2015, { modules: false }]] });
         }).not.to.throw();
       });
 
       it("doesn't throw when passing one of: 'commonjs', 'amd', 'umd', 'systemjs", function() {
         expect(function() {
-          es2015(null, { modules: "commonjs" });
+          babel.transform("", { presets: [[es2015, { modules: "commonjs" }]] });
         }).not.to.throw();
 
         expect(function() {
-          es2015(null, { modules: "amd" });
+          babel.transform("", { presets: [[es2015, { modules: "amd" }]] });
         }).not.to.throw();
 
         expect(function() {
-          es2015(null, { modules: "umd" });
+          babel.transform("", { presets: [[es2015, { modules: "umd" }]] });
         }).not.to.throw();
 
         expect(function() {
-          es2015(null, { modules: "systemjs" });
+          babel.transform("", { presets: [[es2015, { modules: "systemjs" }]] });
         }).not.to.throw();
       });
 
       it("throws when passing neither false nor one of: 'commonjs', 'amd', 'umd', 'systemjs'", function() {
         expect(function() {
-          es2015(null, { modules: 1 });
+          babel.transform("", { presets: [[es2015, { modules: 1 }]] });
         }).to.throw();
       });
     });

--- a/packages/babel-preset-es2016/package.json
+++ b/packages/babel-preset-es2016/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2016",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-preset-es2016/src/index.js
+++ b/packages/babel-preset-es2016/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import transformExponentiationOperator from "@babel/plugin-transform-exponentiation-operator";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     plugins: [transformExponentiationOperator],
   };
-}
+});

--- a/packages/babel-preset-es2017/package.json
+++ b/packages/babel-preset-es2017/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-es2017",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-transform-async-to-generator": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-preset-es2017/src/index.js
+++ b/packages/babel-preset-es2017/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import transformAsyncToGenerator from "@babel/plugin-transform-async-to-generator";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     plugins: [transformAsyncToGenerator],
   };
-}
+});

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -13,6 +13,7 @@
     "types"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-preset-flow/src/index.js
+++ b/packages/babel-preset-flow/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     plugins: [transformFlowStripTypes],
   };
-}
+});

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-syntax-jsx": "7.0.0-beta.40",
     "@babel/plugin-transform-react-display-name": "7.0.0-beta.40",
     "@babel/plugin-transform-react-jsx": "7.0.0-beta.40",

--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -1,10 +1,13 @@
+import { declare } from "@babel/helper-plugin-utils";
 import transformReactJSX from "@babel/plugin-transform-react-jsx";
 import transformSyntaxJSX from "@babel/plugin-syntax-jsx";
 import transformReactDisplayName from "@babel/plugin-transform-react-display-name";
 import transformReactJSXSource from "@babel/plugin-transform-react-jsx-source";
 import transformReactJSXSelf from "@babel/plugin-transform-react-jsx-self";
 
-export default function(api, opts = {}) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   const pragma = opts.pragma || "React.createElement";
   const pragmaFrag = opts.pragmaFrag || "React.Fragment";
   const throwIfNamespace =
@@ -31,4 +34,4 @@ export default function(api, opts = {}) {
       development && transformReactJSXSelf,
     ].filter(Boolean),
   };
-}
+});

--- a/packages/babel-preset-react/test/index.js
+++ b/packages/babel-preset-react/test/index.js
@@ -2,9 +2,9 @@ import react from "../lib";
 import { expect } from "chai";
 
 describe("react preset", () => {
-  it("doesn't throw with no options passed", () => {
+  it("does throw clear error when no options passed for Babel 6", () => {
     expect(() => {
-      react(null);
-    }).not.to.throw();
+      react({ version: "6.5.0" });
+    }).to.throw(Error, /Requires Babel "\^7.0.0-0"/);
   });
 });

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-0",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-proposal-function-bind": "7.0.0-beta.40",
     "@babel/plugin-proposal-logical-assignment-operators": "7.0.0-beta.40",
     "@babel/preset-stage-1": "7.0.0-beta.40"

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -1,9 +1,12 @@
+import { declare } from "@babel/helper-plugin-utils";
 import presetStage1 from "@babel/preset-stage-1";
 
 import transformFunctionBind from "@babel/plugin-proposal-function-bind";
 import transformLogicalAssignmentOperators from "@babel/plugin-proposal-logical-assignment-operators";
 
-export default function(context, opts = {}) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   let loose = false;
   let useBuiltIns = false;
 
@@ -25,4 +28,4 @@ export default function(context, opts = {}) {
     presets: [[presetStage1, { loose, useBuiltIns }]],
     plugins: [transformFunctionBind, transformLogicalAssignmentOperators],
   };
-}
+});

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-proposal-decorators": "7.0.0-beta.40",
     "@babel/plugin-proposal-do-expressions": "7.0.0-beta.40",
     "@babel/plugin-proposal-export-default-from": "7.0.0-beta.40",

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import presetStage2 from "@babel/preset-stage-2";
 
 import transformDecorators from "@babel/plugin-proposal-decorators";
@@ -7,7 +8,9 @@ import transformPipelineOperator from "@babel/plugin-proposal-pipeline-operator"
 import transformNullishCoalescingOperator from "@babel/plugin-proposal-nullish-coalescing-operator";
 import transformDoExpressions from "@babel/plugin-proposal-do-expressions";
 
-export default function(context, opts = {}) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   let loose = false;
   let useBuiltIns = false;
 
@@ -36,4 +39,4 @@ export default function(context, opts = {}) {
       transformDoExpressions,
     ],
   };
-}
+});

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-proposal-export-namespace-from": "7.0.0-beta.40",
     "@babel/plugin-proposal-function-sent": "7.0.0-beta.40",
     "@babel/plugin-proposal-numeric-separator": "7.0.0-beta.40",

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import presetStage3 from "@babel/preset-stage-3";
 
 import transformFunctionSent from "@babel/plugin-proposal-function-sent";
@@ -5,7 +6,9 @@ import transformExportNamespaceFrom from "@babel/plugin-proposal-export-namespac
 import transformNumericSeparator from "@babel/plugin-proposal-numeric-separator";
 import transformThrowExpressions from "@babel/plugin-proposal-throw-expressions";
 
-export default function(context, opts = {}) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   let loose = false;
   let useBuiltIns = false;
 
@@ -32,4 +35,4 @@ export default function(context, opts = {}) {
       transformThrowExpressions,
     ],
   };
-}
+});

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-3",
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.40",
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.40",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.40",

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -1,3 +1,4 @@
+import { declare } from "@babel/helper-plugin-utils";
 import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
 import syntaxImportMeta from "@babel/plugin-syntax-import-meta";
 import transformAsyncGeneratorFunctions from "@babel/plugin-proposal-async-generator-functions";
@@ -6,7 +7,9 @@ import transformObjectRestSpread from "@babel/plugin-proposal-object-rest-spread
 import transformOptionalCatchBinding from "@babel/plugin-proposal-optional-catch-binding";
 import transformUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
 
-export default function(context, opts = {}) {
+export default declare((api, opts) => {
+  api.assertVersion(7);
+
   let loose = false;
   let useBuiltIns = false;
 
@@ -35,4 +38,4 @@ export default function(context, opts = {}) {
       transformUnicodePropertyRegex,
     ],
   };
-}
+});

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -10,6 +10,7 @@
     "typescript"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.40",
     "@babel/plugin-transform-typescript": "7.0.0-beta.40"
   },
   "peerDependencies": {

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -1,7 +1,10 @@
+import { declare } from "@babel/helper-plugin-utils";
 import transformTypeScript from "@babel/plugin-transform-typescript";
 
-export default function() {
+export default declare(api => {
+  api.assertVersion(7);
+
   return {
     plugins: [transformTypeScript],
   };
-}
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7265
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Not really
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This allows plugins to use `api.assertVersion(7)` as a general version, or any semver string to assert that the current version of Babel is one that is supported.

Trying to load `@babel/preset-env` for instance with Babel 6's CLI results in

```
Error: Requires Babel "^7.0.0-0", but was loaded with "6.26.0". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading the wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel. (While processing preset: "/Users/<my stuff>/babel/packages/babel-preset-env/lib/index.js")
    at throwVersionError (/Users/<my stuff>/babel/packages/babel-helper-plugin-utils/lib/index.js:45:11)
    at Object.assertVersion (/Users/<my stuff>/babel/packages/babel-helper-plugin-utils/lib/index.js:11:11)
    at _default (/Users/<my stuff>/babel/packages/babel-preset-env/lib/index.js:132:7)
    at /Users/<my stuff>/babel/packages/babel-helper-plugin-utils/lib/index.js:17:12
    at /private/tmp/node_modules/babel-core/lib/transformation/file/options/option-manager.js:317:46
    at Array.map (<anonymous>)
    at OptionManager.resolvePresets (/private/tmp/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
    at OptionManager.mergePresets (/private/tmp/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
    at OptionManager.mergeOptions (/private/tmp/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
    at OptionManager.init (/private/tmp/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/private/tmp/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/private/tmp/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/private/tmp/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transform (/private/tmp/node_modules/babel-cli/lib/babel/util.js:50:22)
    at Object.compile (/private/tmp/node_modules/babel-cli/lib/babel/util.js:59:12)
    at /private/tmp/node_modules/babel-cli/lib/babel/file.js:142:23
    at Array.forEach (<anonymous>)
    at walk (/private/tmp/node_modules/babel-cli/lib/babel/file.js:133:16)
    at files (/private/tmp/node_modules/babel-cli/lib/babel/file.js:156:7)
    at module.exports (/private/tmp/node_modules/babel-cli/lib/babel/file.js:184:5)
    at Object.<anonymous> (/private/tmp/node_modules/babel-cli/lib/babel/index.js:129:1)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
```

where before it would throw about accessing `loose` on `undefined` or something along those lines because the `options` object isn't passed to plugins in Babel 6.x.