### PR TITLE
Bump compat-table for preset-env

### DIFF
--- a/packages/babel-preset-env/data/built-in-features.js
+++ b/packages/babel-preset-env/data/built-in-features.js
@@ -79,7 +79,33 @@ const es2015 = {
   },
 
   "es6.map": "Map",
-  "es6.set": "Set",
+
+  // This is explicit due to prevent the stage-1 Set proposals under the
+  // category "Set methods" from being included.
+  "es6.set": {
+    features: [
+      "Set / basic functionality",
+      "Set / constructor arguments",
+      "Set / constructor requires new",
+      "Set / constructor accepts null",
+      "Set / constructor invokes add",
+      "Set / iterator closing",
+      "Set / Set.prototype.add returns this",
+      "Set / -0 key converts to +0",
+      "Set / Set.prototype.size",
+      "Set / Set.prototype.delete",
+      "Set / Set.prototype.clear",
+      "Set / Set.prototype.forEach",
+      "Set / Set.prototype.keys",
+      "Set / Set.prototype.values",
+      "Set / Set.prototype.entries",
+      "Set / Set.prototype[Symbol.iterator]",
+      "Set / Set.prototype isn't an instance",
+      "Set / Set iterator prototype chain",
+      "Set / Set[Symbol.species]",
+    ],
+  },
+
   "es6.weak-map": "WeakMap",
   "es6.weak-set": "WeakSet",
 

--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -1150,6 +1150,7 @@
     "chrome": "63",
     "firefox": "58",
     "safari": "11.1",
+    "ios": "11.3",
     "opera": "50"
   },
   "es7.symbol.async-iterator": {

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -229,23 +229,27 @@
     "firefox": "55",
     "safari": "11.1",
     "node": "8.3",
+    "ios": "11.3",
     "opera": "47",
     "electron": "2"
   },
   "proposal-unicode-property-regex": {
     "chrome": "64",
     "safari": "11.1",
+    "ios": "11.3",
     "opera": "51"
   },
   "transform-dotall-regex": {
     "chrome": "62",
     "safari": "11.1",
+    "ios": "11.3",
     "opera": "49"
   },
   "proposal-optional-catch-binding": {
     "chrome": "66",
     "firefox": "58",
     "safari": "11.1",
+    "ios": "11.3",
     "opera": "53"
   }
 }

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -59,7 +59,7 @@
     "@babel/core": "7.0.0-beta.46",
     "@babel/helper-fixtures": "7.0.0-beta.46",
     "@babel/helper-plugin-test-runner": "7.0.0-beta.46",
-    "compat-table": "kangax/compat-table#7c202e2da648fbd9d223d48d1680ec8f15147044",
+    "compat-table": "kangax/compat-table#f405358532e8597614b95af4dd30f2a672583727",
     "electron-to-chromium": "^1.3.27",
     "request": "^2.83.0"
   }

--- a/packages/babel-preset-env/scripts/build-data.js
+++ b/packages/babel-preset-env/scripts/build-data.js
@@ -190,7 +190,9 @@ const getLowestImplementedVersion = ({ features }, env) => {
     // Babel itself doesn't implement the feature correctly,
     // don't count against it
     // only doing this for built-ins atm
-    if (!test.babel && isBuiltIn) {
+    //
+    // NOTE: when/if compat-table adds a babel7 key, we'll want to update this
+    if (!test.babel6 && isBuiltIn) {
       return "-1";
     }
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | y
| License                  | MIT

Staging a few small-ish PRs to hopefully help make landing https://github.com/babel/babel/pull/7646 easier.

This adds mappings for ios 11.3, and limits the scope of the `es6.set` mapping as some stage-1 proposals were added to compat-table.