### PR TITLE
Ensure that the backward-compat logic for plugin-utils copies over the version API properly.

### DIFF
--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -174,8 +174,7 @@ const loadDescriptor = makeWeakCache(
 
     let item = value;
     if (typeof value === "function") {
-      const api = Object.assign(Object.create(context), makeAPI(cache));
-
+      const api = Object.assign({}, context, makeAPI(cache));
       try {
         item = value(api, options, dirname);
       } catch (e) {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7572
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

The `.version` wasn't getting copied over on >7 < beta.40 because it was on the prototype chain and thus ignored. This was almost certainly an unnecessary microoptimization so I'm just reverting that behavior.