### PR TITLE
Migrate babel-core tests to use jest-expect

### DIFF
--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -1,16 +1,15 @@
 import * as babel from "../lib/index";
 import sourceMap from "source-map";
-import assert from "assert";
 import path from "path";
 import Plugin from "../lib/config/plugin";
 import generator from "@babel/generator";
 
 function assertIgnored(result) {
-  assert.ok(!result);
+  expect(result).toBeFalsy();
 }
 
 function assertNotIgnored(result) {
-  assert.ok(!result.ignored);
+  expect(result.ignored).toBeFalsy();
 }
 
 // shim
@@ -48,18 +47,16 @@ describe("parser and generator options", function() {
 
   it("options", function() {
     const string = "original;";
-    assert.deepEqual(
-      newTransform(string).ast,
+    expect(newTransform(string).ast).toEqual(
       babel.transform(string, { ast: true }).ast,
     );
-    assert.equal(newTransform(string).code, string);
+    expect(newTransform(string).code).toBe(string);
   });
 
   it("experimental syntax", function() {
     const experimental = "var a: number = 1;";
 
-    assert.deepEqual(
-      newTransform(experimental).ast,
+    expect(newTransform(experimental).ast).toEqual(
       babel.transform(experimental, {
         ast: true,
         parserOpts: {
@@ -67,7 +64,7 @@ describe("parser and generator options", function() {
         },
       }).ast,
     );
-    assert.equal(newTransform(experimental).code, experimental);
+    expect(newTransform(experimental).code).toBe(experimental);
 
     function newTransformWithPlugins(string) {
       return babel.transform(string, {
@@ -82,8 +79,7 @@ describe("parser and generator options", function() {
       });
     }
 
-    assert.deepEqual(
-      newTransformWithPlugins(experimental).ast,
+    expect(newTransformWithPlugins(experimental).ast).toEqual(
       babel.transform(experimental, {
         ast: true,
         parserOpts: {
@@ -91,14 +87,13 @@ describe("parser and generator options", function() {
         },
       }).ast,
     );
-    assert.equal(newTransformWithPlugins(experimental).code, experimental);
+    expect(newTransformWithPlugins(experimental).code).toBe(experimental);
   });
 
   it("other options", function() {
     const experimental = "if (true) {\n  import a from 'a';\n}";
 
-    assert.notEqual(
-      newTransform(experimental).ast,
+    expect(newTransform(experimental).ast).not.toBe(
       babel.transform(experimental, {
         ast: true,
         parserOpts: {
@@ -106,21 +101,19 @@ describe("parser and generator options", function() {
         },
       }).ast,
     );
-    assert.equal(newTransform(experimental).code, experimental);
+    expect(newTransform(experimental).code).toBe(experimental);
   });
 });
 
 describe("api", function() {
   it("exposes the resolvePlugin method", function() {
-    assert.throws(
-      () => babel.resolvePlugin("nonexistent-plugin"),
+    expect(() => babel.resolvePlugin("nonexistent-plugin")).toThrow(
       /Cannot find module 'babel-plugin-nonexistent-plugin'/,
     );
   });
 
   it("exposes the resolvePreset method", function() {
-    assert.throws(
-      () => babel.resolvePreset("nonexistent-preset"),
+    expect(() => babel.resolvePreset("nonexistent-preset")).toThrow(
       /Cannot find module 'babel-preset-nonexistent-preset'/,
     );
   });
@@ -135,9 +128,9 @@ describe("api", function() {
       res,
     ) {
       if (err) return done(err);
-      assert.equal(res.code, "foo();");
+      expect(res.code).toBe("foo();");
       // keep user options untouched
-      assert.deepEqual(options, { babelrc: false });
+      expect(options).toEqual({ babelrc: false });
       done();
     });
   });
@@ -147,20 +140,19 @@ describe("api", function() {
       babelrc: false,
     };
     Object.freeze(options);
-    assert.equal(
+    expect(
       babel.transformFileSync(__dirname + "/fixtures/api/file.js", options)
         .code,
-      "foo();",
-    );
-    assert.deepEqual(options, { babelrc: false });
+    ).toBe("foo();");
+    expect(options).toEqual({ babelrc: false });
   });
 
   it("options throw on falsy true", function() {
-    return assert.throws(function() {
+    return expect(function() {
       babel.transform("", {
         plugins: [__dirname + "/../../babel-plugin-syntax-jsx", false],
       });
-    }, /.plugins\[1\] must be a string, object, function/);
+    }).toThrow(/.plugins\[1\] must be a string, object, function/);
   });
 
   it("options merge backwards", function() {
@@ -168,9 +160,8 @@ describe("api", function() {
       presets: [__dirname + "/../../babel-preset-es2015"],
       plugins: [__dirname + "/../../babel-plugin-syntax-jsx"],
     }).then(function(result) {
-      assert.ok(
-        result.options.plugins[0].manipulateOptions.toString().indexOf("jsx") >=
-          0,
+      expect(result.options.plugins[0].manipulateOptions.toString()).toEqual(
+        expect.stringContaining("jsx"),
       );
     });
   });
@@ -185,7 +176,7 @@ describe("api", function() {
           return callback;
         }
 
-        assert.equal(visitorType, "enter");
+        expect(visitorType).toBe("enter");
 
         return function() {
           calledIntercept++;
@@ -205,8 +196,8 @@ describe("api", function() {
       ],
     });
 
-    assert.equal(calledRaw, 4);
-    assert.equal(calledIntercept, 4);
+    expect(calledRaw).toBe(4);
+    expect(calledIntercept).toBe(4);
   });
 
   it("pass per preset", function() {
@@ -266,9 +257,9 @@ describe("api", function() {
 
     let result = execTest(true);
 
-    assert.equal(aliasBaseType, "NumberTypeAnnotation");
+    expect(aliasBaseType).toBe("NumberTypeAnnotation");
 
-    assert.deepEqual(result.code, "var x = function x(y) {\n  return y;\n};");
+    expect(result.code).toEqual("var x = function x(y) {\n  return y;\n};");
 
     // 2. passPerPreset: false
 
@@ -276,9 +267,9 @@ describe("api", function() {
 
     result = execTest(false);
 
-    assert.equal(aliasBaseType, null);
+    expect(aliasBaseType).toBeNull();
 
-    assert.deepEqual(result.code, "var x = function x(y) {\n  return y;\n};");
+    expect(result.code).toEqual("var x = function x(y) {\n  return y;\n};");
   });
 
   it("complex plugin and preset ordering", function() {
@@ -325,8 +316,7 @@ describe("api", function() {
       process.env.BABEL_ENV = oldEnv;
     }
 
-    assert.equal(
-      result.code,
+    expect(result.code).toBe(
       [
         "thirteen;",
         "fourteen;",
@@ -374,7 +364,7 @@ describe("api", function() {
       },
     );
 
-    assert.deepEqual(
+    expect(
       [
         "function _classCallCheck(instance, Constructor) {",
         "  if (!(instance instanceof Constructor)) {",
@@ -386,48 +376,46 @@ describe("api", function() {
         "  _classCallCheck(this, Foo);",
         "};",
       ].join("\n"),
-      result.code,
-    );
+    ).toBe(result.code);
 
     const consumer = new sourceMap.SourceMapConsumer(result.map);
 
-    assert.deepEqual(
+    expect(
       consumer.originalPositionFor({
         line: 7,
         column: 4,
       }),
-      {
-        name: null,
-        source: "stdout",
-        line: 1,
-        column: 6,
-      },
-    );
+    ).toEqual({
+      name: null,
+      source: "stdout",
+      line: 1,
+      column: 6,
+    });
   });
 
   it("code option false", function() {
     return transformAsync("foo('bar');", { code: false }).then(function(
       result,
     ) {
-      assert.ok(!result.code);
+      expect(result.code).toBeFalsy();
     });
   });
 
   it("ast option false", function() {
     return transformAsync("foo('bar');", { ast: false }).then(function(result) {
-      assert.ok(!result.ast);
+      expect(result.ast).toBeFalsy();
     });
   });
 
   it("ast option true", function() {
     return transformAsync("foo('bar');", { ast: true }).then(function(result) {
-      assert.ok(result.ast);
+      expect(result.ast).toBeTruthy();
     });
   });
 
   it("ast option default", function() {
     return transformAsync("foo('bar');").then(function(result) {
-      assert.ok(!result.ast);
+      expect(result.ast).toBeFalsy();
     });
   });
 
@@ -455,8 +443,7 @@ describe("api", function() {
         },
       ],
     }).then(function(result) {
-      assert.equal(
-        result.code,
+      expect(result.code).toBe(
         "/*before*/\nstart;\n\n/*after*/\nclass Foo {}\n\n/*before*/\nend;\n\n/*after*/",
       );
     });
@@ -563,7 +550,7 @@ describe("api", function() {
         },
       });
 
-      assert.equal(result.options.comments, false);
+      expect(result.options.comments).toBe(false);
     });
 
     it("BABEL_ENV", function() {
@@ -573,7 +560,7 @@ describe("api", function() {
           foo: { comments: false },
         },
       });
-      assert.equal(result.options.comments, false);
+      expect(result.options.comments).toBe(false);
     });
 
     it("NODE_ENV", function() {
@@ -583,7 +570,7 @@ describe("api", function() {
           foo: { comments: false },
         },
       });
-      assert.equal(result.options.comments, false);
+      expect(result.options.comments).toBe(false);
     });
   });
 
@@ -608,25 +595,25 @@ describe("api", function() {
 
     it("all", function() {
       const script = babel.buildExternalHelpers();
-      assert.ok(script.indexOf("classCallCheck") >= -1);
-      assert.ok(script.indexOf("inherits") >= 0);
+      expect(script).toEqual(expect.stringContaining("classCallCheck"));
+      expect(script).toEqual(expect.stringContaining("inherits"));
     });
 
     it("whitelist", function() {
       const script = babel.buildExternalHelpers(["inherits"]);
-      assert.ok(script.indexOf("classCallCheck") === -1);
-      assert.ok(script.indexOf("inherits") >= 0);
+      expect(script).not.toEqual(expect.stringContaining("classCallCheck"));
+      expect(script).toEqual(expect.stringContaining("inherits"));
     });
 
     it("empty whitelist", function() {
       const script = babel.buildExternalHelpers([]);
-      assert.ok(script.indexOf("classCallCheck") === -1);
-      assert.ok(script.indexOf("inherits") === -1);
+      expect(script).not.toEqual(expect.stringContaining("classCallCheck"));
+      expect(script).not.toEqual(expect.stringContaining("inherits"));
     });
 
     it("underscored", function() {
       const script = babel.buildExternalHelpers(["typeof"]);
-      assert.ok(script.indexOf("typeof") >= 0);
+      expect(script).toEqual(expect.stringContaining("typeof"));
     });
   });
 
@@ -640,16 +627,12 @@ describe("api", function() {
         __dirname + "/fixtures/api/parsing-errors/only-syntax/file.js",
         options,
         function(err) {
-          assert.ok(
-            RegExp(
-              "Support for the experimental syntax 'dynamicImport' isn't currently enabled \\(1:9\\):",
-            ).exec(err.message),
+          expect(err.message).toMatch(
+            "Support for the experimental syntax 'dynamicImport' isn't currently enabled (1:9)",
           );
-          assert.ok(
-            RegExp(
-              "Add @babel/plugin-syntax-dynamic-import \\(https://git.io/vb4Sv\\) to the " +
-                "'plugins' section of your Babel config to enable parsing.",
-            ).exec(err.message),
+          expect(err.message).toMatch(
+            "Add @babel/plugin-syntax-dynamic-import (https://git.io/vb4Sv) to the " +
+              "'plugins' section of your Babel config to enable parsing.",
           );
           done();
         },
@@ -661,16 +644,12 @@ describe("api", function() {
         __dirname + "/fixtures/api/parsing-errors/syntax-and-transform/file.js",
         options,
         function(err) {
-          assert.ok(
-            RegExp(
-              "Support for the experimental syntax 'asyncGenerators' isn't currently enabled \\(1:15\\):",
-            ).exec(err.message),
+          expect(err.message).toMatch(
+            "Support for the experimental syntax 'asyncGenerators' isn't currently enabled (1:15):",
           );
-          assert.ok(
-            RegExp(
-              "Add @babel/plugin-proposal-async-generator-functions \\(https://git.io/vb4yp\\) to the " +
-                "'plugins' section of your Babel config to enable transformation.",
-            ).exec(err.message),
+          expect(err.message).toMatch(
+            "Add @babel/plugin-proposal-async-generator-functions (https://git.io/vb4yp) to the " +
+              "'plugins' section of your Babel config to enable transformation.",
           );
           done();
         },

--- a/packages/babel-core/test/browserify.js
+++ b/packages/babel-core/test/browserify.js
@@ -1,5 +1,4 @@
 import browserify from "browserify";
-import assert from "assert";
 import path from "path";
 import vm from "vm";
 
@@ -11,7 +10,7 @@ describe("browserify", function() {
 
     bundler.bundle(function(err, bundle) {
       if (err) return done(err);
-      assert.ok(bundle.length, "bundle output code");
+      expect(bundle.length).toBeTruthy();
 
       // ensure that the code runs without throwing an exception
       vm.runInNewContext("var global = this;\n" + bundle, {});

--- a/packages/babel-core/test/caching-api.js
+++ b/packages/babel-core/test/caching-api.js
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { makeStrongCache } from "../lib/config/caching";
 
 describe("caching API", () => {
@@ -10,13 +9,13 @@ describe("caching API", () => {
       return { arg, count: count++ };
     });
 
-    assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", count: 0 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", count: 1 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", count: 1 });
+    expect(fn("two")).toBe(fn("two"));
 
-    assert.notEqual(fn("one"), fn("two"));
+    expect(fn("one")).not.toEqual(fn("two"));
   });
 
   it("should allow disabling caching with .never()", () => {
@@ -27,15 +26,15 @@ describe("caching API", () => {
       return { arg, count: count++ };
     });
 
-    assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-    assert.deepEqual(fn("one"), { arg: "one", count: 1 });
-    assert.notEqual(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", count: 0 });
+    expect(fn("one")).toEqual({ arg: "one", count: 1 });
+    expect(fn("one")).not.toEqual(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", count: 4 });
-    assert.deepEqual(fn("two"), { arg: "two", count: 5 });
-    assert.notEqual(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", count: 4 });
+    expect(fn("two")).toEqual({ arg: "two", count: 5 });
+    expect(fn("two")).not.toEqual(fn("two"));
 
-    assert.notEqual(fn("one"), fn("two"));
+    expect(fn("one")).not.toEqual(fn("two"));
   });
 
   it("should allow caching based on a value with .using(fn)", () => {
@@ -48,35 +47,35 @@ describe("caching API", () => {
       return { arg, val, count: count++ };
     });
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "default", count: 0 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "default", count: 1 });
+    expect(fn("two")).toBe(fn("two"));
 
     other = "new";
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "new", count: 2 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "new", count: 3 });
+    expect(fn("two")).toBe(fn("two"));
 
     other = "default";
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "default", count: 0 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "default", count: 1 });
+    expect(fn("two")).toBe(fn("two"));
 
     other = "new";
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "new", count: 2 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "new", count: 3 });
+    expect(fn("two")).toBe(fn("two"));
   });
 
   it("should allow invalidation based on a value with .invalidate(fn)", () => {
@@ -89,35 +88,35 @@ describe("caching API", () => {
       return { arg, val, count: count++ };
     });
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "default", count: 0 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "default", count: 1 });
+    expect(fn("two")).toBe(fn("two"));
 
     other = "new";
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "new", count: 2 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "new", count: 3 });
+    expect(fn("two")).toBe(fn("two"));
 
     other = "default";
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 4 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "default", count: 4 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 5 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "default", count: 5 });
+    expect(fn("two")).toBe(fn("two"));
 
     other = "new";
 
-    assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 6 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", val: "new", count: 6 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 7 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", val: "new", count: 7 });
+    expect(fn("two")).toBe(fn("two"));
   });
 
   it("should allow invalidation with .using and .invalidate", () => {
@@ -132,93 +131,93 @@ describe("caching API", () => {
       return { arg, val, val2, count: count++ };
     });
 
-    assert.deepEqual(fn("one"), {
+    expect(fn("one")).toEqual({
       arg: "one",
       val: "default",
       val2: "another",
       count: 0,
     });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), {
+    expect(fn("two")).toEqual({
       arg: "two",
       val: "default",
       val2: "another",
       count: 1,
     });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toBe(fn("two"));
 
     other = "new";
 
-    assert.deepEqual(fn("one"), {
+    expect(fn("one")).toEqual({
       arg: "one",
       val: "new",
       val2: "another",
       count: 2,
     });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), {
+    expect(fn("two")).toEqual({
       arg: "two",
       val: "new",
       val2: "another",
       count: 3,
     });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toBe(fn("two"));
 
     other = "default";
 
-    assert.deepEqual(fn("one"), {
+    expect(fn("one")).toEqual({
       arg: "one",
       val: "default",
       val2: "another",
       count: 4,
     });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), {
+    expect(fn("two")).toEqual({
       arg: "two",
       val: "default",
       val2: "another",
       count: 5,
     });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toBe(fn("two"));
 
     other = "new";
 
-    assert.deepEqual(fn("one"), {
+    expect(fn("one")).toEqual({
       arg: "one",
       val: "new",
       val2: "another",
       count: 6,
     });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), {
+    expect(fn("two")).toEqual({
       arg: "two",
       val: "new",
       val2: "another",
       count: 7,
     });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toBe(fn("two"));
 
     another = "second";
 
-    assert.deepEqual(fn("one"), {
+    expect(fn("one")).toEqual({
       arg: "one",
       val: "new",
       val2: "second",
       count: 8,
     });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), {
+    expect(fn("two")).toEqual({
       arg: "two",
       val: "new",
       val2: "second",
       count: 9,
     });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toBe(fn("two"));
   });
 
   it("should auto-permacache by default", () => {
@@ -226,13 +225,13 @@ describe("caching API", () => {
 
     const fn = makeStrongCache(arg => ({ arg, count: count++ }));
 
-    assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-    assert.equal(fn("one"), fn("one"));
+    expect(fn("one")).toEqual({ arg: "one", count: 0 });
+    expect(fn("one")).toBe(fn("one"));
 
-    assert.deepEqual(fn("two"), { arg: "two", count: 1 });
-    assert.equal(fn("two"), fn("two"));
+    expect(fn("two")).toEqual({ arg: "two", count: 1 });
+    expect(fn("two")).toBe(fn("two"));
 
-    assert.notEqual(fn("one"), fn("two"));
+    expect(fn("one")).not.toEqual(fn("two"));
   });
 
   it("should throw if you set permacaching and use .using", () => {
@@ -242,7 +241,7 @@ describe("caching API", () => {
       cache.using(() => null);
     });
 
-    assert.throws(() => fn(), /Caching has already been configured/);
+    expect(() => fn()).toThrow(/Caching has already been configured/);
   });
 
   it("should throw if you set permacaching and use .invalidate", () => {
@@ -252,7 +251,7 @@ describe("caching API", () => {
       cache.invalidate(() => null);
     });
 
-    assert.throws(() => fn(), /Caching has already been configured/);
+    expect(() => fn()).toThrow(/Caching has already been configured/);
   });
 
   it("should throw if you set permacaching and use .never", () => {
@@ -262,7 +261,7 @@ describe("caching API", () => {
       cache.never();
     });
 
-    assert.throws(() => fn(), /Caching has already been configured/);
+    expect(() => fn()).toThrow(/Caching has already been configured/);
   });
 
   it("should throw if you set no caching and use .using", () => {
@@ -272,7 +271,7 @@ describe("caching API", () => {
       cache.using(() => null);
     });
 
-    assert.throws(() => fn(), /Caching has already been configured/);
+    expect(() => fn()).toThrow(/Caching has already been configured/);
   });
 
   it("should throw if you set no caching and use .invalidate", () => {
@@ -282,7 +281,7 @@ describe("caching API", () => {
       cache.invalidate(() => null);
     });
 
-    assert.throws(() => fn(), /Caching has already been configured/);
+    expect(() => fn()).toThrow(/Caching has already been configured/);
   });
 
   it("should throw if you set no caching and use .never", () => {
@@ -292,14 +291,13 @@ describe("caching API", () => {
       cache.using(() => null);
     });
 
-    assert.throws(() => fn(), /Caching has already been configured/);
+    expect(() => fn()).toThrow(/Caching has already been configured/);
   });
 
   it("should throw if you configure .forever after exiting", () => {
     const fn = makeStrongCache((arg, cache) => cache);
 
-    assert.throws(
-      () => fn().forever(),
+    expect(() => fn().forever()).toThrow(
       /Cannot change caching after evaluation/,
     );
   });
@@ -307,14 +305,15 @@ describe("caching API", () => {
   it("should throw if you configure .never after exiting", () => {
     const fn = makeStrongCache((arg, cache) => cache);
 
-    assert.throws(() => fn().never(), /Cannot change caching after evaluation/);
+    expect(() => fn().never()).toThrow(
+      /Cannot change caching after evaluation/,
+    );
   });
 
   it("should throw if you configure .using after exiting", () => {
     const fn = makeStrongCache((arg, cache) => cache);
 
-    assert.throws(
-      () => fn().using(() => null),
+    expect(() => fn().using(() => null)).toThrow(
       /Cannot change caching after evaluation/,
     );
   });
@@ -322,8 +321,7 @@ describe("caching API", () => {
   it("should throw if you configure .invalidate after exiting", () => {
     const fn = makeStrongCache((arg, cache) => cache);
 
-    assert.throws(
-      () => fn().invalidate(() => null),
+    expect(() => fn().invalidate(() => null)).toThrow(
       /Cannot change caching after evaluation/,
     );
   });
@@ -339,13 +337,13 @@ describe("caching API", () => {
         return { arg, count: count++ };
       });
 
-      assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-      assert.equal(fn("one"), fn("one"));
+      expect(fn("one")).toEqual({ arg: "one", count: 0 });
+      expect(fn("one")).toBe(fn("one"));
 
-      assert.deepEqual(fn("two"), { arg: "two", count: 1 });
-      assert.equal(fn("two"), fn("two"));
+      expect(fn("two")).toEqual({ arg: "two", count: 1 });
+      expect(fn("two")).toBe(fn("two"));
 
-      assert.notEqual(fn("one"), fn("two"));
+      expect(fn("one")).not.toEqual(fn("two"));
     });
 
     it("should allow disabling caching with cache(false)", () => {
@@ -358,15 +356,15 @@ describe("caching API", () => {
         return { arg, count: count++ };
       });
 
-      assert.deepEqual(fn("one"), { arg: "one", count: 0 });
-      assert.deepEqual(fn("one"), { arg: "one", count: 1 });
-      assert.notEqual(fn("one"), fn("one"));
+      expect(fn("one")).toEqual({ arg: "one", count: 0 });
+      expect(fn("one")).toEqual({ arg: "one", count: 1 });
+      expect(fn("one")).not.toEqual(fn("one"));
 
-      assert.deepEqual(fn("two"), { arg: "two", count: 4 });
-      assert.deepEqual(fn("two"), { arg: "two", count: 5 });
-      assert.notEqual(fn("two"), fn("two"));
+      expect(fn("two")).toEqual({ arg: "two", count: 4 });
+      expect(fn("two")).toEqual({ arg: "two", count: 5 });
+      expect(fn("two")).not.toEqual(fn("two"));
 
-      assert.notEqual(fn("one"), fn("two"));
+      expect(fn("one")).not.toEqual(fn("two"));
     });
 
     it("should allow caching based on a value with cache(fn)", () => {
@@ -381,35 +379,35 @@ describe("caching API", () => {
         return { arg, val, count: count++ };
       });
 
-      assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-      assert.equal(fn("one"), fn("one"));
+      expect(fn("one")).toEqual({ arg: "one", val: "default", count: 0 });
+      expect(fn("one")).toBe(fn("one"));
 
-      assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-      assert.equal(fn("two"), fn("two"));
+      expect(fn("two")).toEqual({ arg: "two", val: "default", count: 1 });
+      expect(fn("two")).toBe(fn("two"));
 
       other = "new";
 
-      assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-      assert.equal(fn("one"), fn("one"));
+      expect(fn("one")).toEqual({ arg: "one", val: "new", count: 2 });
+      expect(fn("one")).toBe(fn("one"));
 
-      assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-      assert.equal(fn("two"), fn("two"));
+      expect(fn("two")).toEqual({ arg: "two", val: "new", count: 3 });
+      expect(fn("two")).toBe(fn("two"));
 
       other = "default";
 
-      assert.deepEqual(fn("one"), { arg: "one", val: "default", count: 0 });
-      assert.equal(fn("one"), fn("one"));
+      expect(fn("one")).toEqual({ arg: "one", val: "default", count: 0 });
+      expect(fn("one")).toBe(fn("one"));
 
-      assert.deepEqual(fn("two"), { arg: "two", val: "default", count: 1 });
-      assert.equal(fn("two"), fn("two"));
+      expect(fn("two")).toEqual({ arg: "two", val: "default", count: 1 });
+      expect(fn("two")).toBe(fn("two"));
 
       other = "new";
 
-      assert.deepEqual(fn("one"), { arg: "one", val: "new", count: 2 });
-      assert.equal(fn("one"), fn("one"));
+      expect(fn("one")).toEqual({ arg: "one", val: "new", count: 2 });
+      expect(fn("one")).toBe(fn("one"));
 
-      assert.deepEqual(fn("two"), { arg: "two", val: "new", count: 3 });
-      assert.equal(fn("two"), fn("two"));
+      expect(fn("two")).toEqual({ arg: "two", val: "new", count: 3 });
+      expect(fn("two")).toBe(fn("two"));
     });
   });
 });

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1,4 +1,3 @@
-import assert from "assert";
 import fs from "fs";
 import path from "path";
 import { loadOptions } from "../lib";
@@ -18,7 +17,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching RegExp values", () => {
@@ -29,7 +28,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching function values", () => {
@@ -40,7 +39,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching string values", () => {
@@ -51,7 +50,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching RegExp values", () => {
@@ -62,7 +61,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching function values", () => {
@@ -73,7 +72,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
     });
 
@@ -86,7 +85,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching RegExp values", () => {
@@ -97,7 +96,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching function values", () => {
@@ -108,7 +107,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching string values", () => {
@@ -119,7 +118,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching RegExp values", () => {
@@ -130,7 +129,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching function values", () => {
@@ -141,7 +140,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
     });
   });
@@ -156,7 +155,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching RegExp values", () => {
@@ -167,7 +166,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching function values", () => {
@@ -178,7 +177,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching string values", () => {
@@ -189,7 +188,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching RegExp values", () => {
@@ -200,7 +199,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching function values", () => {
@@ -211,7 +210,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
     });
 
@@ -224,7 +223,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching RegExp values", () => {
@@ -235,7 +234,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process matching function values", () => {
@@ -246,7 +245,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching string values", () => {
@@ -257,7 +256,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching RegExp values", () => {
@@ -268,7 +267,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching function values", () => {
@@ -279,7 +278,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
     });
   });
@@ -294,7 +293,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process matching RegExp values", () => {
@@ -305,7 +304,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process matching function values", () => {
@@ -316,7 +315,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching string values", () => {
@@ -327,7 +326,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching RegExp values", () => {
@@ -338,7 +337,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching function values", () => {
@@ -349,7 +348,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
     });
 
@@ -362,7 +361,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process matching RegExp values", () => {
@@ -373,7 +372,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process matching function values", () => {
@@ -384,7 +383,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, undefined);
+        expect(opts.comments).toBeUndefined();
       });
 
       it("should process non-matching string values", () => {
@@ -395,7 +394,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching RegExp values", () => {
@@ -406,7 +405,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
 
       it("should process non-matching function values", () => {
@@ -417,7 +416,7 @@ describe("buildConfigChain", function() {
           comments: true,
         });
 
-        assert.equal(opts.comments, true);
+        expect(opts.comments).toBe(true);
       });
     });
   });
@@ -437,7 +436,7 @@ describe("buildConfigChain", function() {
         ],
       });
 
-      assert.equal(opts, null);
+      expect(opts).toBeNull();
     });
 
     it("should not ignore files that don't match", () => {
@@ -450,7 +449,7 @@ describe("buildConfigChain", function() {
         ],
       });
 
-      assert.notEqual(opts, null);
+      expect(opts).not.toBeNull();
     });
   });
 
@@ -465,7 +464,7 @@ describe("buildConfigChain", function() {
         ],
       });
 
-      assert.equal(opts, null);
+      expect(opts).toBeNull();
     });
 
     it("should not ignore files that match", () => {
@@ -478,7 +477,7 @@ describe("buildConfigChain", function() {
         ],
       });
 
-      assert.notEqual(opts, null);
+      expect(opts).not.toBeNull();
     });
   });
 
