### PR TITLE
Update syntax-decorators options

### DIFF
--- a/packages/babel-core/test/fixtures/option-manager/presets/es2015_default_function.js
+++ b/packages/babel-core/test/fixtures/option-manager/presets/es2015_default_function.js
@@ -12,6 +12,11 @@ Object.defineProperty(exports, "__esModule", {
 
 exports.default = function () {
   return {
-    plugins: [require('../../../../../babel-plugin-syntax-decorators')]
+    plugins: [
+      [
+        require('../../../../../babel-plugin-syntax-decorators'),
+        { legacy: true }
+      ],
+    ]
   };
 };

--- a/packages/babel-core/test/fixtures/option-manager/presets/es2015_default_object.js
+++ b/packages/babel-core/test/fixtures/option-manager/presets/es2015_default_object.js
@@ -9,6 +9,11 @@
 exports.__esModule = true;
 module.exports = function() {
   return {
-    plugins: [require('../../../../../babel-plugin-syntax-decorators')]
+    plugins: [
+      [
+        require('../../../../../babel-plugin-syntax-decorators'),
+        { legacy: true }
+      ],
+    ]
   };
 };

--- a/packages/babel-core/test/fixtures/option-manager/presets/es5_function.js
+++ b/packages/babel-core/test/fixtures/option-manager/presets/es5_function.js
@@ -1,7 +1,10 @@
 module.exports = function () {
   return {
     plugins: [
-      require('../../../../../babel-plugin-syntax-decorators'),
+      [
+        require('../../../../../babel-plugin-syntax-decorators'),
+        { legacy: true }
+      ],
     ]
   };
 };

--- a/packages/babel-core/test/fixtures/option-manager/presets/es5_object.js
+++ b/packages/babel-core/test/fixtures/option-manager/presets/es5_object.js
@@ -1,7 +1,10 @@
 module.exports = function() {
   return {
     plugins: [
-      require('../../../../../babel-plugin-syntax-decorators'),
+      [
+        require('../../../../../babel-plugin-syntax-decorators'),
+        { legacy: true }
+      ],
     ]
   };
 };

--- a/packages/babel-plugin-syntax-decorators/README.md
+++ b/packages/babel-plugin-syntax-decorators/README.md
@@ -54,3 +54,8 @@ export class Foo {}
 // decoratorsBeforeExport: false
 export @decorator class Bar {}
 ```
+
+This option allows developers to experimet both the possible syntaxes. This will
+allow collecting an informed feedback from the community, which will help to
+decide which the final syntax should be.
+[tc39/proposal-decorators#69](https://github.com/tc39/proposal-decorators/issues/69)

--- a/packages/babel-plugin-syntax-decorators/README.md
+++ b/packages/babel-plugin-syntax-decorators/README.md
@@ -55,7 +55,6 @@ export class Foo {}
 export @decorator class Bar {}
 ```
 
-This option allows developers to experimet both the possible syntaxes. This will
-allow collecting an informed feedback from the community, which will help to
-decide which the final syntax should be.
-[tc39/proposal-decorators#69](https://github.com/tc39/proposal-decorators/issues/69)
+This option was added to help tc39 collect feedback from the community by allowing experimentation with both possible syntaxes.
+
+For more information, check out: [tc39/proposal-decorators#69](https://github.com/tc39/proposal-decorators/issues/69)

--- a/packages/babel-plugin-syntax-decorators/README.md
+++ b/packages/babel-plugin-syntax-decorators/README.md
@@ -44,7 +44,7 @@ Use the legacy (stage 1) decorators syntax.
 
 ### `decoratorsBeforeExport`
 
-`boolean`, defaults to `false`.
+`boolean`, defaults to `true`.
 
 ```js
 // decoratorsBeforeExport: true

--- a/packages/babel-plugin-syntax-decorators/README.md
+++ b/packages/babel-plugin-syntax-decorators/README.md
@@ -41,3 +41,16 @@ require("@babel/core").transform("code", {
 `boolean`, defaults to `false`.
 
 Use the legacy (stage 1) decorators syntax.
+
+### `decoratorsBeforeExport`
+
+`boolean`, defaults to `false`.
+
+```js
+// decoratorsBeforeExport: true
+@decorator
+export class Foo {}
+
+// decoratorsBeforeExport: false
+export @decorator class Bar {}
+```

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -3,14 +3,37 @@ import { declare } from "@babel/helper-plugin-utils";
 export default declare((api, options) => {
   api.assertVersion(7);
 
-  const { legacy = false } = options;
+  const { legacy = false, decoratorsBeforeExport } = options;
   if (typeof legacy !== "boolean") {
     throw new Error("'legacy' must be a boolean.");
   }
 
+  if (legacy !== true) {
+    throw new Error(
+      "The new decorators proposal is not supported yet." +
+        ' You must pass the `"legacy": true` option to' +
+        " @babel/plugin-syntax-decorators",
+    );
+  }
+
+  if (decoratorsBeforeExport !== undefined) {
+    if (legacy) {
+      throw new Error(
+        "'decoratorsBeforeExport' can't be used with legacy decorators.",
+      );
+    }
+    if (typeof decoratorsBeforeExport !== "boolean") {
+      throw new Error("'decoratorsBeforeExport' must be a boolean.");
+    }
+  }
+
   return {
     manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push(legacy ? "decorators-legacy" : "decorators");
+      parserOpts.plugins.push(
+        legacy
+          ? "decorators-legacy"
+          : ["decorators", { decoratorsBeforeExport }],
+      );
     },
   };
 });

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -3,7 +3,7 @@ import { declare } from "@babel/helper-plugin-utils";
 export default declare((api, options) => {
   api.assertVersion(7);
 
-  const { legacy = false, decoratorsBeforeExport } = options;
+  const { legacy = false } = options;
   if (typeof legacy !== "boolean") {
     throw new Error("'legacy' must be a boolean.");
   }
@@ -16,6 +16,7 @@ export default declare((api, options) => {
     );
   }
 
+  let { decoratorsBeforeExport } = options;
   if (decoratorsBeforeExport !== undefined) {
     if (legacy) {
       throw new Error(
@@ -25,6 +26,8 @@ export default declare((api, options) => {
     if (typeof decoratorsBeforeExport !== "boolean") {
       throw new Error("'decoratorsBeforeExport' must be a boolean.");
     }
+  } else if (!legacy) {
+    decoratorsBeforeExport = true;
   }
 
   return {

--- a/packages/babel-plugin-syntax-decorators/test/index.js
+++ b/packages/babel-plugin-syntax-decorators/test/index.js
@@ -1,0 +1,66 @@
+import { parse } from "@babel/core";
+import syntaxDecorators from "../lib";
+
+function makeParser(code, options) {
+  return () =>
+    parse(code, {
+      babelrc: false,
+      configFile: false,
+      plugins: [[syntaxDecorators, options]],
+    });
+}
+
+describe("'legacy' option", function() {
+  test("must be boolean", function() {
+    expect(makeParser("", { legacy: "legacy" })).toThrow();
+  });
+
+  test("'legacy': false", function() {
+    expect(makeParser("({ @dec fn() {} })", { legacy: false })).toThrow();
+  });
+
+  test("'legacy': true", function() {
+    expect(makeParser("({ @dec fn() {} })", { legacy: true })).notToThrow();
+  });
+
+  test("defaults to 'false'", function() {
+    expect(makeParser("({ @dec fn() {} })", {})).toThrow();
+  });
+});
+
+describe("'decoratorsBeforeExport' option", function() {
+  test("must be boolean", function() {
+    expect(makeParser("", { decoratorsBeforeExport: "before" })).toThrow();
+  });
+
+  test("is incompatible with legacy", function() {
+    expect(
+      makeParser("", { decoratorsBeforeExport: false, legacy: true }),
+    ).toThrow();
+  });
+
+  const BEFORE = "@dec export class Foo {}";
+  const AFTER = "export @dec class Foo {}";
+
+  run(BEFORE, undefined, false);
+  run(AFTER, undefined, true);
+  run(BEFORE, true, false);
+  run(AFTER, true, true);
+  run(BEFORE, false, true);
+  run(AFTER, false, false);
+
+  function run(code, before, throws) {
+    const name =
+      (before === undefined ? "default" : before) +
+      " - decorators " +
+      (code === BEFORE ? "before" : "after") +
+      "export";
+
+    test(name, function() {
+      const expectTheParser = expect(
+        makeParser(code, { decoratorsBeforeExport: before }),
+      );
+      throws ? expectTheParser.toThrow() : expectTheParser.not.toThrow();
+    });
+  }
+});

--- a/packages/babel-plugin-syntax-decorators/test/index.js
+++ b/packages/babel-plugin-syntax-decorators/test/index.js
@@ -15,21 +15,25 @@ describe("'legacy' option", function() {
     expect(makeParser("", { legacy: "legacy" })).toThrow();
   });
 
-  test("'legacy': false", function() {
+  test.skip("'legacy': false", function() {
     expect(makeParser("({ @dec fn() {} })", { legacy: false })).toThrow();
   });
 
   test("'legacy': true", function() {
-    expect(makeParser("({ @dec fn() {} })", { legacy: true })).notToThrow();
+    expect(makeParser("({ @dec fn() {} })", { legacy: true })).not.toThrow();
   });
 
-  test("defaults to 'false'", function() {
+  test.skip("defaults to 'false'", function() {
     expect(makeParser("({ @dec fn() {} })", {})).toThrow();
+  });
+
+  test("it must be true", function() {
+    expect(makeParser("", { legacy: false })).toThrow();
   });
 });
 
 describe("'decoratorsBeforeExport' option", function() {
-  test("must be boolean", function() {
+  test.skip("must be boolean", function() {
     expect(makeParser("", { decoratorsBeforeExport: "before" })).toThrow();
   });
 
@@ -42,6 +46,7 @@ describe("'decoratorsBeforeExport' option", function() {
   const BEFORE = "@dec export class Foo {}";
   const AFTER = "export @dec class Foo {}";
 
+  // These are skipped
   run(BEFORE, undefined, false);
   run(AFTER, undefined, true);
   run(BEFORE, true, false);
@@ -56,7 +61,7 @@ describe("'decoratorsBeforeExport' option", function() {
       (code === BEFORE ? "before" : "after") +
       "export";
 
-    test(name, function() {
+    test.skip(name, function() {
       const expectTheParser = expect(
         makeParser(code, { decoratorsBeforeExport: before }),
       );


### PR DESCRIPTION
* Add decoratorsBeforeExport to the syntax plugin
* Require legacy: true, like in the transform plugin

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

- [x] Tests (I will enable them in #7976, since currently legacy must be true)