### PR TITLE
Migrate more packages' tests to use jest expect assertions

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -28,17 +28,6 @@ const testContext = vm.createContext({
 });
 testContext.global = testContext;
 
-// Add chai's assert to the global context
-// It has to be required inside the testContext as otherwise some assertions do not
-// work as chai would reference globals (RegExp, Array, ...) from this context
-vm.runInContext(
-  "(function(require) { global.assert=require('chai').assert; });",
-  testContext,
-  {
-    displayErrors: true,
-  },
-)(id => runModuleInTestContext(id, __filename));
-
 // Initialize the test context with the polyfill, and then freeze the global to prevent implicit
 // global creation in tests, which could cause things to bleed between tests.
 runModuleInTestContext("@babel/polyfill", __filename);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/exec.js
@@ -19,4 +19,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello, 'hello');
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/input.js
@@ -19,4 +19,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello, 'hello');
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
@@ -38,4 +38,4 @@ function (_Hello) {
   return Outer;
 }(Hello);
 
-assert.equal(new Outer().hello, 'hello');
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/exec.js
@@ -16,4 +16,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello, 'hello');
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/input.js
@@ -16,4 +16,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello, 'hello');
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -45,4 +45,4 @@ function (_Hello) {
   return Outer;
 }(Hello);
 
-assert.equal(new Outer().hello, 'hello');
+expect(new Outer().hello).toBe('hello');

--- a/packages/babel-plugin-proposal-optional-catch-binding/test/fixtures/optional-catch-bindings/exec.js
+++ b/packages/babel-plugin-proposal-optional-catch-binding/test/fixtures/optional-catch-bindings/exec.js
@@ -6,7 +6,7 @@ const test = () => {
     return true;
   }
 }
-assert(test());
+expect(test()).toBe(true);
 
 const test2 = () => {
   try {
@@ -16,4 +16,4 @@ const test2 = () => {
     return true;
   }
 }
-assert(test2());
+expect(test2()).toBe(true);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/duplicate-function-scope.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/duplicate-function-scope.js
@@ -7,4 +7,4 @@ function test () {
   }();
 }
 
-assert(test(), "inner");
+expect(test()).toBe("inner");

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/for-continuation-outer-reference.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/for-continuation-outer-reference.js
@@ -10,4 +10,4 @@ for (let index = 0; index < data.length; index++) {
     let fn = function () {item;};
 }
 
