### PR TITLE
Support Flow's inline interface syntax

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -262,6 +262,19 @@ function andSeparator() {
   this.space();
 }
 
+export function InterfaceTypeAnnotation(node: Object) {
+  this.word("interface");
+  this.space();
+  if (node.extends.length) {
+    this.space();
+    this.word("extends");
+    this.space();
+    this.printList(node.extends, node);
+  }
+  this.space();
+  this.print(node.body, node);
+}
+
 export function IntersectionTypeAnnotation(node: Object) {
   this.printJoin(node.types, node, { separator: andSeparator });
 }

--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -264,8 +264,7 @@ function andSeparator() {
 
 export function InterfaceTypeAnnotation(node: Object) {
   this.word("interface");
-  this.space();
-  if (node.extends.length) {
+  if (node.extends && node.extends.length) {
     this.space();
     this.word("extends");
     this.space();

--- a/packages/babel-generator/test/fixtures/flow/interface-types/input.js
+++ b/packages/babel-generator/test/fixtures/flow/interface-types/input.js
@@ -1,0 +1,3 @@
+type A = interface { p: string };
+type B = interface extends X { p: string };
+type C = interface extends X, Y { p: string };

--- a/packages/babel-generator/test/fixtures/flow/interface-types/output.js
+++ b/packages/babel-generator/test/fixtures/flow/interface-types/output.js
@@ -1,0 +1,9 @@
+type A = interface {
+  p: string
+};
+type B = interface extends X {
+  p: string
+};
+type C = interface extends X, Y {
+  p: string
+};

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -211,6 +211,15 @@ defineType("InterfaceExtends", {
 
 defineInterfaceishType("InterfaceDeclaration");
 
+defineType("InterfaceTypeAnnotation", {
+  visitor: ["extends", "body"],
+  aliases: ["Flow", "FlowType"],
+  fields: {
+    extends: validateOptional(arrayOfType("InterfaceExtends")),
+    body: validateType("ObjectTypeAnnotation"),
+  },
+});
+
 defineType("IntersectionTypeAnnotation", {
   visitor: ["types"],
   aliases: ["Flow", "FlowType"],

--- a/packages/babylon/src/plugins/flow.js
+++ b/packages/babylon/src/plugins/flow.js
@@ -608,6 +608,22 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.finishNode(node, "TypeParameterInstantiation");
     }
 
+    flowParseInterfaceType(): N.FlowInterfaceType {
+      const node = this.startNode();
+      this.expectContextual("interface");
+
+      node.extends = [];
+      if (this.eat(tt._extends)) {
+        do {
+          node.extends.push(this.flowParseInterfaceExtends());
+        } while (this.eat(tt.comma));
+      }
+
+      node.body = this.flowParseObjectType(true, false, false);
+
+      return this.finishNode(node, "InterfaceTypeAnnotation");
+    }
+
     flowParseObjectPropertyKey(): N.Expression {
       return this.match(tt.num) || this.match(tt.string)
         ? this.parseExprAtom()
@@ -1054,6 +1070,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       switch (this.state.type) {
         case tt.name:
+          if (this.isContextual("interface")) {
+            return this.flowParseInterfaceType();
+          }
+
           return this.flowIdentToTypeAnnotation(
             startPos,
             startLoc,

--- a/packages/babylon/test/fixtures/flow/interface-types/basic/input.js
+++ b/packages/babylon/test/fixtures/flow/interface-types/basic/input.js
@@ -1,0 +1,1 @@
+type T = interface { p: string }

--- a/packages/babylon/test/fixtures/flow/interface-types/basic/output.json
+++ b/packages/babylon/test/fixtures/flow/interface-types/basic/output.json
@@ -1,0 +1,156 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 32,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 32
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 32,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 32
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 32,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 32
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "InterfaceTypeAnnotation",
+          "start": 9,
+          "end": 32,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 32
+            }
+          },
+          "extends": [],
+          "body": {
+            "type": "ObjectTypeAnnotation",
+            "start": 19,
+            "end": 32,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 32
+              }
+            },
+            "callProperties": [],
+            "properties": [
+              {
+                "type": "ObjectTypeProperty",
+                "start": 21,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 30
+                  }
+                },
+                "key": {
+                  "type": "Identifier",
+                  "start": 21,
+                  "end": 22,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    },
+                    "identifierName": "p"
+                  },
+                  "name": "p"
+                },
+                "static": false,
+                "kind": "init",
+                "method": false,
+                "value": {
+                  "type": "StringTypeAnnotation",
+                  "start": 24,
+                  "end": 30,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 30
+                    }
+                  }
+                },
+                "variance": null,
+                "optional": false
+              }
+            ],
+            "indexers": [],
+            "internalSlots": [],
+            "exact": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/flow/interface-types/extends-multiple/input.js
+++ b/packages/babylon/test/fixtures/flow/interface-types/extends-multiple/input.js
@@ -1,0 +1,1 @@
+type T = interface extends X, Y { p: string }

--- a/packages/babylon/test/fixtures/flow/interface-types/extends-multiple/output.json
+++ b/packages/babylon/test/fixtures/flow/interface-types/extends-multiple/output.json
@@ -1,0 +1,223 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 45,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 45
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 45,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 45
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 45,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 45
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "InterfaceTypeAnnotation",
+          "start": 9,
+          "end": 45,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 45
+            }
+          },
+          "extends": [
+            {
+              "type": "InterfaceExtends",
+              "start": 27,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 27
+                },
+                "end": {
+                  "line": 1,
+                  "column": 28
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 27,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 28
+                  },
+                  "identifierName": "X"
+                },
+                "name": "X"
+              },
+              "typeParameters": null
+            },
+            {
+              "type": "InterfaceExtends",
+              "start": 30,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 30
+                },
+                "end": {
+                  "line": 1,
+                  "column": 31
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 30,
+                "end": 31,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 31
+                  },
+                  "identifierName": "Y"
+                },
+                "name": "Y"
+              },
+              "typeParameters": null
+            }
+          ],
+          "body": {
+            "type": "ObjectTypeAnnotation",
+            "start": 32,
+            "end": 45,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 32
+              },
+              "end": {
+                "line": 1,
+                "column": 45
+              }
+            },
+            "callProperties": [],
+            "properties": [
+              {
+                "type": "ObjectTypeProperty",
+                "start": 34,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 34
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 43
+                  }
+                },
+                "key": {
+                  "type": "Identifier",
+                  "start": 34,
+                  "end": 35,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 34
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 35
+                    },
+                    "identifierName": "p"
+                  },
+                  "name": "p"
+                },
+                "static": false,
+                "kind": "init",
+                "method": false,
+                "value": {
+                  "type": "StringTypeAnnotation",
+                  "start": 37,
+                  "end": 43,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 43
+                    }
+                  }
+                },
+                "variance": null,
+                "optional": false
+              }
+            ],
+            "indexers": [],
+            "internalSlots": [],
+            "exact": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/flow/interface-types/extends/input.js
+++ b/packages/babylon/test/fixtures/flow/interface-types/extends/input.js
@@ -1,0 +1,1 @@
+type T = interface extends X { p: string }

