### PR TITLE
babel-cli: Output files with .mjs extensions when sourceType:module 

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.40",
-    "@babel/helper-fixtures": "7.0.0-beta.40"
+    "@babel/helper-fixtures": "7.0.0-beta.40",
+    "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.40"
   },
   "bin": {
     "babel": "./bin/babel.js",

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -18,22 +18,26 @@ export default function(commander, filenames, opts) {
       return process.nextTick(callback);
     }
 
-    // remove extension and then append back on .js
-    relative = util.adjustRelative(relative, commander.keepFileExtension);
-
-    const dest = getDest(commander, relative, base);
-
     util.compile(
       src,
       defaults(
         {
-          sourceFileName: slash(path.relative(dest + "/..", src)),
+          sourceFileName: slash(
+            path.relative(getDest(commander, relative, base) + "/..", src),
+          ),
         },
         opts,
       ),
       function(err, res) {
         if (err) return callback(err);
         if (!res) return callback();
+
+        // remove extension and then append back on .js
+        if (!commander.keepFileExtension) {
+          relative = util.adjustRelative(relative, res.sourceType === "module");
+        }
+
+        const dest = getDest(commander, relative, base);
 
         // we've requested explicit sourcemaps to be written to disk
         if (

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -56,7 +56,7 @@ commander.option(
 );
 
 // Basic file input configuration.
-commander.option("--source-type [script|module]", "");
+commander.option("--source-type [script|module|unambiguous]", "");
 commander.option(
   "--no-babelrc",
   "Whether or not to look up .babelrc and .babelignore files",

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -105,9 +105,6 @@ export function requireChokidar() {
   }
 }
 
-export function adjustRelative(relative, keepFileExtension) {
-  if (keepFileExtension) {
-    return relative;
-  }
-  return relative.replace(/\.(\w*?)$/, "") + ".js";
+export function adjustRelative(relative, isModule) {
+  return relative.replace(/\.(\w*?)$/, "") + (isModule ? ".mjs" : ".js");
 }

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/.babelrc
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/.babelrc
@@ -1,0 +1,11 @@
+{
+  sourceType: "script",
+  overrides: [
+    {
+      test: "src/converted-module.mjs",
+      plugins: [
+        "@babel/plugin-transform-modules-commonjs"
+      ]
+    }
+  ]
+}

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/src/converted-module.mjs
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/src/converted-module.mjs
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/src/module.mjs
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/src/module.mjs
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/src/script.js
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/in-files/src/script.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/options.json
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/options.json
@@ -1,0 +1,4 @@
+{
+  "skipDefaultPresets": true,
+  "args": ["src", "--out-dir", "lib"]
+}

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/out-files/lib/converted-module.js
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/out-files/lib/converted-module.js
@@ -1,0 +1,8 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = _default;
+
+function _default() {}

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/out-files/lib/module.mjs
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/out-files/lib/module.mjs
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/out-files/lib/script.js
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/out-files/lib/script.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir-mixed-types --out-dir/stdout.txt
@@ -1,0 +1,1 @@
+🎉  Successfully compiled 3 files with Babel.

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -126,7 +126,7 @@ const buildTest = function(binName, testName, opts) {
 
     let args = [binLoc];
 
-    if (binName !== "babel-external-helpers") {
+    if (binName !== "babel-external-helpers" && !opts.skipDefaultPresets) {
       args.push("--presets", [presetEnvLoc, presetReactLoc].join(","));
     }
 
@@ -182,6 +182,7 @@ fs.readdirSync(fixtureLoc).forEach(function(binName) {
 
       const opts = {
         args: [],
+        skipDefaultPresets: false,
       };
 
       const optionsLoc = path.join(testLoc, "options.json");

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -17,15 +17,8 @@ const fileFilter = function(x) {
   return x !== ".DS_Store";
 };
 
-const presetLocs = [
-  path.join(__dirname, "../../babel-preset-es2015"),
-  path.join(__dirname, "../../babel-preset-react"),
-].join(",");
-
-const pluginLocs = [
-  path.join(__dirname, "/../../babel-plugin-transform-strict-mode"),
-  path.join(__dirname, "/../../babel-plugin-transform-modules-commonjs"),
-].join(",");
+const presetEnvLoc = path.join(__dirname, "../../babel-preset-es2015");
+const presetReactLoc = path.join(__dirname, "../../babel-preset-react");
 
 const readDir = function(loc, filter) {
   const files = {};
@@ -134,7 +127,7 @@ const buildTest = function(binName, testName, opts) {
     let args = [binLoc];
 
     if (binName !== "babel-external-helpers") {
-      args.push("--presets", presetLocs, "--plugins", pluginLocs);
+      args.push("--presets", [presetEnvLoc, presetReactLoc].join(","));
     }
 
     args = args.concat(opts.args);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6222
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This changes the CLI so that if the file being output is a module, and the sourceType wasn't rewritten to `script` by a transform, the file will be output with a `.mjs` extension. This feature is desirable because Node has made it clear that `.mjs` is the primary means to mark a file as a module. It may not end up being the _only_ way, but certainly for users wishing to create dual-mode packages, it will be necessary. That means I'd expect many packages written with ES6 module may want to do:

```
{
  env: {
    commonjs: {
      plugins: ["@babel/transform-modules-commonjs"]
    },
  }
}
```
with
```
babel src -d lib --env-name commonjs
babel src -d lib
```
where the first would compile all module files in `src` into `.js` files in `lib`, with the second command compiling all the files into `.mjs` files in `lib`. There could certainly be other plugins and presets still activated in there.

I don't know that I want to land this as-is, but I'm posting it as motivation. The downside _currently_ is that because we default to `sourceType: module`, this would make _every_ file output as `.mjs`. On the other hand, if we _don't_ do this, it will be painful for users to perform this type of compilation, since we'd have to instead have an option like `--use-mjs` or something, but it's also possible that some files in a project would be CommonJS still, even if most of them are ESM, so a blanket flag like `--use-mjs` would then introduce the opposite problem.

I think we really need to consider defaulting to `sourceType: script` for #6242 and pending #7501.