### PR TITLE
Fix default sourceFileName.

### DIFF
--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -14,7 +14,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
     moduleRoot,
     sourceRoot = moduleRoot,
 
-    sourceFileName = filenameRelative,
+    sourceFileName = path.basename(filenameRelative),
 
     comments = true,
     compact = "auto",

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -38,7 +38,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
 
     generatorOpts: {
       // General generator flags.
-      filename: filenameRelative,
+      filename,
 
       auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
       auxiliaryCommentAfter: opts.auxiliaryCommentAfter,

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -17,7 +17,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
     moduleRoot,
     sourceRoot = moduleRoot,
 
-    sourceFileName = filenameRelative,
+    sourceFileName = path.basename(filenameRelative),
 
     comments = true,
     compact = "auto",

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -6,7 +6,10 @@ import type { ResolvedConfig } from "../config";
 export default function normalizeOptions(config: ResolvedConfig): {} {
   const {
     filename,
-    filenameRelative = filename || "unknown",
+    cwd,
+    filenameRelative = typeof filename === "string"
+      ? path.relative(cwd, filename)
+      : "unknown",
     sourceType = "module",
     inputSourceMap,
     sourceMaps = !!inputSourceMap,
@@ -14,7 +17,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
     moduleRoot,
     sourceRoot = moduleRoot,
 
-    sourceFileName = path.basename(filenameRelative),
+    sourceFileName = filenameRelative,
 
     comments = true,
     compact = "auto",
@@ -24,7 +27,6 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
 
   const options = {
     ...opts,
-
     parserOpts: {
       sourceType:
         path.extname(filenameRelative) === ".mjs" ? "module" : sourceType,
@@ -36,7 +38,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
 
     generatorOpts: {
       // General generator flags.
-      filename,
+      filename: filenameRelative,
 
       auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
       auxiliaryCommentAfter: opts.auxiliaryCommentAfter,

--- a/packages/babel-core/src/transformation/normalize-opts.js
+++ b/packages/babel-core/src/transformation/normalize-opts.js
@@ -27,6 +27,7 @@ export default function normalizeOptions(config: ResolvedConfig): {} {
 
   const options = {
     ...opts,
+
     parserOpts: {
       sourceType:
         path.extname(filenameRelative) === ".mjs" ? "module" : sourceType,

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -400,7 +400,7 @@ describe("api", function() {
       filename: "/some/absolute/file/path.js",
       sourceMaps: true,
     }).then(function(result) {
-      expect(result.map.sources).toEqual(["file/path.js"]);
+      expect(result.map.sources).toEqual(["path.js"]);
     });
   });
 

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -394,6 +394,15 @@ describe("api", function() {
     });
   });
 
+  it("default source map filename", function() {
+    return transformAsync("var a = 10;", {
+      filename: "/some/absolute/file/path.js",
+      sourceMaps: true,
+    }).then(function(result) {
+      expect(result.map.sources).toEqual(["path.js"]);
+    });
+  });
+
   it("code option false", function() {
     return transformAsync("foo('bar');", { code: false }).then(function(
       result,

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -401,7 +401,6 @@ describe("api", function() {
       sourceMaps: true,
     }).then(function(result) {
       expect(result.map.sources).toEqual(["file/path.js"]);
-      expect(result.map.file).toEqual("file/path.js");
     });
   });
 

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -396,10 +396,12 @@ describe("api", function() {
 
   it("default source map filename", function() {
     return transformAsync("var a = 10;", {
+      cwd: "/some/absolute",
       filename: "/some/absolute/file/path.js",
       sourceMaps: true,
     }).then(function(result) {
-      expect(result.map.sources).toEqual(["path.js"]);
+      expect(result.map.sources).toEqual(["file/path.js"]);
+      expect(result.map.file).toEqual("file/path.js");
     });
   });
 

--- a/packages/babel-generator/src/source-map.js
+++ b/packages/babel-generator/src/source-map.js
@@ -19,6 +19,7 @@ export default class SourceMap {
   get() {
     if (!this._cachedMap) {
       const map = (this._cachedMap = new sourceMap.SourceMapGenerator({
+        file: this._opts.filename,
         sourceRoot: this._opts.sourceRoot,
       }));
 

--- a/packages/babel-generator/src/source-map.js
+++ b/packages/babel-generator/src/source-map.js
@@ -19,7 +19,6 @@ export default class SourceMap {
   get() {
     if (!this._cachedMap) {
       const map = (this._cachedMap = new sourceMap.SourceMapGenerator({
-        file: this._opts.filename,
         sourceRoot: this._opts.sourceRoot,
       }));
 


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babelify/pull/255#pullrequestreview-110196926
| Patch: Bug Fix?          | :raising_hand_woman: 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | :raising_hand_woman: 
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This deals with a problem mentioned in [babel/babelify#255][0]. I'm not
super sure about the implications, but it seems this may have been a
regression from Babel 6.

In babel@6, the default `sourceFileName` was the basename of the input
file:

```js
require('babel-core').transform('var a = 10', {
  filename: __filename,
  sourceMaps: true
}).map
// { version: 3,
//   sources: [ 'index.js' ],
//   names: [ 'a' ],
//   mappings: 'AAAA,IAAIA,IAAI,EAAR',
//   file: 'index.js',
//   sourcesContent: [ 'var a = 10' ] } }
```

Currently however, the full file path is used:

```js
require('@babel/core').transformSync('var a = 10', {
  filename: __filename,
  sourceMaps: true
}).map
// { version: 3,
//   sources: [ '/home/goto-bus-stop/Code/babel/repro-babelify-255/index.js' ],
//   names: [ 'a' ],
//   mappings: 'AAAA,IAAIA,IAAI,EAAR',
//   file: '/home/goto-bus-stop/Code/babel/repro-babelify-255/index.js',
//   sourcesContent: [ 'var a = 10' ] } }
```

This patch adds the `path.basename()` call that [Babel 6 used][1] to
@babel/core's default options, so it's the same as back then.

```js
require('../babel/packages/babel-core').transform('var a = 10', {
  filename: __filename,
  sourceMaps: true
}).map
// { version: 3,
//   sources: [ 'index.js' ],
//   names: [ 'a' ],
//   mappings: 'AAAA,IAAIA,IAAI,EAAR',
//   sourcesContent: [ 'var a = 10' ] }
```

This is the desired behaviour for browserify at least, as it expects
relative paths in the source maps and rebases them to a root directory
when generating the final source map.

[0]: https://github.com/babel/babelify/pull/255
[1]: https://github.com/babel/babel/blob/6689d2d23cdb607c326ed5a06855bfb84c050c56/packages/babel-core/src/transformation/file/index.js#L163-L172

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

<!-- Describe your changes below in as much detail as possible -->
