### PR TITLE
Update README.md

### DIFF
--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -205,7 +205,7 @@ Each `ConfigItem` exposes all of the information Babel knows. The fields are:
     You can pass these options from the Babel CLI like so:
   </p>
   <p>
-    <code>babel --name<span class="o">=</span>value</code>
+    <code>babel --config-file<span class="o">=</span>value</code>
   </p>
 </blockquote>
 

--- a/packages/babel-core/README.md
+++ b/packages/babel-core/README.md
@@ -205,7 +205,7 @@ Each `ConfigItem` exposes all of the information Babel knows. The fields are:
     You can pass these options from the Babel CLI like so:
   </p>
   <p>
-    <code>babel --config-file<span class="o">=</span>value</code>
+    <code>babel --option-name<span class="o">=</span>value</code>
   </p>
 </blockquote>
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |No
| Minor: New Feature?      |No
| Tests Added + Pass?      |No
| Documentation PR         |Yes
| Any Dependency Changes?  |No
| License                  | MIT

[skip ci]

Because of the breaking change in 7-beta.46 regarding to monorepos and .babelrc, I needed to switch to babel.config.js, and somehow it could not find it unless I specified its path on the command line. 

I spent more than 45 minutes not getting it to work and even digging into babel core code, because I followed instructions on the babel-core README exactly, meaning I provided the parameter --configFile==... I realize I could have written babel --help and seen the correct parameter, but by choosing a parameter that is multi-word for the example, we show people right away that they need to switch from camelCase to kebab-case when supplying parameters on the command line.