### PR TITLE
Fix reseting modules in jest and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,13 +101,12 @@
       "/test/fixtures/",
       "/test/tmp/",
       "/test/__data__/",
-      "/lib/"
-    ],
-    "modulePaths": [
-      "<rootDir>/packages/"
+      "<rootDir>/packages/[^/]+/lib/"
     ],
     "modulePathIgnorePatterns": [
       "/test/fixtures/",
+      "/test/tmp/",
+      "/test/__data__/",
       "<rootDir>/build/"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -92,19 +92,18 @@
       "/test/tmp/",
       "/test/__data__/",
       "/test/helpers/",
-      "<rootDir>/test/warning.js",
+      "<rootDir>/test/warning\\.js",
       "<rootDir>/build/",
-      "_browser.js"
+      "_browser\\.js"
     ],
     "testEnvironment": "node",
     "setupTestFrameworkScriptFile": "<rootDir>/test/testSetupFile.js",
     "transformIgnorePatterns": [
       "/node_modules/",
-      "/test/fixtures/",
-      "/test/tmp/",
-      "/test/__data__/",
-      "<rootDir>/packages/[^/]+/lib/",
-      "<rootDir>/codemods/[^/]+/lib/"
+      "<rootDir>/packages/babel-standalone/babel(\\.min)?\\.js",
+      "<rootDir>/packages/babel-preset-env-standalone/babel-preset-env(\\.min)?\\.js",
+      "/test/(fixtures|tmp|__data__)/",
+      "<rootDir>/(packages|codemods)/[^/]+/lib/"
     ],
     "modulePathIgnorePatterns": [
       "/test/fixtures/",

--- a/package.json
+++ b/package.json
@@ -78,10 +78,12 @@
   },
   "jest": {
     "collectCoverageFrom": [
+      "packages/*/src/**/*.mjs",
       "packages/*/src/**/*.js",
+      "codemods/*/src/**/*.mjs",
       "codemods/*/src/**/*.js"
     ],
-    "testRegex": "./(packages|codemods)/[^/]+/test/.+\\.js$",
+    "testRegex": "./(packages|codemods)/[^/]+/test/.+\\.m?js$",
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/test/fixtures/",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
       "/test/fixtures/",
       "/test/tmp/",
       "/test/__data__/",
-      "<rootDir>/packages/[^/]+/lib/"
+      "<rootDir>/packages/[^/]+/lib/",
+      "<rootDir>/codemods/[^/]+/lib/"
     ],
     "modulePathIgnorePatterns": [
       "/test/fixtures/",

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -34,7 +34,7 @@ describe("@babel/register - caching", () => {
 
     beforeEach(() => {
       // Since lib/cache is a singleton we need to fully reload it
-      jest.resetModuleRegistry();
+      jest.resetModules();
       const cache = require("../lib/cache");
 
       load = cache.load;

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -55,7 +55,7 @@ describe("@babel/register", function() {
     currentHook = null;
     currentOptions = null;
     sourceMapSupport = false;
-    jest.resetModuleRegistry();
+    jest.resetModules();
   });
 
   test("registers hook correctly", () => {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  |n
| Minor: New Feature?      |n
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

This uses `jest.resetModules();` instead of `jest.resetModuleRegistry();` because the later one is deprecated.

Also fixes the config because we have `lib` folders inside the source folders which should not be ignored.
