### PR TITLE
Remove outdated spec deviation note

### DIFF
--- a/packages/babylon/README.md
+++ b/packages/babylon/README.md
@@ -66,9 +66,7 @@ It is based on [ESTree spec][] with the following deviations:
 - [Program][] and [BlockStatement][] contain additional `directives` field with [Directive][] and [DirectiveLiteral][]
 - [ClassMethod][], [ObjectProperty][], and [ObjectMethod][] value property's properties in [FunctionExpression][] is coerced/brought into the main method node.
 
-AST for JSX code is based on [Facebook JSX AST][] with the addition of one node type:
-
-- `JSXText`
+AST for JSX code is based on [Facebook JSX AST][].
 
 [Babel AST format]: https://github.com/babel/babylon/blob/master/ast/spec.md
 [ESTree spec]: https://github.com/estree/estree


### PR DESCRIPTION
`JSXText` was added to the JSX spec [here](https://github.com/facebook/jsx/pull/80).