### PR TITLE
Remove broken check in checkFunctionNameAndParams

### DIFF
--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -1677,11 +1677,7 @@ export default class ExpressionParser extends LValParser {
 
     const oldStrict = this.state.strict;
     if (isStrict) this.state.strict = isStrict;
-    if (node.id) {
-      // TODO(logan): This check is broken because it passes a node object as
-      // a binding name. Passing the actual string introduces other failures.
-      // this.checkReservedWord(node.id, node.start, true, true);
-    }
+
     if (checkLVal) {
       const nameHash: any = Object.create(null);
       if (node.id) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #7432 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

`checkReservedWord` check is broken but it is no longer needed as the reserved word check is being done in other parts of the code. 