### PR TITLE
Improve README's for several plugins. [skip ci]

### DIFF
--- a/packages/babel-plugin-transform-destructuring/README.md
+++ b/packages/babel-plugin-transform-destructuring/README.md
@@ -7,17 +7,25 @@
 **In**
 
 ```javascript
-let arr = [1,2,3];
-let {x, y, z} = arr;
+let {x, y} = obj;
+
+let [a, b, ...rest] = arr;
 ```
 
 **Out**
 
 ```javascript
-var arr = [1, 2, 3];
-var x = arr.x,
-    y = arr.y,
-    z = arr.z;
+function _toArray(arr) { ... }
+
+let _obj = obj,
+    x = _obj.x,
+    y = _obj.y;
+
+let _arr = arr,
+    _arr2 = _toArray(_arr),
+    a = _arr2[0],
+    b = _arr2[1],
+    rest = _arr2.slice(2);
 ```
 
 ## Installation
@@ -90,3 +98,7 @@ var { ...x } = z;
 var _z = z,
     x = Object.assign({}, _z);
 ```
+
+## References
+
+* [MDN: Destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)

--- a/packages/babel-plugin-transform-exponentiation-operator/README.md
+++ b/packages/babel-plugin-transform-exponentiation-operator/README.md
@@ -4,25 +4,20 @@
 
 ## Example
 
-```js
-// x ** y
+**In**
 
-let squared = 2 ** 2;
-// same as: 2 * 2
+```javascript
+let x = 10 ** 2;
 
-let cubed = 2 ** 3;
-// same as: 2 * 2 * 2
+x **= 3;
+```
 
+**Out**
 
-// x **= y
+```javascript
+let x = Math.pow(10, 2);
 
-let a = 2;
-a **= 2;
-// same as: a = a * a;
-
-let b = 3;
-b **= 3;
-// same as: b = b * b * b;
+x = Math.pow(x, 3);
 ```
 
 ## Installation

--- a/packages/babel-plugin-transform-property-mutators/README.md
+++ b/packages/babel-plugin-transform-property-mutators/README.md
@@ -9,7 +9,10 @@
 ```javascript
 var foo = {
   get bar() {
-    return "bar";
+    return this._bar;
+  },
+  set bar(value) {
+    this._bar = value;
   }
 };
 ```
@@ -20,10 +23,13 @@ var foo = {
 var foo = Object.defineProperties({}, {
   bar: {
     get: function () {
-      return "bar";
+      return this._bar;
     },
-    enumerable: true,
-    configurable: true
+    set: function (value) {
+      this._bar = value;
+    },
+    configurable: true,
+    enumerable: true
   }
 });
 ```

--- a/packages/babel-plugin-transform-proto-to-assign/README.md
+++ b/packages/babel-plugin-transform-proto-to-assign/README.md
@@ -38,7 +38,7 @@ bar.__proto__ = foo;
 **Out**
 
 ```javascript
-var _defaults = ...;
+function _defaults(obj, defaults) { ... }
 
 _defaults(bar, foo);
 ```
@@ -74,3 +74,7 @@ require("@babel/core").transform("code", {
   plugins: ["@babel/plugin-transform-proto-to-assign"]
 });
 ```
+
+## References
+
+* [MDN: Object.prototype.\_\_proto\_\_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)

--- a/packages/babel-plugin-transform-reserved-words/README.md
+++ b/packages/babel-plugin-transform-reserved-words/README.md
@@ -1,0 +1,59 @@
+# @babel/plugin-transform-reserved-words
+
+> Renames variables that are reserved words in ES3 but not ES5+
+
+Some words were reserved in ES3 as potential future keywords but were not
+reserved in ES5 and later. This plugin, to be used when targeting ES3
+environments, renames variables from that set of words.
+
+## Example
+
+**In**
+
+```javascript
+var abstract = 1;
+var x = abstract + 1;
+```
+
+**Out**
+
+```javascript
+var _abstract = 1;
+var x = _abstract + 1;
+```
+
+## Installation
+
+```sh
+npm install --save-dev @babel/plugin-transform-reserved-words
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["@babel/plugin-transform-reserved-words"]
+}
+```
+
+### Via CLI
+
+```sh
+babel --plugins @babel/plugin-transform-reserved-words script.js
+```
+
+### Via Node API
+
+```javascript
+require("@babel/core").transform("code", {
+  plugins: ["@babel/plugin-transform-reserved-words"]
+});
+```
+
+## References
+
+* [ES3 Spec: Future Reserved Words](http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%203rd%20edition,%20December%201999.pdf#page=26)

--- a/packages/babel-plugin-transform-spread/README.md
+++ b/packages/babel-plugin-transform-spread/README.md
@@ -8,14 +8,20 @@
 
 ```js
 var a = ['a', 'b', 'c'];
+
 var b = [...a, 'foo'];
+
+var c = foo(...a);
 ```
 
 **Out**
 
 ```js
-var a = [ 'a', 'b', 'c' ];
-var b = a.concat([ 'foo' ]);
+var a = ['a', 'b', 'c'];
+
+var b = a.concat(['foo']);
+
+var c = foo.apply(void 0, a);
 ```
 
 ## Installation
@@ -71,3 +77,7 @@ require("@babel/core").transform("code", {
 `boolean`, defaults to `false`.
 
 In loose mode, **all** iterables are assumed to be arrays.
+
+## References
+
+* [MDN: Spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | n/a
| Documentation PR         | Yes
| Any Dependency Changes?  | No
| License                  | MIT

Improved the README files for several plugins:

* plugin-transform-reserved-words: Created README file.
* plugin-transform-destructuring: Added an example of object destructuring; added a reference.
* plugin-transform-exponentiation-operator: Changed the example to use input & output format, like other plugins.
* plugin-transform-property-mutators: Added a property setter to the example.
* plugin-transform-proto-to-assign: Changed the example output to conform to reality; added a reference.
* plugin-transform-spread: Added an example of spread syntax in a function call; added a reference.
