### PR TITLE
Classes cleanup

### DIFF
--- a/packages/babel-plugin-transform-classes/src/transformClass.js
+++ b/packages/babel-plugin-transform-classes/src/transformClass.js
@@ -209,21 +209,13 @@ export default function transformClass(
           path.traverse(verifyConstructorVisitor);
         }
 
-        const replaceSupers = new ReplaceSupers(
-          {
-            forceSuperMemoisation: isConstructor,
-            methodPath: path,
-            methodNode: node,
-            objectRef: classState.classRef,
-            superRef: classState.superName,
-            inConstructor: isConstructor,
-            isStatic: node.static,
-            isLoose: classState.isLoose,
-            scope: classState.scope,
-            file: classState.file,
-          },
-          true,
-        );
+        const replaceSupers = new ReplaceSupers({
+          methodPath: path,
+          objectRef: classState.classRef,
+          superRef: classState.superName,
+          isLoose: classState.isLoose,
+          file: classState.file,
+        });
 
         replaceSupers.replace();
 

--- a/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/output.js
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/fixtures/regression/4349/output.js
@@ -14,9 +14,9 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || functio
 
 foo = _obj = {
   bar() {
-    var _ref;
+    var _super$baz;
 
-    return _ref = _get(_getPrototypeOf(_obj), "baz", this), _set(_getPrototypeOf(_obj), "baz", Math.pow(_ref, 12), this, false);
+    return _super$baz = _get(_getPrototypeOf(_obj), "baz", this), _set(_getPrototypeOf(_obj), "baz", Math.pow(_super$baz, 12), this, false);
   }
 
 };

--- a/packages/babel-plugin-transform-object-super/src/index.js
+++ b/packages/babel-plugin-transform-object-super/src/index.js
@@ -2,13 +2,10 @@ import { declare } from "@babel/helper-plugin-utils";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import { types as t } from "@babel/core";
 
-function replacePropertySuper(path, node, scope, getObjectRef, file) {
+function replacePropertySuper(path, getObjectRef, file) {
   const replaceSupers = new ReplaceSupers({
     getObjectRef: getObjectRef,
-    methodNode: node,
     methodPath: path,
-    isStatic: true,
-    scope: scope,
     file: file,
   });
 
@@ -28,13 +25,7 @@ export default declare(api => {
         path.get("properties").forEach(propPath => {
           if (!propPath.isMethod()) return;
 
-          replacePropertySuper(
-            propPath,
-            propPath.node,
-            path.scope,
-            getObjectRef,
-            state,
-          );
+          replacePropertySuper(propPath, getObjectRef, state);
         });
 
         if (objectRef) {

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-exponentiation/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-exponentiation/output.js
@@ -14,8 +14,8 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || functio
 
 foo = _obj = {
   bar: function () {
-    var _ref;
+    var _super$baz;
 
-    return _ref = _get(_getPrototypeOf(_obj), "baz", this), _set(_getPrototypeOf(_obj), "baz", _ref ** 12, this, false);
+    return _super$baz = _get(_getPrototypeOf(_obj), "baz", this), _set(_getPrototypeOf(_obj), "baz", _super$baz ** 12, this, false);
   }
 };

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-postfix/output.js
@@ -5,9 +5,9 @@ var Base = {
 };
 var obj = _obj = {
   bar: function () {
-    var _ref;
+    var _super$test;
 
-    return _ref = Number(babelHelpers.get(babelHelpers.getPrototypeOf(_obj), "test", this)), babelHelpers.set(babelHelpers.getPrototypeOf(_obj), "test", _ref + 1, this, false), _ref;
+    return _super$test = Number(babelHelpers.get(babelHelpers.getPrototypeOf(_obj), "test", this)), babelHelpers.set(babelHelpers.getPrototypeOf(_obj), "test", _super$test + 1, this, false), _super$test;
   }
 };
 Object.setPrototypeOf(obj, Base);

--- a/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/output.js
+++ b/packages/babel-plugin-transform-object-super/test/fixtures/object-super/super-increment-prefix/output.js
@@ -5,9 +5,9 @@ var Base = {
 };
 var obj = _obj = {
   bar: function () {
-    var _ref;
+    var _super$test;
 
-    return _ref = Number(babelHelpers.get(babelHelpers.getPrototypeOf(_obj), "test", this)), babelHelpers.set(babelHelpers.getPrototypeOf(_obj), "test", _ref + 1, this, false);
+    return _super$test = Number(babelHelpers.get(babelHelpers.getPrototypeOf(_obj), "test", this)), babelHelpers.set(babelHelpers.getPrototypeOf(_obj), "test", _super$test + 1, this, false);
   }
 };
 Object.setPrototypeOf(obj, Base);

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -40,6 +40,8 @@ function gatherNodeParts(node: Object, parts: Array) {
     gatherNodeParts(node.id, parts);
   } else if (t.isThisExpression(node)) {
     parts.push("this");
+  } else if (t.isSuper(node)) {
+    parts.push("super");
   }
 }
 


### PR DESCRIPTION
Removes a bunch of state needed for `replaceSupers`, and moves a visitor declaration out of the `transformClass` function.

This is just the first in a series of PRs I'll be making to clean up the class transforms.