### PR TITLE
Expand README for plugin-transform-instanceof [skip ci]

### DIFF
--- a/packages/babel-plugin-transform-instanceof/README.md
+++ b/packages/babel-plugin-transform-instanceof/README.md
@@ -1,5 +1,29 @@
 # @babel/plugin-transform-instanceof
 
+> Wraps `instanceof` expressions to allow constructors to customize the logic with a `Symbol.hasInstance` method
+
+## Example
+
+**In**
+
+```javascript
+foo instanceof Bar;
+```
+
+**Out**
+
+```javascript
+function _instanceof(left, right) {
+  if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
+    return right[Symbol.hasInstance](left);
+  } else {
+    return left instanceof right;
+  }
+}
+
+_instanceof(foo, Bar);
+```
+
 ## Installation
 
 ```sh
@@ -31,3 +55,8 @@ require("@babel/core").transform("code", {
   plugins: ["@babel/plugin-transform-instanceof"]
 });
 ```
+
+## References
+
+* [ES6 Spec: InstanceOf Operator Semantics](https://www.ecma-international.org/ecma-262/6.0/#sec-instanceofoperator)
+* [MDN: Symbol.hasInstance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance)


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Addresses a task in babel/website#780
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | n/a
| Documentation PR         | Yes
| Any Dependency Changes?  | No
| License                  | MIT

Expands the documentation for plugin-transform-instanceof with an explanation of what the plugin does, an example, and references.