### PR TITLE
Fix literal type annotation argument number

### DIFF
--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -183,14 +183,14 @@ Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
 ### booleanLiteralTypeAnnotation
 ```javascript
-t.booleanLiteralTypeAnnotation()
+t.booleanLiteralTypeAnnotation(value)
 ```
 
 See also `t.isBooleanLiteralTypeAnnotation(node, opts)` and `t.assertBooleanLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `value`: `boolean` (default: `null`)
+ - `value`: `boolean` (required)
 
 ---
 
@@ -1408,14 +1408,14 @@ Aliases: `Flow`, `FlowType`
 
 ### numberLiteralTypeAnnotation
 ```javascript
-t.numberLiteralTypeAnnotation()
+t.numberLiteralTypeAnnotation(value)
 ```
 
 See also `t.isNumberLiteralTypeAnnotation(node, opts)` and `t.assertNumberLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `value`: `number` (default: `null`)
+ - `value`: `number` (required)
 
 ---
 
@@ -1776,14 +1776,14 @@ Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
 ### stringLiteralTypeAnnotation
 ```javascript
-t.stringLiteralTypeAnnotation()
+t.stringLiteralTypeAnnotation(value)
 ```
 
 See also `t.isStringLiteralTypeAnnotation(node, opts)` and `t.assertStringLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `value`: `string` (default: `null`)
+ - `value`: `string` (required)
 
 ---
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -26,6 +26,7 @@ defineType("BooleanTypeAnnotation", {
 });
 
 defineType("BooleanLiteralTypeAnnotation", {
+  builder: ["value"],
   aliases: ["Flow", "FlowType"],
   fields: {
     value: validate(assertValueType("boolean")),
@@ -239,6 +240,7 @@ defineType("NullableTypeAnnotation", {
 });
 
 defineType("NumberLiteralTypeAnnotation", {
+  builder: ["value"],
   aliases: ["Flow", "FlowType"],
   fields: {
     value: validate(assertValueType("number")),
@@ -329,6 +331,7 @@ defineType("QualifiedTypeIdentifier", {
 });
 
 defineType("StringLiteralTypeAnnotation", {
+  builder: ["value"],
   aliases: ["Flow", "FlowType"],
   fields: {
     value: validate(assertValueType("string")),


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7697
| Patch: Bug Fix?          | 🐛 
| Major: Breaking Change?  | Maybe (see below)
| Minor: New Feature?      |
| Tests Added + Pass?      | No tests added
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

The flow literal type creation functions in the `@babel/types` package did not take any arguments. As discussed in the linked issue they will need to have the single required  `value` argument listed in the definitions file. I ran the build and also updated the README.
Technically this is a breaking change since the functions now require an argument but they did not work before so I don't think anybody was able to use them without arguments.

There are more functions that have a mismatch of arguments in the fields definition and visitors/builders. I can maybe work on that in the future. Is there someone particularly responsible/invested in the _types_ package?