### PR TITLE
Use jest workers on travis-ci and circleCI

### DIFF
--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -4,7 +4,7 @@ set -e
 jestArgs="--coverage"
 
 if [ -n "$CI" ]; then
-  jestArgs="${jestArgs} --runInBand --ci"
+  jestArgs="${jestArgs} --maxWorkers=4 --ci"
 fi
 
 node_modules/.bin/jest $jestArgs

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,7 @@ if [ "$TEST_DEBUG" ]; then
 fi
 
 if [ -n "$CI" ]; then
-  jestArgs="${jestArgs} --runInBand --ci"
+  jestArgs="${jestArgs} --maxWorkers=4 --ci"
 fi
 
 $node node_modules/.bin/jest $jestArgs "$TEST_GREP"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | maybe #7497 
| Patch: Bug Fix?          |n
| Major: Breaking Change?  |n
| Minor: New Feature?      |n
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Seems to nearly half the time on circle-ci: Before ~11 to 14, Now 6 :)
travis seems to be faster but not as much "only" around 15% or 1min
