### PR TITLE
Babel-cli update dependencie chokidar

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -26,7 +26,7 @@
     "source-map": "^0.5.0"
   },
   "optionalDependencies": {
-    "chokidar": "^1.6.1"
+    "chokidar": "^2.0.3"
   },
   "peerDependencies": {
     "@babel/core": "7.0.0-beta.46"


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | chokidar: update to the latest version
| License                  | MIT

Update the `@bable/cli` watch dependency that used an outdated version.
The old version of `chokidar` is dependent och an old version of `fsevents`  that is dependent on an old version of `node-pre-gyp` that uses an old version of `hawk`. 

`hawk` in it case is using an old version of `hoek` that throws git dependencies scan warning 

![screen shot 2018-05-02 at 10 19 08](https://user-images.githubusercontent.com/1122820/39512736-475a354a-4df2-11e8-827a-97de3d2f36cb.png)

![screen shot 2018-05-02 at 10 20 09](https://user-images.githubusercontent.com/1122820/39512792-768e1660-4df2-11e8-8984-630afd5ef3f7.png)