-assert(data.every(item => item));
+expect(data.every(item => item)).toBe(true);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/scope-bindings.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/scope-bindings.js
@@ -13,12 +13,12 @@ var res = transform(code, {
           Scope: {
             exit: function(path) {
               if (innerScope) {
-                assert(Object.keys(path.scope.bindings).length === 0, 'Inner scope should not have any bindings');
+                expect(Object.keys(path.scope.bindings)).toHaveLength(0);
                 innerScope = false;
                 return;
               }
 
-              assert(Object.keys(path.scope.bindings).length === 2, 'Outer scope subsume the inner-scope binding');
+              expect(Object.keys(path.scope.bindings)).toHaveLength(2);
             }
           }
         }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/switch-break.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/switch-break.js
@@ -2,7 +2,7 @@ if (true) {
   const x = 1;
   switch (x) {
     case 1: {
-      assert(x, 1);
+      expect(x).toBe(1);
       break;
     }
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/exec.js
@@ -19,5 +19,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/input.js
@@ -11,5 +11,5 @@ class Obj extends Base {
 Obj.prototype.test = 2;
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
@@ -49,5 +49,5 @@ function (_Base) {
 
 Obj.prototype.test = 2;
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/exec.js
@@ -1,7 +1,7 @@
 "use strict";
 class Base {
   get test() {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     return 1;
   }
 }
@@ -18,5 +18,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/input.js
@@ -1,7 +1,7 @@
 "use strict";
 class Base {
   get test() {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     return 1;
   }
 }
@@ -18,5 +18,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
@@ -30,7 +30,7 @@ function () {
   _createClass(Base, [{
     key: "test",
     get: function () {
-      assert.equal(this, obj);
+      expect(this).toBe(obj);
       return 1;
     }
   }]);
@@ -65,5 +65,5 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/exec.js
@@ -14,5 +14,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/input.js
@@ -14,5 +14,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
@@ -51,5 +51,5 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/exec.js
@@ -17,5 +17,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/input.js
@@ -17,5 +17,5 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
@@ -64,5 +64,5 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/exec.js
@@ -19,7 +19,7 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, 1);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBe(1);
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/input.js
@@ -19,7 +19,7 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, 1);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBe(1);
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
@@ -61,7 +61,7 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, 1);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBe(1);
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/exec.js
@@ -19,10 +19,10 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(called, false);
-assert.equal(Base.prototype.test, 1);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(called).toBe(false);
+expect(Base.prototype.test).toBe(1);
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/input.js
@@ -17,11 +17,11 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.throws(() => {
+expect(() => {
   // this requires helpers to be in file (not external), so they
   // are in "strict" mode code.
   obj.set();
-});
-assert.equal(Base.prototype.test, 1);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.prototype.test).toBe(1);
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
@@ -70,11 +70,11 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.throws(() => {
+expect(() => {
   // this requires helpers to be in file (not external), so they
   // are in "strict" mode code.
   obj.set();
-});
-assert.equal(Base.prototype.test, 1);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.prototype.test).toBe(1);
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/exec.js
@@ -14,7 +14,7 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/input.js
@@ -14,7 +14,7 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -55,7 +55,7 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/exec.js
@@ -14,8 +14,8 @@ class Obj extends Base {
 }
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(called, false);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(called).toBe(false);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/input.js
@@ -11,7 +11,7 @@ class Obj extends Base {
 }
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -53,7 +53,7 @@ function (_Base) {
 }(Base);
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/exec.js
@@ -9,7 +9,7 @@ class Obj extends Base {
 }
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/input.js
@@ -9,7 +9,7 @@ class Obj extends Base {
 }
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -50,7 +50,7 @@ function (_Base) {
 }(Base);
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/exec.js
@@ -14,8 +14,8 @@ class Obj extends Base {
 }
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(value, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(value).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/input.js
@@ -5,7 +5,7 @@ class Base {
 let value = 2;
 class Obj extends Base {
   set test(v) {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     value = v;
   }
 
@@ -15,8 +15,8 @@ class Obj extends Base {
 }
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(value, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(value).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -49,7 +49,7 @@ function (_Base) {
   }, {
     key: "test",
     set: function (v) {
-      assert.equal(this, obj);
+      expect(this).toBe(obj);
       value = v;
     }
   }]);
@@ -58,8 +58,8 @@ function (_Base) {
 }(Base);
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, undefined);
-assert.equal(value, 2);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBeUndefined();
+expect(value).toBe(2);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/exec.js
@@ -18,8 +18,8 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(value, 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(value).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/input.js
@@ -18,8 +18,8 @@ Object.defineProperty(Obj.prototype, 'test', {
 });
 
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(value, 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(value).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
@@ -70,8 +70,8 @@ Object.defineProperty(Obj.prototype, 'test', {
   configurable: true
 });
 const obj = new Obj();
-assert.equal(obj.set(), 3);
-assert.equal(value, 3);
-assert.equal(Base.prototype.test, undefined);
-assert.equal(Obj.prototype.test, 2);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(value).toBe(3);
+expect(Base.prototype.test).toBeUndefined();
+expect(Obj.prototype.test).toBe(2);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/exec.js
@@ -1,6 +1,6 @@
 class Point {
   getX() {
-    assert.equal(this.x, 3); // C
+    expect(this.x).toBe(3); // C
   }
 }
 
@@ -9,8 +9,8 @@ class ColorPoint extends Point {
     super();
     this.x = 2;
     super.x = 3;
-    assert.equal(this.x, 3)   // A
-    assert.equal(super.x, undefined)  // B
+    expect(this.x).toBe(3);   // A
+    expect(super.x).toBeUndefined();  // B
   }
 
   m() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/input.js
@@ -1,6 +1,6 @@
 class Point {
   getX() {
-    assert.equal(this.x, 3); // C
+    expect(this.x).toBe(3); // C
   }
 }
 
@@ -9,8 +9,8 @@ class ColorPoint extends Point {
     super();
     this.x = 2;
     super.x = 3;
-    assert.equal(this.x, 3);   // A
-    assert.equal(super.x, undefined);  // B
+    expect(this.x).toBe(3);   // A
+    expect(super.x).toBeUndefined();  // B
   }
 
   m() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -10,7 +10,7 @@ function () {
   babelHelpers.createClass(Point, [{
     key: "getX",
     value: function getX() {
-      assert.equal(this.x, 3); // C
+      expect(this.x).toBe(3); // C
     }
   }]);
   return Point;
@@ -29,10 +29,10 @@ function (_Point) {
     babelHelpers.classCallCheck(this, ColorPoint);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(ColorPoint).call(this));
     _this.x = 2;
-    babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, _this, true)
-    assert.equal(_this.x, 3); // A
+    babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, _this, true);
+    expect(_this.x).toBe(3); // A
 
-    assert.equal(babelHelpers.get(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", babelHelpers.assertThisInitialized(_this)), undefined); // B
+    expect(babelHelpers.get(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", babelHelpers.assertThisInitialized(_this))).toBeUndefined(); // B
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -29,7 +29,7 @@ function (_Point) {
     babelHelpers.classCallCheck(this, ColorPoint);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(ColorPoint).call(this));
     _this.x = 2;
-    babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, _this, true);
+    babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, _this, true)
     expect(_this.x).toBe(3); // A
 
     expect(babelHelpers.get(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", babelHelpers.assertThisInitialized(_this))).toBeUndefined(); // B

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/exec.js
@@ -13,4 +13,4 @@ class Table extends Parent {
 
 const table = new Table();
 
-assert(table.returnParam(false) === false);
+expect(table.returnParam(false)).toBe(false);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/exec.js
@@ -21,4 +21,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/input.js
@@ -21,4 +21,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
@@ -44,4 +44,4 @@ function (_Hello) {
   return Outer;
 }(Hello);
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/exec.js
@@ -18,4 +18,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/input.js
@@ -18,4 +18,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -51,4 +51,4 @@ function (_Hello) {
   return Outer;
 }(Hello);
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/exec.js
@@ -21,4 +21,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/input.js
@@ -21,4 +21,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
@@ -31,4 +31,4 @@ function (_Hello) {
   return Outer;
 }(Hello);
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/exec.js
@@ -18,4 +18,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/input.js
@@ -18,4 +18,4 @@ class Outer extends Hello {
   }
 }
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -38,4 +38,4 @@ function (_Hello) {
   return Outer;
 }(Hello);
 
-assert.equal(new Outer().hello(), 'hello');
+expect(new Outer().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/loose/symbol/exec.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/loose/symbol/exec.js
@@ -6,5 +6,5 @@ var foo = {
   }
 };
 
-assert(foo[Symbol.iterator], "foobar")
-assert(foo[k], k)
+expect(foo[Symbol.iterator]).toBe("foobar")
+expect(foo[k]).toBe(k)

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/symbol/exec.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/symbol/exec.js
@@ -6,5 +6,5 @@ var foo = {
   }
 };
 
-assert(foo[Symbol.iterator], "foobar")
-assert(foo[k], k)
+expect(foo[Symbol.iterator]).toBe("foobar")
+expect(foo[k]).toBe(k)

--- a/packages/babel-plugin-transform-jscript/test/fixtures/jscript/arrow-function/exec.js
+++ b/packages/babel-plugin-transform-jscript/test/fixtures/jscript/arrow-function/exec.js
@@ -6,4 +6,4 @@ class MyClass {
   }
 }
 
-assert(new MyClass().test());
+expect(new MyClass().test()).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-data-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-data-defined-on-parent/exec.js
@@ -12,5 +12,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-data-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-data-defined-on-parent/input.js
@@ -12,5 +12,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
@@ -20,5 +20,5 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-getter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-getter-defined-on-parent/exec.js
@@ -1,7 +1,7 @@
 "use strict";
 const Base = {
   get test() {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     return 1;
   }
 };
@@ -15,5 +15,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-getter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-getter-defined-on-parent/input.js
@@ -1,7 +1,7 @@
 "use strict";
 const Base = {
   get test() {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     return 1;
   }
 };
@@ -15,5 +15,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
@@ -10,7 +10,7 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || functio
 
 const Base = {
   get test() {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     return 1;
   }
 
@@ -24,5 +24,5 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), 1);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBe(1);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-not-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-not-defined-on-parent/exec.js
@@ -11,5 +11,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-not-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-not-defined-on-parent/input.js
@@ -11,5 +11,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
@@ -18,5 +18,5 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-setter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-setter-defined-on-parent/exec.js
@@ -14,5 +14,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-setter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-setter-defined-on-parent/input.js
@@ -14,5 +14,5 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
@@ -23,5 +23,5 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.test, 2);
-assert.equal(obj.get(), undefined);
+expect(obj.test).toBe(2);
+expect(obj.get()).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-defined-on-parent/exec.js
@@ -12,6 +12,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-defined-on-parent/input.js
@@ -12,6 +12,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, 3);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBe(3);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
@@ -24,6 +24,6 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, 3);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBe(3);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-non-configurable-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-non-configurable-defined-on-parent/exec.js
@@ -16,6 +16,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-non-writable-defined-on-parent-loose/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-non-writable-defined-on-parent-loose/exec.js
@@ -15,6 +15,6 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-non-writable-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-data-non-writable-defined-on-parent/exec.js
@@ -16,8 +16,8 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-getter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-getter-defined-on-parent/exec.js
@@ -16,9 +16,9 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(called, false);
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(called).toBe(false);
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-getter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-getter-defined-on-parent/input.js
@@ -14,10 +14,10 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   // this requires helpers to be in file (not external), so they
   // are in "strict" mode code.
   obj.set();
-});
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
@@ -27,10 +27,10 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.throws(() => {
+expect(() => {
   // this requires helpers to be in file (not external), so they
   // are in "strict" mode code.
   obj.set();
-});
-assert.equal(Base.test, 1);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.test).toBe(1);
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-configurable-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-configurable-on-obj/exec.js
@@ -15,11 +15,11 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, false);
-assert.equal(desc.writable, true);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(false);
+expect(desc.writable).toBe(true);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-configurable-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-configurable-on-obj/input.js
@@ -15,11 +15,11 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, false);
-assert.equal(desc.writable, true);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(false);
+expect(desc.writable).toBe(true);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-configurable-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-configurable-on-obj/output.js
@@ -26,10 +26,10 @@ Object.defineProperty(obj, 'test', {
   enumerable: true
 });
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, false);
-assert.equal(desc.writable, true);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(false);
+expect(desc.writable).toBe(true);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-enumerable-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-enumerable-on-obj/exec.js
@@ -15,11 +15,11 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, true);
-assert.equal(desc.enumerable, false);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(true);
+expect(desc.enumerable).toBe(false);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-enumerable-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-enumerable-on-obj/input.js
@@ -15,11 +15,11 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, true);
-assert.equal(desc.enumerable, false);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(true);
+expect(desc.enumerable).toBe(false);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-enumerable-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-enumerable-on-obj/output.js
@@ -26,10 +26,10 @@ Object.defineProperty(obj, 'test', {
   enumerable: false
 });
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, true);
-assert.equal(desc.enumerable, false);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(true);
+expect(desc.enumerable).toBe(false);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj-loose/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj-loose/exec.js
@@ -14,11 +14,11 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, false);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(false);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj/exec.js
@@ -15,13 +15,13 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, false);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(false);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj/input.js
@@ -15,13 +15,13 @@ Object.defineProperty(obj, 'test', {
 });
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);
 
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, false);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(false);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-non-writable-on-obj/output.js
@@ -26,12 +26,12 @@ Object.defineProperty(obj, 'test', {
   enumerable: true
 });
 Object.setPrototypeOf(obj, Base);
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+}).toThrow();
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);
 const desc = Object.getOwnPropertyDescriptor(obj, 'test');
