### PR TITLE
Lazy load tagged template literal strings

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -6,4 +6,4 @@ var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/hel
 
 var _templateObject;
 
-tag((_templateObject = _templateObject || (0, _taggedTemplateLiteral2.default)(["foo"])));
+tag(_templateObject = _templateObject || /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -6,4 +6,4 @@ var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/hel
 
 var _templateObject;
 
-tag(_templateObject = _templateObject || /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]));
+tag(_templateObject || (_templateObject = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"])));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -4,6 +4,14 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
-var _templateObject;
+function _templateObject() {
+  const data = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]);
 
-tag(_templateObject || (_templateObject = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"])));
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
+
+tag(_templateObject());

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -4,6 +4,6 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
-var _templateObject = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]);
+var _templateObject;
 
-tag(_templateObject);
+tag((_templateObject = _templateObject || (0, _taggedTemplateLiteral2.default)(["foo"])));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -6,4 +6,4 @@ var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/hel
 
 var _templateObject;
 
-tag((_templateObject = _templateObject || (0, _taggedTemplateLiteral2.default)(["foo"])));
+tag(_templateObject = _templateObject || /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -6,4 +6,4 @@ var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/hel
 
 var _templateObject;
 
-tag(_templateObject = _templateObject || /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]));
+tag(_templateObject || (_templateObject = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"])));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -4,6 +4,14 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
-var _templateObject;
+function _templateObject() {
+  const data = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]);
 
-tag(_templateObject || (_templateObject = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"])));
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
+
+tag(_templateObject());

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -4,6 +4,6 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
-var _templateObject = /*#__PURE__*/ (0, _taggedTemplateLiteral2.default)(["foo"]);
+var _templateObject;
 
-tag(_templateObject);
+tag((_templateObject = _templateObject || (0, _taggedTemplateLiteral2.default)(["foo"])));

--- a/packages/babel-plugin-transform-template-literals/src/index.js
+++ b/packages/babel-plugin-transform-template-literals/src/index.js
@@ -90,22 +90,17 @@ export default declare((api, options) => {
         const lazyLoad = t.logicalExpression(
           "||",
           t.cloneNode(templateObject),
-          callExpression,
-        );
-
-        const conditionalAssignment = t.assignmentExpression(
-          "=",
-          t.cloneNode(templateObject),
-          lazyLoad,
+          t.assignmentExpression(
+            "=",
+            t.cloneNode(templateObject),
+            callExpression,
+          ),
         );
 
         scope.push({ id: templateObject });
 
         path.replaceWith(
-          t.callExpression(node.tag, [
-            conditionalAssignment,
-            ...quasi.expressions,
-          ]),
+          t.callExpression(node.tag, [lazyLoad, ...quasi.expressions]),
         );
       },
 

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
@@ -1,16 +1,15 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["some template"]),
-    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["some template"]);
+var _templateObject, _templateObject2;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
 var tag = v => v;
 
 function foo() {
-  return tag(_templateObject);
+  return tag((_templateObject = _templateObject || _taggedTemplateLiteral(["some template"])));
 }
 
 function bar() {
-  return tag(_templateObject2);
+  return tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteral(["some template"])));
 }
 
 expect(foo()).toBe(foo());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
@@ -1,15 +1,33 @@
-var _templateObject, _templateObject2;
+function _templateObject2() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["some template"]);
+
+  _templateObject2 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["some template"]);
+
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
 var tag = v => v;
 
 function foo() {
-  return tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["some template"])));
+  return tag(_templateObject());
 }
 
 function bar() {
-  return tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["some template"])));
+  return tag(_templateObject2());
 }
 
 expect(foo()).toBe(foo());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
@@ -5,11 +5,11 @@ function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(
 var tag = v => v;
 
 function foo() {
-  return tag((_templateObject = _templateObject || _taggedTemplateLiteral(["some template"])));
+  return tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral(["some template"]));
 }
 
 function bar() {
-  return tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteral(["some template"])));
+  return tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral(["some template"]));
 }
 
 expect(foo()).toBe(foo());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/cache-revision/output.js
