### PR TITLE
Make the filename option, as exposed to the plugins, consistently relative to the working directory

### DIFF
--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,4 +1,3 @@
-const includes = require("lodash/includes");
 const readdir = require("fs-readdir-recursive");
 const helper = require("@babel/helper-fixtures");
 const rimraf = require("rimraf");
@@ -51,7 +50,7 @@ const assertTest = function(stdout, stderr, opts) {
 
   if (opts.stderr) {
     if (opts.stderrContains) {
-      expect(includes(stderr, expectStderr)).toBe(true);
+      expect(stderr).toContain(expectStderr);
     } else {
       expect(stderr).toBe(expectStderr);
     }
@@ -65,7 +64,7 @@ const assertTest = function(stdout, stderr, opts) {
 
   if (opts.stdout) {
     if (opts.stdoutContains) {
-      expect(includes(stdout, expectStdout)).toBe(true);
+      expect(stdout).toContain(expectStdout);
     } else {
       expect(stdout).toBe(expectStdout);
     }

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -28,12 +28,17 @@ export default function loadPrivatePartialConfig(
 
   const args = inputOpts ? validate("arguments", inputOpts) : {};
 
-  const { envName = getEnv(), cwd = "." } = args;
+  const { envName = getEnv(), cwd = ".", root: rootDir = "." } = args;
   const absoluteCwd = path.resolve(cwd);
+  const absoluteRootDir = path.resolve(absoluteCwd, rootDir);
 
   const context: ConfigContext = {
-    filename: args.filename ? path.resolve(cwd, args.filename) : null,
+    filename:
+      typeof args.filename === "string"
+        ? path.resolve(cwd, args.filename)
+        : undefined,
     cwd: absoluteCwd,
+    root: absoluteRootDir,
     envName,
   };
 
@@ -50,9 +55,14 @@ export default function loadPrivatePartialConfig(
   // to not change behavior.
   options.babelrc = false;
   options.configFile = false;
-  options.envName = envName;
-  options.cwd = absoluteCwd;
   options.passPerPreset = false;
+  options.envName = context.envName;
+  options.cwd = context.cwd;
+  options.root = context.root;
+  options.filename =
+    typeof context.filename === "string"
+      ? path.relative(context.cwd, context.filename)
+      : undefined;
 
   options.plugins = configChain.plugins.map(descriptor =>
     createItemFromDescriptor(descriptor),

--- a/packages/babel-core/src/transformation/plugin-pass.js
+++ b/packages/babel-core/src/transformation/plugin-pass.js
@@ -7,14 +7,19 @@ export default class PluginPass {
   key: ?string;
   file: File;
   opts: Object;
+
+  // The working directory that Babel's options are loaded relative to.
+  cwd: string;
+
+  // The path of the file being compiled, relative to the working directory.
   filename: string | void;
 
   constructor(file: File, key: ?string, options: ?Object) {
     this.key = key;
     this.file = file;
     this.opts = options || {};
-    this.filename =
-      typeof file.opts.filename === "string" ? file.opts.filename : undefined;
+    this.cwd = file.opts.cwd;
+    this.filename = file.opts.filename;
   }
 
   set(key: mixed, val: mixed) {

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -906,6 +906,7 @@ describe("buildConfigChain", function() {
       babelrc: false,
       configFile: false,
       cwd: process.cwd(),
+      root: process.cwd(),
       envName: "development",
       passPerPreset: false,
       plugins: [],
@@ -935,8 +936,9 @@ describe("buildConfigChain", function() {
         }),
       ).toEqual({
         ...getDefaults(),
-        filename,
+        filename: path.basename(filename),
         cwd: path.dirname(filename),
+        root: path.dirname(filename),
         comments: true,
       });
     });
@@ -946,8 +948,9 @@ describe("buildConfigChain", function() {
 
       expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
         ...getDefaults(),
-        filename,
+        filename: path.basename(filename),
         cwd: path.dirname(filename),
+        root: path.dirname(filename),
         comments: true,
       });
     });
@@ -957,8 +960,9 @@ describe("buildConfigChain", function() {
 
       expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
         ...getDefaults(),
-        filename,
+        filename: path.basename(filename),
         cwd: path.dirname(filename),
+        root: path.dirname(filename),
         comments: true,
       });
     });
@@ -998,8 +1002,9 @@ describe("buildConfigChain", function() {
 
       expect(loadOptions({ filename, cwd: path.dirname(filename) })).toEqual({
         ...getDefaults(),
-        filename,
+        filename: path.basename(filename),
         cwd: path.dirname(filename),
+        root: path.dirname(filename),
         comments: true,
       });
     });

--- a/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/exec.js
+++ b/packages/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/exec.js
@@ -1,10 +1,10 @@
 var actual = transform(
   'var x = <sometag />',
-  Object.assign({}, opts, { filename: '/fake/path/mock.js' })
+  Object.assign({}, opts, { filename: 'fake/path/mock.js' })
 ).code;
 
 var expected = multiline([
-  'var _jsxFileName = "/fake/path/mock.js";',
+  'var _jsxFileName = "fake/path/mock.js";',
   'var x = <sometag __source={{',
   '  fileName: _jsxFileName,',
   '  lineNumber: 1',

--- a/packages/babel-preset-react/test/fixtures/preset-options/development/exec.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development/exec.js
@@ -1,10 +1,10 @@
 const actual = transform(
   '<Foo bar="baz" />',
-  Object.assign({}, opts, { filename: '/fake/path/mock.js' })
+  Object.assign({}, opts, { filename: 'fake/path/mock.js' })
 ).code;
 
 const expected = multiline([
-  'var _jsxFileName = "/fake/path/mock.js";',
+  'var _jsxFileName = "fake/path/mock.js";',
   'React.createElement(Foo, {',
   '  bar: "baz",',
   '  __source: {',


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Currently the `opts.filename` value exposed to plugins is just whatever the user passed. While it _could_ be relative to the working directory, if Babel was passed an absolute URL, it'll be absolute.

This PR explicitly ensures the filename is a relative path based on the working directory. This also exposes an officially endorsed API for reading the working directory path.