-assert.equal(desc.configurable, true);
-assert.equal(desc.writable, false);
-assert.equal(desc.enumerable, true);
+expect(desc.configurable).toBe(true);
+expect(desc.writable).toBe(false);
+expect(desc.enumerable).toBe(true);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/exec.js
@@ -11,6 +11,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/input.js
@@ -11,6 +11,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -22,6 +22,6 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj-loose/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj-loose/exec.js
@@ -13,7 +13,7 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(called, false);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, undefined);
+expect(obj.set()).toBe(3);
+expect(called).toBe(false);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/exec.js
@@ -14,9 +14,9 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(called, false);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, undefined);
+}).toThrow();
+expect(called).toBe(false);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/input.js
@@ -11,10 +11,10 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   // this requires helpers to be in file (not external), so they
   // are in "strict" mode code.
   obj.set();
-});
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, undefined);
+}).toThrow();
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -22,10 +22,10 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.throws(() => {
+expect(() => {
   // this requires helpers to be in file (not external), so they
   // are in "strict" mode code.
   obj.set();
-});
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, undefined);
+}).toThrow();
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/exec.js
@@ -9,6 +9,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/input.js
@@ -9,6 +9,6 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -20,6 +20,6 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 3);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(3);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj-loose/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj-loose/exec.js
@@ -13,7 +13,7 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(value, 2);
-assert.equal(obj.test, undefined);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(value).toBe(2);
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/exec.js
@@ -14,9 +14,9 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.throws(() => {
+expect(() => {
   obj.set();
-});
-assert.equal(value, 2);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, undefined);
+}).toThrow();
+expect(value).toBe(2);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/input.js
@@ -5,7 +5,7 @@ const Base = {
 let value = 2;
 const obj = {
   set test(v) {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     value = v;
   },
 
@@ -15,7 +15,7 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(value, 3);
-assert.equal(obj.test, undefined);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(value).toBe(3);
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -16,7 +16,7 @@ const Base = {};
 let value = 2;
 const obj = _obj = {
   set test(v) {
-    assert.equal(this, obj);
+    expect(this).toBe(obj);
     value = v;
   },
 
@@ -26,7 +26,7 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(Base.test, undefined);
-assert.equal(value, 3);
-assert.equal(obj.test, undefined);
+expect(obj.set()).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(value).toBe(3);
+expect(obj.test).toBeUndefined();

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-setter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-setter-defined-on-parent/exec.js
@@ -15,7 +15,7 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(value, 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(value).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-setter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-setter-defined-on-parent/input.js
@@ -15,7 +15,7 @@ const obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.equal(obj.set(), 3);
-assert.equal(value, 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(value).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
@@ -28,7 +28,7 @@ const obj = _obj = {
 
 };
 Object.setPrototypeOf(obj, Base);
-assert.equal(obj.set(), 3);
-assert.equal(value, 3);
-assert.equal(Base.test, undefined);
-assert.equal(obj.test, 2);
+expect(obj.set()).toBe(3);
+expect(value).toBe(3);
+expect(Base.test).toBeUndefined();
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-class-super-property-in-key/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-class-super-property-in-key/exec.js
@@ -18,4 +18,4 @@ const Outer = {
 };
 Object.setPrototypeOf(Outer, Hello);
 
-assert.equal(Outer.constructor().hello(), 'hello');
+expect(Outer.constructor().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-class-super-property-in-key/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-class-super-property-in-key/input.js
@@ -18,4 +18,4 @@ const Outer = {
 };
 Object.setPrototypeOf(Outer, Hello);
 
-assert.equal(Outer.constructor().hello(), 'hello');
+expect(Outer.constructor().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-class-super-property-in-key/output.js
@@ -20,4 +20,4 @@ const Outer = _obj = {
   }
 };
 Object.setPrototypeOf(Outer, Hello);
-assert.equal(Outer.constructor().hello(), 'hello');
+expect(Outer.constructor().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-object-super-property-in-key/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-object-super-property-in-key/exec.js
@@ -18,4 +18,4 @@ const Outer = {
 };
 Object.setPrototypeOf(Outer, Hello);
 
-assert.equal(Outer.constructor().hello(), 'hello');
+expect(Outer.constructor().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-object-super-property-in-key/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-object-super-property-in-key/input.js
@@ -18,4 +18,4 @@ const Outer = {
 };
 Object.setPrototypeOf(Outer, Hello);
 
-assert.equal(Outer.constructor().hello(), 'hello');
+expect(Outer.constructor().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/nested-object-super-property-in-key/output.js
@@ -18,4 +18,4 @@ const Outer = _obj = {
   }
 };
 Object.setPrototypeOf(Outer, Hello);
-assert.equal(Outer.constructor().hello(), 'hello');
+expect(Outer.constructor().hello()).toBe('hello');

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/exec.js
@@ -9,6 +9,6 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.strictEqual(obj.bar(), 1);
-assert.strictEqual(Base.test, '1');
-assert.strictEqual(obj.test, 2);
+expect(obj.bar()).toBe(1);
+expect(Base.test).toBe('1');
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/input.js
@@ -9,6 +9,6 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.strictEqual(obj.bar(), 1);
-assert.strictEqual(Base.test, '1');
-assert.strictEqual(obj.test, 2);
+expect(obj.bar()).toBe(1);
+expect(Base.test).toBe('1');
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/output.js
@@ -11,6 +11,6 @@ var obj = _obj = {
   }
 };
 Object.setPrototypeOf(obj, Base);
-assert.strictEqual(obj.bar(), 1);
-assert.strictEqual(Base.test, '1');
-assert.strictEqual(obj.test, 2);
+expect(obj.bar()).toBe(1);
+expect(Base.test).toBe('1');
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/exec.js
@@ -9,6 +9,6 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.strictEqual(obj.bar(), 2);
-assert.strictEqual(Base.test, '1');
-assert.strictEqual(obj.test, 2);
+expect(obj.bar()).toBe(2);
+expect(Base.test).toBe('1');
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/input.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/input.js
@@ -9,6 +9,6 @@ var obj = {
 };
 Object.setPrototypeOf(obj, Base);
 
-assert.strictEqual(obj.bar(), 2);
-assert.strictEqual(Base.test, '1');
-assert.strictEqual(obj.test, 2);
+expect(obj.bar()).toBe(2);
+expect(Base.test).toBe('1');
+expect(obj.test).toBe(2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/output.js
@@ -11,6 +11,6 @@ var obj = _obj = {
   }
 };
 Object.setPrototypeOf(obj, Base);
-assert.strictEqual(obj.bar(), 2);
-assert.strictEqual(Base.test, '1');
-assert.strictEqual(obj.test, 2);
+expect(obj.bar()).toBe(2);
+expect(Base.test).toBe('1');
+expect(obj.test).toBe(2);


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Working towards #7476 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | NA
| Major: Breaking Change?  | Yes, removed `chai.assert` from the context in which test fixtures are run
| Minor: New Feature?      | NA
| Tests Added + Pass?      | 👍
| Documentation PR         | NA
| Any Dependency Changes?  | NA
| License                  | MIT

* Migrate -optional-catch-binding, -block-scoping to use jest expect assertions
* Migrate -transform-classes tests to use jest expect assertions
* Migrate -transform-object-super tests to use jest expect assertions
* Migrate -computed-properties and -jscript tests to use jest expect assertions