### PR TITLE
Allow 'babelrc' and 'babelrcRoots' in config files (but not .babelrc/extends)

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -148,7 +148,7 @@ export function buildRootChain(
 
   const configFileChain = emptyChain();
   if (configFile) {
-    const result = loadFileChain(validateFile(configFile), context);
+    const result = loadFileChain(validateConfigFile(configFile), context);
     if (!result) return null;
 
     mergeChain(configFileChain, result);
@@ -180,7 +180,7 @@ export function buildRootChain(
     }
 
     if (babelrcFile) {
-      const result = loadFileChain(validateFile(babelrcFile), context);
+      const result = loadFileChain(validateBabelrcFile(babelrcFile), context);
       if (!result) return null;
 
       mergeChain(fileChain, result);
@@ -231,10 +231,24 @@ function babelrcLoadEnabled(
   return micromatch(pkgData.directories, babelrcPatterns).length > 0;
 }
 
-const validateFile = makeWeakCache((file: ConfigFile): ValidatedFile => ({
+const validateConfigFile = makeWeakCache((file: ConfigFile): ValidatedFile => ({
   filepath: file.filepath,
   dirname: file.dirname,
-  options: validate("file", file.options),
+  options: validate("configfile", file.options),
+}));
+
+const validateBabelrcFile = makeWeakCache(
+  (file: ConfigFile): ValidatedFile => ({
+    filepath: file.filepath,
+    dirname: file.dirname,
+    options: validate("babelrcfile", file.options),
+  }),
+);
+
+const validateExtendFile = makeWeakCache((file: ConfigFile): ValidatedFile => ({
+  filepath: file.filepath,
+  dirname: file.dirname,
+  options: validate("extendsfile", file.options),
 }));
 
 /**
@@ -434,7 +448,7 @@ function mergeExtendsChain(
   }
 
   files.add(file);
-  const fileChain = loadFileChain(validateFile(file), context, files);
+  const fileChain = loadFileChain(validateExtendFile(file), context, files);
   files.delete(file);
 
   if (!fileChain) return false;

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -49,6 +49,7 @@ export default function loadPrivatePartialConfig(
   // passed back to Babel a second time, it will be in the right structure
   // to not change behavior.
   options.babelrc = false;
+  options.configFile = false;
   options.envName = envName;
   options.cwd = absoluteCwd;
   options.passPerPreset = false;

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -243,7 +243,14 @@ export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";
 export type RootInputSourceMapOption = {} | boolean;
 
-export type OptionsType = "arguments" | "file" | "env" | "preset" | "override";
+export type OptionsType =
+  | "arguments"
+  | "env"
+  | "preset"
+  | "override"
+  | "configfile"
+  | "babelrcfile"
+  | "extendsfile";
 
 export function validate(type: OptionsType, opts: {}): ValidatedOptions {
   assertNoDuplicateSourcemap(opts);

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -36,17 +36,20 @@ const ROOT_VALIDATORS: ValidatorSet = {
   filenameRelative: (assertString: Validator<
     $PropertyType<ValidatedOptions, "filenameRelative">,
   >),
-  babelrc: (assertBoolean: Validator<
-    $PropertyType<ValidatedOptions, "babelrc">,
-  >),
-  babelrcRoots: (assertBabelrcSearch: Validator<
-    $PropertyType<ValidatedOptions, "babelrcRoots">,
-  >),
   code: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "code">>),
   ast: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "ast">>),
 
   envName: (assertString: Validator<
     $PropertyType<ValidatedOptions, "envName">,
+  >),
+};
+
+const BABELRC_VALIDATORS: ValidatorSet = {
+  babelrc: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "babelrc">,
+  >),
+  babelrcRoots: (assertBabelrcSearch: Validator<
+    $PropertyType<ValidatedOptions, "babelrcRoots">,
   >),
 };
 
@@ -262,6 +265,22 @@ export function validate(type: OptionsType, opts: {}): ValidatedOptions {
     if (type !== "arguments" && ROOT_VALIDATORS[key]) {
       throw new Error(`.${key} is only allowed in root programmatic options`);
     }
+    if (
+      type !== "arguments" &&
+      type !== "configfile" &&
+      BABELRC_VALIDATORS[key]
+    ) {
+      if (type === "babelrcfile" || type === "extendsfile") {
+        throw new Error(
+          `.${key} is not allowed in .babelrc or "extend"ed files, only in root programmatic options, ` +
+            `or babel.config.js/config file options`,
+        );
+      }
+
+      throw new Error(
+        `.${key} is only allowed in root programmatic options, or babel.config.js/config file options`,
+      );
+    }
     if (type === "env" && key === "env") {
       throw new Error(`.${key} is not allowed inside another env block`);
     }
@@ -275,6 +294,7 @@ export function validate(type: OptionsType, opts: {}): ValidatedOptions {
     const validator =
       COMMON_VALIDATORS[key] ||
       NONPRESET_VALIDATORS[key] ||
+      BABELRC_VALIDATORS[key] ||
       ROOT_VALIDATORS[key];
 
     if (validator) validator(key, opts[key]);

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -904,6 +904,7 @@ describe("buildConfigChain", function() {
   describe("config files", () => {
     const getDefaults = () => ({
       babelrc: false,
+      configFile: false,
       cwd: process.cwd(),
       envName: "development",
       passPerPreset: false,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7874, Fixes #7922
| Patch: Bug Fix?          | 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This allows `babel.config.js` files to define `babelrcRoots` so that users don't have to specify that option in multiple places if they don't want to.

Also properly sets `configFile: false` when a partial config is loaded, so we don't double-process the config.