### PR TITLE
Fix typo [skip-ci]

### DIFF
--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -145,7 +145,7 @@ if (program.eval || program.print) {
     });
     args = args.slice(i);
 
-    // We have to handle require ourselfs, as we want to require it in the context of babel-register
+    // We have to handle require ourselves, as we want to require it in the context of babel-register
     if (program.require) {
       let requireFileName = program.require;
       if (!path.isAbsolute(requireFileName)) {


### PR DESCRIPTION

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | Not really
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         | Yes
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

It used to say `ourselfs`, now it says `ourselves`.

Thanks!