### PR TITLE
[Doc] [skip-ci] Remove build-babylon from contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ descriptive name, and add the following:
 After writing tests for babylon, just build it by running:
 
 ```sh
-$ make build-babylon
+$ make build
 ```
 
 Then, to run the tests, use:


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR         | Yes
| Any Dependency Changes?  |
| License                  | MIT

`build-babylon` is removed from Makefile. 
