### PR TITLE
Default to sourceType:script when parsing files.

### DIFF
--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -7,7 +7,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
   const {
     filename,
     filenameRelative = filename || "unknown",
-    sourceType = "module",
+    sourceType = "script",
     inputSourceMap,
     sourceMaps = !!inputSourceMap,
 

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -39,6 +39,7 @@ program.option(
   "List of extensions to hook into [.es6,.js,.es,.jsx,.mjs]",
   collect,
 );
+program.option("--source-type [script|module|unambiguous]", "");
 program.option("-w, --plugins [string]", "", collect);
 program.option("-b, --presets [string]", "", collect);
 /* eslint-enable max-len */
@@ -53,6 +54,7 @@ register({
   only: program.only,
   plugins: program.plugins,
   presets: program.presets,
+  sourceType: program.sourceType,
 });
 
 const replPlugin = ({ types: t }) => ({
@@ -90,6 +92,7 @@ const _eval = function(code, filename) {
     filename: filename,
     presets: program.presets,
     plugins: (program.plugins || []).concat([replPlugin]),
+    sourceType: program.sourceType,
   }).code;
 
   return vm.runInThisContext(code, {
@@ -131,7 +134,10 @@ if (program.eval || program.print) {
       }
 
       if (arg[0] === "-") {
-        const parsedArg = program[arg.slice(2)];
+        const name = arg.slice(2);
+        const parsedArg =
+          name === "source-type" ? program.sourceType : program[arg.slice(2)];
+
         if (parsedArg && parsedArg !== true) {
           ignoreNext = true;
         }

--- a/packages/babel-node/test/index.js
+++ b/packages/babel-node/test/index.js
@@ -123,6 +123,7 @@ const buildTest = function(binName, testName, opts) {
 
     let args = [binLoc];
 
+    args.push("--source-type", "module");
     args.push("--presets", presetLocs, "--plugins", pluginLocs);
     args.push("--only", "../../../../packages/*/test");
 

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -20,8 +20,7 @@ export default declare((api, options) => {
     strictMode,
     noInterop,
     lazy = false,
-    // Defaulting to 'true' for now. May change before 7.x major.
-    allowCommonJSExports = true,
+    allowCommonJSExports = false,
   } = options;
 
   if (

--- a/packages/babel-plugin-transform-modules-commonjs/test/copied-nodes.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/copied-nodes.js
@@ -5,6 +5,7 @@ test("Doesn't use the same object for two different nodes in the AST", function(
   const code = 'import Foo from "bar"; Foo; Foo;';
 
   const ast = babel.transform(code, {
+    sourceType: "module",
     ast: true,
     plugins: [[require("../"), { loose: true }]],
   }).ast;

--- a/packages/babel-plugin-transform-modules-commonjs/test/esmodule-flag.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/esmodule-flag.js
@@ -20,6 +20,7 @@ test("Re-export doesn't overwrite __esModule flag", function() {
   context.exports = context.module.exports;
 
   code = babel.transform(code, {
+    sourceType: "module",
     plugins: [[require("../"), { loose: true }]],
     ast: false,
   }).code;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/source-map/exec.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/source-map/exec.js
@@ -23,6 +23,7 @@ var tests = [
 
 tests.forEach(function (code) {
   var res = transform(code, {
+    sourceType: "module",
     sourceMap: true,
     plugins: opts.plugins
   });

--- a/packages/babel-preset-env/test/debug-fixtures.js
+++ b/packages/babel-preset-env/test/debug-fixtures.js
@@ -51,7 +51,7 @@ const buildTest = opts => {
     saveInFiles(opts.inFiles);
 
     let args = [binLoc];
-    args = args.concat(opts.args);
+    args = args.concat(opts.args, "--source-type", "module");
 
     const spawn = child.spawn(process.execPath, args);
 

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -105,6 +105,7 @@ describe("@babel/register", function() {
 
   test("hook transpiles with config", () => {
     setupRegister({
+      sourceType: "module",
       babelrc: false,
       sourceMaps: false,
       plugins: ["@babel/transform-modules-commonjs"],
@@ -117,6 +118,7 @@ describe("@babel/register", function() {
 
   test("hook transpiles with babelrc", () => {
     setupRegister({
+      sourceType: "module",
       babelrc: true,
       sourceMaps: false,
     });

--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -134,6 +134,7 @@ function loadScripts(transformFn, scripts) {
       executed: false,
       plugins: getPluginsOrPresetsFromScript(script, "data-plugins"),
       presets: getPluginsOrPresetsFromScript(script, "data-presets"),
+      sourceType: script.getAttribute("data-source-type") || undefined,
     };
 
     if (script.src) {

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -78,6 +78,7 @@ const assert = require("assert");
 
     it("handles presets with options", () => {
       const output = Babel.transform("export let x", {
+        sourceType: "module",
         presets: [["es2015", { modules: false }]],
       }).code;
       assert.equal(output, "export var x;");


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6242
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Y
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Alright, let's have this discussion since #6242 never really took off, and most of my TODOs in there have landed.

I am of the opinion that Babel 7 should parse `.js` files using the `script` parse goal, and `.mjs` files with the `module` parse goal. In Babel 6, and 7 up to present, the default has been `module`. I also want to make clear that you can still _easily_ set `sourceType:module` in your Babel config to keep the current behavior, but the important question here is the default, because it influences many other parts of Babel's transformations.

There are a few primary issues surrounding using `module` as the default:

* Many perfectly valid Script files will fail to parse. This means that users attempting to run Babel on things in node_modules for instance will fail to parse.
* Defaulting to `module` means Babel converts top-level `this` to `undefined` and injects `use strict`, which can break when run against arbitrary files
* When performing transformations, Babel needs to know whether to inject `import` or `require`, and it does so based on the `sourceType`. Defaulting to `module` means we may inject `import` into valid `CommonJS` modules, breaking them.
* When writing files to disk with `babel-cli` we'd ideally add `.mjs` to files that are modules, and `.js` to scripts. If we default to `module` then we'd potentially output `.mjs` extensions on CommonJS files.

These issues become more problematic when you consider that people are more frequently running Babel across arbitrary `node_modules` dependencies. Realistically this pattern is only going to increase in frequency for forseeable future.

Node now follows this same pattern, with `.js` meaning CommonJS and `.mjs` meaning ESM. There is potential for a field to land in `package.json` that would allow toggling this behavior, and once that lands we could for instance consider a `sourceType: packageMode` option or something, but even with that the default in Node will remain `.js` for CommonJS.

Given all of this, it seems like it would be in the best interest of Babel to follow that same pattern, by requiring users to either use `.mjs` or opt into specific ESM behavior in their Babel configuration.
