### PR TITLE
Fix "ran" to "run" for monorepo.md

### DIFF
--- a/doc/design/monorepo.md
+++ b/doc/design/monorepo.md
@@ -15,7 +15,7 @@ This is quite taboo but let's look at the pros and cons:
  * Easy to coordinate changes across modules.
  * Single place to report issues.
  * Easier to setup a development environment.
- * Tests across modules are ran together which finds bugs that touch multiple modules easier.
+ * Tests across modules are run together which finds bugs that touch multiple modules easier.
 
 **Cons:**
 


### PR DESCRIPTION
I just want to improve the document. The verb should be "run" not ran because "run" has past participle is "run"