### PR TITLE
Fix a typo in a babylon flow plugin comment

### DIFF
--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -34,6 +34,7 @@ function isEsModuleType(bodyElement: N.Node): boolean {
   );
 }
 
+
 function hasTypeImportKind(node: N.Node): boolean {
   return node.importKind === "type" || node.importKind === "typeof";
 }
@@ -1487,8 +1488,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return { consequent, failed };
     }
 
-    // Given an expression, walks throught its arrow functions whose body is
-    // an expression and throught conditional expressions. It returns every
+    // Given an expression, walks through out its arrow functions whose body is
+    // an expression and through out conditional expressions. It returns every
     // function which has been parsed with a return type but could have been
     // parenthesized expressions.
     // These functions are separated into two arrays: one containing the ones


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->
This change fixes a few typos within a code comment, assuming that `throught` was meant to be `through out`.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | Yes <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
