### PR TITLE
fix(babel-plugin-transform-typescript): do not remove unused imports

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -260,6 +260,10 @@ export default declare(api => {
   }
 
   function isImportTypeOnly(binding, programPath) {
+    if (!binding.referencePaths.length) {
+      return false;
+    }
+
     for (const path of binding.referencePaths) {
       if (!isInType(path)) {
         return false;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/keep-unused/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/keep-unused/input.mjs
@@ -1,0 +1,1 @@
+import a from "lib";

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/keep-unused/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/keep-unused/output.mjs
@@ -1,0 +1,1 @@
+import a from "lib";


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7592 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
See #7592 for an example of what this fixes.
The added `test` passes *only* with the `src` changes ✓
The other tests still pass ✓ but if anyone with more experience thinks the new behavior is not desired / could break stuff, please come forward :)