### PR TITLE
Restore passing SIGINT signals to spawned child processes on v6.x

### DIFF
--- a/packages/babel-cli/src/babel-node.js
+++ b/packages/babel-cli/src/babel-node.js
@@ -90,5 +90,9 @@ getV8Flags(function (err, v8Flags) {
         }
       });
     });
+    process.on("SIGINT", () => {
+      proc.kill("SIGINT");
+      process.exit(1);
+    });
   }
 });


### PR DESCRIPTION
(adapted to different v6.x source tree from commit 7e423de911aee7ee3bf09543411f207f2778cf08 and #7511 by David Fraser)

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5861
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
