### PR TITLE
Re-add TEST_ONLY and use Jest's -t for TEST_GREP.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 set -e
 
-if [ -z "$TEST_GREP" ]; then
-   TEST_GREP=""
-fi
-
 node="node"
-jestArgs=""
+jestArgs=()
 
 if [ "$TEST_DEBUG" ]; then
   node="node --inspect-brk"
-  jestArgs="${jestArgs} --runInBand"
+  jestArgs+=("--runInBand")
 fi
 
 if [ -n "$CI" ]; then
-  jestArgs="${jestArgs} --maxWorkers=4 --ci"
+  jestArgs+=("--maxWorkers=4")
+  jestArgs+=("--ci")
 fi
 
-$node node_modules/.bin/jest $jestArgs "$TEST_GREP"
+if [ -n "$TEST_GREP" ]; then
+  jestArgs+=("-t")
+  jestArgs+=("$TEST_GREP")
+fi
+
+if [ -n "$TEST_ONLY" ]; then
+  jestArgs+=("packages/.*$TEST_ONLY.*/test")
+fi
+
+$node node_modules/.bin/jest "${jestArgs[@]}"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

In #7455 we lost TEST_ONLY, but some of the docs still reference it.

I also changed TEST_GREP to use Jest's `-t`, which I think is more consistent with the behavior before #7455.

I actually successfully did something with Bash. Amazing.