### PR TITLE
Restore passing SIGINT signals to spawned child processes

### DIFF
--- a/packages/babel-node/src/babel-node.js
+++ b/packages/babel-node/src/babel-node.js
@@ -95,5 +95,9 @@ getV8Flags(function(err, v8Flags) {
         }
       });
     });
+    process.on("SIGINT", () => {
+      proc.kill("SIGINT");
+      process.exit(1);
+    });
   }
 });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Restores https://github.com/babel/babel/pull/5861, which was lost when I rebased the PR for [moving babel-node to its own package](https://github.com/babel/babel/pull/6023).