### PR TITLE
Uncomment super increment expression set tests

### DIFF
--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/exec.js
@@ -11,5 +11,4 @@ Object.setPrototypeOf(obj, Base);
 
 assert.strictEqual(obj.bar(), 1);
 assert.strictEqual(Base.test, '1');
-// TODO(jridgewell): Post #7687, uncomment this.
-// assert.strictEqual(obj.test, 2);
+assert.strictEqual(obj.test, 2);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/exec.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/exec.js
@@ -11,5 +11,4 @@ Object.setPrototypeOf(obj, Base);
 
 assert.strictEqual(obj.bar(), 2);
 assert.strictEqual(Base.test, '1');
-// TODO(jridgewell): Post #7687, uncomment this.
-// assert.strictEqual(obj.test, 2);
+assert.strictEqual(obj.test, 2);


### PR DESCRIPTION
This was failing because of the bugs fixed by #7687.

Fixes #7703.