### PR TITLE
Change babel-preset-env docs according Browserslist best practices

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -29,7 +29,7 @@ not dead
 
 The full list of queries could be found in [Browserslist docs](https://github.com/browserslist/browserslist#queries).
 
-If you need to use different browsers for Autoprefixer and Babel, you can use `browsers` options of each tool.
+If you need to use different browsers for Babel, you can specify Browserslist queries in `targets.browsers` option.
 
 You may also target browsers supporting ES Modules (https://www.ecma-international.org/ecma-262/6.0/#sec-modules). When specifying this option, the browsers field will be ignored. You can use this approach in combination with `<script type="module"></script>` to conditionally serve smaller scripts to users (https://jakearchibald.com/2017/es-modules-in-browsers/#nomodule-for-backwards-compatibility).
 
@@ -47,7 +47,7 @@ You may also target browsers supporting ES Modules (https://www.ecma-internation
 }
 ```
 
-Similarly, if you're targeting Node.js instead of the browser, you can configure @babel/preset-env to only include the polyfills and transforms necessary for a particular version:
+Similarly, if you're targeting Node.js instead of the browser, you can configure `@babel/preset-env` to only include the polyfills and transforms necessary for a particular version:
 
 ```json
 {

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -31,7 +31,7 @@ not dead
 
 The full list of queries could be found in [Browserslist docs](https://github.com/browserslist/browserslist#queries).
 
-If you need to use different browssers for Autoprefixer and Babel, you can use `browsers` options of each tool.
+If you need to use different browsers for Autoprefixer and Babel, you can use `browsers` options of each tool.
 
 You may also target browsers supporting ES Modules (https://www.ecma-international.org/ecma-262/6.0/#sec-modules). When specifying this option, the browsers field will be ignored. You can use this approach in combination with `<script type="module"></script>` to conditionally serve smaller scripts to users (https://jakearchibald.com/2017/es-modules-in-browsers/#nomodule-for-backwards-compatibility).
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -18,22 +18,20 @@ Without any configuration options, @babel/preset-env behaves exactly the same as
 
 You can also configure it to only include the polyfills and transforms needed for the browsers you support. Compiling only what's needed can make your bundles smaller and your life easier.
 
-This example only includes the polyfills and code transforms needed for coverage of users > 0.25%, ignoring Internet Explorer 11 and Opera Mini. We use [browserslist](https://github.com/ai/browserslist) to parse this information, so you can use [any valid query format supported by browserslist](https://github.com/ai/browserslist#queries).
+By default, it includes the polyfills and code transforms needed for [this modern browsers](http://browserl.ist/?q=defaults).
 
-```js
-{
-  "presets": [
-    ["@babel/preset-env", {
-      "targets": {
-        // The % refers to the global coverage of users from browserslist
-        "browsers": [ ">0.25%", "not dead"]
-      }
-    }]
-  ]
-}
+If you want to specify own target browsers, we recommend to use [`.browserslistrc`](https://github.com/browserslist/browserslist) config. This config is used by many tools including Autoprefixer.
+
+This example only includes the polyfills and code transforms needed for coverage of users > 0.25%, ignoring browsers without security updates like IE Internet Explorer 10 and BlackBerry.
+
+```
+> 0.25%
+not dead
 ```
 
-> You can also target individual versions of browsers instead of using a query with `"targets": { "chrome": "66" }`.
+The full list of queries could be found in [Browserslist docs](https://github.com/browserslist/browserslist#queries).
+
+If you need to use different browssers for Autoprefixer and Babel, you can use `browsers` options of each tool.
 
 You may also target browsers supporting ES Modules (https://www.ecma-international.org/ecma-262/6.0/#sec-modules). When specifying this option, the browsers field will be ignored. You can use this approach in combination with `<script type="module"></script>` to conditionally serve smaller scripts to users (https://jakearchibald.com/2017/es-modules-in-browsers/#nomodule-for-backwards-compatibility).
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -18,9 +18,9 @@ Without any configuration options, @babel/preset-env behaves exactly the same as
 
 You can also configure it to only include the polyfills and transforms needed for the browsers you support. Compiling only what's needed can make your bundles smaller and your life easier.
 
-If you want to specify own target browsers, we recommend to use [`.browserslistrc`](https://github.com/browserslist/browserslist) config. This config is used by many tools including Autoprefixer.
+If you want to specify own target browsers, we recommend to target specific browsers, we recommend using a [`.browserslistrc`](https://github.com/browserslist/browserslist) config, which is also used by many tools including Autoprefixer.
 
-This example only includes the polyfills and code transforms needed for coverage of users > 0.25%, ignoring browsers without security updates like IE Internet Explorer 10 and BlackBerry.
+For example, to only include polyfills and code transforms needed for users whose browsers have >0.25% market share (ignoring browsers without security updates like IE 10 and BlackBerry):
 
 ```
 > 0.25%
@@ -29,7 +29,7 @@ not dead
 
 The full list of queries could be found in [Browserslist docs](https://github.com/browserslist/browserslist#queries).
 
-If you need to use different browsers for Babel, you can specify Browserslist queries in `targets.browsers` option.
+If you need to use different browsers for Babel, you can also specify Browserslist queries in the [targets.browsers option](https://github.com/babel/babel/tree/master/packages/babel-preset-env#targetsbrowsers) in your Babel config.
 
 You may also target browsers supporting ES Modules (https://www.ecma-international.org/ecma-262/6.0/#sec-modules). When specifying this option, the browsers field will be ignored. You can use this approach in combination with `<script type="module"></script>` to conditionally serve smaller scripts to users (https://jakearchibald.com/2017/es-modules-in-browsers/#nomodule-for-backwards-compatibility).
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -18,8 +18,6 @@ Without any configuration options, @babel/preset-env behaves exactly the same as
 
 You can also configure it to only include the polyfills and transforms needed for the browsers you support. Compiling only what's needed can make your bundles smaller and your life easier.
 
-By default, it includes the polyfills and code transforms needed for [this modern browsers](http://browserl.ist/?q=defaults).
-
 If you want to specify own target browsers, we recommend to use [`.browserslistrc`](https://github.com/browserslist/browserslist) config. This config is used by many tools including Autoprefixer.
 
 This example only includes the polyfills and code transforms needed for coverage of users > 0.25%, ignoring browsers without security updates like IE Internet Explorer 10 and BlackBerry.


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7829
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR         | 👍
| Any Dependency Changes?  |
| License                  | MIT

Having common config with target browsers instead of separate `browsers` option in every tool will be better for our community.

1. The single place with config to Autoprefixer, babel and many other tools will reduce mistakes when you developer change config in only one place
2. The single config will be useful for new developers. Instead of asking the same “do we support X browser”, a new developer will just look into Browserslist config
3. Common config will force developers to create more tool based on target browsers. Like [postcss-normalize](https://github.com/jonathantneal/postcss-normalize), which insert `normalize.css` rules needed only for target browsers.

Autoprefixer, PostCSS and CRA force only Browserslist config, instead of per-tool `browsers` option.

/cc @yavorsky
