### PR TITLE
Fix super in class fields.

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/general/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/general/constructor-collision/output.js
@@ -2,17 +2,11 @@ var foo = "bar";
 
 var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
-
-  _initialiseProps.call(this);
-
-  var foo = "foo";
-};
-
-var _initialiseProps = function () {
   Object.defineProperty(this, "bar", {
     configurable: true,
     enumerable: true,
     writable: true,
     value: foo
   });
+  var _foo = "foo";
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/general/super-with-collision/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/general/super-with-collision/input.js
@@ -1,0 +1,6 @@
+class A {
+  force = force;
+  foo = super.method();
+
+  constructor(force) {}
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/general/super-with-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/general/super-with-collision/output.js
@@ -1,0 +1,15 @@
+var A = function A(_force) {
+  babelHelpers.classCallCheck(this, A);
+  Object.defineProperty(this, "force", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: force
+  });
+  Object.defineProperty(this, "foo", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: babelHelpers.get(A.prototype.__proto__ || Object.getPrototypeOf(A.prototype), "method", babelHelpers.assertThisInitialized(this)).call(this)
+  });
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/loose/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/loose/constructor-collision/output.js
@@ -2,12 +2,6 @@ var foo = "bar";
 
 var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
-
-  _initialiseProps.call(this);
-
-  var foo = "foo";
-};
-
-var _initialiseProps = function () {
   this.bar = foo;
+  var _foo = "foo";
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
@@ -56,8 +56,23 @@ var _this = this;
 
 (function () {
   class Baz {
-    constructor(force) {
-      _initialiseProps.call(this);
+    constructor(_force) {
+      var _this4 = this;
+
+      Object.defineProperty(this, "fn", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: function () {
+          return console.log(_this4);
+        }
+      });
+      Object.defineProperty(this, "force", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: force
+      });
     }
 
   }
@@ -70,25 +85,6 @@ var _this = this;
       return console.log(_this);
     }
   });
-
-  var _initialiseProps = function () {
-    var _this4 = this;
-
-    Object.defineProperty(this, "fn", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function () {
-        return console.log(_this4);
-      }
-    });
-    Object.defineProperty(this, "force", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: force
-    });
-  };
 });
 
 var qux = function () {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7574, fixes #6913
| Patch: Bug Fix?          | :+1: 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

>  Never extract class fields into an initializer function
>
> It was needed to avoid collision of identifiers used in fields
initializers with variables declared in the constructor, but it
broke `this` handling.
> This commit removes that behavior and instead renames the
colliding variables.