@@ -5,11 +5,11 @@ function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(
 var tag = v => v;
 
 function foo() {
-  return tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral(["some template"]));
+  return tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["some template"])));
 }
 
 function bar() {
-  return tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral(["some template"]));
+  return tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["some template"])));
 }
 
 expect(foo()).toBe(foo());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -1,7 +1,6 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow"]),
-    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"]);
+var _templateObject, _templateObject2;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = tag(_templateObject);
-var bar = tag(_templateObject2, 1);
+var foo = tag((_templateObject = _templateObject || _taggedTemplateLiteral(["wow"])));
+var bar = tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteral(["first", "second"])), 1);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -2,5 +2,5 @@ var _templateObject, _templateObject2;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = tag((_templateObject = _templateObject || _taggedTemplateLiteral(["wow"])));
-var bar = tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteral(["first", "second"])), 1);
+var foo = tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral(["wow"]));
+var bar = tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"]), 1);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -2,5 +2,5 @@ var _templateObject, _templateObject2;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral(["wow"]));
-var bar = tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"]), 1);
+var foo = tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow"])));
+var bar = tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"])), 1);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/simple-tag/output.js
@@ -1,6 +1,24 @@
-var _templateObject, _templateObject2;
+function _templateObject2() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"]);
+
+  _templateObject2 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["wow"]);
+
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow"])));
-var bar = tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["first", "second"])), 1);
+var foo = tag(_templateObject());
+var bar = tag(_templateObject2(), 1);

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
@@ -2,6 +2,6 @@ var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = bar((_templateObject = _templateObject || _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
-var bar = bar((_templateObject2 = _templateObject2 || _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
-var bar = bar((_templateObject3 = _templateObject3 || _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());
+var foo = bar(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""]), 42, _.foobar());
+var bar = bar(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""]), 42, _.foobar());
+var bar = bar(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""]), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
@@ -1,9 +1,7 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""]),
-    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""]),
-    _templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
+var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = bar(_templateObject, 42, _.foobar());
-var bar = bar(_templateObject2, 42, _.foobar());
-var bar = bar(_templateObject3, 42, _.baz());
+var foo = bar((_templateObject = _templateObject || _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
+var bar = bar((_templateObject2 = _templateObject2 || _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
+var bar = bar((_templateObject3 = _templateObject3 || _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
@@ -2,6 +2,6 @@ var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = bar(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""]), 42, _.foobar());
-var bar = bar(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""]), 42, _.foobar());
-var bar = bar(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""]), 42, _.baz());
+var foo = bar(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
+var bar = bar(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
+var bar = bar(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/tag/output.js
@@ -1,7 +1,35 @@
-var _templateObject, _templateObject2, _templateObject3;
+function _templateObject3() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
+
+  _templateObject3 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject2() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""]);
+
+  _templateObject2 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""]);
+
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-var foo = bar(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
-var bar = bar(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
-var bar = bar(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());
+var foo = bar(_templateObject(), 42, _.foobar());
+var bar = bar(_templateObject2(), 42, _.foobar());
+var bar = bar(_templateObject3(), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
@@ -2,15 +2,15 @@ var _templateObject, _templateObject2, _templateObject3, _templateObject4, _temp
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"]));
-tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]));
-tag(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"]), 0);
-tag(_templateObject4 = _templateObject4 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"]), 0);
-tag(_templateObject5 = _templateObject5 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"]), 0, 1);
-tag(_templateObject6 = _templateObject6 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"]), 0, 1);
-tag(_templateObject7 = _templateObject7 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"]), 0, 1);
+tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"])));
+tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"])));
+tag(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"])), 0);
+tag(_templateObject4 || (_templateObject4 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"])), 0);
+tag(_templateObject5 || (_templateObject5 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
+tag(_templateObject6 || (_templateObject6 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
+tag(_templateObject7 || (_templateObject7 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8 = _templateObject8 || /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]));
+  tag(_templateObject8 || (_templateObject8 = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"])));
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
@@ -1,16 +1,94 @@
-var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5, _templateObject6, _templateObject7, _templateObject8;
+function _templateObject8() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]);
+
+  _templateObject8 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject7() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"]);
+
+  _templateObject7 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject6() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"]);
+
+  _templateObject6 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject5() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"]);
+
+  _templateObject5 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject4() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"]);
+
+  _templateObject4 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject3() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"]);
+
+  _templateObject3 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject2() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]);
+
+  _templateObject2 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"]);
+
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"])));
-tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"])));
-tag(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"])), 0);
-tag(_templateObject4 || (_templateObject4 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"])), 0);
-tag(_templateObject5 || (_templateObject5 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
-tag(_templateObject6 || (_templateObject6 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
-tag(_templateObject7 || (_templateObject7 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
+tag(_templateObject());
+tag(_templateObject2());
+tag(_templateObject3(), 0);
+tag(_templateObject4(), 0);
+tag(_templateObject5(), 0, 1);
+tag(_templateObject6(), 0, 1);
+tag(_templateObject7(), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8 || (_templateObject8 = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"])));
+  tag(_templateObject8());
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
@@ -2,15 +2,15 @@ var _templateObject, _templateObject2, _templateObject3, _templateObject4, _temp
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-tag((_templateObject = _templateObject || _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"])));
-tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteral([void 0], ["\\01"])));
-tag((_templateObject3 = _templateObject3 || _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"])), 0);
-tag((_templateObject4 = _templateObject4 || _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"])), 0);
-tag((_templateObject5 = _templateObject5 || _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
-tag((_templateObject6 = _templateObject6 || _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
-tag((_templateObject7 = _templateObject7 || _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
+tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"]));
+tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]));
+tag(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"]), 0);
+tag(_templateObject4 = _templateObject4 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"]), 0);
+tag(_templateObject5 = _templateObject5 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"]), 0, 1);
+tag(_templateObject6 = _templateObject6 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"]), 0, 1);
+tag(_templateObject7 = _templateObject7 || /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"]), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag((_templateObject8 = _templateObject8 || _taggedTemplateLiteral([void 0], ["\\01"])));
+  tag(_templateObject8 = _templateObject8 || /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]));
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/default/template-revision/output.js
@@ -1,23 +1,16 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"]),
-    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]),
-    _templateObject3 = /*#__PURE__*/ _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"]),
-    _templateObject4 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"]),
-    _templateObject5 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"]),
-    _templateObject6 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"]),
-    _templateObject7 = /*#__PURE__*/ _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"]),
-    _templateObject8 = /*#__PURE__*/ _taggedTemplateLiteral([void 0], ["\\01"]);
+var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5, _templateObject6, _templateObject7, _templateObject8;
 
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
-tag(_templateObject);
-tag(_templateObject2);
-tag(_templateObject3, 0);
-tag(_templateObject4, 0);
-tag(_templateObject5, 0, 1);
-tag(_templateObject6, 0, 1);
-tag(_templateObject7, 0, 1);
+tag((_templateObject = _templateObject || _taggedTemplateLiteral([void 0], ["\\unicode and \\u{55}"])));
+tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteral([void 0], ["\\01"])));
+tag((_templateObject3 = _templateObject3 || _taggedTemplateLiteral([void 0, "right"], ["\\xg", "right"])), 0);
+tag((_templateObject4 = _templateObject4 || _taggedTemplateLiteral(["left", void 0], ["left", "\\xg"])), 0);
+tag((_templateObject5 = _templateObject5 || _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
+tag((_templateObject6 = _templateObject6 || _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
+tag((_templateObject7 = _templateObject7 || _taggedTemplateLiteral(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8);
+  tag((_templateObject8 = _templateObject8 || _taggedTemplateLiteral([void 0], ["\\01"])));
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
@@ -1,7 +1,35 @@
-var _templateObject, _templateObject2, _templateObject3;
+function _templateObject3() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
+
+  _templateObject3 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject2() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""]);
+
+  _templateObject2 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""]);
+
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-var foo = bar(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
-var bar = bar(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
-var bar = bar(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());
+var foo = bar(_templateObject(), 42, _.foobar());
+var bar = bar(_templateObject2(), 42, _.foobar());
+var bar = bar(_templateObject3(), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
@@ -2,6 +2,6 @@ var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-var foo = bar((_templateObject = _templateObject || _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
-var bar = bar((_templateObject2 = _templateObject2 || _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
-var bar = bar((_templateObject3 = _templateObject3 || _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());
+var foo = bar(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""]), 42, _.foobar());
+var bar = bar(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""]), 42, _.foobar());
+var bar = bar(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""]), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
@@ -1,9 +1,7 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""]),
-    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""]),
-    _templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""]);
+var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-var foo = bar(_templateObject, 42, _.foobar());
-var bar = bar(_templateObject2, 42, _.foobar());
-var bar = bar(_templateObject3, 42, _.baz());
+var foo = bar((_templateObject = _templateObject || _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
+var bar = bar((_templateObject2 = _templateObject2 || _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
+var bar = bar((_templateObject3 = _templateObject3 || _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/tag/output.js
@@ -2,6 +2,6 @@ var _templateObject, _templateObject2, _templateObject3;
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-var foo = bar(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""]), 42, _.foobar());
-var bar = bar(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""]), 42, _.foobar());
-var bar = bar(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""]), 42, _.baz());
+var foo = bar(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\na", "b ", ""], ["wow\\na", "b ", ""])), 42, _.foobar());
+var bar = bar(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\nab", " ", ""], ["wow\\nab", " ", ""])), 42, _.foobar());
+var bar = bar(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["wow\naB", " ", ""], ["wow\\naB", " ", ""])), 42, _.baz());

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
@@ -1,23 +1,16 @@
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"]),
-    _templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]),
-    _templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"]),
-    _templateObject4 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"]),
-    _templateObject5 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"]),
-    _templateObject6 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"]),
-    _templateObject7 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"]),
-    _templateObject8 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]);
+var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5, _templateObject6, _templateObject7, _templateObject8;
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-tag(_templateObject);
-tag(_templateObject2);
-tag(_templateObject3, 0);
-tag(_templateObject4, 0);
-tag(_templateObject5, 0, 1);
-tag(_templateObject6, 0, 1);
-tag(_templateObject7, 0, 1);
+tag((_templateObject = _templateObject || _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"])));
+tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteralLoose([void 0], ["\\01"])));
+tag((_templateObject3 = _templateObject3 || _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"])), 0);
+tag((_templateObject4 = _templateObject4 || _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"])), 0);
+tag((_templateObject5 = _templateObject5 || _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
+tag((_templateObject6 = _templateObject6 || _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
+tag((_templateObject7 = _templateObject7 || _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8);
+  tag((_templateObject8 = _templateObject8 || _taggedTemplateLiteralLoose([void 0], ["\\01"])));
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
@@ -1,16 +1,94 @@
-var _templateObject, _templateObject2, _templateObject3, _templateObject4, _templateObject5, _templateObject6, _templateObject7, _templateObject8;
+function _templateObject8() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]);
+
+  _templateObject8 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject7() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"]);
+
+  _templateObject7 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject6() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"]);
+
+  _templateObject6 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject5() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"]);
+
+  _templateObject5 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject4() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"]);
+
+  _templateObject4 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject3() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"]);
+
+  _templateObject3 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject2() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]);
+
+  _templateObject2 = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject() {
+  const data = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"]);
+
+  _templateObject = function () {
+    return data;
+  };
+
+  return data;
+}
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"])));
-tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"])));
-tag(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"])), 0);
-tag(_templateObject4 || (_templateObject4 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"])), 0);
-tag(_templateObject5 || (_templateObject5 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
-tag(_templateObject6 || (_templateObject6 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
-tag(_templateObject7 || (_templateObject7 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
+tag(_templateObject());
+tag(_templateObject2());
+tag(_templateObject3(), 0);
+tag(_templateObject4(), 0);
+tag(_templateObject5(), 0, 1);
+tag(_templateObject6(), 0, 1);
+tag(_templateObject7(), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8 || (_templateObject8 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"])));
+  tag(_templateObject8());
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
@@ -2,15 +2,15 @@ var _templateObject, _templateObject2, _templateObject3, _templateObject4, _temp
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-tag((_templateObject = _templateObject || _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"])));
-tag((_templateObject2 = _templateObject2 || _taggedTemplateLiteralLoose([void 0], ["\\01"])));
-tag((_templateObject3 = _templateObject3 || _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"])), 0);
-tag((_templateObject4 = _templateObject4 || _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"])), 0);
-tag((_templateObject5 = _templateObject5 || _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
-tag((_templateObject6 = _templateObject6 || _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
-tag((_templateObject7 = _templateObject7 || _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
+tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"]));
+tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]));
+tag(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"]), 0);
+tag(_templateObject4 = _templateObject4 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"]), 0);
+tag(_templateObject5 = _templateObject5 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"]), 0, 1);
+tag(_templateObject6 = _templateObject6 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"]), 0, 1);
+tag(_templateObject7 = _templateObject7 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"]), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag((_templateObject8 = _templateObject8 || _taggedTemplateLiteralLoose([void 0], ["\\01"])));
+  tag(_templateObject8 = _templateObject8 || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]));
 }

--- a/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
+++ b/packages/babel-plugin-transform-template-literals/test/fixtures/loose/template-revision/output.js
@@ -2,15 +2,15 @@ var _templateObject, _templateObject2, _templateObject3, _templateObject4, _temp
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
-tag(_templateObject = _templateObject || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"]));
-tag(_templateObject2 = _templateObject2 || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]));
-tag(_templateObject3 = _templateObject3 || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"]), 0);
-tag(_templateObject4 = _templateObject4 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"]), 0);
-tag(_templateObject5 = _templateObject5 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"]), 0, 1);
-tag(_templateObject6 = _templateObject6 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"]), 0, 1);
-tag(_templateObject7 = _templateObject7 || /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"]), 0, 1);
+tag(_templateObject || (_templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\unicode and \\u{55}"])));
+tag(_templateObject2 || (_templateObject2 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"])));
+tag(_templateObject3 || (_templateObject3 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0, "right"], ["\\xg", "right"])), 0);
+tag(_templateObject4 || (_templateObject4 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0], ["left", "\\xg"])), 0);
+tag(_templateObject5 || (_templateObject5 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\xg", "right"])), 0, 1);
+tag(_templateObject6 || (_templateObject6 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u000g", "right"])), 0, 1);
+tag(_templateObject7 || (_templateObject7 = /*#__PURE__*/ _taggedTemplateLiteralLoose(["left", void 0, "right"], ["left", "\\u{-0}", "right"])), 0, 1);
 
 function a() {
   var undefined = 4;
-  tag(_templateObject8 = _templateObject8 || /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"]));
+  tag(_templateObject8 || (_templateObject8 = /*#__PURE__*/ _taggedTemplateLiteralLoose([void 0], ["\\01"])));
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7723
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         
| Any Dependency Changes?  |
| License                  | MIT


This change makes `_templateObject` lazy loaded. While working on it, I removed the pure annotation because I was not sure if it is still useful when used like this (please correct me if wrong). 
I was also not sure if it is recommended to clone `templateObject` every time it is used as an argument to create a new AST node. In this case, I used the existing code in the file as kind of a guidance and cloned the node each time. I appreciate every bit of feedback! :)