### PR TITLE
Rename decorators&decorators2 plugins to decorators-legacy&decorators.

### DIFF
--- a/packages/babel-generator/test/fixtures/types/Decorator/options.json
+++ b/packages/babel-generator/test/fixtures/types/Decorator/options.json
@@ -1,1 +1,1 @@
-{ "plugins": ["decorators"] }
+{ "plugins": ["decorators-legacy"] }

--- a/packages/babel-generator/test/fixtures/typescript/class-parameter-properties-with-decorators/options.json
+++ b/packages/babel-generator/test/fixtures/typescript/class-parameter-properties-with-decorators/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["typescript", "decorators"]
+  "plugins": ["typescript", "decorators-legacy"]
 }

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -10,7 +10,7 @@ export default declare((api, options) => {
 
   return {
     manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push(legacy ? "decorators" : "decorators2");
+      parserOpts.plugins.push(legacy ? "decorators-legacy" : "decorators");
     },
   };
 });

--- a/packages/babylon/src/index.js
+++ b/packages/babylon/src/index.js
@@ -67,8 +67,8 @@ function getParserClass(
   pluginsFromOptions: $ReadOnlyArray<string>,
 ): Class<Parser> {
   if (
-    pluginsFromOptions.indexOf("decorators") >= 0 &&
-    pluginsFromOptions.indexOf("decorators2") >= 0
+    pluginsFromOptions.indexOf("decorators-legacy") >= 0 &&
+    pluginsFromOptions.indexOf("decorators") >= 0
   ) {
     throw new Error("Cannot use decorators and decorators2 plugin together");
   }

--- a/packages/babylon/src/parser/expression.js
+++ b/packages/babylon/src/parser/expression.js
@@ -1265,7 +1265,7 @@ export default class ExpressionParser extends LValParser {
       }
 
       if (this.match(tt.at)) {
-        if (this.hasPlugin("decorators2")) {
+        if (this.hasPlugin("decorators")) {
           this.raise(
             this.state.start,
             "Stage 2 decorators disallow object literal property decorators",

--- a/packages/babylon/src/parser/lval.js
+++ b/packages/babylon/src/parser/lval.js
@@ -261,7 +261,7 @@ export default class LValParser extends NodeUtils {
         break;
       } else {
         const decorators = [];
-        if (this.match(tt.at) && this.hasPlugin("decorators2")) {
+        if (this.match(tt.at) && this.hasPlugin("decorators")) {
           this.raise(
             this.state.start,
             "Stage 2 decorators cannot be used to decorate parameters",

--- a/packages/babylon/src/parser/statement.js
+++ b/packages/babylon/src/parser/statement.js
@@ -226,7 +226,7 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseDecorators(allowExport?: boolean): void {
-    if (this.hasPlugin("decorators2")) {
+    if (this.hasPlugin("decorators")) {
       allowExport = false;
     }
 
@@ -259,12 +259,12 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseDecorator(): N.Decorator {
-    this.expectOnePlugin(["decorators", "decorators2"]);
+    this.expectOnePlugin(["decorators-legacy", "decorators"]);
 
     const node = this.startNode();
     this.next();
 
-    if (this.hasPlugin("decorators2")) {
+    if (this.hasPlugin("decorators")) {
       // Every time a decorator class expression is evaluated, a new empty array is pushed onto the stack
       // So that the decorators of any nested class expressions will be dealt with separately
       this.state.decoratorStack.push([]);
@@ -1521,7 +1521,7 @@ export default class StatementParser extends ExpressionParser {
       this.state.type.keyword === "function" ||
       this.state.type.keyword === "class" ||
       this.isContextual("async") ||
-      (this.match(tt.at) && this.expectPlugin("decorators2"))
+      (this.match(tt.at) && this.expectPlugin("decorators"))
     );
   }
 

--- a/packages/babylon/test/fixtures/experimental/_no-plugin/decorators/options.json
+++ b/packages/babylon/test/fixtures/experimental/_no-plugin/decorators/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators, decorators2' (1:0)",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators' (1:0)",
   "plugins": []
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/class-property/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/class-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["classProperties", "classPrivateProperties", "decorators2"]
+  "plugins": ["classProperties", "classPrivateProperties", "decorators"]
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/compued-property/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/compued-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators2", "classProperties"]
+  "plugins": ["decorators", "classProperties"]
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
@@ -1,5 +1,5 @@
 {
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling the parser plugin: 'decorators2' (1:7)",
+  "throws": "This experimental syntax requires enabling the parser plugin: 'decorators' (1:7)",
   "plugins": null
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators2"]
+  "plugins": ["decorators"]
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/plugin-conflict/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/plugin-conflict/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["decorators", "decorators2"],
+  "plugins": ["decorators-legacy", "decorators"],
   "throws": "Cannot use decorators and decorators2 plugin together"
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/private-property/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/private-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["classProperties", "classPrivateProperties", "decorators2"]
+  "plugins": ["classProperties", "classPrivateProperties", "decorators"]
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/static-property/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/static-property/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["classProperties", "decorators2"]
+  "plugins": ["classProperties", "decorators"]
 }

--- a/packages/babylon/test/fixtures/experimental/decorators/computed-member-expr-on-prop/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators/computed-member-expr-on-prop/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators", "classProperties"]
+  "plugins": ["decorators-legacy", "classProperties"]
 }

--- a/packages/babylon/test/fixtures/experimental/decorators/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators"]
+  "plugins": ["decorators-legacy"]
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/40/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/40/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators"]
+  "plugins": ["decorators-legacy"]
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/41/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/41/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["decorators"],
+  "plugins": ["decorators-legacy"],
   "throws": "Leading decorators must be attached to a class declaration (1:5)"
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/42/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/42/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["decorators"],
+  "plugins": ["decorators-legacy"],
   "throws": "You have trailing decorators with no method (1:18)"
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/47/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/47/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     "classProperties",
-    "decorators"
+    "decorators-legacy"
   ]
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/48/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/48/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     "classProperties",
-    "decorators"
+    "decorators-legacy"
   ]
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/49/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/49/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators"]
+  "plugins": ["decorators-legacy"]
 }

--- a/packages/babylon/test/fixtures/experimental/uncategorised/62/options.json
+++ b/packages/babylon/test/fixtures/experimental/uncategorised/62/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["decorators"]
+  "plugins": ["decorators-legacy"]
 }

--- a/packages/babylon/test/fixtures/typescript/class/parameter-properties-with-decorators/options.json
+++ b/packages/babylon/test/fixtures/typescript/class/parameter-properties-with-decorators/options.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["typescript", "decorators"]
+  "plugins": ["typescript", "decorators-legacy"]
 }

--- a/scripts/tests/flow/run_babylon_flow_tests.js
+++ b/scripts/tests/flow/run_babylon_flow_tests.js
@@ -114,7 +114,7 @@ const flowOptionsMapping = {
   esproposal_class_instance_fields: "classProperties",
   esproposal_class_static_fields: "classProperties",
   esproposal_export_star_as: "exportNamespaceFrom",
-  esproposal_decorators: "decorators",
+  esproposal_decorators: "decorators-legacy",
   esproposal_optional_chaining: "optionalChaining",
   types: "flowComments",
 };


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Reasons:
1) Naming consistency with Babel plugins
2) Sooner or later the decorators2 plugin should become decorators