### PR TITLE
add lock bot for closed issues [skip ci]

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,14 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 183
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  👋 This thread has been automatically locked because it has been closed for a period of time 😴 and exact/similar
+  problems may have been fixed already in a later version 🙂.
+  Please open a new issue for related bugs and link to relevant comments in this thread.
+# Issues or pull requests with these labels will not be locked
+# exemptLabels:
+#   - no-locking
+# Limit to only `issues` or `pulls`
+# only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -3,10 +3,11 @@
 # Number of days of inactivity before a closed issue or pull request is locked
 daysUntilLock: 183
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  👋 This thread has been automatically locked because it has been closed for a period of time 😴 and exact/similar
-  problems may have been fixed already in a later version 🙂.
-  Please open a new issue for related bugs and link to relevant comments in this thread.
+lockComment: false
+#lockComment: >
+#  👋 This thread has been automatically locked because it has been closed for a period of time 😴 and exact/similar
+#  problems may have been fixed already in a later version 🙂.
+#  Please open a new issue for related bugs and link to relevant comments in this thread.
 # Issues or pull requests with these labels will not be locked
 # exemptLabels:
 #   - no-locking


### PR DESCRIPTION
This is only for closed issues.

I don't really want any comments just to say it's locked - just spam if it sends a notification? Maybe I change it to 1 year + no comment?