### PR TITLE
Allow StringLiteral and NumericLiteral as ObjectTypeProperty.key

### DIFF
--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -1553,7 +1553,7 @@ See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(no
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `key`: `Identifier` (required)
+ - `key`: `Identifier | StringLiteral` (required)
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -291,7 +291,7 @@ defineType("ObjectTypeProperty", {
   visitor: ["key", "value", "variance"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
-    key: validateType("Identifier"),
+    key: validateType(["Identifier", "StringLiteral"]),
     value: validateType("FlowType"),
     kind: validate(assertOneOf("init", "get", "set")),
     static: validate(assertValueType("boolean")),


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7635
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | no
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Previously `ObjectTypeProperty` validator only accepted `Identifier` as a key what made impossible to describe some object types using babel-types.

Validation rule changed to also accept `StringLiteral` ~~and `NumericLiteral`~~