### PR TITLE
Move subclass inheritance to end

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1155/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1155/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo(options) {
     babelHelpers.classCallCheck(this, Foo);
     var parentOptions = {};
@@ -16,5 +14,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, parentOptions));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -399,22 +399,14 @@ helpers.inherits = () => template.program.ast`
     if (typeof superClass !== "function" && superClass !== null) {
       throw new TypeError("Super expression must either be null or a function");
     }
-    subClass.prototype = Object.create(superClass && superClass.prototype, {
-      constructor: {
-        value: subClass,
-        enumerable: false,
-        writable: true,
-        configurable: true
-      }
-    });
+    setPrototypeOf(subClass.prototype, superClass && superClass.prototype);
     if (superClass) setPrototypeOf(subClass, superClass);
   }
 `;
 
 helpers.inheritsLoose = () => template.program.ast`
   export default function _inheritsLoose(subClass, superClass) {
-    subClass.prototype = Object.create(superClass.prototype);
-    subClass.prototype.constructor = subClass;
+    subClass.prototype.__proto__ = superClass && superClass.prototype;
     subClass.__proto__ = superClass;
   }
 `;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
@@ -13,8 +13,6 @@ let Hello = function Hello() {
 let Outer =
 /*#__PURE__*/
 function (_Hello) {
-  babelHelpers.inherits(Outer, _Hello);
-
   function Outer() {
     var _this;
 
@@ -30,6 +28,7 @@ function (_Hello) {
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
 
+  babelHelpers.inherits(Outer, _Hello);
   return Outer;
 }(Hello);
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -19,8 +19,6 @@ function () {
 let Outer =
 /*#__PURE__*/
 function (_Hello) {
-  babelHelpers.inherits(Outer, _Hello);
-
   function Outer() {
     var _this;
 
@@ -37,6 +35,7 @@ function (_Hello) {
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
 
+  babelHelpers.inherits(Outer, _Hello);
   return Outer;
 }(Hello);
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo(...args) {
     var _temp, _this;
 
@@ -12,5 +10,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args)), _this.bar = "foo", _temp));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
@@ -3,8 +3,6 @@ var Child =
 function (_Parent) {
   "use strict";
 
-  babelHelpers.inherits(Child, _Parent);
-
   function Child() {
     var _this;
 
@@ -18,5 +16,6 @@ function (_Parent) {
     return _this;
   }
 
+  babelHelpers.inherits(Child, _Parent);
   return Child;
 }(Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
@@ -6,13 +6,12 @@ function withContext(ComposedComponent) {
   function (_Component) {
     "use strict";
 
-    babelHelpers.inherits(WithContext, _Component);
-
     function WithContext() {
       babelHelpers.classCallCheck(this, WithContext);
       return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(WithContext).apply(this, arguments));
     }
 
+    babelHelpers.inherits(WithContext, _Component);
     return WithContext;
   }(Component), _class.propTypes = {
     context: PropTypes.shape({

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -21,8 +21,6 @@ var B =
 function (_A) {
   "use strict";
 
-  babelHelpers.inherits(B, _A);
-
   function B(...args) {
     var _temp, _this;
 
@@ -30,5 +28,6 @@ function (_A) {
     return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(_this), _temp));
   }
 
+  babelHelpers.inherits(B, _A);
   return B;
 }(A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-expression/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _temp, _this;
 
@@ -13,5 +11,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-statement/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -14,5 +12,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo(...args) {
     var _temp, _this;
 
@@ -12,5 +10,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), _temp));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
@@ -3,8 +3,6 @@ var Child =
 function (_Parent) {
   "use strict";
 
-  babelHelpers.inherits(Child, _Parent);
-
   function Child() {
     var _this;
 
@@ -16,5 +14,6 @@ function (_Parent) {
     return _this;
   }
 
+  babelHelpers.inherits(Child, _Parent);
   return Child;
 }(Parent);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
@@ -6,13 +6,12 @@ function withContext(ComposedComponent) {
   function (_Component) {
     "use strict";
 
-    babelHelpers.inherits(WithContext, _Component);
-
     function WithContext() {
       babelHelpers.classCallCheck(this, WithContext);
       return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(WithContext).apply(this, arguments));
     }
 
+    babelHelpers.inherits(WithContext, _Component);
     return WithContext;
   }(Component), babelHelpers.defineProperty(_class, "propTypes", {
     context: PropTypes.shape({

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -21,8 +21,6 @@ var B =
 function (_A) {
   "use strict";
 
-  babelHelpers.inherits(B, _A);
-
   function B(...args) {
     var _temp, _this;
 
@@ -30,5 +28,6 @@ function (_A) {
     return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(_this)), _temp));
   }
 
+  babelHelpers.inherits(B, _A);
   return B;
 }(A);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _temp, _this;
 
@@ -13,5 +11,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -14,5 +12,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -2,11 +2,11 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -30,8 +30,6 @@ var Test = function Test() {
   var Other =
   /*#__PURE__*/
   function (_Test) {
-    _inherits(Other, _Test);
-
     function Other() {
       var _getPrototypeOf2;
 
@@ -47,6 +45,8 @@ var Test = function Test() {
         return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));
       }), _temp));
     }
+
+    _inherits(Other, _Test);
 
     return Other;
   }(Test);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
@@ -6,13 +6,12 @@ function withContext(ComposedComponent) {
   function (_Component) {
     "use strict";
 
-    babelHelpers.inherits(WithContext, _Component);
-
     function WithContext() {
       babelHelpers.classCallCheck(this, WithContext);
       return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(WithContext).apply(this, arguments));
     }
 
+    babelHelpers.inherits(WithContext, _Component);
     return WithContext;
   }(Component), _class.propTypes = {
     context: PropTypes.shape({

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/regression/7030/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/regression/7030/output.js
@@ -4,15 +4,15 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function generateAsyncAction(type) {
   type = type.toUpperCase();
@@ -32,8 +32,6 @@ var A =
 function (_B) {
   "use strict";
 
-  _inherits(A, _B);
-
   function A(timestamp) {
     var _this;
 
@@ -44,6 +42,8 @@ function (_B) {
     _this.moment = moment(timestamp);
     return _this;
   }
+
+  _inherits(A, _B);
 
   return A;
 }(B);

--- a/packages/babel-plugin-transform-classes/src/transformClass.js
+++ b/packages/babel-plugin-transform-classes/src/transformClass.js
@@ -179,6 +179,7 @@ export default function transformClass(
     }
 
     pushDescriptors();
+    pushInheritsToBody();
   }
 
   function pushBody() {
@@ -236,8 +237,6 @@ export default function transformClass(
   }
 
   function pushDescriptors() {
-    pushInheritsToBody();
-
     const { body } = classState;
 
     let instanceProps;
@@ -538,8 +537,6 @@ export default function transformClass(
     }
 
     classState.body.push(classState.construct);
-
-    pushInheritsToBody();
   }
 
   /**
@@ -550,9 +547,9 @@ export default function transformClass(
 
     setState({ pushedInherits: true });
 
-    // Unshift to ensure that the constructor inheritance is set up before
+    // Push to ensure that the constructor inheritance is set up after
     // any properties can be assigned to the prototype.
-    classState.body.unshift(
+    classState.body.push(
       t.expressionStatement(
         t.callExpression(
           classState.file.addHelper(

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -1,4 +1,4 @@
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype.__proto__ = superClass && superClass.prototype; subClass.__proto__ = superClass; }
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() {} Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, _setPrototypeOf(function Super() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); }, Class)); }; return _wrapNativeSuper(Class); }
 
@@ -13,11 +13,11 @@ var List =
 function (_Array) {
   "use strict";
 
-  _inheritsLoose(List, _Array);
-
   function List() {
     return _Array.apply(this, arguments) || this;
   }
+
+  _inheritsLoose(List, _Array);
 
   return List;
 }(_wrapNativeSuper(Array));

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/shadowed/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/shadowed/output.js
@@ -9,12 +9,11 @@ let List =
 function (_Array) {
   "use strict";
 
-  babelHelpers.inherits(List, _Array);
-
   function List() {
     babelHelpers.classCallCheck(this, List);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(List).apply(this, arguments));
   }
 
+  babelHelpers.inherits(List, _Array);
   return List;
 }(Array);

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -1,10 +1,10 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() {} Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, _setPrototypeOf(function Super() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); }, Class)); }; return _wrapNativeSuper(Class); }
 
@@ -19,13 +19,13 @@ var List =
 function (_Array) {
   "use strict";
 
-  _inherits(List, _Array);
-
   function List() {
     _classCallCheck(this, List);
 
     return _possibleConstructorReturn(this, _getPrototypeOf(List).apply(this, arguments));
   }
+
+  _inherits(List, _Array);
 
   return List;
 }(_wrapNativeSuper(Array));

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -14,10 +18,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -29,8 +29,6 @@ Base.prototype.test = 1;
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -43,6 +41,8 @@ function (_Base) {
       return _get(_getPrototypeOf(Obj.prototype), "test", this);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
@@ -9,10 +13,6 @@ function _get(target, property, receiver) { if (typeof Reflect !== "undefined" &
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -41,8 +41,6 @@ function () {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -55,6 +53,8 @@ function (_Base) {
       return _get(_getPrototypeOf(Obj.prototype), "test", this);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -14,10 +18,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -27,8 +27,6 @@ let Base = function Base() {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -41,6 +39,8 @@ function (_Base) {
       return _get(_getPrototypeOf(Obj.prototype), "test", this);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
@@ -9,10 +13,6 @@ function _get(target, property, receiver) { if (typeof Reflect !== "undefined" &
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -40,8 +40,6 @@ function () {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -54,6 +52,8 @@ function (_Base) {
       return _get(_getPrototypeOf(Obj.prototype), "test", this);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -18,10 +22,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -37,8 +37,6 @@ Object.defineProperty(Base.prototype, 'test', {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -51,6 +49,8 @@ function (_Base) {
       return _set(_getPrototypeOf(Obj.prototype), "test", 3, this, true);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
@@ -13,10 +17,6 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -46,8 +46,6 @@ function () {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -60,6 +58,8 @@ function (_Base) {
       return _set(_getPrototypeOf(Obj.prototype), "test", 3, this, true);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -18,10 +22,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -31,8 +31,6 @@ let Base = function Base() {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -45,6 +43,8 @@ function (_Base) {
       return _set(_getPrototypeOf(Obj.prototype), "test", 3, this, true);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -18,10 +22,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -31,8 +31,6 @@ let Base = function Base() {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -48,6 +46,8 @@ function (_Base) {
     key: "test",
     get: function () {}
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -18,10 +22,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -31,8 +31,6 @@ let Base = function Base() {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -45,6 +43,8 @@ function (_Base) {
       return _set(_getPrototypeOf(Obj.prototype), "test", 3, this, true);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -18,10 +22,6 @@ function _superPropBase(object, property) { while (!Object.prototype.hasOwnPrope
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 let Base = function Base() {
@@ -33,8 +33,6 @@ let value = 2;
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -53,6 +51,8 @@ function (_Base) {
       value = v;
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
@@ -13,10 +17,6 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -46,8 +46,6 @@ function () {
 let Obj =
 /*#__PURE__*/
 function (_Base) {
-  _inherits(Obj, _Base);
-
   function Obj() {
     _classCallCheck(this, Obj);
 
@@ -60,6 +58,8 @@ function (_Base) {
       return _set(_getPrototypeOf(Obj.prototype), "test", 3, this, true);
     }
   }]);
+
+  _inherits(Obj, _Base);
 
   return Obj;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
@@ -1,6 +1,6 @@
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _inheritsLoose(subClass, superClass) { subClass.prototype.__proto__ = superClass && superClass.prototype; subClass.__proto__ = superClass; }
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 let B = function B() {
   "use strict";
@@ -11,14 +11,14 @@ let A =
 function (_B) {
   "use strict";
 
-  _inheritsLoose(A, _B);
-
   function A(track) {
     var _this;
 
     if (track !== undefined) _this = _B.call(this, track) || this;else _this = _B.call(this) || this;
     return _assertThisInitialized(_this);
   }
+
+  _inheritsLoose(A, _B);
 
   return A;
 }(B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
@@ -3,8 +3,6 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Test, _Foo);
-
   function Test() {
     var _Foo$prototype$test, _Foo$prototype$test2;
 
@@ -25,5 +23,6 @@ function (_Foo) {
     return _this;
   }
 
+  babelHelpers.inheritsLoose(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-properties/output.js
@@ -3,8 +3,6 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Test, _Foo);
-
   function Test() {
     var _this;
 
@@ -14,5 +12,6 @@ function (_Foo) {
     return _this;
   }
 
+  babelHelpers.inheritsLoose(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
@@ -3,8 +3,6 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Test, _Foo);
-
   function Test() {
     var _this;
 
@@ -21,5 +19,6 @@ function (_Foo) {
     return _Foo.wow.call(this);
   };
 
+  babelHelpers.inheritsLoose(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/output.js
@@ -3,13 +3,12 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Foo, _Bar);
-
   function Foo() {
     var _this;
 
     return babelHelpers.assertThisInitialized(_this);
   }
 
+  babelHelpers.inheritsLoose(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/output.js
@@ -3,13 +3,12 @@ var Child =
 function (_Base) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Child, _Base);
-
   function Child() {
     var _this;
 
     return false || babelHelpers.assertThisInitialized(_this);
   }
 
+  babelHelpers.inheritsLoose(Child, _Base);
   return Child;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-object/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-object/output.js
@@ -3,13 +3,12 @@ var Child =
 function (_Base) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Child, _Base);
-
   function Child() {
     var _this;
 
     return {} || babelHelpers.assertThisInitialized(_this);
   }
 
+  babelHelpers.inheritsLoose(Child, _Base);
   return Child;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/redefining-getter-method-in-subclass/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/redefining-getter-method-in-subclass/exec.js
@@ -1,0 +1,14 @@
+class Base {
+  get test() {
+  }
+}
+
+class Sub extends Base {
+  // Redefining method here
+  test() {
+    return 1;
+  }
+}
+
+expect(new Sub().test()).toBe(1);
+

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/redefining-getter-method-in-subclass/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/redefining-getter-method-in-subclass/input.js
@@ -1,0 +1,14 @@
+class Base {
+  get test() {
+  }
+}
+
+class Sub extends Base {
+  // Redefining method here
+  test() {
+    return 1;
+  }
+}
+
+expect(new Sub().test()).toBe(1);
+

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/redefining-getter-method-in-subclass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/redefining-getter-method-in-subclass/output.js
@@ -1,0 +1,35 @@
+var Base =
+/*#__PURE__*/
+function () {
+  "use strict";
+
+  function Base() {}
+
+  babelHelpers.createClass(Base, [{
+    key: "test",
+    get: function get() {}
+  }]);
+  return Base;
+}();
+
+var Sub =
+/*#__PURE__*/
+function (_Base) {
+  "use strict";
+
+  function Sub() {
+    return _Base.apply(this, arguments) || this;
+  }
+
+  var _proto = Sub.prototype;
+
+  // Redefining method here
+  _proto.test = function test() {
+    return 1;
+  };
+
+  babelHelpers.inheritsLoose(Sub, _Base);
+  return Sub;
+}(Base);
+
+expect(new Sub().test()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class-id-member-expression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class-id-member-expression/output.js
@@ -3,12 +3,11 @@ var BaseController =
 function (_Chaplin$Controller) {
   "use strict";
 
-  babelHelpers.inheritsLoose(BaseController, _Chaplin$Controller);
-
   function BaseController() {
     return _Chaplin$Controller.apply(this, arguments) || this;
   }
 
+  babelHelpers.inheritsLoose(BaseController, _Chaplin$Controller);
   return BaseController;
 }(Chaplin.Controller);
 
@@ -17,11 +16,10 @@ var BaseController2 =
 function (_Chaplin$Controller$A) {
   "use strict";
 
-  babelHelpers.inheritsLoose(BaseController2, _Chaplin$Controller$A);
-
   function BaseController2() {
     return _Chaplin$Controller$A.apply(this, arguments) || this;
   }
 
+  babelHelpers.inheritsLoose(BaseController2, _Chaplin$Controller$A);
   return BaseController2;
 }(Chaplin.Controller.Another);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class/output.js
@@ -3,11 +3,10 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inheritsLoose(Test, _Foo);
-
   function Test() {
     return _Foo.apply(this, arguments) || this;
   }
 
+  babelHelpers.inheritsLoose(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2663/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2663/output.js
@@ -15,8 +15,6 @@ var _binarySerializer = babelHelpers.interopRequireDefault(require("./helpers/bi
 var Connection =
 /*#__PURE__*/
 function (_EventEmitter) {
-  babelHelpers.inherits(Connection, _EventEmitter);
-
   function Connection(endpoint, joinKey, joinData, roomId) {
     var _this;
 
@@ -39,6 +37,7 @@ function (_EventEmitter) {
       this.sock.close();
     }
   }]);
+  babelHelpers.inherits(Connection, _EventEmitter);
   return Connection;
 }(_events.EventEmitter);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/output.js
@@ -10,8 +10,6 @@ var _BaseFoo2 = babelHelpers.interopRequireDefault(require("./BaseFoo"));
 var SubFoo =
 /*#__PURE__*/
 function (_BaseFoo) {
-  babelHelpers.inherits(SubFoo, _BaseFoo);
-
   function SubFoo() {
     babelHelpers.classCallCheck(this, SubFoo);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(SubFoo).apply(this, arguments));
@@ -24,6 +22,7 @@ function (_BaseFoo) {
       console.log('SubFoo.talk');
     }
   }]);
+  babelHelpers.inherits(SubFoo, _BaseFoo);
   return SubFoo;
 }(_BaseFoo2.default);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
@@ -10,8 +10,6 @@ var _react = babelHelpers.interopRequireDefault(require("react"));
 var RandomComponent =
 /*#__PURE__*/
 function (_Component) {
-  babelHelpers.inherits(RandomComponent, _Component);
-
   function RandomComponent() {
     babelHelpers.classCallCheck(this, RandomComponent);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(RandomComponent).call(this));
@@ -25,6 +23,7 @@ function (_Component) {
       }, _react.default.createElement("h2", null, "Hi there!"));
     }
   }]);
+  babelHelpers.inherits(RandomComponent, _Component);
   return RandomComponent;
 }(_react.Component);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
@@ -12,8 +12,6 @@ var b = function b() {
 var a1 =
 /*#__PURE__*/
 function (_b) {
-  babelHelpers.inherits(a1, _b);
-
   function a1() {
     var _this;
 
@@ -27,14 +25,13 @@ function (_b) {
     return _this;
   }
 
+  babelHelpers.inherits(a1, _b);
   return a1;
 }(b);
 
 var a2 =
 /*#__PURE__*/
 function (_b2) {
-  babelHelpers.inherits(a2, _b2);
-
   function a2() {
     var _this2;
 
@@ -48,6 +45,7 @@ function (_b2) {
     return _this2;
   }
 
+  babelHelpers.inherits(a2, _b2);
   return a2;
 }(b);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -21,8 +21,6 @@ var ColorPoint =
 function (_Point) {
   "use strict";
 
-  babelHelpers.inherits(ColorPoint, _Point);
-
   function ColorPoint() {
     var _this;
 
@@ -43,6 +41,7 @@ function (_Point) {
       this.getX();
     }
   }]);
+  babelHelpers.inherits(ColorPoint, _Point);
   return ColorPoint;
 }(Point);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/output.js
@@ -3,8 +3,6 @@ var A =
 function (_B) {
   "use strict";
 
-  babelHelpers.inherits(A, _B);
-
   function A() {
     var _this;
 
@@ -22,5 +20,6 @@ function (_B) {
     return _this;
   }
 
+  babelHelpers.inherits(A, _B);
   return A;
 }(B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T2494/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T2494/output.js
@@ -4,13 +4,12 @@ var x = {
   function (_Foo) {
     "use strict";
 
-    babelHelpers.inherits(_class, _Foo);
-
     function _class() {
       babelHelpers.classCallCheck(this, _class);
       return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(_class).apply(this, arguments));
     }
 
+    babelHelpers.inherits(_class, _Foo);
     return _class;
   }(Foo)
 };

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T2997/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T2997/output.js
@@ -9,8 +9,6 @@ var B =
 function (_A) {
   "use strict";
 
-  babelHelpers.inherits(B, _A);
-
   function B() {
     var _this;
 
@@ -18,5 +16,6 @@ function (_A) {
     return babelHelpers.possibleConstructorReturn(_this, _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this)));
   }
 
+  babelHelpers.inherits(B, _A);
   return B;
 }(A);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
@@ -1,14 +1,14 @@
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
@@ -25,8 +25,6 @@ var A =
 function (_B) {
   "use strict";
 
-  _inherits(A, _B);
-
   function A(track) {
     var _this;
 
@@ -35,6 +33,8 @@ function (_B) {
     if (track !== undefined) _this = _possibleConstructorReturn(this, _getPrototypeOf(A).call(this, track));else _this = _possibleConstructorReturn(this, _getPrototypeOf(A).call(this));
     return _possibleConstructorReturn(_this);
   }
+
+  _inherits(A, _B);
 
   return A;
 }(B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -3,8 +3,6 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inherits(Test, _Foo);
-
   function Test() {
     var _babelHelpers$getProt, _babelHelpers$get;
 
@@ -44,5 +42,6 @@ function (_Foo) {
       (_babelHelpers$get3 = babelHelpers.get(babelHelpers.getPrototypeOf(Test), "foo", this)).call.apply(_babelHelpers$get3, [this, "test"].concat(Array.prototype.slice.call(arguments)));
     }
   }]);
+  babelHelpers.inherits(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
@@ -3,8 +3,6 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inherits(Test, _Foo);
-
   function Test() {
     var _this;
 
@@ -15,5 +13,6 @@ function (_Foo) {
     return _this;
   }
 
+  babelHelpers.inherits(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
@@ -3,8 +3,6 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inherits(Test, _Foo);
-
   function Test() {
     var _this;
 
@@ -21,5 +19,6 @@ function (_Foo) {
       return babelHelpers.get(babelHelpers.getPrototypeOf(Test), "wow", this).call(this);
     }
   }]);
+  babelHelpers.inherits(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/constructor/output.js
@@ -10,8 +10,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -21,6 +19,7 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -14,5 +12,6 @@ function (_Bar) {
     }));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -13,5 +11,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this);
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-3/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -16,5 +14,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this);
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -15,5 +13,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this);
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -12,5 +10,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this);
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/output.js
@@ -3,8 +3,6 @@ var Child =
 function (_Base) {
   "use strict";
 
-  babelHelpers.inherits(Child, _Base);
-
   function Child() {
     var _this;
 
@@ -12,5 +10,6 @@ function (_Base) {
     return babelHelpers.possibleConstructorReturn(_this, false);
   }
 
+  babelHelpers.inherits(Child, _Base);
   return Child;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-object/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-object/output.js
@@ -3,8 +3,6 @@ var Child =
 function (_Base) {
   "use strict";
 
-  babelHelpers.inherits(Child, _Base);
-
   function Child() {
     var _this;
 
@@ -12,5 +10,6 @@ function (_Base) {
     return babelHelpers.possibleConstructorReturn(_this, {});
   }
 
+  babelHelpers.inherits(Child, _Base);
   return Child;
 }(Base);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/export-super-class/output.mjs
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/export-super-class/output.mjs
@@ -1,13 +1,12 @@
 var _default =
 /*#__PURE__*/
 function (_A) {
-  babelHelpers.inherits(_default, _A);
-
   function _default() {
     babelHelpers.classCallCheck(this, _default);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(_default).apply(this, arguments));
   }
 
+  babelHelpers.inherits(_default, _A);
   return _default;
 }(A);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
@@ -13,8 +13,6 @@ var Hello = function Hello() {
 var Outer =
 /*#__PURE__*/
 function (_Hello) {
-  babelHelpers.inherits(Outer, _Hello);
-
   function Outer() {
     var _this2 = this;
 
@@ -41,6 +39,7 @@ function (_Hello) {
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
 
+  babelHelpers.inherits(Outer, _Hello);
   return Outer;
 }(Hello);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -19,8 +19,6 @@ function () {
 var Outer =
 /*#__PURE__*/
 function (_Hello) {
-  babelHelpers.inherits(Outer, _Hello);
-
   function Outer() {
     var _this;
 
@@ -46,6 +44,7 @@ function (_Hello) {
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
 
+  babelHelpers.inherits(Outer, _Hello);
   return Outer;
 }(Hello);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
@@ -13,8 +13,6 @@ var Hello = function Hello() {
 var Outer =
 /*#__PURE__*/
 function (_Hello) {
-  babelHelpers.inherits(Outer, _Hello);
-
   function Outer() {
     var _this;
 
@@ -28,6 +26,7 @@ function (_Hello) {
     return babelHelpers.possibleConstructorReturn(_this, Inner);
   }
 
+  babelHelpers.inherits(Outer, _Hello);
   return Outer;
 }(Hello);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -19,8 +19,6 @@ function () {
 var Outer =
 /*#__PURE__*/
 function (_Hello) {
-  babelHelpers.inherits(Outer, _Hello);
-
   function Outer() {
     var _this;
 
@@ -35,6 +33,7 @@ function (_Hello) {
     return babelHelpers.possibleConstructorReturn(_this, Inner);
   }
 
+  babelHelpers.inherits(Outer, _Hello);
   return Outer;
 }(Hello);
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/redefining-getter-method-in-subclass/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/redefining-getter-method-in-subclass/exec.js
@@ -1,0 +1,14 @@
+class Base {
+  get test() {
+  }
+}
+
+class Sub extends Base {
+  // Redefining method here
+  test() {
+    return 1;
+  }
+}
+
+expect(new Sub().test()).toBe(1);
+

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/redefining-getter-method-in-subclass/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/redefining-getter-method-in-subclass/input.js
@@ -1,0 +1,14 @@
+class Base {
+  get test() {
+  }
+}
+
+class Sub extends Base {
+  // Redefining method here
+  test() {
+    return 1;
+  }
+}
+
+expect(new Sub().test()).toBe(1);
+

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/redefining-getter-method-in-subclass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/redefining-getter-method-in-subclass/output.js
@@ -1,0 +1,38 @@
+var Base =
+/*#__PURE__*/
+function () {
+  "use strict";
+
+  function Base() {
+    babelHelpers.classCallCheck(this, Base);
+  }
+
+  babelHelpers.createClass(Base, [{
+    key: "test",
+    get: function get() {}
+  }]);
+  return Base;
+}();
+
+var Sub =
+/*#__PURE__*/
+function (_Base) {
+  "use strict";
+
+  function Sub() {
+    babelHelpers.classCallCheck(this, Sub);
+    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Sub).apply(this, arguments));
+  }
+
+  babelHelpers.createClass(Sub, [{
+    key: "test",
+    // Redefining method here
+    value: function test() {
+      return 1;
+    }
+  }]);
+  babelHelpers.inherits(Sub, _Base);
+  return Sub;
+}(Base);
+
+expect(new Sub().test()).toBe(1);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-anonymous/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-anonymous/output.js
@@ -3,13 +3,12 @@ var TestEmpty =
 function (_ref) {
   "use strict";
 
-  babelHelpers.inherits(TestEmpty, _ref);
-
   function TestEmpty() {
     babelHelpers.classCallCheck(this, TestEmpty);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestEmpty).apply(this, arguments));
   }
 
+  babelHelpers.inherits(TestEmpty, _ref);
   return TestEmpty;
 }(
 /*#__PURE__*/
@@ -28,13 +27,12 @@ var TestConstructorOnly =
 function (_ref2) {
   "use strict";
 
-  babelHelpers.inherits(TestConstructorOnly, _ref2);
-
   function TestConstructorOnly() {
     babelHelpers.classCallCheck(this, TestConstructorOnly);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestConstructorOnly).apply(this, arguments));
   }
 
+  babelHelpers.inherits(TestConstructorOnly, _ref2);
   return TestConstructorOnly;
 }(
 /*#__PURE__*/
@@ -53,13 +51,12 @@ var TestMethodOnly =
 function (_ref3) {
   "use strict";
 
-  babelHelpers.inherits(TestMethodOnly, _ref3);
-
   function TestMethodOnly() {
     babelHelpers.classCallCheck(this, TestMethodOnly);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestMethodOnly).apply(this, arguments));
   }
 
+  babelHelpers.inherits(TestMethodOnly, _ref3);
   return TestMethodOnly;
 }(
 /*#__PURE__*/
@@ -82,13 +79,12 @@ var TestConstructorAndMethod =
 function (_ref4) {
   "use strict";
 
-  babelHelpers.inherits(TestConstructorAndMethod, _ref4);
-
   function TestConstructorAndMethod() {
     babelHelpers.classCallCheck(this, TestConstructorAndMethod);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestConstructorAndMethod).apply(this, arguments));
   }
 
+  babelHelpers.inherits(TestConstructorAndMethod, _ref4);
   return TestConstructorAndMethod;
 }(
 /*#__PURE__*/
@@ -111,13 +107,12 @@ var TestMultipleMethods =
 function (_ref5) {
   "use strict";
 
-  babelHelpers.inherits(TestMultipleMethods, _ref5);
-
   function TestMultipleMethods() {
     babelHelpers.classCallCheck(this, TestMultipleMethods);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestMultipleMethods).apply(this, arguments));
   }
 
+  babelHelpers.inherits(TestMultipleMethods, _ref5);
   return TestMultipleMethods;
 }(
 /*#__PURE__*/

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-id-member-expression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-id-member-expression/output.js
@@ -3,13 +3,12 @@ var BaseController =
 function (_Chaplin$Controller) {
   "use strict";
 
-  babelHelpers.inherits(BaseController, _Chaplin$Controller);
-
   function BaseController() {
     babelHelpers.classCallCheck(this, BaseController);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(BaseController).apply(this, arguments));
   }
 
+  babelHelpers.inherits(BaseController, _Chaplin$Controller);
   return BaseController;
 }(Chaplin.Controller);
 
@@ -18,12 +17,11 @@ var BaseController2 =
 function (_Chaplin$Controller$A) {
   "use strict";
 
-  babelHelpers.inherits(BaseController2, _Chaplin$Controller$A);
-
   function BaseController2() {
     babelHelpers.classCallCheck(this, BaseController2);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(BaseController2).apply(this, arguments));
   }
 
+  babelHelpers.inherits(BaseController2, _Chaplin$Controller$A);
   return BaseController2;
 }(Chaplin.Controller.Another);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class/output.js
@@ -3,12 +3,11 @@ var Test =
 function (_Foo) {
   "use strict";
 
-  babelHelpers.inherits(Test, _Foo);
-
   function Test() {
     babelHelpers.classCallCheck(this, Test);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).apply(this, arguments));
   }
 
+  babelHelpers.inherits(Test, _Foo);
   return Test;
 }(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -1,10 +1,10 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 
@@ -19,8 +19,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  _inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -30,6 +28,8 @@ function (_Bar) {
 
     return _this;
   }
+
+  _inherits(Foo, _Bar);
 
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -1,10 +1,10 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 
@@ -19,8 +19,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  _inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -30,6 +28,8 @@ function (_Bar) {
 
     return _this = _possibleConstructorReturn(this, _getPrototypeOf(Foo).call(this));
   }
+
+  _inherits(Foo, _Bar);
 
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -16,5 +14,6 @@ function (_Bar) {
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -17,5 +15,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -15,5 +13,6 @@ function (_Bar) {
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -13,5 +11,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -12,5 +10,6 @@ function (_Bar) {
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, babelHelpers.assertThisInitialized(_this)));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -16,5 +14,6 @@ function (_Bar) {
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -17,5 +15,6 @@ function (_Bar) {
     return _this;
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -13,5 +11,6 @@ function (_Bar) {
     return babelHelpers.possibleConstructorReturn(_this);
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
@@ -3,8 +3,6 @@ var Foo =
 function (_Bar) {
   "use strict";
 
-  babelHelpers.inherits(Foo, _Bar);
-
   function Foo() {
     var _this;
 
@@ -13,5 +11,6 @@ function (_Bar) {
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }
 
+  babelHelpers.inherits(Foo, _Bar);
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-3/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-3/output.js
@@ -10,8 +10,6 @@ var _store = require("./store");
 let Login =
 /*#__PURE__*/
 function (_React$Component) {
-  babelHelpers.inherits(Login, _React$Component);
-
   function Login() {
     babelHelpers.classCallCheck(this, Login);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Login).apply(this, arguments));
@@ -23,6 +21,7 @@ function (_React$Component) {
       return (0, _store.getForm)().toJS();
     }
   }]);
+  babelHelpers.inherits(Login, _React$Component);
   return Login;
 }(React.Component);
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
@@ -5,13 +5,12 @@ function broken(x) {
     function (_Bar) {
       "use strict";
 
-      babelHelpers.inherits(Foo, _Bar);
-
       function Foo() {
         babelHelpers.classCallCheck(this, Foo);
         return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).apply(this, arguments));
       }
 
+      babelHelpers.inherits(Foo, _Bar);
       return Foo;
     }(Bar);
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -15,6 +15,10 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -23,10 +27,6 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || function _getPrototypeOf(o) { return o.__proto__; }; return _getPrototypeOf(o); }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
@@ -34,8 +34,6 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 var App =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(App, _Component);
-
   function App() {
     var _getPrototypeOf2;
 
@@ -56,6 +54,8 @@ function (_Component) {
       this.exportType = _args.default.get('type', window.location.href);
     }
   }]);
+
+  _inherits(App, _Component);
 
   return App;
 }(Component);

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
@@ -11,8 +11,6 @@ let App =
 function (_React$Component) {
   "use strict";
 
-  babelHelpers.inherits(App, _React$Component);
-
   function App() {
     babelHelpers.classCallCheck(this, App);
     return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(App).apply(this, arguments));
@@ -31,5 +29,6 @@ function (_React$Component) {
     </div>;
     }
   }]);
