### PR TITLE
Fix incorrect value of _cache in _wrapNativeSuper

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -455,7 +455,7 @@ helpers.wrapNativeSuper = () => template.program.ast`
       return _sPO(new Constructor, Class.prototype);
     };
 
-  var _cache = typeof Map === "function" && new Map();
+  var _cache = typeof Map === "function" ? new Map() : undefined;
 
   export default function _wrapNativeSuper(Class) {
     if (typeof Class !== "function") {

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -6,7 +6,7 @@ var _sPO = Object.setPrototypeOf || function _sPO(o, p) { o.__proto__ = p; retur
 
 var _construct = typeof Reflect === "object" && Reflect.construct || function _construct(Parent, args, Class) { var Constructor, a = [null]; a.push.apply(a, args); Constructor = Parent.bind.apply(Parent, a); return _sPO(new Constructor(), Class.prototype); };
 
-var _cache = typeof Map === "function" && new Map();
+var _cache = typeof Map === "function" ? new Map() : undefined;
 
 function _wrapNativeSuper(Class) { if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() {} Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _sPO(Wrapper, _sPO(function Super() { return _construct(Class, arguments, _gPO(this).constructor); }, Class)); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -12,7 +12,7 @@ var _sPO = Object.setPrototypeOf || function _sPO(o, p) { o.__proto__ = p; retur
 
 var _construct = typeof Reflect === "object" && Reflect.construct || function _construct(Parent, args, Class) { var Constructor, a = [null]; a.push.apply(a, args); Constructor = Parent.bind.apply(Parent, a); return _sPO(new Constructor(), Class.prototype); };
 
-var _cache = typeof Map === "function" && new Map();
+var _cache = typeof Map === "function" ? new Map() : undefined;
 
 function _wrapNativeSuper(Class) { if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() {} Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _sPO(Wrapper, _sPO(function Super() { return _construct(Class, arguments, _gPO(this).constructor); }, Class)); }
 

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -16,7 +16,7 @@ var _sPO = Object.setPrototypeOf || function _sPO(o, p) { o.__proto__ = p; retur
 
 var _construct = (typeof Reflect === "undefined" ? "undefined" : _typeof(Reflect)) === "object" && Reflect.construct || function _construct(Parent, args, Class) { var Constructor, a = [null]; a.push.apply(a, args); Constructor = Parent.bind.apply(Parent, a); return _sPO(new Constructor(), Class.prototype); };
 
-var _cache = typeof Map === "function" && new Map();
+var _cache = typeof Map === "function" ? new Map() : undefined;
 
 function _wrapNativeSuper(Class) { if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() {} Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _sPO(Wrapper, _sPO(function Super() { return _construct(Class, arguments, _gPO(this).constructor); }, Class)); }
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

_I noticed this when inspecting the build output of a project. The fix is small, so I'm submitting it as a PR directly instead of opening an issue. Hope that's alright._

The boolean expression in the definition of the `_cache` variable in the `_wrapNativeSuper` helper returns `false` in environments where Map is missing. This would make [the later `typeof` check](https://github.com/babel/babel/blob/91a114f74a554d46959d5aa5c3c6200b7a01916b/packages/babel-helpers/src/helpers.js#L465) pass, since it only checks if the type is actually `undefined`.

This change explicitly sets `_cache` to `undefined` if Map is missing, to ensure the cache methods will be ignored.
