### PR TITLE
Make 'sourceType:unambiguous' use 'module' when import.meta is used.

### DIFF
--- a/packages/babylon/src/parser/base.js
+++ b/packages/babylon/src/parser/base.js
@@ -11,6 +11,7 @@ export default class BaseParser {
   inModule: boolean;
   plugins: { [key: string]: boolean };
   filename: ?string;
+  sawUnambiguousESM: boolean = false;
 
   // Initialized by Tokenizer
   state: State;

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -957,6 +957,8 @@ export default class ExpressionParser extends LValParser {
         { code: "BABEL_PARSER_SOURCETYPE_MODULE_REQUIRED" },
       );
     }
+    this.sawUnambiguousESM = true;
+
     return this.parseMetaProperty(node, id, "meta");
   }
 

--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -146,8 +146,25 @@ export default class StatementParser extends ExpressionParser {
         let result;
         if (starttype == tt._import) {
           result = this.parseImport(node);
+
+          if (
+            result.type === "ImportDeclaration" &&
+            (!result.importKind || result.importKind === "value")
+          ) {
+            this.sawUnambiguousESM = true;
+          }
         } else {
           result = this.parseExport(node);
+
+          if (
+            (result.type === "ExportNamedDeclaration" &&
+              (!result.exportKind || result.exportKind === "value")) ||
+            (result.type === "ExportAllDeclaration" &&
+              (!result.exportKind || result.exportKind === "value")) ||
+            result.type === "ExportDefaultDeclaration"
+          ) {
+            this.sawUnambiguousESM = true;
+          }
         }
 
         this.assertModuleNodeAllowed(node);

--- a/packages/babylon/test/fixtures/core/sourcetype-unambiguous/import-meta/input.js
+++ b/packages/babylon/test/fixtures/core/sourcetype-unambiguous/import-meta/input.js
@@ -1,0 +1,1 @@
+console.log(import.meta);

--- a/packages/babylon/test/fixtures/core/sourcetype-unambiguous/import-meta/options.json
+++ b/packages/babylon/test/fixtures/core/sourcetype-unambiguous/import-meta/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "unambiguous",
+  "plugins": ["importMeta"]
+}

--- a/packages/babylon/test/fixtures/core/sourcetype-unambiguous/import-meta/output.json
+++ b/packages/babylon/test/fixtures/core/sourcetype-unambiguous/import-meta/output.json
@@ -1,0 +1,165 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 25,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 25
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 25,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 25
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 25,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        },
+        "expression": {
+          "type": "CallExpression",
+          "start": 0,
+          "end": 24,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 24
+            }
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "start": 0,
+            "end": 11,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            },
+            "object": {
+              "type": "Identifier",
+              "start": 0,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                },
+                "identifierName": "console"
+              },
+              "name": "console"
+            },
+            "property": {
+              "type": "Identifier",
+              "start": 8,
+              "end": 11,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11
+                },
+                "identifierName": "log"
+              },
+              "name": "log"
+            },
+            "computed": false
+          },
+          "arguments": [
+            {
+              "type": "MetaProperty",
+              "start": 12,
+              "end": 23,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 12
+                },
+                "end": {
+                  "line": 1,
+                  "column": 23
+                }
+              },
+              "meta": {
+                "type": "Identifier",
+                "start": 12,
+                "end": 18,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 18
+                  },
+                  "identifierName": "import"
+                },
+                "name": "import"
+              },
+              "property": {
+                "type": "Identifier",
+                "start": 19,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 23
+                  },
+                  "identifierName": "meta"
+                },
+                "name": "meta"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7522
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

See https://github.com/babel/babel/issues/7522