### PR TITLE
Backport: Named exports should always take priority over star exports

### DIFF
--- a/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-amd/test/fixtures/amd/export-from/expected.js
@@ -4,8 +4,10 @@ define(["exports", "foo"], function (exports, _foo) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+  var _exportNames = {};
   Object.keys(_foo).forEach(function (key) {
     if (key === "default" || key === "__esModule") return;
+    if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/interop/export-from/expected.js
@@ -3,11 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+var _exportNames = {};
 
 var _foo = require("foo");
 
 Object.keys(_foo).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/regression/T7165/expected.js
@@ -3,11 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+var _exportNames = {};
 
 var _bar = require('bar');
 
 Object.keys(_bar).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/actual.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/actual.js
@@ -1,1 +1,9 @@
+export let z = 100;
 export * from 'mod';
+export class a {}
+export function b() {}
+export { c } from 'mod';
+export let d = 42;
+export let e = 1, f = 2;
+export { f as g }
+export default function() {}

--- a/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-commonjs/test/fixtures/strict/export-all/expected.js
@@ -3,11 +3,22 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+var _exportNames = {
+  z: true,
+  a: true,
+  b: true,
+  c: true,
+  d: true,
+  e: true,
+  f: true,
+  g: true
+};
 
 var _mod = require('mod');
 
 Object.keys(_mod).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {
@@ -15,3 +26,21 @@ Object.keys(_mod).forEach(function (key) {
     }
   });
 });
+exports.b = b;
+Object.defineProperty(exports, 'c', {
+  enumerable: true,
+  get: function () {
+    return _mod.c;
+  }
+});
+
+exports.default = function () {};
+
+var z = exports.z = 100;
+class a {}
+exports.a = a;
+function b() {}
+var d = exports.d = 42;
+var e = exports.e = 1,
+    f = exports.f = 2;
+exports.g = f;

--- a/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/export-from-6/expected.js
+++ b/packages/babel-plugin-transform-es2015-modules-umd/test/fixtures/umd/export-from-6/expected.js
@@ -16,8 +16,10 @@
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+  var _exportNames = {};
   Object.keys(_foo).forEach(function (key) {
     if (key === "default" || key === "__esModule") return;
+    if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2438
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR back-ports #6238 and #3468 for 6.x. The fix for #2438 has landed in 7.x, but is not available in 6.x

//CC @loganfsmyth