### PR TITLE
Check MemberExpression nodes in `isPure`

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -619,7 +619,10 @@ export default class Scope {
       }
       return true;
     } else if (t.isMemberExpression(node)) {
-      return this.isPure(node.object, constantsOnly);
+      return (
+        this.isPure(node.object, constantsOnly) &&
+        this.isPure(node.property, constantsOnly)
+      );
     } else if (t.isClassMethod(node)) {
       if (node.computed && !this.isPure(node.key, constantsOnly)) return false;
       if (node.kind === "get" || node.kind === "set") return false;

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -618,6 +618,8 @@ export default class Scope {
         if (!this.isPure(prop, constantsOnly)) return false;
       }
       return true;
+    } else if (t.isMemberExpression(node)) {
+      return this.isPure(node.object, constantsOnly);
     } else if (t.isClassMethod(node)) {
       if (node.computed && !this.isPure(node.key, constantsOnly)) return false;
       if (node.kind === "get" || node.kind === "set") return false;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | x
| Major: Breaking Change?  | x
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR         | 
| Any Dependency Changes?  |
| License                  | MIT

I noticed that `isPure` is failing in case where it shouldn't. Currently is doesn't check MemberExpression's at all. Originally, I was going to copy `isPure` and use my own version, with the added ability to return `true` if the binding is from the top-level scope (so it's safe to hoist there). I was happy to find that babel's `isPure` already does this! Let's say I was trying to implement CSS-in-JS hoisting. The scope check allows this:

```js
import React from 'react';
import { color } from 'colors';

class App extends React.Component {
  render() {
    return <View style={{ backgroundColor: 'red', color: color }}>hi</View>;
  }
}
```

to be transformed into this:

```js
'use strict';

var _react = require('react');

var _react2 = _interopRequireDefault(_react);

var _colors = require('colors');

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var _ref = { backgroundColor: 'red', color: _colors.color };

class App extends _react2.default.Component {
  render() {
    return _react2.default.createElement(
      View,
      { style: _ref },
      'hi'
    );
  }
}
```

Assuming we are detecting `style` props and checking if the ObjectExpression inside of them is pure. That's sweet! But let's say I make a simple change and instead use `colors.color` instead of `color` inside the render function:

```js
import React from 'react';
import * as colors from 'colors';

class App extends React.Component {
  render() {
    return (
      <View style={{ backgroundColor: 'red', color: colors.color }}>hi</View>
    );
  }
}
```

Using the current babel `isPure` would fail in this case. Here's the output:

```js
'use strict';

var _react = require('react');

var _react2 = _interopRequireDefault(_react);

var _colors = require('colors');

var colors = _interopRequireWildcard(_colors);

// boilerplate snipped

class App extends _react2.default.Component {
  render() {
    return _react2.default.createElement(
      View,
      { style: { backgroundColor: 'red', color: colors.color } },
      'hi'
    );
  }
}
```

The problem is that we don't traverse into MemberExpression nodes, when there's no reason we shouldn't. Now that we traverse, we eventually hit `colors` and notice that's it's a top-level binding, so the same logic as before marks this is safe to hoist. The new behavior is now:

```js
var _ref = { backgroundColor: 'red', color: colors.color };

class App extends _react2.default.Component {
  render() {
    return _react2.default.createElement(
      View,
      { style: _ref },
      'hi'
    );
  }
}
```

It must be common in React-land at least to use this syntax (I do it all the time to pull colors from my style guide). Adding this might allow apps to take advantage of hoisting a lot more.

To be honest, I don't have time to figure all of babel's setup and thoroughly add tests and such. This PR is a starting point for somebody else to finish.