### PR TITLE
[skip ci] Use queries according Browserslist Best Practices

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -26,7 +26,7 @@ This example only includes the polyfills and code transforms needed for coverage
     ["@babel/preset-env", {
       "targets": {
         // The % refers to the global coverage of users from browserslist
-        "browsers": [ ">0.25%", "not ie 11", "not op_mini all"]
+        "browsers": [ ">0.25%", "not dead"]
       }
     }]
   ]


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         | Yes
| Any Dependency Changes?  | No
| License                  | MIT

After @jamiebuilds tweet about `last 2 browsers` we [asked many developers](https://github.com/browserslist/browserslist/issues/250) from local communities to tell us, what will be the best practices for `browserslist`.

Promoting removing Opera Mini is not good practice since it is very popular for low-powerful phones.

Here is a quote from @unicodeveloper about Opera Mini in Africa:

> Personally, I see people use Opera Mini everyday here. In the streets, in cafes, in buses, everywhere you can think of
> 100M - Africa
> 25M - Nigeria alone
> That's several millions of users still actively using Opera Mini.

So promoting removing Opera Mini will make Web accessible only for Western people with fast Internet and powerful smartphones.

I changed the example to `not dead`, since `dead` is a better query. It contains browsers without security updates. Removing them will make Web safer.

/cc @tkadlec @ireade @hzoo