--- a/packages/babylon/test/fixtures/flow/interface-types/extends/output.json
+++ b/packages/babylon/test/fixtures/flow/interface-types/extends/output.json
@@ -1,0 +1,190 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 42,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 42
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 42,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 42
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 42,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 42
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "InterfaceTypeAnnotation",
+          "start": 9,
+          "end": 42,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 42
+            }
+          },
+          "extends": [
+            {
+              "type": "InterfaceExtends",
+              "start": 27,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 27
+                },
+                "end": {
+                  "line": 1,
+                  "column": 28
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 27,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 28
+                  },
+                  "identifierName": "X"
+                },
+                "name": "X"
+              },
+              "typeParameters": null
+            }
+          ],
+          "body": {
+            "type": "ObjectTypeAnnotation",
+            "start": 29,
+            "end": 42,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 29
+              },
+              "end": {
+                "line": 1,
+                "column": 42
+              }
+            },
+            "callProperties": [],
+            "properties": [
+              {
+                "type": "ObjectTypeProperty",
+                "start": 31,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 31
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 40
+                  }
+                },
+                "key": {
+                  "type": "Identifier",
+                  "start": 31,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 31
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 32
+                    },
+                    "identifierName": "p"
+                  },
+                  "name": "p"
+                },
+                "static": false,
+                "kind": "init",
+                "method": false,
+                "value": {
+                  "type": "StringTypeAnnotation",
+                  "start": 34,
+                  "end": 40,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 34
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 40
+                    }
+                  }
+                },
+                "variance": null,
+                "optional": false
+              }
+            ],
+            "indexers": [],
+            "internalSlots": [],
+            "exact": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Flow added support for interface type annotations, which can be used inline like object type annotations, in https://github.com/facebook/flow/commit/4f93f3adb7a5fedd3d572d62d718cf48c15a08ce.

This adds the matching support to Babylon. Note that `interface` was already disallowed as a type identifier (i.e., `type interface = string`), so this syntax does not break any existing programs.