### PR TITLE
Expose a prefix that plugins can use to annotate labelled statements and directives so they will be stripped out.

### DIFF
--- a/packages/babel-core/src/config/helpers/config-api.js
+++ b/packages/babel-core/src/config/helpers/config-api.js
@@ -17,7 +17,12 @@ export type PluginAPI = {
   env: EnvFunction,
   async: () => boolean,
   assertVersion: typeof assertVersion,
+  prefix: string,
 };
+
+export const UUID_prefix = `__BABEL_PRIVATE_${Math.floor(
+  Math.random() * Number.MAX_SAFE_INTEGER,
+).toString(16)}__`;
 
 export default function makeAPI(
   cache: CacheConfigurator<{ envName: string }>,
@@ -43,6 +48,7 @@ export default function makeAPI(
     env,
     async: () => false,
     assertVersion,
+    prefix: UUID_prefix,
   };
 }
 

--- a/packages/babel-core/test/strip-metadata.js
+++ b/packages/babel-core/test/strip-metadata.js
@@ -1,0 +1,86 @@
+import * as babel from "../lib/index";
+
+describe("strip-metadata", function() {
+  it("removes prefixed directives", function() {
+    const result = babel.transform("", {
+      plugins: [
+        function({ prefix, types: t }) {
+          return {
+            visitor: {
+              Program(path) {
+                path.pushContainer("directives", [
+                  t.directive(t.directiveLiteral(`some directive1`)),
+                  t.directive(t.directiveLiteral(`${prefix}some directive2`)),
+                  t.directive(t.directiveLiteral(`some directive3`)),
+                  t.directive(t.directiveLiteral(`${prefix}some directive4`)),
+                  t.directive(t.directiveLiteral(`some directive5`)),
+                ]);
+              },
+            },
+          };
+        },
+      ],
+    });
+
+    expect(result.code).toEqual(
+      [`"some directive1";`, `"some directive3";`, `"some directive5";`].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("removes prefixed labeled statements", function() {
+    const result = babel.transform("", {
+      plugins: [
+        function({ prefix, types: t }) {
+          return {
+            visitor: {
+              Program(path) {
+                path.pushContainer("body", [
+                  t.labeledStatement(t.identifier(`l1`), t.blockStatement([])),
+                  t.labeledStatement(
+                    t.identifier(`${prefix}l2`),
+                    t.blockStatement([]),
+                  ),
+                  t.labeledStatement(t.identifier(`l3`), t.blockStatement([])),
+                  t.labeledStatement(
+                    t.identifier(`${prefix}l4`),
+                    t.blockStatement([]),
+                  ),
+                  t.labeledStatement(t.identifier(`l5`), t.blockStatement([])),
+                  t.ifStatement(
+                    t.booleanLiteral(true),
+                    t.labeledStatement(
+                      t.identifier(`${prefix}l6`),
+                      t.blockStatement([]),
+                    ),
+                  ),
+                  t.ifStatement(
+                    t.booleanLiteral(true),
+                    t.labeledStatement(
+                      t.identifier(`l7`),
+                      t.blockStatement([]),
+                    ),
+                  ),
+                ]);
+              },
+            },
+          };
+        },
+      ],
+    });
+
+    expect(result.code).toEqual(
+      [
+        `l1: {}`,
+        ``,
+        `l3: {}`,
+        ``,
+        `l5: {}`,
+        ``,
+        `if (true) ;`,
+        `if (true) l7: {}`,
+      ].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Posting for thoughts. This idea popped into my head a while back and I'm curious what people think about it.

We have this problem where sometimes plugins will flag nodes with either random properties, or Symbols, or store them in WeakSets. I think that's a great approach when you are confident that the node won't be duplicated later, like if you are in direct control of a subtraversal and  no other plugins can get in your way. On the other hand, it's entirely possible for unrelated plugins to copy or replace a node for one reason or another, and often this will clear random flags on the node.

This PR makes Babel automatically strip out directives like:
   
```
"BABEL_PREFIX_some whatever";
```
and whole labeled statements like
```
BABEL_PREFIX_whatever: {
  // a normal JS block
}
```

I'm proposing this PR because it seems like it could be kind of handy for us. It would be relatively straightforward to inject directives that contain metadata about a given block. The labeled statements I could also see, though they are probably harder to manage. On the other hand since they allow actually non-string content, they can interact with other transforms.

Essentially it exposes a `prefix` field on the plugin API object that can be used inside directive literals or inside the labels of labeled statements to make them be deleted at the end of Babel's transformation phase. We could for instance use this approach to mark each of Babel's helper functions with a directive, so they are easier to pick out when transforming a given file. It could also be useful as a way of injecting metadata about a function's bindings or something.

Thoughts?