### PR TITLE
Run build-no-bundle in the watcher to get the right files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ watch: clean
 
 	# Ensure that build artifacts for types are created during local
 	# development too.
-	BABEL_ENV=development ./node_modules/.bin/gulp build
+	BABEL_ENV=development ./node_modules/.bin/gulp build-no-bundle
 	node ./packages/babel-types/scripts/generateTypeHelpers.js
 	node scripts/generators/flow.js > ./packages/babel-types/lib/index.js.flow
 	BABEL_ENV=development ./node_modules/.bin/gulp watch


### PR DESCRIPTION
Running `build` here first runs the build with Rollup, and makes `gulp watch` later skip it since the files have the same mtime. `watch` runs `build-no-bundle` interally, so we should be running it here too.