### PR TITLE
Run node 9 on circleci and remove from travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   build:
     working_directory: ~/babel
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:9
     steps:
       - checkout
       - restore-cache: *restore-yarn-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   directories:
   - node_modules
 node_js:
-  - '9'
+  # We test the latest version on circleci
   - '8'
   - '6'
   - '4'


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #7497 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

do not run node 9 on travis but run it on circle
