### PR TITLE
Remove setting BABEL_ENV to test by default in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ MAKEFLAGS = -j1
 FLOW_COMMIT = 622bbc4f07acb77eb1109830c70815f827401d90
 TEST262_COMMIT = 52f70e2f637731aae92a9c9a2d831310c3ab2e1e
 
-export BABEL_ENV = test
-
 # Fix color output until TravisCI fixes https://github.com/travis-ci/travis-ci/issues/7967
 export FORCE_COLOR = true
 
@@ -69,7 +67,7 @@ test-clean:
 		$(call clean-source-test, $(source)))
 
 test-only:
-	./scripts/test.sh
+	BABEL_ENV=test ./scripts/test.sh
 	make test-clean
 
 test: lint test-only
@@ -79,7 +77,7 @@ test-ci: bootstrap test-only
 test-ci-coverage: SHELL:=/bin/bash
 test-ci-coverage:
 	BABEL_COVERAGE=true BABEL_ENV=test make bootstrap
-	TEST_TYPE=cov ./scripts/test-cov.sh
+	BABEL_ENV=test TEST_TYPE=cov ./scripts/test-cov.sh
 	bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json
 
 bootstrap-flow:


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7654
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This was causing `BABEL_ENV=production make build-dist` to run with `test` env, which passed `node: current` as target to preset-env during the prod build.