### PR TITLE
preset-env - add Symbol.asyncIterator to shippedProposals builtIns

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -412,7 +412,7 @@ The following are currently supported:
 **Builtins**
 
 - [Promise.prototype.finally](https://github.com/tc39/proposal-promise-finally)
-- [Symbol.asycIterator](https://github.com/tc39/proposal-async-iteration)
+- [Symbol.asyncIterator](https://github.com/tc39/proposal-async-iteration)
 
 **Features**
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -412,6 +412,7 @@ The following are currently supported:
 **Builtins**
 
 - [Promise.prototype.finally](https://github.com/tc39/proposal-promise-finally)
+- [Symbol.asycIterator](https://github.com/tc39/proposal-async-iteration)
 
 **Features**
 

--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -1151,5 +1151,11 @@
     "firefox": "58",
     "safari": "11.1",
     "opera": "50"
+  },
+  "es7.symbol.async-iterator": {
+    "chrome": "63",
+    "firefox": "57",
+    "safari": "tp",
+    "opera": "50"
   }
 }

--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -2,7 +2,8 @@
 // shipped by browsers, and are enabled by the `shippedProposals` option.
 
 const builtIns = {
-  "es7.promise.finally": "Promise.prototype.finally"
+  "es7.promise.finally": "Promise.prototype.finally",
+  "es7.symbol.async-iterator": "Asynchronous Iterators",
 };
 
 const features = {

--- a/packages/babel-preset-env/src/built-in-definitions.js
+++ b/packages/babel-preset-env/src/built-in-definitions.js
@@ -16,7 +16,7 @@ export const definitions = {
     WeakMap: "es6.weak-map",
     WeakSet: "es6.weak-set",
     Promise: ["es6.object.to-string", "es6.promise"],
-    Symbol: "es6.symbol",
+    Symbol: ["es6.symbol", "es7.symbol.async-iterator"],
   },
 
   instanceMethods: {

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
@@ -19,6 +19,7 @@ Using polyfills with `entry` option:
 [src/in.js] Replaced `@babel/polyfill` with the following polyfills:
   es6.array.sort { "chrome":"60" }
   es7.promise.finally { "chrome":"60" }
+  es7.symbol.async-iterator { "chrome":"60" }
   web.timers { "chrome":"60" }
   web.immediate { "chrome":"60" }
   web.dom.iterable { "chrome":"60" }

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
@@ -150,6 +150,7 @@ Using polyfills with `entry` option:
   es7.string.pad-start {}
   es7.string.pad-end {}
   es7.promise.finally {}
+  es7.symbol.async-iterator {}
   web.timers {}
   web.immediate {}
   web.dom.iterable {}

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
@@ -8,6 +8,8 @@ require("core-js/modules/es6.array.index-of");
 
 require("regenerator-runtime/runtime");
 
+require("core-js/modules/es7.symbol.async-iterator");
+
 require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.promise");


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7505  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Builtin `es7.symbol.async-iterator` was missing from shippedProposals
Added this builtin also to `built-in-definitions.js` so `use-built-ins-plugin.js` would add this polyfill when adding Symbol.