### PR TITLE
Unify `main` property in package.json [ci skip]

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -2,7 +2,7 @@
   "name": "@babel/core",
   "version": "7.0.0-beta.46",
   "description": "Babel compiler core.",
-  "main": "./lib/index.js",
+  "main": "lib/index.js",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -4,7 +4,7 @@
   "description": "Transforms logical assignment operators into short-circuited assignments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
   "license": "MIT",
-  "main": "lib",
+  "main": "lib/index.js",
   "keywords": [
     "babel-plugin"
   ],

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -4,7 +4,7 @@
   "description": "Remove nullish coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-nullish-coalescing-opearator",
   "license": "MIT",
-  "main": "lib",
+  "main": "lib/index.js",
   "keywords": [
     "babel-plugin"
   ],

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -4,7 +4,7 @@
   "description": "Allow parsing of the logical assignment operators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
   "license": "MIT",
-  "main": "lib",
+  "main": "lib/index.js",
   "keywords": [
     "babel-plugin"
   ],

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -4,7 +4,7 @@
   "description": "Allow parsing of the nullish-coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
   "license": "MIT",
-  "main": "lib",
+  "main": "lib/index.js",
   "keywords": [
     "babel-plugin"
   ],


### PR DESCRIPTION
| Q | A
| ------------------------ | ---
| Fixed Issues?            | ✖️
| Patch: Bug Fix?          | ✅
| Major: Breaking Change?  | ✖️
| Minor: New Feature?      | ✖️
| Tests Added + Pass?      | ✖️ (No test added)
| Documentation PR         | ✖️
| Any Dependency Changes?  | ✖️
| License                  | MIT

I found almost `package.json` in packages has

```json
{
  "main": "lib/index.js"
}
```

but only 5 packages didn't follow the rule, so I fixed it 😉

```
138 packages in total

babel-core/package.json|5 col 4| "main": "./lib/index.js",
babel-plugin-syntax-nullish-coalescing-operator/package.json|7 col 4| "main": "lib",
babel-plugin-syntax-logical-assignment-operators/package.json|7 col 4| "main": "lib",
babel-plugin-proposal-nullish-coalescing-operator/package.json|7 col 4| "main": "lib",
babel-plugin-proposal-logical-assignment-operators/package.json|7 col 4| "main": "lib",
babel-preset-env-standalone/package.json|5 col 4| "main": "babel-preset-env.js",
```