### PR TITLE
OptionalMemberExpression properties are not referenced

### DIFF
--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.44",
-    "@babel/helper-plugin-test-runner": "7.0.0-beta.44"
+    "@babel/helper-plugin-test-runner": "7.0.0-beta.44",
+    "@babel/plugin-transform-block-scoping": "7.0.0-beta.44"
   }
 }

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/7642/input.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/7642/input.js
@@ -1,0 +1,7 @@
+{
+  const foo = 1;
+}
+
+{
+  const foo = ({})?.foo;
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/7642/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/7642/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-optional-chaining", "transform-block-scoping"]
+}

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/7642/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/7642/output.js
@@ -1,0 +1,8 @@
+{
+  var foo = 1;
+}
+{
+  var _ref;
+
+  var _foo = (_ref = {}) === null || _ref === void 0 ? void 0 : _ref.foo;
+}

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -14,6 +14,7 @@ export default function isReferenced(node: Object, parent: Object): boolean {
     // no: parent.NODE
     case "MemberExpression":
     case "JSXMemberExpression":
+    case "OptionalMemberExpression":
       if (parent.property === node && parent.computed) {
         return true;
       } else if (parent.object === node) {


### PR DESCRIPTION
This is a regression from #7288.

Fixes #7642.