### PR TITLE
remove @babel/preset-latest from docs

### DIFF
--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -6,7 +6,7 @@
 npm install @babel/preset-env --save-dev
 ```
 
-Without any configuration options, `@babel/preset-env` behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-es2017) together (or the deprecated `babel-preset-lastest`).
+Without any configuration options, `@babel/preset-env` behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-preset-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-preset-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-preset-es2017) together (or the deprecated `babel-preset-latest`).
 
 > We don't recommend using `preset-env` this way because it doesn't take advantage of its ability to target specific browsers.
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -6,7 +6,7 @@
 npm install @babel/preset-env --save-dev
 ```
 
-Without any configuration options, @babel/preset-env behaves exactly the same as @babel/preset-es2015, @babel/preset-es2016 and @babel/preset-es2017 together.
+Without any configuration options, [`@babel/preset-env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-es2017) together.
 
 > We don't recommend using `preset-env` this way because it doesn't take advantage of its ability to target specific browsers.
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -6,7 +6,7 @@
 npm install @babel/preset-env --save-dev
 ```
 
-Without any configuration options, [`@babel/preset-env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-es2017) together (or the deprecated `babel-preset-lastest`).
+Without any configuration options, `@babel/preset-env` behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-es2017) together (or the deprecated `babel-preset-lastest`).
 
 > We don't recommend using `preset-env` this way because it doesn't take advantage of its ability to target specific browsers.
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -6,7 +6,7 @@
 npm install @babel/preset-env --save-dev
 ```
 
-Without any configuration options, @babel/preset-env behaves exactly the same as @babel/preset-latest (or @babel/preset-es2015, @babel/preset-es2016, and @babel/preset-es2017 together).
+Without any configuration options, @babel/preset-env behaves exactly the same as @babel/preset-es2015, @babel/preset-es2016 and @babel/preset-es2017 together.
 
 > We don't recommend using `preset-env` this way because it doesn't take advantage of its ability to target specific browsers.
 

--- a/packages/babel-preset-env/README.md
+++ b/packages/babel-preset-env/README.md
@@ -6,7 +6,7 @@
 npm install @babel/preset-env --save-dev
 ```
 
-Without any configuration options, [`@babel/preset-env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-es2017) together.
+Without any configuration options, [`@babel/preset-env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) behaves exactly the same as [`@babel/preset-es2015`](https://github.com/babel/babel/tree/master/packages/babel-es2015), [`@babel/preset-es2016`](https://github.com/babel/babel/tree/master/packages/babel-es2016) and [`@babel/preset-es2017`](https://github.com/babel/babel/tree/master/packages/babel-es2017) together (or the deprecated `babel-preset-lastest`).
 
 > We don't recommend using `preset-env` this way because it doesn't take advantage of its ability to target specific browsers.
 


### PR DESCRIPTION
because it's deprecated

[see preview](https://github.com/pravdomil/babel/blob/patch-2/packages/babel-preset-env/README.md)