### PR TITLE
Ensure that the internal plugin load does not read the user's config.

### DIFF
--- a/packages/babel-core/src/transformation/block-hoist-plugin.js
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.js
@@ -13,6 +13,7 @@ export default function loadBlockHoistPlugin(): Plugin {
     // which loads this file, and this 'loadConfig' loading plugins.
     const config = loadConfig({
       babelrc: false,
+      configFile: false,
       plugins: [blockHoistPlugin],
     });
     LOADED_PLUGIN = config ? config.passes[0][0] : undefined;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Error from #7358, though only an issue if you have `babel.config.js`, so not technically a regression.