### PR TITLE
Enable parsing of `|> await`

### DIFF
--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -1834,7 +1834,7 @@ export default class ExpressionParser extends LValParser {
     }
     if (
       this.state.potentialSoloAwaitAt !== this.state.lastTokStart ||
-      this.match(tt.pipeline)
+      (!this.match(tt.pipeline) && !this.isLineTerminator())
     ) {
       node.argument = this.parseMaybeUnary();
     }

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -1832,7 +1832,10 @@ export default class ExpressionParser extends LValParser {
         "await* has been removed from the async functions proposal. Use Promise.all() instead.",
       );
     }
-    if (this.state.potentialSoloAwaitAt !== this.state.lastTokStart) {
+    if (
+      this.state.potentialSoloAwaitAt !== this.state.lastTokStart ||
+      this.match(tt.pipeline)
+    ) {
       node.argument = this.parseMaybeUnary();
     }
     return this.finishNode(node, "AwaitExpression");

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -299,6 +299,7 @@ export default class ExpressionParser extends LValParser {
           this.expectPlugin("pipelineOperator");
           // Support syntax such as 10 |> x => x + 1
           this.state.potentialArrowAt = startPos;
+          this.state.potentialSoloAwaitAt = startPos;
         }
 
         if (node.operator === "??") {
@@ -1831,7 +1832,9 @@ export default class ExpressionParser extends LValParser {
         "await* has been removed from the async functions proposal. Use Promise.all() instead.",
       );
     }
-    node.argument = this.parseMaybeUnary();
+    if (this.state.potentialSoloAwaitAt !== this.state.lastTokStart) {
+      node.argument = this.parseMaybeUnary();
+    }
     return this.finishNode(node, "AwaitExpression");
   }
 

--- a/packages/babylon/src/tokenizer/state.js
+++ b/packages/babylon/src/tokenizer/state.js
@@ -16,6 +16,7 @@ export default class State {
     this.input = input;
 
     this.potentialArrowAt = -1;
+    this.potentialSoloAwaitAt = -1;
 
     this.noArrowAt = [];
     this.noArrowParamsConversionAt = [];
@@ -72,6 +73,9 @@ export default class State {
 
   // Used to signify the start of a potential arrow function
   potentialArrowAt: number;
+
+  // Used to signify the start of a potential solo await in a pipeline
+  potentialSoloAwaitAt: number;
 
   // Used to signify the start of an expression which looks like a
   // typed arrow function, but it isn't

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi-semi/input.js
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi-semi/input.js
@@ -1,0 +1,4 @@
+async function foo() {
+  a |> f |> await;
+  b
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi-semi/options.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi-semi/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["pipelineOperator"]
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi-semi/output.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi-semi/output.json
@@ -1,0 +1,215 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 47,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 47,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 47,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 21,
+          "end": 47,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 25,
+              "end": 41,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 18
+                }
+              },
+              "expression": {
+                "type": "BinaryExpression",
+                "start": 25,
+                "end": 41,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 18
+                  }
+                },
+                "left": {
+                  "type": "BinaryExpression",
+                  "start": 25,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 8
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 25,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "operator": "|>",
+                  "right": {
+                    "type": "Identifier",
+                    "start": 30,
+                    "end": 31,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 8
+                      },
+                      "identifierName": "f"
+                    },
+                    "name": "f"
+                  }
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "AwaitExpression",
+                  "start": 35,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 18
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "ExpressionStatement",
+              "start": 44,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 3
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 44,
+                "end": 45,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "identifierName": "b"
+                },
+                "name": "b"
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi/input.js
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi/input.js
@@ -1,0 +1,4 @@
+async function foo() {
+  a |> f |> await
+  b
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi/options.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["pipelineOperator"]
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi/output.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-asi/output.json
@@ -1,0 +1,215 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 46,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 46,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 46,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 21,
+          "end": 46,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 25,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                }
+              },
+              "expression": {
+                "type": "BinaryExpression",
+                "start": 25,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 17
+                  }
+                },
+                "left": {
+                  "type": "BinaryExpression",
+                  "start": 25,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 8
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 25,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "operator": "|>",
+                  "right": {
+                    "type": "Identifier",
+                    "start": 30,
+                    "end": 31,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 8
+                      },
+                      "identifierName": "f"
+                    },
+                    "name": "f"
+                  }
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "AwaitExpression",
+                  "start": 35,
+                  "end": 40,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 17
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "ExpressionStatement",
+              "start": 43,
+              "end": 44,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 3
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 43,
+                "end": 44,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "identifierName": "b"
+                },
+                "name": "b"
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-expr/input.js
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-expr/input.js
@@ -1,0 +1,3 @@
+async function foo() {
+  return a |> await b |> f;
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-expr/options.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-expr/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["pipelineOperator"]
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-expr/output.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-expr/output.json
@@ -1,0 +1,200 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 52,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 52,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 21,
+          "end": 52,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ReturnStatement",
+              "start": 25,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 27
+                }
+              },
+              "argument": {
+                "type": "BinaryExpression",
+                "start": 32,
+                "end": 49,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 26
+                  }
+                },
+                "left": {
+                  "type": "BinaryExpression",
+                  "start": 32,
+                  "end": 44,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 21
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 32,
+                    "end": 33,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 10
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "operator": "|>",
+                  "right": {
+                    "type": "AwaitExpression",
+                    "start": 37,
+                    "end": 44,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 21
+                      }
+                    },
+                    "argument": {
+                      "type": "Identifier",
+                      "start": 43,
+                      "end": 44,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 20
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 21
+                        },
+                        "identifierName": "b"
+                      },
+                      "name": "b"
+                    }
+                  }
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "Identifier",
+                  "start": 48,
+                  "end": 49,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 26
+                    },
+                    "identifierName": "f"
+                  },
+                  "name": "f"
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-trailing/input.js
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-trailing/input.js
@@ -1,0 +1,3 @@
+async function foo() {
+  a |> f |> await
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-trailing/options.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-trailing/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["pipelineOperator"]
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await-trailing/output.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await-trailing/output.json
@@ -1,0 +1,183 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 42,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 42,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 42,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 21,
+          "end": 42,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 25,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                }
+              },
+              "expression": {
+                "type": "BinaryExpression",
+                "start": 25,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 17
+                  }
+                },
+                "left": {
+                  "type": "BinaryExpression",
+                  "start": 25,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 8
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 25,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "operator": "|>",
+                  "right": {
+                    "type": "Identifier",
+                    "start": 30,
+                    "end": 31,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 8
+                      },
+                      "identifierName": "f"
+                    },
+                    "name": "f"
+                  }
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "AwaitExpression",
+                  "start": 35,
+                  "end": 40,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 17
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await/input.js
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await/input.js
@@ -1,0 +1,3 @@
+async function foo() {
+  return a |> await |> f;
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await/options.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["pipelineOperator"]
+}

