### PR TITLE
Fix small typo with decorators legacy option [skip ci]

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/index.js
+++ b/packages/babel-plugin-proposal-decorators/src/index.js
@@ -14,7 +14,7 @@ export default declare((api, options) => {
   if (legacy !== true) {
     throw new Error(
       "The new decorators proposal is not supported yet." +
-        ' You muse pass the `"legacy": true` option to' +
+        ' You must pass the `"legacy": true` option to' +
         " @babel/plugin-proposal-decorators",
     );
   }

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -25,7 +25,7 @@ export default declare((api, opts = {}) => {
   if (decoratorsLegacy !== true) {
     throw new Error(
       "The new decorators proposal is not supported yet." +
-        ' You muse pass the `"decoratorsLegacy": true` option to' +
+        ' You must pass the `"decoratorsLegacy": true` option to' +
         " @babel/preset-stage-0",
     );
   }

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -30,7 +30,7 @@ export default declare((api, opts = {}) => {
   if (decoratorsLegacy !== true) {
     throw new Error(
       "The new decorators proposal is not supported yet." +
-        ' You muse pass the `"decoratorsLegacy": true` option to' +
+        ' You must pass the `"decoratorsLegacy": true` option to' +
         " @babel/preset-stage-1",
     );
   }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -29,7 +29,7 @@ export default declare((api, opts = {}) => {
   if (decoratorsLegacy !== true) {
     throw new Error(
       "The new decorators proposal is not supported yet." +
-        ' You muse pass the `"decoratorsLegacy": true` option to' +
+        ' You must pass the `"decoratorsLegacy": true` option to' +
         " @babel/preset-stage-2",
     );
   }


### PR DESCRIPTION
Thanks @TrejGun.

https://github.com/babel/babel/commit/339dfddca55728efac5e2865e2f1d0f3c5caadbf#r28663655