### PR TITLE
Cleanup object super traversal

### DIFF
--- a/packages/babel-plugin-transform-object-super/src/index.js
+++ b/packages/babel-plugin-transform-object-super/src/index.js
@@ -25,20 +25,16 @@ export default declare(api => {
         const getObjectRef = () =>
           (objectRef = objectRef || path.scope.generateUidIdentifier("obj"));
 
-        path.get("properties").forEach(propertyPath => {
-          if (!propertyPath.isMethod()) return;
+        path.get("properties").forEach(propPath => {
+          if (!propPath.isMethod()) return;
 
-          const propPaths: Array = path.get("properties");
-          for (let propPath of propPaths) {
-            if (propPath.isObjectProperty()) propPath = propPath.get("value");
-            replacePropertySuper(
-              propPath,
-              propPath.node,
-              path.scope,
-              getObjectRef,
-              state,
-            );
-          }
+          replacePropertySuper(
+            propPath,
+            propPath.node,
+            path.scope,
+            getObjectRef,
+            state,
+          );
         });
 
         if (objectRef) {


### PR DESCRIPTION
Also fixes a few bugs with super traversal in general (needs to run on computed keys, but not initializers, unless it's static).

