### PR TITLE
Add an option to Babylon to have decorators before export

### DIFF
--- a/packages/babylon/src/index.js
+++ b/packages/babylon/src/index.js
@@ -71,7 +71,7 @@ function getParserClass(
     hasPlugin(pluginsFromOptions, "decorators-legacy")
   ) {
     throw new Error(
-      "Cannot use decorators and decorators-legacy plugin together",
+      "Cannot use the decorators and decorators-legacy plugin together",
     );
   }
 

--- a/packages/babylon/src/index.js
+++ b/packages/babylon/src/index.js
@@ -67,39 +67,39 @@ function getParserClass(
   pluginsFromOptions: $ReadOnlyArray<string>,
 ): Class<Parser> {
   if (
-    pluginsFromOptions.indexOf("decorators-legacy") >= 0 &&
-    pluginsFromOptions.indexOf("decorators") >= 0
+    hasPlugin(pluginsFromOptions, "decorators") &&
+    hasPlugin(pluginsFromOptions, "decorators-legacy")
   ) {
-    throw new Error("Cannot use decorators and decorators2 plugin together");
+    throw new Error(
+      "Cannot use decorators and decorators-legacy plugin together",
+    );
   }
 
   // Filter out just the plugins that have an actual mixin associated with them.
-  let pluginList = pluginsFromOptions.filter(
-    p => p === "estree" || p === "flow" || p === "jsx" || p === "typescript",
-  );
+  let pluginList = pluginsFromOptions.filter(plugin => {
+    const p = getPluginName(plugin);
+    return p === "estree" || p === "flow" || p === "jsx" || p === "typescript";
+  });
 
-  if (pluginList.indexOf("flow") >= 0) {
+  if (hasPlugin(pluginList, "flow")) {
     // ensure flow plugin loads last
-    pluginList = pluginList.filter(plugin => plugin !== "flow");
+    pluginList = pluginList.filter(p => getPluginName(p) !== "flow");
     pluginList.push("flow");
   }
 
-  if (
-    pluginList.indexOf("flow") >= 0 &&
-    pluginList.indexOf("typescript") >= 0
-  ) {
+  if (hasPlugin(pluginList, "flow") && hasPlugin(pluginList, "typescript")) {
     throw new Error("Cannot combine flow and typescript plugins.");
   }
 
-  if (pluginList.indexOf("typescript") >= 0) {
+  if (hasPlugin(pluginList, "typescript")) {
     // ensure typescript plugin loads last
-    pluginList = pluginList.filter(plugin => plugin !== "typescript");
+    pluginList = pluginList.filter(p => getPluginName(p) !== "typescript");
     pluginList.push("typescript");
   }
 
-  if (pluginList.indexOf("estree") >= 0) {
+  if (hasPlugin(pluginList, "estree")) {
     // ensure estree plugin loads first
-    pluginList = pluginList.filter(plugin => plugin !== "estree");
+    pluginList = pluginList.filter(p => getPluginName(p) !== "estree");
     pluginList.unshift("estree");
   }
 
@@ -113,4 +113,12 @@ function getParserClass(
     parserClassCache[key] = cls;
   }
   return cls;
+}
+
+function getPluginName(plugin) {
+  return Array.isArray(plugin) ? plugin[0] : plugin;
+}
+
+function hasPlugin(pluginsList, name) {
+  return pluginsList.some(plugin => getPluginName(plugin) === name);
 }

--- a/packages/babylon/src/parser/base.js
+++ b/packages/babylon/src/parser/base.js
@@ -26,6 +26,10 @@ export default class BaseParser {
   }
 
   hasPlugin(name: string): boolean {
-    return !!this.plugins[name];
+    return Object.hasOwnProperty.call(this.plugins, name);
+  }
+
+  getPluginOption(plugin: string, name: string) {
+    if (this.hasPlugin(plugin)) return this.plugins[plugin][name];
   }
 }

--- a/packages/babylon/src/parser/index.js
+++ b/packages/babylon/src/parser/index.js
@@ -41,9 +41,10 @@ export default class Parser extends StatementParser {
 function pluginsMap(
   pluginList: $ReadOnlyArray<string>,
 ): { [key: string]: boolean } {
-  const pluginMap = {};
-  for (const name of pluginList) {
-    pluginMap[name] = true;
+  const pluginMap = Object.create(null);
+  for (const plugin of pluginList) {
+    const [name, options = {}] = Array.isArray(plugin) ? plugin : [plugin];
+    pluginMap[name] = options;
   }
   return pluginMap;
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/input.mjs
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/input.mjs
@@ -1,0 +1,1 @@
+export default (@decorator class Foo {})

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/options.json
@@ -1,0 +1,6 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    ["decorators", { "decoratorsBeforeExport": true }]
+  ]
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/output.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-with-parens/output.json
@@ -1,0 +1,136 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 40,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 40
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 40,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 40
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 0,
+        "end": 40,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 40
+          }
+        },
+        "declaration": {
+          "type": "ClassExpression",
+          "start": 16,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 1,
+              "column": 39
+            }
+          },
+          "decorators": [
+            {
+              "type": "Decorator",
+              "start": 16,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 26
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 17,
+                "end": 26,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 26
+                  },
+                  "identifierName": "decorator"
+                },
+                "name": "decorator"
+              }
+            }
+          ],
+          "id": {
+            "type": "Identifier",
+            "start": 33,
+            "end": 36,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 33
+              },
+              "end": {
+                "line": 1,
+                "column": 36
+              },
+              "identifierName": "Foo"
+            },
+            "name": "Foo"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start": 37,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 37
+              },
+              "end": {
+                "line": 1,
+                "column": 39
+              }
+            },
+            "body": []
+          },
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 15
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-without-parens/input.mjs
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-without-parens/input.mjs
@@ -1,0 +1,1 @@
+export default @decorator class Foo {}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-without-parens/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default-decorated-expression-without-parens/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    ["decorators", { "decoratorsBeforeExport": true }]
+  ],
+  "throws": "Unexpected token (1:15)"
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/input.mjs
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/input.mjs
@@ -1,0 +1,2 @@
+@decorator
+export default class Foo {}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/options.json
@@ -1,0 +1,6 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    ["decorators", { "decoratorsBeforeExport": true }]
+  ]
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/output.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export-default/output.json
@@ -1,0 +1,132 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 38,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 27
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 38,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 27
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 11,
+        "end": 38,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 27
+          }
+        },
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start": 0,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 27
+            }
+          },
+          "decorators": [
+            {
+              "type": "Decorator",
+              "start": 0,
+              "end": 10,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 10
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 1,
+                "end": 10,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "identifierName": "decorator"
+                },
+                "name": "decorator"
+              }
+            }
+          ],
+          "id": {
+            "type": "Identifier",
+            "start": 32,
+            "end": 35,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 21
+              },
+              "end": {
+                "line": 2,
+                "column": 24
+              },
+              "identifierName": "Foo"
+            },
+            "name": "Foo"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start": 36,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 25
+              },
+              "end": {
+                "line": 2,
+                "column": 27
+              }
+            },
+            "body": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/input.mjs
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/input.mjs
@@ -1,0 +1,2 @@
+@decorator
+export class Foo {}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/options.json
@@ -1,0 +1,6 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    ["decorators", { "decoratorsBeforeExport": true }]
+  ]
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/output.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/decoratorsBeforeExport-export/output.json
@@ -1,0 +1,134 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 30,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 19
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 30,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 19
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 11,
+        "end": 30,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 19
+          }
+        },
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start": 0,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 19
+            }
+          },
+          "decorators": [
+            {
+              "type": "Decorator",
+              "start": 0,
+              "end": 10,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 10
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 1,
+                "end": 10,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "identifierName": "decorator"
+                },
+                "name": "decorator"
+              }
+            }
+          ],
+          "id": {
+            "type": "Identifier",
+            "start": 24,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 16
+              },
+              "identifierName": "Foo"
+            },
+            "name": "Foo"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start": 28,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 17
+              },
+              "end": {
+                "line": 2,
+                "column": 19
+              }
+            },
+            "body": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
@@ -1,5 +1,5 @@
 {
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling the parser plugin: 'decorators' (1:7)",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators, decorators-legacy' (1:7)",
   "plugins": null
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/plugin-conflict/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/plugin-conflict/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["decorators-legacy", "decorators"],
-  "throws": "Cannot use decorators and decorators2 plugin together"
+  "throws": "Cannot use decorators and decorators-legacy plugin together"
 }

--- a/packages/babylon/test/fixtures/experimental/decorators-2/plugin-conflict/options.json
+++ b/packages/babylon/test/fixtures/experimental/decorators-2/plugin-conflict/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["decorators-legacy", "decorators"],
-  "throws": "Cannot use decorators and decorators-legacy plugin together"
+  "throws": "Cannot use the decorators and decorators-legacy plugin together"
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | :+1: 
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT


- 8f76ff3 adds support for options to Babylon plugins.

- 3c5c47f adds support for decorators before export (via `["decorators2", { "decoratorsBeforeExport": true }]`). I think that this should be an option because the discussion about it is still open; this would allow us to experiment both syntaxes. We can discuss about what the default value is.