### PR TITLE
Fix type error

### DIFF
--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -1425,7 +1425,7 @@ export default class StatementParser extends ExpressionParser {
       this.match(tt._const) ||
       this.match(tt._var)
     ) {
-      this.raise(
+      return this.raise(
         this.state.start,
         "Only expressions, functions or classes are allowed as the `default` export.",
       );


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         |
| Any Dependency Changes?  |
| License                  | MIT

Fixes a type error: We need to `return this.raise` or else this function is considered to potentially return `undefined`.