### PR TITLE
Don't fold class property calls

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -51,26 +51,19 @@ export default declare((api, options) => {
     environmentVisitor,
   ]);
 
-  const foldDefinePropertyCalls = nodes =>
-    t.expressionStatement(
-      nodes.reduce((folded, node) => {
-        // update defineProperty's obj argument
-        node.arguments[0] = folded;
-        return node;
-      }),
-    );
-
   const buildClassPropertySpec = (
     ref,
     { key, value, computed },
     scope,
     state,
   ) => {
-    return t.callExpression(state.addHelper("defineProperty"), [
-      ref,
-      t.isIdentifier(key) && !computed ? t.stringLiteral(key.name) : key,
-      value || scope.buildUndefinedNode(),
-    ]);
+    return t.expressionStatement(
+      t.callExpression(state.addHelper("defineProperty"), [
+        ref,
+        t.isIdentifier(key) && !computed ? t.stringLiteral(key.name) : key,
+        value || scope.buildUndefinedNode(),
+      ]),
+    );
   };
 
   const buildClassPropertyLoose = (ref, { key, value, computed }, scope) => {
@@ -168,16 +161,7 @@ export default declare((api, options) => {
           }
         }
 
-        const afterNodes =
-          !loose && staticNodes.length
-            ? foldDefinePropertyCalls(staticNodes)
-            : staticNodes;
-
         if (instanceBody.length) {
-          const assignments = loose
-            ? instanceBody
-            : foldDefinePropertyCalls(instanceBody);
-
           if (!constructor) {
             const newConstructor = t.classMethod(
               "constructor",
@@ -210,10 +194,10 @@ export default declare((api, options) => {
             const bareSupers = [];
             constructor.traverse(findBareSupers, bareSupers);
             for (const bareSuper of bareSupers) {
-              bareSuper.insertAfter(assignments);
+              bareSuper.insertAfter(instanceBody);
             }
           } else {
-            constructor.get("body").unshiftContainer("body", assignments);
+            constructor.get("body").unshiftContainer("body", instanceBody);
           }
         }
 
@@ -221,7 +205,7 @@ export default declare((api, options) => {
           prop.remove();
         }
 
-        if (computedNodes.length === 0 && afterNodes.length === 0) return;
+        if (computedNodes.length === 0 && staticNodes.length === 0) return;
 
         if (path.isClassExpression()) {
           path.scope.push({ id: ref });
@@ -234,7 +218,7 @@ export default declare((api, options) => {
         }
 
         path.insertBefore(computedNodes);
-        path.insertAfter(afterNodes);
+        path.insertAfter(staticNodes);
       },
     },
   };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types/output.js
@@ -3,7 +3,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 class C {
   // Output should not use `_initialiseProps`
   constructor(T) {
-    _defineProperty(_defineProperty(this, "x", void 0), "y", 0);
+    _defineProperty(this, "x", void 0);
+
+    _defineProperty(this, "y", 0);
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
@@ -28,7 +28,15 @@ function () {
 
   function MyClass() {
     babelHelpers.classCallCheck(this, MyClass);
-    babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(this, null, "null"), _undefined, "undefined"), void 0, "void 0"), _ref3, "regex"), foo, "foo"), _bar, "bar"), _baz, "baz"), `template`, "template"), _ref4, "template-with-expression");
+    babelHelpers.defineProperty(this, null, "null");
+    babelHelpers.defineProperty(this, _undefined, "undefined");
+    babelHelpers.defineProperty(this, void 0, "void 0");
+    babelHelpers.defineProperty(this, _ref3, "regex");
+    babelHelpers.defineProperty(this, foo, "foo");
+    babelHelpers.defineProperty(this, _bar, "bar");
+    babelHelpers.defineProperty(this, _baz, "baz");
+    babelHelpers.defineProperty(this, `template`, "template");
+    babelHelpers.defineProperty(this, _ref4, "template-with-expression");
   }
 
   babelHelpers.createClass(MyClass, [{
@@ -51,4 +59,7 @@ function () {
   return MyClass;
 }();
 
-babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(babelHelpers.defineProperty(MyClass, _one, "test"), 2 * 4 + 7, "247"), 2 * four + 7, "247"), _ref, "247");
+babelHelpers.defineProperty(MyClass, _one, "test");
+babelHelpers.defineProperty(MyClass, 2 * 4 + 7, "247");
+babelHelpers.defineProperty(MyClass, 2 * four + 7, "247");
+babelHelpers.defineProperty(MyClass, _ref, "247");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-with-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-with-collision/output.js
@@ -2,5 +2,6 @@ var A = function A(_force) {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
-  babelHelpers.defineProperty(babelHelpers.defineProperty(this, "force", force), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", this).call(this));
+  babelHelpers.defineProperty(this, "force", force);
+  babelHelpers.defineProperty(this, "foo", babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", this).call(this));
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6153/output.js
@@ -39,9 +39,10 @@ var _this = this;
     constructor(_force) {
       var _this4 = this;
 
-      babelHelpers.defineProperty(babelHelpers.defineProperty(this, "fn", function () {
+      babelHelpers.defineProperty(this, "fn", function () {
         return console.log(_this4);
-      }), "force", force);
+      });
+      babelHelpers.defineProperty(this, "force", force);
     }
 
   }


### PR DESCRIPTION
This undoes the property call folding from #6656.

It complicates the private property transforms, since they boil down to `map.set(this, value)` and we definitely don't want the next call define a property on the map.

/cc @Andarist