### PR TITLE
Inherit parens in replaceWith

### DIFF
--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -166,6 +166,7 @@ export function replaceWith(replacement) {
   if (oldNode) {
     t.inheritsComments(replacement, oldNode);
     t.removeComments(oldNode);
+    t.inheritParens(replacement, oldNode);
   }
 
   // replace the node

--- a/packages/babel-types/src/index.js
+++ b/packages/babel-types/src/index.js
@@ -75,6 +75,7 @@ export {
 export {
   default as removeTypeDuplicates,
 } from "./modifications/flow/removeTypeDuplicates";
+export { default as inheritParens } from "./modifications/inheritParens";
 
 // retrievers
 export {

--- a/packages/babel-types/src/modifications/inheritParens.js
+++ b/packages/babel-types/src/modifications/inheritParens.js
@@ -1,0 +1,15 @@
+// @flow
+
+/**
+ * Add parens to a node if it's needed.
+ */
+export default function inheritParens<T: Object>(child: T, parent: Object): T {
+  if (parent.extra && parent.extra.parenthesized) {
+    if (!child.extra) {
+      child.extra = {};
+    }
+    child.extra.parenthesized = true;
+    child.extra.parenStart = parent.extra.parenStart;
+  }
+  return child;
+}


### PR DESCRIPTION
If the original expression had parens then add parens around the new
expression too,

Based on  #7015

Co-authored-by: Toru Kobayashi <koba0004@gmail.com>

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | No
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