--- a/packages/babylon/test/fixtures/experimental/pipeline-operator/await/output.json
+++ b/packages/babylon/test/fixtures/experimental/pipeline-operator/await/output.json
@@ -1,0 +1,183 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 50,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 50,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 50,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 21,
+          "end": 50,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ReturnStatement",
+              "start": 25,
+              "end": 48,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25
+                }
+              },
+              "argument": {
+                "type": "BinaryExpression",
+                "start": 32,
+                "end": 47,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 24
+                  }
+                },
+                "left": {
+                  "type": "BinaryExpression",
+                  "start": 32,
+                  "end": 42,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 32,
+                    "end": 33,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 10
+                      },
+                      "identifierName": "a"
+                    },
+                    "name": "a"
+                  },
+                  "operator": "|>",
+                  "right": {
+                    "type": "AwaitExpression",
+                    "start": 37,
+                    "end": 42,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 19
+                      }
+                    }
+                  }
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "Identifier",
+                  "start": 46,
+                  "end": 47,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 24
+                    },
+                    "identifierName": "f"
+                  },
+                  "name": "f"
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | No 
| Any Dependency Changes?  | No
| License                  | MIT

As part of the work on the pipeline operator, the suggestion for F# style (Proposal 1) is the enable `|> await` without a RHS expression. It does break any other tests, but it might break `|> await expr`, which is currently supported in the pipeline plugin, although those tests don't fail, so maybe not.

I think we should support both, as the spec for the pipeline operator hasn't actually been updated to make `|> await` normative (see [here](https://github.com/tc39/proposal-pipeline-operator/pull/85)). The idea is to enable us to develop babel plugins around the proposals, so I think we should prefer not to break the current babel plugin, since it matches the current spec.

This may not be ready, but I'm definitely struggling a bit here, so hoping to get some thoughts / suggestions / feedback on this.

cc @js-choi @littledan 