### PR TITLE
Disable flow on transformClass, fix preset-env errors

### DIFF
--- a/packages/babel-plugin-transform-classes/src/transformClass.js
+++ b/packages/babel-plugin-transform-classes/src/transformClass.js
@@ -1,4 +1,3 @@
-// @flow
 import type { NodePath } from "@babel/traverse";
 import nameFunction from "@babel/helper-function-name";
 import ReplaceSupers from "@babel/helper-replace-supers";

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -15,7 +15,7 @@ const validIncludesAndExcludes = new Set([
   ...defaultWebIncludes,
 ]);
 
-const pluginToRegExp = (plugin: any): RegExp => {
+const pluginToRegExp = (plugin: any): ?RegExp => {
   if (plugin instanceof RegExp) return plugin;
   try {
     return new RegExp(`^${normalizePluginName(plugin)}$`);
@@ -24,7 +24,7 @@ const pluginToRegExp = (plugin: any): RegExp => {
   }
 };
 
-const selectPlugins = (regexp: RegExp): Array<string> =>
+const selectPlugins = (regexp: ?RegExp): Array<string> =>
   Array.from(validIncludesAndExcludes).filter(
     item => regexp instanceof RegExp && regexp.test(item),
   );
@@ -32,7 +32,7 @@ const selectPlugins = (regexp: RegExp): Array<string> =>
 const flatten = array => [].concat(...array);
 
 const expandIncludesAndExcludes = (
-  plugins: Array<string | RegExp> = [],
+  plugins: Array<string> = [],
   type: string,
 ): Array<string> => {
   if (plugins.length === 0) return plugins;

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -32,10 +32,10 @@ const selectPlugins = (regexp: ?RegExp): Array<string> =>
 const flatten = array => [].concat(...array);
 
 const expandIncludesAndExcludes = (
-  plugins: Array<string> = [],
+  plugins: Array<string | RegExp> = [],
   type: string,
 ): Array<string> => {
-  if (plugins.length === 0) return plugins;
+  if (plugins.length === 0) return [];
 
   const selectedPlugins = plugins.map(plugin =>
     selectPlugins(pluginToRegExp(plugin)),
@@ -67,9 +67,7 @@ export const checkDuplicateIncludeExcludes = (
   include: Array<string> = [],
   exclude: Array<string> = [],
 ): void => {
-  const duplicates: Array<string> = include.filter(
-    opt => exclude.indexOf(opt) >= 0,
-  );
+  const duplicates = include.filter(opt => exclude.indexOf(opt) >= 0);
 
   invariant(
     duplicates.length === 0,

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -14,10 +14,10 @@ export type BuiltInsOption = false | "entry" | "usage";
 export type Options = {
   configPath: string,
   debug: boolean,
-  exclude: Array<string>,
+  exclude: Array<string | RegExp>,
   forceAllTransforms: boolean,
   ignoreBrowserslistConfig: boolean,
-  include: Array<string>,
+  include: Array<string | RegExp>,
   loose: boolean,
   modules: ModuleOption,
   shippedProposals: boolean,


### PR DESCRIPTION
Disabled Flow from `transformClass.js` (see #7444) which caused a cascade of errors, as per @loganfsmyth [request](https://github.com/babel/babel/pull/7444#discussion_r175861060). Also fixed small Flow issues I found in other files so now `yarn flow` pass.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Fix
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
