### PR TITLE
[bebal-generator] fix: don't write ': ' token when name is null

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -198,8 +198,10 @@ export function FunctionTypeAnnotation(node: Object, parent: Object) {
 export function FunctionTypeParam(node: Object) {
   this.print(node.name, node);
   if (node.optional) this.token("?");
-  this.token(":");
-  this.space();
+  if (node.name) {
+    this.token(":");
+    this.space();
+  }
   this.print(node.typeAnnotation, node);
 }
 

--- a/packages/babel-generator/test/fixtures/flow/type-alias/input.js
+++ b/packages/babel-generator/test/fixtures/flow/type-alias/input.js
@@ -12,3 +12,5 @@ type overloads =
   & ((x: string) => number)
   & ((x: number) => string)
 ;
+
+type func = string => string;

--- a/packages/babel-generator/test/fixtures/flow/type-alias/output.js
+++ b/packages/babel-generator/test/fixtures/flow/type-alias/output.js
@@ -8,3 +8,4 @@ type union = {
   type: "B"
 };
 type overloads = (x: string) => number & (x: number) => string;
+type func = (string) => string;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I found the following bug and this PR fixes it.

```
// @flow

// input source string
type fn = string => string;

// generated
type fn = (: string) => string;
```