### PR TITLE
Class Props: Don't rename constructor collisions with static props

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -199,7 +199,10 @@ export default declare((api, options) => {
           }
 
           const state = { scope: constructor.scope };
-          for (const prop of props) prop.traverse(referenceVisitor, state);
+          for (const prop of props) {
+            if (prop.node.static) continue;
+            prop.traverse(referenceVisitor, state);
+          }
 
           //
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/constructor-collision/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/constructor-collision/input.js
@@ -2,8 +2,10 @@ var foo = "bar";
 
 class Foo {
   bar = foo;
+  static bar = baz;
 
   constructor() {
     var foo = "foo";
+    var baz = "baz";
   }
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/constructor-collision/output.js
@@ -6,4 +6,7 @@ var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
   this.bar = foo;
   var _foo = "foo";
+  var baz = "baz";
 };
+
+Foo.bar = baz;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/constructor-collision/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/constructor-collision/input.js
@@ -2,8 +2,10 @@ var foo = "bar";
 
 class Foo {
   bar = foo;
+  static bar = baz;
 
   constructor() {
     var foo = "foo";
+    var baz = "baz";
   }
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/constructor-collision/output.js
@@ -6,4 +6,7 @@ var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
   babelHelpers.defineProperty(this, "bar", foo);
   var _foo = "foo";
+  var baz = "baz";
 };
+
+babelHelpers.defineProperty(Foo, "bar", baz);


### PR DESCRIPTION
Static props aren't evaluated inside the constructor, so there can't be a collision.