### PR TITLE
TypeScript: Fix TSInferType .typeParameter type.

### DIFF
--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -2131,7 +2131,7 @@ See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeParameter`: `TSType` (required)
+ - `typeParameter`: `TSTypeParameter` (required)
 
 ---
 

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -238,7 +238,7 @@ defineType("TSInferType", {
   aliases: ["TSType"],
   visitor: ["typeParameter"],
   fields: {
-    typeParameter: validateType("TSType"),
+    typeParameter: validateType("TSTypeParameter"),
   },
 });
 

--- a/packages/babylon/src/plugins/typescript.js
+++ b/packages/babylon/src/plugins/typescript.js
@@ -637,7 +637,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.expectContextual("infer");
       const typeParameter = this.startNode();
       typeParameter.name = this.parseIdentifierName(typeParameter.start);
-      node.typeParameter = this.finishNode(typeParameter, "TypeParameter");
+      node.typeParameter = this.finishNode(typeParameter, "TSTypeParameter");
       return this.finishNode(node, "TSInferType");
     }
 

--- a/packages/babylon/test/fixtures/typescript/types/conditional-infer/output.json
+++ b/packages/babylon/test/fixtures/typescript/types/conditional-infer/output.json
@@ -181,7 +181,7 @@
                   }
                 },
                 "typeParameter": {
-                  "type": "TypeParameter",
+                  "type": "TSTypeParameter",
                   "start": 35,
                   "end": 36,
                   "loc": {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Various `ast-types` test failures, e.g. https://travis-ci.org/benjamn/ast-types/jobs/369634972
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Fixed existing tests that expected `TypeParameter`
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Follow-up to https://github.com/babel/babel/pull/7404

There is no `TypeParameter` type in the Babylon TypeScript AST hierarchy. Flow does have a `TypeParameter` type, but it should not be confused with the TypeScript `TSTypeParameter`, since Flow !== TypeScript, and the types have totally different fields. Instead, the `.typeParameter.type` of a Babylon-parsed `TSInferType` node should be `TSTypeParameter`.

It would probably be fine to leave the declared type of the `TSInferType` `.typeParameter` field as `TSType` instead of `TSTypeParameter`, but the more specific `TSTypeParameter` type should be safe/correct, since the TypeScript [`parseInferType` function](https://github.com/Microsoft/TypeScript/blob/66d6e5e6e007ce3ac70b7371c3e7ac46a99a0fcd/src/compiler/parser.ts#L3006) always uses `SyntaxKind.TypeParameter`.

I noticed this typo because it has been causing `ast-types` test failures lately, e.g. https://travis-ci.org/benjamn/ast-types/jobs/369634972