### PR TITLE
Add extra metadata to __source prop

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/exec.js
+++ b/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/exec.js
@@ -7,7 +7,9 @@ var expected = multiline([
   'var _jsxFileName = "/fake/path/mock.js";',
   'var x = <sometag __source={{',
   '  fileName: _jsxFileName,',
-  '  lineNumber: 1',
+  '  lineNumber: 1,',
+  '  colNumber: 8,',
+  '  toLineNumber: 1',
   '}} />;',
 ]);
 


### PR DESCRIPTION
__source prop will now have column number along with line number of opening element
as well as line number of closing element

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | NA
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Might be
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm working on an extension for chrome devtools, that's also devtools in itself.

Basically it's devtools' workspaces done right.

Along with giving devs a text editor right inside devtools, that automagically points to project directory, they can literally pick any element on the page and it'll take them to the `file:line:col` where that element originated.

While I work on Vue and Angular support, this PR will probably be the last nail in wrapping up React support

### Please watch screencast to see aforementioned stuff in action
## [▶ Watch ScreenCast](https://drive.google.com/open?id=1NYrHJ8onFgoAM9UIyZ8XNZoIGneK8JxA)
