### PR TITLE
Replace lodash/map with array equivalent

### DIFF
--- a/packages/babel-generator/src/node/whitespace.js
+++ b/packages/babel-generator/src/node/whitespace.js
@@ -1,4 +1,3 @@
-import map from "lodash/map";
 import * as t from "@babel/types";
 
 type WhitespaceObject = {
@@ -220,7 +219,7 @@ export const list = {
    */
 
   VariableDeclaration(node: Object): Array<Object> {
-    return map(node.declarations, "init");
+    return node.declarations ? node.declarations.map(decl => decl.init) : [];
   },
 
   /**

--- a/packages/babel-generator/src/node/whitespace.js
+++ b/packages/babel-generator/src/node/whitespace.js
@@ -219,7 +219,7 @@ export const list = {
    */
 
   VariableDeclaration(node: Object): Array<Object> {
-    return node.declarations ? node.declarations.map(decl => decl.init) : [];
+    return node.declarations.map(decl => decl.init);
   },
 
   /**


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | n
| License                  | MIT

I#m working on improving babel-standalone and noticed that this is totally unnecessary as `arr.map()` should be supported everywhere.