+  babelHelpers.inherits(App, _React$Component);
   return App;
 }(React.Component);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns-useESModules/output.js
@@ -1,23 +1,23 @@
 var _classCallCheck = require("@babel/runtime/helpers/builtin/es6/classCallCheck");
 
+var _inherits = require("@babel/runtime/helpers/builtin/es6/inherits");
+
 var _possibleConstructorReturn = require("@babel/runtime/helpers/builtin/es6/possibleConstructorReturn");
 
 var _getPrototypeOf = require("@babel/runtime/helpers/builtin/es6/getPrototypeOf");
-
-var _inherits = require("@babel/runtime/helpers/builtin/es6/inherits");
 
 let Foo =
 /*#__PURE__*/
 function (_Bar) {
   "use strict";
 
-  _inherits(Foo, _Bar);
-
   function Foo() {
     _classCallCheck(this, Foo);
 
     return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
   }
+
+  _inherits(Foo, _Bar);
 
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useBuiltIns/output.js
@@ -1,23 +1,23 @@
 var _classCallCheck = require("@babel/runtime/helpers/builtin/classCallCheck");
 
+var _inherits = require("@babel/runtime/helpers/builtin/inherits");
+
 var _possibleConstructorReturn = require("@babel/runtime/helpers/builtin/possibleConstructorReturn");
 
 var _getPrototypeOf = require("@babel/runtime/helpers/builtin/getPrototypeOf");
-
-var _inherits = require("@babel/runtime/helpers/builtin/inherits");
 
 let Foo =
 /*#__PURE__*/
 function (_Bar) {
   "use strict";
 
-  _inherits(Foo, _Bar);
-
   function Foo() {
     _classCallCheck(this, Foo);
 
     return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
   }
+
+  _inherits(Foo, _Bar);
 
   return Foo;
 }(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules/output.js
@@ -1,23 +1,23 @@
 var _classCallCheck = require("@babel/runtime/helpers/es6/classCallCheck");
 
+var _inherits = require("@babel/runtime/helpers/es6/inherits");
+
 var _possibleConstructorReturn = require("@babel/runtime/helpers/es6/possibleConstructorReturn");
 
 var _getPrototypeOf = require("@babel/runtime/helpers/es6/getPrototypeOf");
-
-var _inherits = require("@babel/runtime/helpers/es6/inherits");
 
 let Foo =
 /*#__PURE__*/
 function (_Bar) {
   "use strict";
 
-  _inherits(Foo, _Bar);
-
   function Foo() {
     _classCallCheck(this, Foo);
 
     return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
   }
+
+  _inherits(Foo, _Bar);
 
   return Foo;
 }(Bar);

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -4,11 +4,11 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } _setPrototypeOf(subClass.prototype, superClass && superClass.prototype); if (superClass) _setPrototypeOf(subClass, superClass); }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() {} Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, _setPrototypeOf(function Super() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); }, Class)); }; return _wrapNativeSuper(Class); }
 
@@ -21,13 +21,13 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.getPrototypeOf || functio
 var MyDate =
 /*#__PURE__*/
 function (_Date) {
-  _inherits(MyDate, _Date);
-
   function MyDate(time) {
     _classCallCheck(this, MyDate);
 
     return _possibleConstructorReturn(this, _getPrototypeOf(MyDate).call(this, time));
   }
+
+  _inherits(MyDate, _Date);
 
   return MyDate;
 }(_wrapNativeSuper(Date));


### PR DESCRIPTION
We were using `Object.create` to setup the prototype chain at the start of the class definition, which lead to #7771.

I was a bit worried about a speed hit, but it seems everyone optimizes the two patterns the same way.
https://jsbench.github.io/#f9fca52407643d96458a35763b201215

Fixes #7771.