### PR TITLE
Migrate `babel-cli` and `babel-generator` tests to use jest-expect

### DIFF
--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,13 +1,11 @@
 const includes = require("lodash/includes");
 const readdir = require("fs-readdir-recursive");
 const helper = require("@babel/helper-fixtures");
-const assert = require("assert");
 const rimraf = require("rimraf");
 const outputFileSync = require("output-file-sync");
 const child = require("child_process");
 const merge = require("lodash/merge");
 const path = require("path");
-const chai = require("chai");
 const fs = require("fs");
 
 const fixtureLoc = path.join(__dirname, "fixtures");
@@ -53,15 +51,9 @@ const assertTest = function(stdout, stderr, opts) {
 
   if (opts.stderr) {
     if (opts.stderrContains) {
-      assert.ok(
-        includes(stderr, expectStderr),
-        "stderr " +
-          JSON.stringify(stderr) +
-          " didn't contain " +
-          JSON.stringify(expectStderr),
-      );
+      expect(includes(stderr, expectStderr)).toBeTruthy();
     } else {
-      chai.expect(stderr).to.equal(expectStderr, "stderr didn't match");
+      expect(stderr).toBe(expectStderr);
     }
   } else if (stderr) {
     throw new Error("stderr:\n" + stderr);
@@ -73,15 +65,9 @@ const assertTest = function(stdout, stderr, opts) {
 
   if (opts.stdout) {
     if (opts.stdoutContains) {
-      assert.ok(
-        includes(stdout, expectStdout),
-        "stdout " +
-          JSON.stringify(stdout) +
-          " didn't contain " +
-          JSON.stringify(expectStdout),
-      );
+      expect(includes(stdout, expectStdout)).toBeTruthy();
     } else {
-      chai.expect(stdout).to.equal(expectStdout, "stdout didn't match");
+      expect(stdout).toBe(expectStdout);
     }
   } else if (stdout) {
     throw new Error("stdout:\n" + stdout);
@@ -96,24 +82,19 @@ const assertTest = function(stdout, stderr, opts) {
         filename !== ".babelrc" &&
         !opts.inFiles.hasOwnProperty(filename)
       ) {
-        const expect = opts.outFiles[filename];
+        const expected = opts.outFiles[filename];
         const actual = actualFiles[filename];
 
-        chai.expect(expect, "Output is missing: " + filename).to.not.be
-          .undefined;
+        expect(expected).not.toBe(undefined);
 
-        if (expect) {
-          chai
-            .expect(actual)
-            .to.equal(expect, "Compiled output does not match: " + filename);
+        if (expected) {
+          expect(actual).toBe(expected);
         }
       }
     });
 
     Object.keys(opts.outFiles).forEach(function(filename) {
-      chai
-        .expect(actualFiles, "Extraneous file in output: " + filename)
-        .to.contain.key(filename);
+      expect(actualFiles).toHaveProperty([filename]);
     });
   }
 };

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -51,7 +51,7 @@ const assertTest = function(stdout, stderr, opts) {
 
   if (opts.stderr) {
     if (opts.stderrContains) {
-      expect(includes(stderr, expectStderr)).toBeTruthy();
+      expect(includes(stderr, expectStderr)).toBe(true);
     } else {
       expect(stderr).toBe(expectStderr);
     }
@@ -65,7 +65,7 @@ const assertTest = function(stdout, stderr, opts) {
 
   if (opts.stdout) {
     if (opts.stdoutContains) {
-      expect(includes(stdout, expectStdout)).toBeTruthy();
+      expect(includes(stdout, expectStdout)).toBe(true);
     } else {
       expect(stdout).toBe(expectStdout);
     }

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -85,7 +85,7 @@ const assertTest = function(stdout, stderr, opts) {
         const expected = opts.outFiles[filename];
         const actual = actualFiles[filename];
 
-        expect(expected).not.toBe(undefined);
+        expect(expected).not.toBeUndefined();
 
         if (expected) {
           expect(actual).toBe(expected);

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -575,7 +575,7 @@ describe("buildConfigChain", function() {
       //     fixture("nonexistant-fake"),
       //   ],
       // });
-      // assert.notEqual(opts2, null);
+      // expect(opts2).not.toBeNull();
       //
       // const opts3 = loadOptions({
       //   filename: fixture("nonexistant-fake", "folder", "src.js"),
@@ -585,7 +585,7 @@ describe("buildConfigChain", function() {
       //     fixture("nonexistant-fake"),
       //   ],
       // });
-      // assert.notEqual(opts3, null);
+      // expect(opts3).not.toBeNull();
     });
   });
 

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -250,9 +250,13 @@ describe("generation", function() {
     });
 
     expect(Array.isArray(generated.rawMappings)).toBe(true);
+
+    expect(
+      Object.getOwnPropertyDescriptor(generated, "map"),
+    ).not.toHaveProperty("value");
+
     expect(generated).toHaveProperty("map");
     expect(typeof generated.map).toBe("object");
-    expect(generated.map).not.toHaveProperty("value");
   });
 });
 

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1,8 +1,6 @@
 import Printer from "../lib/printer";
 import generate, { CodeGenerator } from "../lib";
-import assert from "assert";
 import { parse } from "babylon";
-import chai from "chai";
 import * as t from "@babel/types";
 import fs from "fs";
 import path from "path";
@@ -11,12 +9,12 @@ import fixtures from "@babel/helper-fixtures";
 describe("generation", function() {
   it("completeness", function() {
     Object.keys(t.VISITOR_KEYS).forEach(function(type) {
-      assert.ok(!!Printer.prototype[type], type + " should exist");
+      expect(Printer.prototype[type]).toBeTruthy();
     });
 
     Object.keys(Printer.prototype).forEach(function(type) {
       if (!/[A-Z]/.test(type[0])) return;
-      assert.ok(t.VISITOR_KEYS[type], type + " should not exist");
+      expect(t.VISITOR_KEYS[type]).toBeTruthy();
     });
   });
 
@@ -46,7 +44,7 @@ describe("generation", function() {
 
     const generated = generate(combinedAst, { sourceMaps: true }, sources);
 
-    chai.expect(generated.map).to.deep.equal(
+    expect(generated.map).toEqual(
       {
         version: 3,
         sources: ["a.js", "b.js"],
@@ -61,7 +59,7 @@ describe("generation", function() {
       "sourcemap was incorrectly generated",
     );
 
-    chai.expect(generated.rawMappings).to.deep.equal(
+    expect(generated.rawMappings).toEqual(
       [
         {
           name: undefined,
@@ -157,12 +155,9 @@ describe("generation", function() {
       "raw mappings were incorrectly generated",
     );
 
-    chai
-      .expect(generated.code)
-      .to.equal(
-        "function hi(msg) {\n  console.log(msg);\n}\n\nhi('hello');",
-        "code was incorrectly generated",
-      );
+    expect(generated.code).toBe(
+      "function hi(msg) {\n  console.log(msg);\n}\n\nhi('hello');",
+    );
   });
 
   it("identifierName", function() {
@@ -189,7 +184,7 @@ describe("generation", function() {
       code,
     );
 
-    chai.expect(generated.map).to.deep.equal(
+    expect(generated.map).toEqual(
       {
         version: 3,
         sources: ["inline"],
@@ -200,7 +195,7 @@ describe("generation", function() {
       "sourcemap was incorrectly generated",
     );
 
-    chai.expect(generated.rawMappings).to.deep.equal(
+    expect(generated.rawMappings).toEqual(
       [
         {
           name: undefined,
@@ -242,12 +237,7 @@ describe("generation", function() {
       "raw mappings were incorrectly generated",
     );
 
-    chai
-      .expect(generated.code)
-      .to.equal(
-        "function foo2() {\n  bar2;\n}",
-        "code was incorrectly generated",
-      );
+    expect(generated.code).toBe("function foo2() {\n  bar2;\n}");
   });
 
   it("lazy source map generation", function() {
@@ -259,14 +249,10 @@ describe("generation", function() {
       sourceMaps: true,
     });
 
-    chai.expect(generated.rawMappings).to.be.an("array");
-
-    chai
-      .expect(generated)
-      .ownPropertyDescriptor("map")
-      .not.to.have.property("value");
-
-    chai.expect(generated.map).to.be.an("object");
+    expect(Array.isArray(generated.rawMappings)).toBe(true);
+    expect(generated).toHaveProperty("map");
+    expect(typeof generated.map).toBe("object");
+    expect(generated.map).not.toHaveProperty("value");
   });
 });
 
@@ -294,7 +280,7 @@ describe("programmatic generation", function() {
     );
 
     const ast = parse(generate(ifStatement).code);
-    assert.equal(ast.program.body[0].consequent.type, "BlockStatement");
+    expect(ast.program.body[0].consequent.type).toBe("BlockStatement");
   });
 
   it("prints directives in block with empty body", function() {
@@ -304,12 +290,9 @@ describe("programmatic generation", function() {
     );
 
     const output = generate(blockStatement).code;
-    assert.equal(
-      output,
-      `{
+    expect(output).toBe(`{
   "use strict";
-}`,
-    );
+}`);
   });
 
   it("flow object indentation", function() {
@@ -320,12 +303,9 @@ describe("programmatic generation", function() {
     );
 
     const output = generate(objectStatement).code;
-    assert.equal(
-      output,
-      `{
+    expect(output).toBe(`{
   bar: string
-}`,
-    );
+}`);
   });
 
   it("flow object exact", function() {
@@ -337,12 +317,9 @@ describe("programmatic generation", function() {
     );
 
     const output = generate(objectStatement).code;
-    assert.equal(
-      output,
-      `{|
+    expect(output).toBe(`{|
   bar: string
-|}`,
-    );
+|}`);
   });
 
   it("flow object indentation with empty leading ObjectTypeProperty", function() {
@@ -359,12 +336,9 @@ describe("programmatic generation", function() {
 
     const output = generate(objectStatement).code;
 
-    assert.equal(
-      output,
-      `{
+    expect(output).toBe(`{
   [key: any]: number
-}`,
-    );
+}`);
   });
 });
 
@@ -372,7 +346,7 @@ describe("CodeGenerator", function() {
   it("generate", function() {
     const codeGen = new CodeGenerator(t.numericLiteral(123));
     const code = codeGen.generate().code;
-    assert.equal(parse(code).program.body[0].expression.value, 123);
+    expect(parse(code).program.body[0].expression.value).toBe(123);
   });
 });
 
@@ -385,7 +359,7 @@ suites.forEach(function(testSuite) {
         task.title,
         !task.disabled &&
           function() {
-            const expect = task.expect;
+            const expected = task.expect;
             const actual = task.actual;
             const actualCode = actual.code;
 
@@ -399,17 +373,15 @@ suites.forEach(function(testSuite) {
               const result = generate(actualAst, task.options, actualCode);
 
               if (
-                !expect.code &&
+                !expected.code &&
                 result.code &&
-                fs.statSync(path.dirname(expect.loc)).isDirectory() &&
+                fs.statSync(path.dirname(expected.loc)).isDirectory() &&
                 !process.env.CI
               ) {
-                console.log(`New test file created: ${expect.loc}`);
-                fs.writeFileSync(expect.loc, result.code);
+                console.log(`New test file created: ${expected.loc}`);
+                fs.writeFileSync(expected.loc, result.code);
               } else {
-                chai
-                  .expect(result.code)
-                  .to.be.equal(expect.code, actual.loc + " !== " + expect.loc);
+                expect(result.code).toBe(expected.code);
               }
             }
           },

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/class-static-properties/properties-without-initializer/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/class-static-properties/properties-without-initializer/exec.js
@@ -7,4 +7,4 @@ class Example {
 }
 
 expect(Example).toHaveProperty("prop");
-expect(Example.prop).toBe(undefined);
+expect(Example.prop).toBeUndefined();

--- a/packages/babel-plugin-proposal-logical-assignment-operators/test/fixtures/logical-assignment/null-coalescing/exec.js
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/test/fixtures/logical-assignment/null-coalescing/exec.js
@@ -11,10 +11,10 @@ var obj = {
   },
 };
 
-assert.equal(obj.x ??= 1, 1);
-assert.equal(sets, 1);
-assert.equal(obj.x ??= 2, 1);
-assert.equal(sets, 1);
+expect(obj.x ??= 1).toBe(1);
+expect(sets).toBe(1);
+expect(obj.x ??= 2).toBe(1);
+expect(sets).toBe(1);
 
 var gets = 0;
 var deep = {
@@ -25,25 +25,25 @@ var deep = {
 };
 
 obj.x = undefined;
-assert.equal(deep.obj.x ??= 1, 1);
-assert.equal(gets, 1);
-assert.equal(deep.obj.x ??= 2, 1);
-assert.equal(gets, 2);
+expect(deep.obj.x ??= 1).toBe(1);
+expect(gets).toBe(1);
+expect(deep.obj.x ??= 2).toBe(1);
+expect(gets).toBe(2);
 
 var key = 0;
 obj.x = undefined;
-assert.equal(obj[++key] ??= 1, 1);
-assert.equal(key, 1);
+expect(obj[++key] ??= 1).toBe(1);
+expect(key).toBe(1);
 key = 0;
-assert.equal(obj[++key] ??= 2, 1);
-assert.equal(key, 1);
+expect(obj[++key] ??= 2).toBe(1);
+expect(key).toBe(1);
 
 obj.x = undefined;
 key = 0;
-assert.equal(deep.obj[++key] ??= 1, 1);
-assert.equal(gets, 3);
-assert.equal(key, 1);
+expect(deep.obj[++key] ??= 1).toBe(1);
+expect(gets).toBe(3);
+expect(key).toBe(1);
 key = 0;
-assert.equal(deep.obj[++key] ??= 2, 1);
-assert.equal(gets, 4);
-assert.equal(key, 1);
+expect(deep.obj[++key] ??= 2).toBe(1);
+expect(gets).toBe(4);
+expect(key).toBe(1);

--- a/packages/babel-plugin-proposal-logical-assignment-operators/test/fixtures/logical-assignment/null-coalescing/input.js
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/test/fixtures/logical-assignment/null-coalescing/input.js
@@ -11,10 +11,10 @@ var obj = {
   },
 };
 
-assert.equal(obj.x ??= 1, 1);
-assert.equal(sets, 1);
-assert.equal(obj.x ??= 2, 1);
-assert.equal(sets, 1);
+expect(obj.x ??= 1).toBe(1);
+expect(sets, 1);
+expect(obj.x ??= 2).toBe(1);
+expect(sets, 1);
 
 var gets = 0;
 var deep = {
@@ -25,25 +25,25 @@ var deep = {
 };
 
 obj.x = undefined;
-assert.equal(deep.obj.x ??= 1, 1);
-assert.equal(gets, 1);
-assert.equal(deep.obj.x ??= 2, 1);
-assert.equal(gets, 2);
+expect(deep.obj.x ??= 1).toBe(1);
+expect(gets, 1);
+expect(deep.obj.x ??= 2).toBe(1);
+expect(gets, 2);
 
 var key = 0;
 obj.x = undefined;
-assert.equal(obj[++key] ??= 1, 1);
-assert.equal(key, 1);
+expect(obj[++key] ??= 1).toBe(1);
+expect(key, 1);
 key = 0;
-assert.equal(obj[++key] ??= 2, 1);
-assert.equal(key, 1);
+expect(obj[++key] ??= 2).toBe(1);
+expect(key, 1);
 
 obj.x = undefined;
 key = 0;
-assert.equal(deep.obj[++key] ??= 1, 1);
-assert.equal(gets, 3);
-assert.equal(key, 1);
+expect(deep.obj[++key] ??= 1).toBe(1);
+expect(gets, 3);
+expect(key, 1);
 key = 0;
-assert.equal(deep.obj[++key] ??= 2, 1);
-assert.equal(gets, 4);
-assert.equal(key, 1);
+expect(deep.obj[++key] ??= 2).toBe(1);
+expect(gets, 4);
+expect(key, 1);

--- a/packages/babel-plugin-proposal-logical-assignment-operators/test/fixtures/logical-assignment/null-coalescing/output.js
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/test/fixtures/logical-assignment/null-coalescing/output.js
@@ -13,10 +13,10 @@ var obj = {
   }
 
 };
-assert.equal((_obj$x = obj.x) !== null && _obj$x !== void 0 ? _obj$x : obj.x = 1, 1);
-assert.equal(sets, 1);
-assert.equal((_obj$x2 = obj.x) !== null && _obj$x2 !== void 0 ? _obj$x2 : obj.x = 2, 1);
-assert.equal(sets, 1);
+expect((_obj$x = obj.x) !== null && _obj$x !== void 0 ? _obj$x : obj.x = 1).toBe(1);
+expect(sets, 1);
+expect((_obj$x2 = obj.x) !== null && _obj$x2 !== void 0 ? _obj$x2 : obj.x = 2).toBe(1);
+expect(sets, 1);
 var gets = 0;
 var deep = {
   get obj() {
@@ -26,23 +26,23 @@ var deep = {
 
 };
 obj.x = undefined;
-assert.equal((_x = (_deep$obj = deep.obj).x) !== null && _x !== void 0 ? _x : _deep$obj.x = 1, 1);
-assert.equal(gets, 1);
-assert.equal((_x2 = (_deep$obj2 = deep.obj).x) !== null && _x2 !== void 0 ? _x2 : _deep$obj2.x = 2, 1);
-assert.equal(gets, 2);
+expect((_x = (_deep$obj = deep.obj).x) !== null && _x !== void 0 ? _x : _deep$obj.x = 1).toBe(1);
+expect(gets, 1);
+expect((_x2 = (_deep$obj2 = deep.obj).x) !== null && _x2 !== void 0 ? _x2 : _deep$obj2.x = 2).toBe(1);
+expect(gets, 2);
 var key = 0;
 obj.x = undefined;
-assert.equal((_obj = obj[_ref = ++key]) !== null && _obj !== void 0 ? _obj : obj[_ref] = 1, 1);
-assert.equal(key, 1);
+expect((_obj = obj[_ref = ++key]) !== null && _obj !== void 0 ? _obj : obj[_ref] = 1).toBe(1);
+expect(key, 1);
 key = 0;
-assert.equal((_obj2 = obj[_ref2 = ++key]) !== null && _obj2 !== void 0 ? _obj2 : obj[_ref2] = 2, 1);
-assert.equal(key, 1);
+expect((_obj2 = obj[_ref2 = ++key]) !== null && _obj2 !== void 0 ? _obj2 : obj[_ref2] = 2).toBe(1);
+expect(key, 1);
 obj.x = undefined;
 key = 0;
-assert.equal((_ref4 = (_deep$obj3 = deep.obj)[_ref3 = ++key]) !== null && _ref4 !== void 0 ? _ref4 : _deep$obj3[_ref3] = 1, 1);
-assert.equal(gets, 3);
-assert.equal(key, 1);
+expect((_ref4 = (_deep$obj3 = deep.obj)[_ref3 = ++key]) !== null && _ref4 !== void 0 ? _ref4 : _deep$obj3[_ref3] = 1).toBe(1);
+expect(gets, 3);
+expect(key, 1);
 key = 0;
-assert.equal((_ref6 = (_deep$obj4 = deep.obj)[_ref5 = ++key]) !== null && _ref6 !== void 0 ? _ref6 : _deep$obj4[_ref5] = 2, 1);
-assert.equal(gets, 4);
-assert.equal(key, 1);
+expect((_ref6 = (_deep$obj4 = deep.obj)[_ref5 = ++key]) !== null && _ref6 !== void 0 ? _ref6 : _deep$obj4[_ref5] = 2).toBe(1);
+expect(gets, 4);
+expect(key, 1);

--- a/packages/babel-preset-es2015/test/fixtures/traceur/Classes/ExtendStrange.js
+++ b/packages/babel-preset-es2015/test/fixtures/traceur/Classes/ExtendStrange.js
@@ -8,7 +8,7 @@ expect(c).toBeInstanceOf(Object);
 expect(Object.getPrototypeOf(c)).toBe(C.prototype);
 expect(Object.getPrototypeOf(Object.getPrototypeOf(c))).toBeNull();
 
-expect(c.toString).toBe(undefined);
+expect(c.toString).toBeUndefined();
 
 class D extends null {
   constructor(...args) {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Working towards #7476 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | NA
| Major: Breaking Change?  | NA
| Minor: New Feature?      | NA
| Tests Added + Pass?      | 👍
| Documentation PR         | NA
| Any Dependency Changes?  | NA
| License                  | MIT

* Migrate babel-cli tests to use jest-expect
* Migrate babel-generator tests to use jest-expect
