### PR TITLE
Fix for running babel in a symlinked directory

### DIFF
--- a/packages/babel-core/src/transformation/file/options/build-config-chain.js
+++ b/packages/babel-core/src/transformation/file/options/build-config-chain.js
@@ -34,7 +34,7 @@ export default function buildConfigChain(opts: Object = {}, log?: Logger) {
   builder.mergeConfig({
     options: opts,
     alias: "base",
-    dirname: filename && path.dirname(filename)
+    dirname: filename && path.resolve(__dirname, path.dirname(filename))
   });
 
   return builder.configs;


### PR DESCRIPTION
For my use case, I'm using yarn workspaces, however I want to be able to symlink a package under the workspace file structure. Due to the way yarn only installs babel packages in the root `node_modules` directory, without this change the directory resolves to the real location which then can't resolve any of the babel preset and plugin packages when it runs babel as part of the `install` and I end up with errors similar to the below.

```
Error: Couldn't find preset "env" relative to directory "src"
```
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Bug Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
