### PR TITLE
Fix flowtype errors introduced in #7503.

### DIFF
--- a/packages/babylon/src/plugins/estree.js
+++ b/packages/babylon/src/plugins/estree.js
@@ -288,12 +288,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       isGenerator: boolean,
       isAsync: boolean,
       isPattern: boolean,
+      containsEsc: boolean,
     ): ?N.ObjectMethod {
       const node: N.EstreeProperty = (super.parseObjectMethod(
         prop,
         isGenerator,
         isAsync,
         isPattern,
+        containsEsc,
       ): any);
 
       if (node) {

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -1837,6 +1837,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       isAsync: boolean,
       isPattern: boolean,
       refShorthandDefaultPos: ?Pos,
+      containsEsc: boolean,
     ): void {
       if ((prop: $FlowFixMe).variance) {
         this.unexpected((prop: $FlowFixMe).variance.start);
@@ -1859,6 +1860,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         isAsync,
         isPattern,
         refShorthandDefaultPos,
+        containsEsc,
       );
 
       // add typeParameters if we found them


### PR DESCRIPTION
There was a new function param added in #7503 but it wasn't added in the plugins that override it.