### PR TITLE
Skip minification of large bundles during CI builds.

### DIFF
--- a/scripts/gulp-tasks.js
+++ b/scripts/gulp-tasks.js
@@ -131,10 +131,12 @@ function registerStandalonePackageTask(
           plugins,
         }),
         gulp.dest(standalonePath),
-        uglify(),
+      ].concat(
+        // Minification is super slow, so we skip it in CI.
+        process.env.CI ? [] : uglify(),
         rename({ extname: ".min.js" }),
-        gulp.dest(standalonePath),
-      ],
+        gulp.dest(standalonePath)
+      ),
       cb
     );
   });


### PR DESCRIPTION
Locally with the new branch:
```
$ time CI=true make build-standalone build-preset-env-standalone
./node_modules/.bin/gulp build-babel-standalone
[11:15:48] Using gulpfile ~/projects/babel/gulpfile.js
[11:15:48] Starting 'build-babel-standalone'...
[11:16:00] Version: webpack 3.11.0
   Asset     Size  Chunks                    Chunk Names
babel.js  2.74 MB       0  [emitted]  [big]  main
[11:16:00] Finished 'build-babel-standalone' after 12 s
./node_modules/.bin/gulp build-babel-preset-env-standalone
[11:16:02] Using gulpfile ~/projects/babel/gulpfile.js
[11:16:02] Starting 'build-babel-preset-env-standalone'...
[11:16:10] Version: webpack 3.11.0
              Asset     Size  Chunks                    Chunk Names
babel-preset-env.js  1.81 MB       0  [emitted]  [big]  main
[11:16:10] Finished 'build-babel-preset-env-standalone' after 7.7 s

27.65s user 0.94s system 123% cpu 23.192 total
```

vs with the old branch
```
$ time make build-standalone build-preset-env-standalone 
./node_modules/.bin/gulp build-babel-standalone
[11:14:07] Using gulpfile ~/projects/babel/gulpfile.js
[11:14:07] Starting 'build-babel-standalone'...
[11:14:19] Version: webpack 3.11.0
   Asset     Size  Chunks                    Chunk Names
babel.js  2.74 MB       0  [emitted]  [big]  main
[11:14:55] Finished 'build-babel-standalone' after 48 s
./node_modules/.bin/gulp build-babel-preset-env-standalone
[11:14:57] Using gulpfile ~/projects/babel/gulpfile.js
[11:14:57] Starting 'build-babel-preset-env-standalone'...
[11:15:05] Version: webpack 3.11.0
              Asset     Size  Chunks                    Chunk Names
babel-preset-env.js  1.81 MB       0  [emitted]  [big]  main
[11:15:28] Finished 'build-babel-preset-env-standalone' after 32 s

90.00s user 14.53s system 126% cpu 1:22.52 total
```