### PR TITLE
Correctly assign super properties

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -601,6 +601,15 @@ helpers.set = () => template.program.ast`
 
       if (parent !== null) {
         _set(parent, property, value, receiver);
+      } else if (Object.defineProperty) {
+        Object.defineProperty(receiver, property, {
+          value: value,
+          enumerable: true,
+          configurable: true,
+          writable: true
+        });
+      } else {
+        receiver[property] = value;
       }
     } else if ("value" in desc && desc.writable) {
       desc.value = value;

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/assigning-super-properties/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/assigning-super-properties/exec.js
@@ -1,0 +1,12 @@
+class Foo {}
+
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test = 1;
+  }
+}
+
+const obj = new Test();
+
+expect(obj.test).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/assigning-super-properties/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/assigning-super-properties/input.js
@@ -1,0 +1,8 @@
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test = 1;
+    super.test.whatever = 2;
+    super.boo.more *= 2;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/assigning-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/assigning-super-properties/output.js
@@ -1,0 +1,17 @@
+var Test =
+/*#__PURE__*/
+function (_Foo) {
+  babelHelpers.inheritsLoose(Test, _Foo);
+
+  function Test() {
+    var _this;
+
+    _this = _Foo.call(this) || this;
+    babelHelpers.set(_Foo.prototype, "test", 1, _this);
+    babelHelpers.get(_Foo.prototype, "test", _this).whatever = 2;
+    babelHelpers.get(_Foo.prototype, "boo", _this).more *= 2;
+    return _this;
+  }
+
+  return Test;
+}(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/exec.js
@@ -1,0 +1,17 @@
+class Foo {}
+
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test = 0;
+  }
+
+  inc() {
+    super.test++;
+  }
+}
+
+const obj = new Test();
+obj.inc();
+
+expect(obj.test).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/exec.js
@@ -14,4 +14,4 @@ class Test extends Foo {
 const obj = new Test();
 obj.inc();
 
-expect(obj.test).toBe(1);
+expect(obj.test).toBe(NaN);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/input.js
@@ -1,0 +1,7 @@
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test++;
+    super.hey.whatever--;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/updating-super-properties/output.js
@@ -1,0 +1,18 @@
+var Test =
+/*#__PURE__*/
+function (_Foo) {
+  babelHelpers.inheritsLoose(Test, _Foo);
+
+  function Test() {
+    var _this;
+
+    _this = _Foo.call(this) || this;
+    var _ref = _Foo.prototype.test;
+    babelHelpers.set(_Foo.prototype, "test", _ref + 1, _this);
+    _ref;
+    babelHelpers.get(_Foo.prototype, "hey", _this).whatever--;
+    return _this;
+  }
+
+  return Test;
+}(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/assigning-super-properties/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/assigning-super-properties/exec.js
@@ -1,0 +1,12 @@
+class Foo {}
+
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test = 1;
+  }
+}
+
+const obj = new Test();
+
+expect(obj.test).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/assigning-super-properties/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/assigning-super-properties/input.js
@@ -1,0 +1,8 @@
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test = 1;
+    super.test.whatever = 2;
+    super.boo.more *= 2;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/assigning-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/assigning-super-properties/output.js
@@ -1,0 +1,18 @@
+var Test =
+/*#__PURE__*/
+function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
+  function Test() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Test);
+    _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
+    babelHelpers.set(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", 1, _this);
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).whatever = 2;
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "boo", babelHelpers.assertThisInitialized(_this)).more *= 2;
+    return _this;
+  }
+
+  return Test;
+}(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/exec.js
@@ -1,0 +1,17 @@
+class Foo {}
+
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test = 0;
+  }
+
+  inc() {
+    super.test++;
+  }
+}
+
+const obj = new Test();
+obj.inc();
+
+expect(obj.test).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/exec.js
@@ -14,4 +14,4 @@ class Test extends Foo {
 const obj = new Test();
 obj.inc();
 
-expect(obj.test).toBe(1);
+expect(obj.test).toBe(NaN);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/input.js
@@ -1,0 +1,11 @@
+class Test extends Foo {
+  constructor() {
+    super();
+    super.test++;
+    super.hey.whatever--;
+  }
+
+  get x() {
+    return super['value']++;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/updating-super-properties/output.js
@@ -1,0 +1,29 @@
+var Test =
+/*#__PURE__*/
+function (_Foo) {
+  babelHelpers.inherits(Test, _Foo);
+
+  function Test() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Test);
+    _this = babelHelpers.possibleConstructorReturn(this, (Test.__proto__ || Object.getPrototypeOf(Test)).call(this));
+
+    var _ref = babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this));
+
+    babelHelpers.set(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "test", _ref + 1, _this);
+    _ref;
+    babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), "hey", babelHelpers.assertThisInitialized(_this)).whatever--;
+    return _this;
+  }
+
+  babelHelpers.createClass(Test, [{
+    key: "x",
+    get: function get() {
+      var _ref2;
+
+      return _ref2 = babelHelpers.get(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), 'value', this), babelHelpers.set(Test.prototype.__proto__ || Object.getPrototypeOf(Test.prototype), 'value', _ref2 + 1, this), _ref2;
+    }
+  }]);
+  return Test;
+}(Foo);

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/output.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/output.js
@@ -1,6 +1,6 @@
 var _obj;
 
-function _set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
+function _set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } else if (Object.defineProperty) { Object.defineProperty(receiver, property, { value: value, enumerable: true, configurable: true, writable: true }); } else { receiver[property] = value; } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
 
 function _get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return _get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } }
 

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-exponentiation/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-exponentiation/output.js
@@ -1,6 +1,6 @@
 var _obj;
 
-function _set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
+function _set(object, property, value, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent !== null) { _set(parent, property, value, receiver); } else if (Object.defineProperty) { Object.defineProperty(receiver, property, { value: value, enumerable: true, configurable: true, writable: true }); } else { receiver[property] = value; } } else if ("value" in desc && desc.writable) { desc.value = value; } else { var setter = desc.set; if (setter !== undefined) { setter.call(receiver, value); } } return value; }
 
 function _get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return _get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #3536 Fixes #4312 Fixes #5769 Fixes #5774
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

This is a rebase of #3536 with additional fixes and tests. It ensures that we never assign anything to the superclass prototype and instead use the helper to do so.