@@ -491,7 +490,7 @@ describe("buildConfigChain", function() {
         only: [],
       });
 
-      assert.equal(opts, null);
+      expect(opts).toBeNull();
     });
 
     it("should ignore files that match ignore and also only", () => {
@@ -502,7 +501,7 @@ describe("buildConfigChain", function() {
         only: [fixture("nonexistant-fake", "src.js")],
       });
 
-      assert.equal(opts, null);
+      expect(opts).toBeNull();
     });
 
     it("should not ignore files that match only and not ignore", () => {
@@ -512,7 +511,7 @@ describe("buildConfigChain", function() {
         only: [fixture("nonexistant-fake", "src.js")],
       });
 
-      assert.notEqual(opts, null);
+      expect(opts).not.toBeNull();
     });
 
     it("should not ignore files when no ignore/only are specified", () => {
@@ -521,7 +520,7 @@ describe("buildConfigChain", function() {
         babelrc: false,
       });
 
-      assert.notEqual(opts, null);
+      expect(opts).not.toBeNull();
     });
 
     it("should allow negation of only", () => {
@@ -533,7 +532,7 @@ describe("buildConfigChain", function() {
           fixture("nonexistant-fake", "other.js"),
         ],
       });
-      assert.equal(opts1, null);
+      expect(opts1).toBeNull();
 
       const opts2 = loadOptions({
         filename: fixture("nonexistant-fake", "src.js"),
@@ -543,7 +542,7 @@ describe("buildConfigChain", function() {
           fixture("nonexistant-fake", "src.js"),
         ],
       });
-      assert.notEqual(opts2, null);
+      expect(opts2).not.toBeNull();
 
       const opts3 = loadOptions({
         filename: fixture("nonexistant-fake", "folder", "src.js"),
@@ -553,7 +552,7 @@ describe("buildConfigChain", function() {
           fixture("nonexistant-fake", "folder"),
         ],
       });
-      assert.notEqual(opts3, null);
+      expect(opts3).not.toBeNull();
     });
 
     it("should allow negation of ignore", () => {
@@ -565,7 +564,7 @@ describe("buildConfigChain", function() {
           fixture("nonexistant-fake"),
         ],
       });
-      assert.equal(opts1, null);
+      expect(opts1).toBeNull();
 
       // Tests disabled pending https://github.com/babel/babel/issues/6907
       // const opts2 = loadOptions({
@@ -603,9 +602,9 @@ describe("buildConfigChain", function() {
         inputOpts.plugins = plugins2;
         const opts2 = loadOptions(inputOpts);
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.notEqual(opts1.plugins[0], opts2.plugins[1]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).not.toBe(opts2.plugins[1]);
       });
 
       it("should cache the env plugins by identity", () => {
@@ -628,9 +627,9 @@ describe("buildConfigChain", function() {
           },
         });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.equal(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
       });
 
       it("should cache the env presets by identity", () => {
@@ -653,9 +652,9 @@ describe("buildConfigChain", function() {
           },
         });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.equal(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
       });
 
       it("should cache the plugin options by identity", () => {
@@ -664,9 +663,9 @@ describe("buildConfigChain", function() {
         const opts1 = loadOptions({ plugins });
         const opts2 = loadOptions({ plugins });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.equal(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
       });
 
       it("should cache the presets options by identity", () => {
@@ -675,9 +674,9 @@ describe("buildConfigChain", function() {
         const opts1 = loadOptions({ presets });
         const opts2 = loadOptions({ presets });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.strictEqual(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
       });
 
       it("should not cache the presets options with passPerPreset", () => {
@@ -687,11 +686,11 @@ describe("buildConfigChain", function() {
         const opts2 = loadOptions({ presets, passPerPreset: true });
         const opts3 = loadOptions({ presets, passPerPreset: false });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 0);
-        assert.equal(opts3.plugins.length, 1);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(0);
+        expect(opts3.plugins).toHaveLength(1);
 
-        assert.strictEqual(opts1.plugins[0], opts3.plugins[0]);
+        expect(opts1.plugins[0]).toBe(opts3.plugins[0]);
       });
     });
 
@@ -727,16 +726,16 @@ describe("buildConfigChain", function() {
         const opts3 = loadOptions({ filename });
         const opts4 = loadOptions({ filename });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.equal(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
 
-        assert.equal(opts3.plugins.length, 1);
-        assert.equal(opts4.plugins.length, 1);
-        assert.equal(opts3.plugins[0], opts4.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts3.plugins[0]).toBe(opts4.plugins[0]);
 
         // Identity changed after touch().
-        assert.notEqual(opts1.plugins[0], opts3.plugins[0]);
+        expect(opts1.plugins[0]).not.toBe(opts3.plugins[0]);
       });
 
       it("should cache .babelrc files by mtime", () => {
@@ -761,16 +760,16 @@ describe("buildConfigChain", function() {
         const opts3 = loadOptions({ filename });
         const opts4 = loadOptions({ filename });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.equal(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
 
-        assert.equal(opts3.plugins.length, 1);
-        assert.equal(opts4.plugins.length, 1);
-        assert.equal(opts3.plugins[0], opts4.plugins[0]);
+        expect(opts3.plugins).toHaveLength(1);
+        expect(opts4.plugins).toHaveLength(1);
+        expect(opts3.plugins[0]).toBe(opts4.plugins[0]);
 
         // Identity changed after touch().
-        assert.notEqual(opts1.plugins[0], opts3.plugins[0]);
+        expect(opts1.plugins[0]).not.toBe(opts3.plugins[0]);
       });
 
       it("should cache .babelrc.js files programmable behavior", () => {
@@ -787,16 +786,16 @@ describe("buildConfigChain", function() {
         const opts3 = loadOptions({ filename, envName: "new-env" });
         const opts4 = loadOptions({ filename, envName: "new-env" });
 
-        assert.equal(opts1.plugins.length, 1);
-        assert.equal(opts2.plugins.length, 1);
-        assert.equal(opts1.plugins[0], opts2.plugins[0]);
+        expect(opts1.plugins).toHaveLength(1);
+        expect(opts2.plugins).toHaveLength(1);
+        expect(opts1.plugins[0]).toBe(opts2.plugins[0]);
 
-        assert.equal(opts3.plugins.length, 1);
-        assert.equal(opts4.plugins.length, 1);
-        assert.equal(opts3.plugins[0], opts4.plugins[0]);
+        expect(opts3.plugins).toHaveLength(1);
+        expect(opts4.plugins).toHaveLength(1);
+        expect(opts3.plugins[0]).toBe(opts4.plugins[0]);
 
         // Identity changed with different .env
-        assert.notEqual(opts1.plugins[0], opts3.plugins[0]);
+        expect(opts1.plugins[0]).not.toBe(opts3.plugins[0]);
       });
     });
   });
@@ -815,7 +814,7 @@ describe("buildConfigChain", function() {
         ],
       });
 
-      assert.equal(opts.comments, false);
+      expect(opts.comments).toBe(false);
     });
 
     it("should not apply non-matching overrides over base configs", () => {
@@ -831,7 +830,7 @@ describe("buildConfigChain", function() {
         ],
       });
 
-      assert.equal(opts.comments, true);
+      expect(opts.comments).toBe(true);
     });
   });
 
@@ -861,7 +860,7 @@ describe("buildConfigChain", function() {
     it("should load .babelrc", () => {
       const filename = fixture("config-files", "babelrc", "src.js");
 
-      assert.deepEqual(loadOptions({ filename }), {
+      expect(loadOptions({ filename })).toEqual({
         ...getDefaults(),
         filename,
         comments: true,
@@ -871,7 +870,7 @@ describe("buildConfigChain", function() {
     it("should load .babelrc.js", () => {
       const filename = fixture("config-files", "babelrc-js", "src.js");
 
-      assert.deepEqual(loadOptions({ filename }), {
+      expect(loadOptions({ filename })).toEqual({
         ...getDefaults(),
         filename,
         comments: true,
@@ -881,7 +880,7 @@ describe("buildConfigChain", function() {
     it("should load package.json#babel", () => {
       const filename = fixture("config-files", "pkg", "src.js");
 
-      assert.deepEqual(loadOptions({ filename }), {
+      expect(loadOptions({ filename })).toEqual({
         ...getDefaults(),
         filename,
         comments: true,
@@ -891,14 +890,13 @@ describe("buildConfigChain", function() {
     it("should load .babelignore", () => {
       const filename = fixture("config-files", "babelignore", "src.js");
 
-      assert.deepEqual(loadOptions({ filename }), null);
+      expect(loadOptions({ filename })).toBeNull();
     });
 
     it("should throw if there are both .babelrc and .babelrc.js", () => {
       const filename = fixture("config-files", "both-babelrc", "src.js");
 
-      assert.throws(
-        () => loadOptions({ filename }),
+      expect(() => loadOptions({ filename })).toThrow(
         /Multiple configuration files found/,
       );
     });
@@ -906,8 +904,7 @@ describe("buildConfigChain", function() {
     it("should throw if there are both .babelrc and package.json", () => {
       const filename = fixture("config-files", "pkg-babelrc", "src.js");
 
-      assert.throws(
-        () => loadOptions({ filename }),
+      expect(() => loadOptions({ filename })).toThrow(
         /Multiple configuration files found/,
       );
     });
@@ -915,8 +912,7 @@ describe("buildConfigChain", function() {
     it("should throw if there are both .babelrc.js and package.json", () => {
       const filename = fixture("config-files", "pkg-babelrc-js", "src.js");
 
-      assert.throws(
-        () => loadOptions({ filename }),
+      expect(() => loadOptions({ filename })).toThrow(
         /Multiple configuration files found/,
       );
     });
@@ -924,7 +920,7 @@ describe("buildConfigChain", function() {
     it("should ignore package.json without a 'babel' property", () => {
       const filename = fixture("config-files", "pkg-ignored", "src.js");
 
-      assert.deepEqual(loadOptions({ filename }), {
+      expect(loadOptions({ filename })).toEqual({
         ...getDefaults(),
         filename,
         comments: true,
@@ -934,8 +930,7 @@ describe("buildConfigChain", function() {
     it("should show helpful errors for .babelrc", () => {
       const filename = fixture("config-files", "babelrc-error", "src.js");
 
-      assert.throws(
-        () => loadOptions({ filename }),
+      expect(() => loadOptions({ filename })).toThrow(
         /Error while parsing config - /,
       );
     });
@@ -943,14 +938,13 @@ describe("buildConfigChain", function() {
     it("should show helpful errors for .babelrc.js", () => {
       const filename = fixture("config-files", "babelrc-js-error", "src.js");
 
-      assert.throws(() => loadOptions({ filename }), /Babelrc threw an error/);
+      expect(() => loadOptions({ filename })).toThrow(/Babelrc threw an error/);
     });
 
     it("should show helpful errors for package.json", () => {
       const filename = fixture("config-files", "pkg-error", "src.js");
 
-      assert.throws(
-        () => loadOptions({ filename }),
+      expect(() => loadOptions({ filename })).toThrow(
         /Error while parsing JSON - /,
       );
     });

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,6 +1,5 @@
 import loadConfig from "../lib/config";
 import path from "path";
-import { expect } from "chai";
 
 describe("@babel/core config loading", () => {
   const FILEPATH = path.join(
@@ -41,7 +40,7 @@ describe("@babel/core config loading", () => {
       const opts = makeOpts();
 
       const options1 = loadConfig(opts).options;
-      expect(options1.plugins.map(p => p.key)).to.eql([
+      expect(options1.plugins.map(p => p.key)).toEqual([
         "plugin1",
         "plugin2",
         "plugin6",
@@ -51,16 +50,16 @@ describe("@babel/core config loading", () => {
       ]);
 
       const options2 = loadConfig(opts).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
-        expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        expect(options2.plugins[i]).toBe(options1.plugins[i]);
       }
     });
 
     it("should load and cache the config for unique opts objects", () => {
       const options1 = loadConfig(makeOpts(true)).options;
-      expect(options1.plugins.map(p => p.key)).to.eql([
+      expect(options1.plugins.map(p => p.key)).toEqual([
         "plugin1",
         "plugin2",
         "plugin4",
@@ -68,10 +67,10 @@ describe("@babel/core config loading", () => {
       ]);
 
       const options2 = loadConfig(makeOpts(true)).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
-        expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        expect(options2.plugins[i]).toBe(options1.plugins[i]);
       }
     });
 
@@ -83,26 +82,26 @@ describe("@babel/core config loading", () => {
       process.env.INVALIDATE_PLUGIN1 = true;
 
       const options2 = loadConfig(opts).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 0) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
 
       process.env.INVALIDATE_PLUGIN3 = true;
 
       const options3 = loadConfig(opts).options;
-      expect(options3.plugins.length).to.equal(options1.plugins.length);
+      expect(options3.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 0 || i === 5) {
-          expect(options3.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options3.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options3.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options3.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });
@@ -115,26 +114,26 @@ describe("@babel/core config loading", () => {
       process.env.INVALIDATE_PRESET1 = true;
 
       const options2 = loadConfig(opts).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 5) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
 
       process.env.INVALIDATE_PRESET2 = true;
 
       const options3 = loadConfig(opts).options;
-      expect(options3.plugins.length).to.equal(options1.plugins.length);
+      expect(options3.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 4 || i === 5) {
-          expect(options3.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options3.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options3.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options3.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });
@@ -147,13 +146,13 @@ describe("@babel/core config loading", () => {
       process.env.INVALIDATE_BABELRC = true;
 
       const options2 = loadConfig(opts).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 0 || i === 1 || i === 4 || i === 5 || i === 6) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });
@@ -166,10 +165,10 @@ describe("@babel/core config loading", () => {
       const options1 = loadConfig(opts).options;
 
       const options2 = loadConfig(Object.assign({}, opts)).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
-        expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+        expect(options2.plugins[i]).toBe(options1.plugins[i]);
       }
     });
 
@@ -182,13 +181,13 @@ describe("@babel/core config loading", () => {
         ...opts,
         plugins: opts.plugins.slice(),
       }).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
         if (i === 2) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });
@@ -202,13 +201,13 @@ describe("@babel/core config loading", () => {
         ...opts,
         presets: opts.presets.slice(),
       }).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options2.plugins.length; i++) {
         if (i === 3) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });
@@ -221,13 +220,13 @@ describe("@babel/core config loading", () => {
       process.env.INVALIDATE_PLUGIN6 = true;
 
       const options2 = loadConfig(opts).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 2) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });
@@ -240,13 +239,13 @@ describe("@babel/core config loading", () => {
       process.env.INVALIDATE_PRESET3 = true;
 
       const options2 = loadConfig(opts).options;
-      expect(options2.plugins.length).to.equal(options1.plugins.length);
+      expect(options2.plugins.length).toBe(options1.plugins.length);
 
       for (let i = 0; i < options1.plugins.length; i++) {
         if (i === 3) {
-          expect(options2.plugins[i]).not.to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).not.toBe(options1.plugins[i]);
         } else {
-          expect(options2.plugins[i]).to.equal(options1.plugins[i]);
+          expect(options2.plugins[i]).toBe(options1.plugins[i]);
         }
       }
     });

--- a/packages/babel-core/test/evaluation.js
+++ b/packages/babel-core/test/evaluation.js
@@ -1,5 +1,4 @@
 import traverse from "@babel/traverse";
-import assert from "assert";
 import { parse } from "babylon";
 
 describe("evaluation", function() {
@@ -9,8 +8,8 @@ describe("evaluation", function() {
 
       visitor[type] = function(path) {
         const evaluate = path.evaluate();
-        assert.equal(evaluate.confident, !notConfident);
-        assert.deepEqual(evaluate.value, value);
+        expect(evaluate.confident).toEqual(!notConfident);
+        expect(evaluate.value).toEqual(value);
       };
 
       traverse(

--- a/packages/babel-core/test/fixtures/parse/output.json
+++ b/packages/babel-core/test/fixtures/parse/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 90,
+  "end": 91,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 6,
-      "column": 1
+      "line": 7,
+      "column": 0
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 90,
+    "end": 91,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 6,
-        "column": 1
+        "line": 7,
+        "column": 0
       }
     },
     "sourceType": "module",

--- a/packages/babel-core/test/fixtures/plugins/nested-if-alternate/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/nested-if-alternate/exec.js
@@ -18,4 +18,4 @@ var res = transform('', {
   ],
 });
 
-assert.equal(eval(res.code), 23);
+expect(eval(res.code)).toBe(23);

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-7064/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-7064/exec.js
@@ -2,20 +2,20 @@ class Bar {
   test() {
     // pass
     (() => {
-      assert.strictEqual(this.constructor, Bar);
+      expect(this.constructor).toBe(Bar);
     })();
 
     // pass
     (() => {
-      assert.strictEqual(this.constructor, Bar);
+      expect(this.constructor).toBe(Bar);
     }).call(this);
 
     (async () => {
-      assert.strictEqual(this.constructor, Bar);
+      expect(this.constructor).toBe(Bar);
     })();
 
     (async () => {
-      assert.strictEqual(this.constructor, Bar);
+      expect(this.constructor).toBe(Bar);
     }).call(this);
   }
 }

--- a/packages/babel-core/test/fixtures/transformation/regenerator/default-parameters/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/regenerator/default-parameters/exec.js
@@ -2,5 +2,5 @@ function* foo(bar = "bar") {
   return bar;
 }
 
-assert.deepEqual(foo().next().value, "bar");
-assert.deepEqual(foo("foo").next().value, "foo");
+expect(foo().next().value).toBe("bar");
+expect(foo("foo").next().value).toBe("foo");

--- a/packages/babel-core/test/fixtures/transformation/regenerator/destructuring-parameters/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/regenerator/destructuring-parameters/exec.js
@@ -2,4 +2,4 @@ function* foo({ bar }) {
   return bar;
 }
 
-assert(foo({ bar: "bar" }).next().value, "bar");
+expect(foo({ bar: "bar" }).next().value).toBe("bar");

--- a/packages/babel-core/test/fixtures/transformation/regenerator/destructuring/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/regenerator/destructuring/exec.js
@@ -3,14 +3,14 @@ function* foo() {
   return bar;
 }
 
-assert.equal(foo().next().value, "bar");
+expect(foo().next().value).toBe("bar");;
 
 function* foo2({ bar = 0 }) {
   return bar;
 }
 
-assert.equal(foo2({ bar: undefined }).next().value, 0);
-assert.equal(foo2({ bar: 3 }).next().value, 3);
+expect(foo2({ bar: undefined }).next().value).toBe(0);
+expect(foo2({ bar: 3 }).next().value).toBe(3);
 
 function* foo3() {
   loop:
@@ -44,14 +44,14 @@ function* foo3() {
 
 var gen3 = foo3();
 
-assert.equal(gen3.next().value, "iteration");
-assert.equal(gen3.next({what: "one", value: 3}).done, false);
-assert.equal(gen3.next({what: "one", value: 2}).done, true);
+expect(gen3.next().value).toBe("iteration");
+expect(gen3.next({what: "one", value: 3}).done).toBe(false);
+expect(gen3.next({what: "one", value: 2}).done).toBe(true);
 
 var gen4 = foo3();
-assert.equal(gen4.next().value, "iteration");
-assert.equal(gen4.next({what: "two", value: "sometext"}).done, true);
+expect(gen4.next().value).toBe("iteration");
+expect(gen4.next({what: "two", value: "sometext"}).done).toBe(true);
 
 var gen5 = foo3();
-assert.equal(gen5.next().value, "iteration");
-assert.equal(gen5.next({what: "three"}).done, true);
+expect(gen5.next().value).toBe("iteration");
+expect(gen5.next({what: "three"}).done).toBe(true);

--- a/packages/babel-core/test/fixtures/transformation/regenerator/rest-parameters/exec.js
+++ b/packages/babel-core/test/fixtures/transformation/regenerator/rest-parameters/exec.js
@@ -2,4 +2,4 @@ function* foo(...items) {
   return items;
 }
 
-assert.deepEqual(foo(1, 2, 3).next().value, [1, 2, 3]);
+expect(foo(1, 2, 3).next().value).toEqual([1, 2, 3]);

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -1,14 +1,13 @@
-import assert from "assert";
 import { loadOptions } from "../lib";
 import path from "path";
 
 describe("option-manager", () => {
   it("throws for babel 5 plugin", () => {
-    return assert.throws(() => {
+    return expect(() => {
       loadOptions({
         plugins: [({ Plugin }) => new Plugin("object-assign", {})],
       });
-    }, /Babel 5 plugin is being run with an unsupported Babel/);
+    }).toThrow(/Babel 5 plugin is being run with an unsupported Babel/);
   });
 
   describe("config plugin/preset flattening and overriding", () => {
@@ -24,12 +23,12 @@ describe("option-manager", () => {
     it("should throw if a plugin is repeated", () => {
       const { calls, plugin } = makePlugin();
 
-      assert.throws(() => {
+      expect(() => {
         loadOptions({
           plugins: [plugin, plugin],
         });
-      }, /Duplicate plugin\/preset detected/);
-      assert.deepEqual(calls, []);
+      }).toThrow(/Duplicate plugin\/preset detected/);
+      expect(calls).toEqual([]);
     });
 
     it("should not throw if a repeated plugin has a different name", () => {
@@ -39,8 +38,8 @@ describe("option-manager", () => {
       loadOptions({
         plugins: [[plugin1, { arg: 1 }], [plugin2, { arg: 2 }, "some-name"]],
       });
-      assert.deepEqual(calls1, [{ arg: 1 }]);
-      assert.deepEqual(calls2, [{ arg: 2 }]);
+      expect(calls1).toEqual([{ arg: 1 }]);
+      expect(calls2).toEqual([{ arg: 2 }]);
     });
 
     it("should merge .env[] plugins with parent presets", () => {
@@ -56,19 +55,19 @@ describe("option-manager", () => {
           },
         },
       });
-      assert.deepEqual(calls1, [{ arg: 3 }]);
-      assert.deepEqual(calls2, [{ arg: 2 }]);
+      expect(calls1).toEqual([{ arg: 3 }]);
+      expect(calls2).toEqual([{ arg: 2 }]);
     });
 
     it("should throw if a preset is repeated", () => {
       const { calls, plugin: preset } = makePlugin();
 
-      assert.throws(() => {
+      expect(() => {
         loadOptions({
           presets: [preset, preset],
-        });
-      }, /Duplicate plugin\/preset detected/);
-      assert.deepEqual(calls, []);
+        }).toThrow(/Duplicate plugin\/preset detected/);
+      });
+      expect(calls).toEqual([]);
     });
 
     it("should not throw if a repeated preset has a different name", () => {
@@ -78,8 +77,8 @@ describe("option-manager", () => {
       loadOptions({
         presets: [[preset1, { arg: 1 }], [preset2, { arg: 2 }, "some-name"]],
       });
-      assert.deepEqual(calls1, [{ arg: 1 }]);
-      assert.deepEqual(calls2, [{ arg: 2 }]);
+      expect(calls1).toEqual([{ arg: 1 }]);
+      expect(calls2).toEqual([{ arg: 2 }]);
     });
 
     it("should merge .env[] presets with parent presets", () => {
@@ -95,8 +94,8 @@ describe("option-manager", () => {
           },
         },
       });
-      assert.deepEqual(calls1, [{ arg: 3 }]);
-      assert.deepEqual(calls2, [{ arg: 2 }]);
+      expect(calls1).toEqual([{ arg: 3 }]);
+      expect(calls2).toEqual([{ arg: 2 }]);
     });
 
     it("should not merge .env[] presets with parent presets when passPerPreset", () => {
@@ -113,41 +112,42 @@ describe("option-manager", () => {
           },
         },
       });
-      assert.deepEqual(calls1, [{ arg: 1 }, { arg: 3 }]);
-      assert.deepEqual(calls2, [{ arg: 2 }]);
+      expect(calls1).toEqual([{ arg: 1 }, { arg: 3 }]);
+      expect(calls2).toEqual([{ arg: 2 }]);
     });
   });
 
   describe("mergeOptions", () => {
     it("throws for removed babel 5 options", () => {
-      return assert.throws(() => {
+      return expect(() => {
         loadOptions({
           randomOption: true,
         });
-      }, /Unknown option: .randomOption/);
+      }).toThrow(/Unknown option: .randomOption/);
     });
 
     it("throws for removed babel 5 options", () => {
-      return assert.throws(
-        () => {
-          loadOptions({
-            auxiliaryComment: true,
-            blacklist: true,
-          });
-        },
+      return expect(() => {
+        loadOptions({
+          auxiliaryComment: true,
+          blacklist: true,
+        });
+      }).toThrow(
         // eslint-disable-next-line max-len
         /Using removed Babel 5 option: .auxiliaryComment - Use `auxiliaryCommentBefore` or `auxiliaryCommentAfter`/,
       );
     });
 
     it("throws for resolved but erroring preset", () => {
-      return assert.throws(() => {
+      return expect(() => {
         loadOptions({
           presets: [
             path.join(__dirname, "fixtures/option-manager/not-a-preset"),
           ],
         });
-      }, /While processing: .*option-manager(?:\/|\\\\)not-a-preset\.js/);
+      }).toThrow(
+        /While processing: .*option-manager(?:\/|\\\\)not-a-preset\.js/,
+      );
     });
   });
 
@@ -160,23 +160,21 @@ describe("option-manager", () => {
           ],
         });
 
-        assert.equal(true, Array.isArray(options.plugins));
-        assert.equal(1, options.plugins.length);
-        assert.equal(0, options.presets.length);
+        expect(Array.isArray(options.plugins)).toBe(true);
+        expect(options.plugins).toHaveLength(1);
+        expect(options.presets).toHaveLength(0);
       });
     }
 
     function presetThrowsTest(name, msg) {
       it(name, function() {
-        assert.throws(
-          () =>
-            loadOptions({
-              presets: [
-                path.join(__dirname, "fixtures/option-manager/presets", name),
-              ],
-            }),
-          msg,
-        );
+        expect(() =>
+          loadOptions({
+            presets: [
+              path.join(__dirname, "fixtures/option-manager/presets", name),
+            ],
+          }),
+        ).toThrow(msg);
       });
     }
 

--- a/packages/babel-core/test/parse.js
+++ b/packages/babel-core/test/parse.js
@@ -1,4 +1,3 @@
-import assert from "assert";
 import fs from "fs";
 import path from "path";
 import { parse } from "../lib";
@@ -10,16 +9,20 @@ function fixture(...args) {
 describe("parse", function() {
   it("should parse using configuration from .babelrc when a filename is provided", function() {
     const input = fs.readFileSync(fixture("input.js"), "utf8");
-    const output = fs.readFileSync(fixture("output.json"), "utf8");
-    assert(
-      parse(input, { filename: fixture("input.js"), cwd: fixture() }),
-      output,
-    );
+    const output = require(fixture("output"));
+
+    const result = parse(input, {
+      filename: fixture("input.js"),
+      cwd: fixture(),
+    });
+    expect(JSON.parse(JSON.stringify(result))).toEqual(output);
   });
 
   it("should parse using passed in configuration", function() {
     const input = fs.readFileSync(fixture("input.js"), "utf8");
-    const output = fs.readFileSync(fixture("output.json"), "utf8");
-    assert(parse(input, { parserOpts: { plugins: ["decorators"] } }), output);
+    const output = require(fixture("output.json"));
+
+    const result = parse(input, { parserOpts: { plugins: ["decorators"] } });
+    expect(JSON.parse(JSON.stringify(result))).toEqual(output);
   });
 });

--- a/packages/babel-core/test/path.js
+++ b/packages/babel-core/test/path.js
@@ -1,6 +1,5 @@
 import { transform } from "../lib/index";
 import Plugin from "../lib/config/plugin";
-import chai from "chai";
 
 describe("traversal path", function() {
   it("replaceWithSourceString", function() {
@@ -18,7 +17,7 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("console.whatever();");
+    expect(actualCode).toBe("console.whatever();");
   });
 
   it("replaceWith (arrow expression body to block statement body)", function() {
@@ -47,7 +46,7 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("var fn = () => {\n  return true;\n};");
+    expect(actualCode).toBe("var fn = () => {\n  return true;\n};");
   });
 
   it("replaceWith (arrow block statement body to expression body)", function() {
@@ -68,7 +67,7 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("var fn = () => true;");
+    expect(actualCode).toBe("var fn = () => true;");
   });
 
   it("replaceWith (for-in left expression to variable declaration)", function() {
@@ -98,7 +97,7 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("for (var KEY in right);");
+    expect(actualCode).toBe("for (var KEY in right);");
   });
 
   it("replaceWith (for-in left variable declaration to expression)", function() {
@@ -119,7 +118,7 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("for (KEY in right);");
+    expect(actualCode).toBe("for (KEY in right);");
   });
 
   it("replaceWith (for-loop left expression to variable declaration)", function() {
@@ -149,7 +148,7 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("for (var KEY;;);");
+    expect(actualCode).toBe("for (var KEY;;);");
   });
 
   it("replaceWith (for-loop left variable declaration to expression)", function() {
@@ -170,6 +169,6 @@ describe("traversal path", function() {
       ],
     }).code;
 
-    chai.expect(actualCode).to.be.equal("for (KEY;;);");
+    expect(actualCode).toBe("for (KEY;;);");
   });
 });

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -1,4 +1,3 @@
-import assert from "assert";
 import * as babel from "../lib/index";
 import path from "path";
 
@@ -238,102 +237,114 @@ describe("addon resolution", function() {
   it("should throw about module: usage for presets", function() {
     process.chdir("throw-module-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["foo"],
       });
       // eslint-disable-next-line max-len
-    }, /Cannot find module 'babel-preset-foo'.*\n- If you want to resolve "foo", use "module:foo"/);
+    }).toThrow(
+      /Cannot find module 'babel-preset-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
+    );
   });
 
   it("should throw about module: usage for plugins", function() {
     process.chdir("throw-module-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["foo"],
       });
       // eslint-disable-next-line max-len
-    }, /Cannot find module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/);
+    }).toThrow(
+      /Cannot find module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/,
+    );
   });
 
   it("should throw about @babel usage for presets", function() {
     process.chdir("throw-babel-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["foo"],
       });
       // eslint-disable-next-line max-len
-    }, /Cannot find module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/);
+    }).toThrow(
+      /Cannot find module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/,
+    );
   });
 
   it("should throw about @babel usage for plugins", function() {
     process.chdir("throw-babel-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["foo"],
       });
       // eslint-disable-next-line max-len
-    }, /Cannot find module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/);
+    }).toThrow(
+      /Cannot find module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/,
+    );
   });
 
   it("should throw about passing a preset as a plugin", function() {
     process.chdir("throw-opposite-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["testplugin"],
       });
       // eslint-disable-next-line max-len
-    }, /Cannot find module 'babel-preset-testplugin'.*\n- Did you accidentally pass a preset as a plugin\?/);
+    }).toThrow(
+      /Cannot find module 'babel-preset-testplugin'.*\n- Did you accidentally pass a preset as a plugin\?/,
+    );
   });
 
   it("should throw about passing a plugin as a preset", function() {
     process.chdir("throw-opposite-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["testpreset"],
       });
       // eslint-disable-next-line max-len
-    }, /Cannot find module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a plugin as a preset\?/);
+    }).toThrow(
+      /Cannot find module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a plugin as a preset\?/,
+    );
   });
 
   it("should throw about missing presets", function() {
     process.chdir("throw-missing-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         presets: ["foo"],
       });
-    }, /Cannot find module 'babel-preset-foo'/);
+    }).toThrow(/Cannot find module 'babel-preset-foo'/);
   });
 
   it("should throw about missing plugins", function() {
     process.chdir("throw-missing-paths");
 
-    assert.throws(() => {
+    expect(() => {
       babel.transform("", {
         filename: "filename.js",
         babelrc: false,
         plugins: ["foo"],
       });
-    }, /Cannot find module 'babel-plugin-foo'/);
+    }).toThrow(/Cannot find module 'babel-plugin-foo'/);
   });
 });

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -22,6 +22,7 @@ const testContext = vm.createContext({
   transform: babel.transform,
   setTimeout: setTimeout,
   setImmediate: setImmediate,
+  expect,
 });
 testContext.global = testContext;
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Working towards #7476 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | NA
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | NA
| Any Dependency Changes?  | NA
| License                  | MIT

* Replace `assert.*equal` calls with appropriate `expect` calls

* Used codemods at: https://gist.github.com/devenbansod/03c5cff857661e076cbec72fcb2e7eb3 (along with some manual intervention and review)