### PR TITLE
Tweak es2015-related plugin order in preset-env

### DIFF
--- a/packages/babel-preset-env/data/plugin-features.js
+++ b/packages/babel-preset-env/data/plugin-features.js
@@ -1,30 +1,55 @@
 const es2015 = {
+  "transform-template-literals": {
+    features: ["template literals"],
+  },
+  "transform-literals": {
+    features: ["Unicode code point escapes"],
+  },
+  "transform-function-name": {
+    features: ['function "name" property'],
+  },
   "transform-arrow-functions": {
-    features: [
-      "arrow functions",
-    ],
+    features: ["arrow functions"],
   },
   "transform-block-scoped-functions": {
-    features: [
-      "block-level function declaration"
-    ],
-  },
-  "transform-block-scoping": {
-    features: [
-      "const",
-      "let",
-    ],
+    features: ["block-level function declaration"],
   },
   "transform-classes": {
-    features: [
-      "class",
-      "super",
-    ],
+    features: ["class", "super"],
+  },
+  "transform-object-super": {
+    features: ["super"],
+  },
+  "transform-shorthand-properties": {
+    features: ["object literal extensions / shorthand properties"],
+  },
+  "transform-duplicate-keys": {
+    features: ["miscellaneous / duplicate property names in strict mode"],
   },
   "transform-computed-properties": {
+    features: ["object literal extensions / computed properties"],
+  },
+  "transform-for-of": {
+    features: ["for..of loops"],
+  },
+  "transform-sticky-regex": {
     features: [
-      "object literal extensions / computed properties",
+      'RegExp "y" and "u" flags / "y" flag, lastIndex',
+      'RegExp "y" and "u" flags / "y" flag',
     ],
+  },
+  "transform-unicode-regex": {
+    features: [
+      'RegExp "y" and "u" flags / "u" flag, case folding',
+      'RegExp "y" and "u" flags / "u" flag, Unicode code point escapes',
+      'RegExp "y" and "u" flags / "u" flag',
+    ],
+  },
+  "transform-spread": {
+    features: ["spread (...) operator"],
+  },
+  "transform-parameters": {
+    features: ["default function parameters", "rest parameters"],
   },
   "transform-destructuring": {
     features: [
@@ -33,95 +58,29 @@ const es2015 = {
       "destructuring, parameters",
     ],
   },
-  "transform-duplicate-keys": {
-    features: [
-      "miscellaneous / duplicate property names in strict mode",
-    ],
-  },
-  "transform-for-of": {
-    features: [
-      "for..of loops",
-    ],
-  },
-  "transform-function-name": {
-    features: [
-      "function \"name\" property",
-    ]
-  },
-  "transform-literals": {
-    features: [
-      "Unicode code point escapes",
-    ],
-  },
-  "transform-object-super": {
-    features: [
-      "super",
-    ],
-  },
-  "transform-parameters": {
-    features: [
-      "default function parameters",
-      "rest parameters",
-    ],
-  },
-  "transform-shorthand-properties": {
-    features: [
-      "object literal extensions / shorthand properties",
-    ],
-  },
-  "transform-spread": {
-    features: [
-      "spread (...) operator",
-    ],
-  },
-  "transform-sticky-regex": {
-    features: [
-      "RegExp \"y\" and \"u\" flags / \"y\" flag, lastIndex",
-      "RegExp \"y\" and \"u\" flags / \"y\" flag",
-    ],
-  },
-  "transform-template-literals": {
-    features: [
-      "template literals",
-    ],
+  "transform-block-scoping": {
+    features: ["const", "let"],
   },
   "transform-typeof-symbol": {
-    features: [
-      "Symbol / typeof support"
-    ],
-  },
-  "transform-unicode-regex": {
-    features: [
-      "RegExp \"y\" and \"u\" flags / \"u\" flag, case folding",
-      "RegExp \"y\" and \"u\" flags / \"u\" flag, Unicode code point escapes",
-      "RegExp \"y\" and \"u\" flags / \"u\" flag",
-    ],
+    features: ["Symbol / typeof support"],
   },
   "transform-new-target": {
-    features: [
-      "new.target",
-    ],
+    features: ["new.target"],
   },
   "transform-regenerator": {
-    features: [
-      "generators",
-    ],
-  }
+    features: ["generators"],
+  },
 };
 
 const es2016 = {
   "transform-exponentiation-operator": {
-    features: [
-      "exponentiation (**) operator",
-    ],
-  }
+    features: ["exponentiation (**) operator"],
+  },
 };
 
 const es2017 = {
   "transform-async-to-generator": {
-    features: [
-      "async functions",
-    ],
+    features: ["async functions"],
   },
 };
 

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -1,4 +1,33 @@
 {
+  "transform-template-literals": {
+    "chrome": "41",
+    "edge": "13",
+    "firefox": "34",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "opera": "28",
+    "electron": "0.24"
+  },
+  "transform-literals": {
+    "chrome": "44",
+    "edge": "12",
+    "firefox": "53",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "opera": "31",
+    "electron": "0.31"
+  },
+  "transform-function-name": {
+    "chrome": "51",
+    "firefox": "53",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "opera": "38",
+    "electron": "1.2"
+  },
   "transform-arrow-functions": {
     "chrome": "47",
     "edge": "13",
@@ -20,16 +49,6 @@
     "opera": "28",
     "electron": "0.24"
   },
-  "transform-block-scoping": {
-    "chrome": "49",
-    "edge": "14",
-    "firefox": "51",
-    "safari": "10",
-    "node": "6",
-    "ios": "10",
-    "opera": "36",
-    "electron": "1"
-  },
   "transform-classes": {
     "chrome": "46",
     "edge": "13",
@@ -40,24 +59,25 @@
     "opera": "33",
     "electron": "0.36"
   },
-  "transform-computed-properties": {
-    "chrome": "44",
-    "edge": "12",
-    "firefox": "34",
-    "safari": "7.1",
-    "node": "4",
-    "ios": "8",
-    "opera": "31",
-    "electron": "0.31"
-  },
-  "transform-destructuring": {
-    "chrome": "51",
-    "firefox": "53",
+  "transform-object-super": {
+    "chrome": "46",
+    "edge": "13",
+    "firefox": "45",
     "safari": "10",
-    "node": "6.5",
+    "node": "5",
     "ios": "10",
-    "opera": "38",
-    "electron": "1.2"
+    "opera": "33",
+    "electron": "0.36"
+  },
+  "transform-shorthand-properties": {
+    "chrome": "43",
+    "edge": "12",
+    "firefox": "33",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "opera": "30",
+    "electron": "0.29"
   },
   "transform-duplicate-keys": {
     "chrome": "42",
@@ -69,6 +89,16 @@
     "opera": "29",
     "electron": "0.27"
   },
+  "transform-computed-properties": {
+    "chrome": "44",
+    "edge": "12",
+    "firefox": "34",
+    "safari": "7.1",
+    "node": "4",
+    "ios": "8",
+    "opera": "31",
+    "electron": "0.31"
+  },
   "transform-for-of": {
     "chrome": "51",
     "edge": "15",
@@ -79,29 +109,30 @@
     "opera": "38",
     "electron": "1.2"
   },
-  "transform-function-name": {
-    "chrome": "51",
-    "firefox": "53",
+  "transform-sticky-regex": {
+    "chrome": "49",
+    "edge": "13",
+    "firefox": "3",
     "safari": "10",
-    "node": "6.5",
+    "node": "6",
     "ios": "10",
-    "opera": "38",
-    "electron": "1.2"
+    "opera": "36",
+    "electron": "1"
   },
-  "transform-literals": {
-    "chrome": "44",
-    "edge": "12",
-    "firefox": "53",
-    "safari": "9",
-    "node": "4",
-    "ios": "9",
-    "opera": "31",
-    "electron": "0.31"
+  "transform-unicode-regex": {
+    "chrome": "50",
+    "edge": "13",
+    "firefox": "46",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "opera": "37",
+    "electron": "1.1"
   },
-  "transform-object-super": {
+  "transform-spread": {
     "chrome": "46",
     "edge": "13",
-    "firefox": "45",
+    "firefox": "36",
     "safari": "10",
     "node": "5",
     "ios": "10",
@@ -118,45 +149,24 @@
     "opera": "36",
     "electron": "1"
   },
-  "transform-shorthand-properties": {
-    "chrome": "43",
-    "edge": "12",
-    "firefox": "33",
-    "safari": "9",
-    "node": "4",
-    "ios": "9",
-    "opera": "30",
-    "electron": "0.29"
-  },
-  "transform-spread": {
-    "chrome": "46",
-    "edge": "13",
-    "firefox": "36",
+  "transform-destructuring": {
+    "chrome": "51",
+    "firefox": "53",
     "safari": "10",
-    "node": "5",
+    "node": "6.5",
     "ios": "10",
-    "opera": "33",
-    "electron": "0.36"
+    "opera": "38",
+    "electron": "1.2"
   },
-  "transform-sticky-regex": {
+  "transform-block-scoping": {
     "chrome": "49",
-    "edge": "13",
-    "firefox": "3",
+    "edge": "14",
+    "firefox": "51",
     "safari": "10",
     "node": "6",
     "ios": "10",
     "opera": "36",
     "electron": "1"
-  },
-  "transform-template-literals": {
-    "chrome": "41",
-    "edge": "13",
-    "firefox": "34",
-    "safari": "9",
-    "node": "4",
-    "ios": "9",
-    "opera": "28",
-    "electron": "0.24"
   },
   "transform-typeof-symbol": {
     "chrome": "38",
@@ -167,16 +177,6 @@
     "ios": "9",
     "opera": "25",
     "electron": "0.2"
-  },
-  "transform-unicode-regex": {
-    "chrome": "50",
-    "edge": "13",
-    "firefox": "46",
-    "safari": "10",
-    "node": "6",
-    "ios": "10",
-    "opera": "37",
-    "electron": "1.1"
   },
   "transform-new-target": {
     "chrome": "46",

--- a/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
+  transform-template-literals { "android":"4" }
+  transform-literals { "android":"4" }
+  transform-function-name { "android":"4" }
   transform-arrow-functions { "android":"4" }
   transform-block-scoped-functions { "android":"4" }
-  transform-block-scoping { "android":"4" }
   transform-classes { "android":"4" }
-  transform-computed-properties { "android":"4" }
-  transform-destructuring { "android":"4" }
-  transform-duplicate-keys { "android":"4" }
-  transform-for-of { "android":"4" }
-  transform-function-name { "android":"4" }
-  transform-literals { "android":"4" }
   transform-object-super { "android":"4" }
-  transform-parameters { "android":"4" }
   transform-shorthand-properties { "android":"4" }
-  transform-spread { "android":"4" }
+  transform-duplicate-keys { "android":"4" }
+  transform-computed-properties { "android":"4" }
+  transform-for-of { "android":"4" }
   transform-sticky-regex { "android":"4" }
-  transform-template-literals { "android":"4" }
-  transform-typeof-symbol { "android":"4" }
   transform-unicode-regex { "android":"4" }
+  transform-spread { "android":"4" }
+  transform-parameters { "android":"4" }
+  transform-destructuring { "android":"4" }
+  transform-block-scoping { "android":"4" }
+  transform-typeof-symbol { "android":"4" }
   transform-new-target { "android":"4" }
   transform-regenerator { "android":"4" }
   transform-exponentiation-operator { "android":"4" }

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
@@ -8,9 +8,9 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
-  transform-destructuring { "node":"6" }
-  transform-for-of { "node":"6" }
   transform-function-name { "node":"6" }
+  transform-for-of { "node":"6" }
+  transform-destructuring { "node":"6" }
   transform-exponentiation-operator { "node":"6" }
   transform-async-to-generator { "node":"6" }
   transform-dotall-regex { "node":"6" }

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
@@ -11,24 +11,24 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  transform-template-literals {}
+  transform-literals {}
+  transform-function-name {}
   transform-arrow-functions {}
   transform-block-scoped-functions {}
-  transform-block-scoping {}
   transform-classes {}
-  transform-computed-properties {}
-  transform-destructuring {}
-  transform-duplicate-keys {}
-  transform-for-of {}
-  transform-function-name {}
-  transform-literals {}
   transform-object-super {}
-  transform-parameters {}
   transform-shorthand-properties {}
-  transform-spread {}
+  transform-duplicate-keys {}
+  transform-computed-properties {}
+  transform-for-of {}
   transform-sticky-regex {}
-  transform-template-literals {}
-  transform-typeof-symbol {}
   transform-unicode-regex {}
+  transform-spread {}
+  transform-parameters {}
+  transform-destructuring {}
+  transform-block-scoping {}
+  transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}

--- a/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
@@ -10,24 +10,24 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
+  transform-template-literals { "ie":"10" }
+  transform-literals { "ie":"10" }
+  transform-function-name { "ie":"10", "node":"6" }
   transform-arrow-functions { "ie":"10" }
   transform-block-scoped-functions { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
   transform-classes { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-destructuring { "ie":"10", "node":"6" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-for-of { "ie":"10", "node":"6" }
-  transform-function-name { "ie":"10", "node":"6" }
-  transform-literals { "ie":"10" }
   transform-object-super { "ie":"10" }
-  transform-parameters { "ie":"10" }
   transform-shorthand-properties { "ie":"10" }
-  transform-spread { "ie":"10" }
+  transform-duplicate-keys { "ie":"10" }
+  transform-computed-properties { "ie":"10" }
+  transform-for-of { "ie":"10", "node":"6" }
   transform-sticky-regex { "ie":"10" }
-  transform-template-literals { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
   transform-unicode-regex { "ie":"10" }
+  transform-spread { "ie":"10" }
+  transform-parameters { "ie":"10" }
+  transform-destructuring { "ie":"10", "node":"6" }
+  transform-block-scoping { "ie":"10" }
+  transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
@@ -15,13 +15,13 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
-  transform-block-scoping { "electron":"0.36" }
-  transform-destructuring { "electron":"0.36" }
-  transform-for-of { "electron":"0.36" }
   transform-function-name { "electron":"0.36" }
-  transform-parameters { "electron":"0.36" }
+  transform-for-of { "electron":"0.36" }
   transform-sticky-regex { "electron":"0.36" }
   transform-unicode-regex { "electron":"0.36" }
+  transform-parameters { "electron":"0.36" }
+  transform-destructuring { "electron":"0.36" }
+  transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
   transform-exponentiation-operator { "electron":"0.36" }
   transform-async-to-generator { "electron":"0.36" }

--- a/packages/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
@@ -8,24 +8,24 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  transform-template-literals {}
+  transform-literals {}
+  transform-function-name {}
   transform-arrow-functions {}
   transform-block-scoped-functions {}
-  transform-block-scoping {}
   transform-classes {}
-  transform-computed-properties {}
-  transform-destructuring {}
-  transform-duplicate-keys {}
-  transform-for-of {}
-  transform-function-name {}
-  transform-literals {}
   transform-object-super {}
-  transform-parameters {}
   transform-shorthand-properties {}
-  transform-spread {}
+  transform-duplicate-keys {}
+  transform-computed-properties {}
+  transform-for-of {}
   transform-sticky-regex {}
-  transform-template-literals {}
-  transform-typeof-symbol {}
   transform-unicode-regex {}
+  transform-spread {}
+  transform-parameters {}
+  transform-destructuring {}
+  transform-block-scoping {}
+  transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}

--- a/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
@@ -16,10 +16,10 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
-  transform-destructuring { "firefox":"52" }
-  transform-for-of { "firefox":"52" }
-  transform-function-name { "firefox":"52" }
   transform-literals { "firefox":"52" }
+  transform-function-name { "firefox":"52" }
+  transform-for-of { "firefox":"52" }
+  transform-destructuring { "firefox":"52" }
   transform-dotall-regex { "firefox":"52", "node":"7.4" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
@@ -6,24 +6,24 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
+  transform-template-literals {}
+  transform-literals {}
+  transform-function-name {}
   transform-arrow-functions {}
   transform-block-scoped-functions {}
-  transform-block-scoping {}
   transform-classes {}
-  transform-computed-properties {}
-  transform-destructuring {}
-  transform-duplicate-keys {}
-  transform-for-of {}
-  transform-function-name {}
-  transform-literals {}
   transform-object-super {}
-  transform-parameters {}
   transform-shorthand-properties {}
-  transform-spread {}
+  transform-duplicate-keys {}
+  transform-computed-properties {}
+  transform-for-of {}
   transform-sticky-regex {}
-  transform-template-literals {}
-  transform-typeof-symbol {}
   transform-unicode-regex {}
+  transform-spread {}
+  transform-parameters {}
+  transform-destructuring {}
+  transform-block-scoping {}
+  transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}

--- a/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -13,24 +13,24 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
+  transform-template-literals { "ie":"10", "safari":"7" }
+  transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
+  transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }
   transform-block-scoped-functions { "ie":"10", "ios":"9", "safari":"7" }
-  transform-block-scoping { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-classes { "ie":"10", "ios":"9", "safari":"7" }
-  transform-computed-properties { "ie":"10", "safari":"7" }
-  transform-destructuring { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-duplicate-keys { "ie":"10", "safari":"7" }
-  transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
   transform-object-super { "ie":"10", "ios":"9", "safari":"7" }
-  transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-shorthand-properties { "ie":"10", "safari":"7" }
-  transform-spread { "ie":"10", "ios":"9", "safari":"7" }
+  transform-duplicate-keys { "ie":"10", "safari":"7" }
+  transform-computed-properties { "ie":"10", "safari":"7" }
+  transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-template-literals { "ie":"10", "safari":"7" }
-  transform-typeof-symbol { "ie":"10", "safari":"7" }
   transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
+  transform-spread { "ie":"10", "ios":"9", "safari":"7" }
+  transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-destructuring { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-block-scoping { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-typeof-symbol { "ie":"10", "safari":"7" }
   transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
@@ -10,23 +10,23 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
-  transform-arrow-functions { "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
   transform-template-literals { "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
+  transform-literals { "firefox":"50", "ie":"11" }
+  transform-function-name { "firefox":"50", "ie":"11" }
+  transform-arrow-functions { "ie":"11" }
+  transform-classes { "ie":"11" }
+  transform-object-super { "ie":"11" }
+  transform-shorthand-properties { "ie":"11" }
+  transform-duplicate-keys { "ie":"11" }
+  transform-computed-properties { "ie":"11" }
+  transform-for-of { "firefox":"50", "ie":"11" }
+  transform-sticky-regex { "ie":"11" }
   transform-unicode-regex { "ie":"11" }
+  transform-spread { "ie":"11" }
+  transform-parameters { "firefox":"50", "ie":"11" }
+  transform-destructuring { "firefox":"50", "ie":"11" }
+  transform-block-scoping { "firefox":"50", "ie":"11" }
+  transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
@@ -10,23 +10,23 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
-  transform-arrow-functions { "ie":"11" }
-  transform-block-scoping { "firefox":"50", "ie":"11" }
-  transform-classes { "ie":"11" }
-  transform-computed-properties { "ie":"11" }
-  transform-destructuring { "firefox":"50", "ie":"11" }
-  transform-duplicate-keys { "ie":"11" }
-  transform-for-of { "firefox":"50", "ie":"11" }
-  transform-function-name { "firefox":"50", "ie":"11" }
-  transform-literals { "firefox":"50", "ie":"11" }
-  transform-object-super { "ie":"11" }
-  transform-parameters { "firefox":"50", "ie":"11" }
-  transform-shorthand-properties { "ie":"11" }
-  transform-spread { "ie":"11" }
-  transform-sticky-regex { "ie":"11" }
   transform-template-literals { "ie":"11" }
-  transform-typeof-symbol { "ie":"11" }
+  transform-literals { "firefox":"50", "ie":"11" }
+  transform-function-name { "firefox":"50", "ie":"11" }
+  transform-arrow-functions { "ie":"11" }
+  transform-classes { "ie":"11" }
+  transform-object-super { "ie":"11" }
+  transform-shorthand-properties { "ie":"11" }
+  transform-duplicate-keys { "ie":"11" }
+  transform-computed-properties { "ie":"11" }
+  transform-for-of { "firefox":"50", "ie":"11" }
+  transform-sticky-regex { "ie":"11" }
   transform-unicode-regex { "ie":"11" }
+  transform-spread { "ie":"11" }
+  transform-parameters { "firefox":"50", "ie":"11" }
+  transform-destructuring { "firefox":"50", "ie":"11" }
+  transform-block-scoping { "firefox":"50", "ie":"11" }
+  transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
@@ -19,24 +19,24 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
+  transform-template-literals { "ie":"10" }
+  transform-literals { "ie":"10" }
+  transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-arrow-functions { "ie":"10" }
   transform-block-scoped-functions { "ie":"10" }
-  transform-block-scoping { "electron":"0.36", "ie":"10" }
   transform-classes { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-destructuring { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-literals { "ie":"10" }
   transform-object-super { "ie":"10" }
-  transform-parameters { "electron":"0.36", "ie":"10" }
   transform-shorthand-properties { "ie":"10" }
-  transform-spread { "ie":"10" }
+  transform-duplicate-keys { "ie":"10" }
+  transform-computed-properties { "ie":"10" }
+  transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-template-literals { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
   transform-unicode-regex { "electron":"0.36", "ie":"10" }
+  transform-spread { "ie":"10" }
+  transform-parameters { "electron":"0.36", "ie":"10" }
+  transform-destructuring { "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-block-scoping { "electron":"0.36", "ie":"10" }
+  transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
   transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
@@ -10,24 +10,24 @@ Using targets:
 Using modules transform: commonjs
 
 Using plugins:
+  transform-template-literals { "ie":"10" }
+  transform-literals { "ie":"10" }
+  transform-function-name { "ie":"10" }
   transform-arrow-functions { "ie":"10" }
   transform-block-scoped-functions { "ie":"10" }
-  transform-block-scoping { "ie":"10" }
   transform-classes { "ie":"10" }
-  transform-computed-properties { "ie":"10" }
-  transform-destructuring { "ie":"10" }
-  transform-duplicate-keys { "ie":"10" }
-  transform-for-of { "ie":"10" }
-  transform-function-name { "ie":"10" }
-  transform-literals { "ie":"10" }
   transform-object-super { "ie":"10" }
-  transform-parameters { "ie":"10" }
   transform-shorthand-properties { "ie":"10" }
-  transform-spread { "ie":"10" }
+  transform-duplicate-keys { "ie":"10" }
+  transform-computed-properties { "ie":"10" }
+  transform-for-of { "ie":"10" }
   transform-sticky-regex { "ie":"10" }
-  transform-template-literals { "ie":"10" }
-  transform-typeof-symbol { "ie":"10" }
   transform-unicode-regex { "ie":"10" }
+  transform-spread { "ie":"10" }
+  transform-parameters { "ie":"10" }
+  transform-destructuring { "ie":"10" }
+  transform-block-scoping { "ie":"10" }
+  transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/input.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/input.js
@@ -1,0 +1,5 @@
+// https://github.com/babel/babel/issues/7557
+for (let [a] of c) {
+  a = 1;
+  () => a;
+}

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/options.json
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/options.json
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["../../../../lib", {
+      "modules": false
+    }]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
@@ -1,0 +1,42 @@
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+// https://github.com/babel/babel/issues/7557
+var _iteratorNormalCompletion = true;
+var _didIteratorError = false;
+var _iteratorError = undefined;
+
+try {
+  var _loop = function _loop() {
+    var _step$value = _slicedToArray(_step.value, 1),
+        a = _step$value[0];
+
+    a = 1;
+
+    (function () {
+      return a;
+    });
+  };
+
+  for (var _iterator = c[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+    _loop();
+  }
+} catch (err) {
+  _didIteratorError = true;
+  _iteratorError = err;
+} finally {
+  try {
+    if (!_iteratorNormalCompletion && _iterator.return != null) {
+      _iterator.return();
+    }
+  } finally {
+    if (_didIteratorError) {
+      throw _iteratorError;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7557
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

Good ol' plugin ordering, as a temp fix... made preset-env match preset-es2015's order outright.

@xandris I added your sample code as a test case.