### PR TITLE
Change SO link to HTTPS [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ Search open/closed issues before submitting since someone might have asked the s
 If you have a support request or question please submit them to one of this resources:
 
 * Slack Community: https://babeljs.slack.com (you can sign-up at https://slack.babeljs.io/ for an invite)
-* StackOverflow: http://stackoverflow.com/questions/tagged/babeljs using the tag `babeljs`
+* StackOverflow: https://stackoverflow.com/questions/tagged/babeljs using the tag `babeljs`
 * Also have a look at the readme for more information on how to get support:
   https://github.com/babel/babel/blob/master/README.md
 


### PR DESCRIPTION
Since SO supports HTTPS now. Note: I hadn't seen the PR template before making the edit, and didn't include `[skip ci]` in the actual commit message, so I hope this works too. Edit: Nope, didn't work. Sorry.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR         | Yes
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
