### PR TITLE
Support Flow's proto modifier syntax for declared classes

### DIFF
--- a/packages/babel-generator/src/generators/flow.js
+++ b/packages/babel-generator/src/generators/flow.js
@@ -472,6 +472,10 @@ export function ObjectTypeIndexer(node: Object) {
 }
 
 export function ObjectTypeProperty(node: Object) {
+  if (node.proto) {
+    this.word("proto");
+    this.space();
+  }
   if (node.static) {
     this.word("static");
     this.space();

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -460,7 +460,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } while (this.eat(tt.comma));
       }
 
-      node.body = this.flowParseObjectType(true, false, false);
+      node.body = this.flowParseObjectType(true, false, false, isClass);
     }
 
     flowParseInterfaceExtends(): N.FlowInterfaceExtends {
@@ -755,6 +755,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       allowStatic: boolean,
       allowExact: boolean,
       allowSpread: boolean,
+      allowProto: boolean,
     ): N.FlowObjectTypeAnnotation {
       const oldInType = this.state.inType;
       this.state.inType = true;
@@ -782,7 +783,18 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       while (!this.match(endDelim)) {
         let isStatic = false;
+        let protoStart: ?number = null;
         const node = this.startNode();
+
+        if (allowProto && this.isContextual("proto")) {
+          const lookahead = this.lookahead();
+
+          if (lookahead.type !== tt.colon && lookahead.type !== tt.question) {
+            this.next();
+            protoStart = this.state.start;
+            allowStatic = false;
+          }
+        }
 
         if (allowStatic && this.isContextual("static")) {
           const lookahead = this.lookahead();
@@ -797,6 +809,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const variance = this.flowParseVariance();
 
         if (this.eat(tt.bracketL)) {
+          if (protoStart != null) {
+            this.unexpected(protoStart);
+          }
           if (this.eat(tt.bracketL)) {
             if (variance) {
               this.unexpected(variance.start);
@@ -810,6 +825,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             );
           }
         } else if (this.match(tt.parenL) || this.isRelational("<")) {
+          if (protoStart != null) {
+            this.unexpected(protoStart);
+          }
           if (variance) {
             this.unexpected(variance.start);
           }
@@ -835,6 +853,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             this.flowParseObjectTypeProperty(
               node,
               isStatic,
+              protoStart,
               variance,
               kind,
               allowSpread,
@@ -857,6 +876,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     flowParseObjectTypeProperty(
       node: N.FlowObjectTypeProperty | N.FlowObjectTypeSpreadProperty,
       isStatic: boolean,
+      protoStart: ?number,
       variance: ?N.FlowVariance,
       kind: string,
       allowSpread: boolean,
@@ -867,6 +887,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             null,
             "Spread operator cannot appear in class or interface definitions",
           );
+        }
+        if (protoStart != null) {
+          this.unexpected(protoStart);
         }
         if (variance) {
           this.unexpected(
@@ -881,6 +904,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       } else {
         node.key = this.flowParseObjectPropertyKey();
         node.static = isStatic;
+        node.proto = protoStart != null;
         node.kind = kind;
 
         let optional = false;
@@ -888,6 +912,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // This is a method property
           node.method = true;
 
+          if (protoStart != null) {
+            this.unexpected(protoStart);
+          }
           if (variance) {
             this.unexpected(variance.start);
           }
@@ -1116,10 +1143,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           );
 
         case tt.braceL:
-          return this.flowParseObjectType(false, false, true);
+          return this.flowParseObjectType(false, false, true, false);
 
         case tt.braceBarL:
-          return this.flowParseObjectType(false, true, true);
+          return this.flowParseObjectType(false, true, true, false);
 
         case tt.bracketL:
           return this.flowParseTupleType();

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -427,7 +427,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     // Interfaces
 
-    flowParseInterfaceish(node: N.FlowDeclare, isClass?: boolean): void {
+    flowParseInterfaceish(
+      node: N.FlowDeclare,
+      isClass?: boolean = false,
+    ): void {
       node.id = this.flowParseRestrictedIdentifier(/*liberal*/ !isClass);
 
       if (this.isRelational("<")) {
@@ -653,7 +656,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } while (this.eat(tt.comma));
       }
 
-      node.body = this.flowParseObjectType(true, false, false);
+      node.body = this.flowParseObjectType(true, false, false, false);
 
       return this.finishNode(node, "InterfaceTypeAnnotation");
     }

--- a/packages/babel-parser/test/fixtures/flow/call-properties/3/output.json
+++ b/packages/babel-parser/test/fixtures/flow/call-properties/3/output.json
@@ -284,6 +284,7 @@
                         "name": "y"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/class-properties/getter-setter/output.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/getter-setter/output.json
@@ -112,6 +112,7 @@
                 "name": "a"
               },
               "static": false,
+              "proto": false,
               "kind": "get",
               "method": true,
               "value": {
@@ -181,6 +182,7 @@
                 "name": "b"
               },
               "static": false,
+              "proto": false,
               "kind": "set",
               "method": true,
               "value": {
@@ -302,6 +304,7 @@
                 "value": "c"
               },
               "static": false,
+              "proto": false,
               "kind": "get",
               "method": true,
               "value": {
@@ -374,6 +377,7 @@
                 "value": "d"
               },
               "static": false,
+              "proto": false,
               "kind": "set",
               "method": true,
               "value": {
@@ -495,6 +499,7 @@
                 "value": 1
               },
               "static": false,
+              "proto": false,
               "kind": "get",
               "method": true,
               "value": {
@@ -567,6 +572,7 @@
                 "value": 2
               },
               "static": false,
+              "proto": false,
               "kind": "set",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/class-properties/named-static/output.json
+++ b/packages/babel-parser/test/fixtures/flow/class-properties/named-static/output.json
@@ -112,6 +112,7 @@
                 "name": "static"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/comment/02-type-include/output.json
+++ b/packages/babel-parser/test/fixtures/flow/comment/02-type-include/output.json
@@ -109,6 +109,7 @@
                 "name": "foo"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -161,6 +162,7 @@
                 "name": "bar"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -213,6 +215,7 @@
                 "name": "baz"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/comment/03-type-flow-include/output.json
+++ b/packages/babel-parser/test/fixtures/flow/comment/03-type-flow-include/output.json
@@ -109,6 +109,7 @@
                 "name": "foo"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -161,6 +162,7 @@
                 "name": "bar"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -213,6 +215,7 @@
                 "name": "baz"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-export/export-class/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-export/export-class/output.json
@@ -175,6 +175,7 @@
                         "name": "meth"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": true,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-module/10/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-module/10/output.json
@@ -105,6 +105,7 @@
                   "name": "foo"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": true,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-module/5/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-module/5/output.json
@@ -158,6 +158,7 @@
                       "name": "foo"
                     },
                     "static": false,
+                    "proto": false,
                     "kind": "init",
                     "method": true,
                     "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-module/6/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-module/6/output.json
@@ -151,6 +151,7 @@
                         "name": "foo"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": true,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-statements/10/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-statements/10/output.json
@@ -112,6 +112,7 @@
                 "name": "foo"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -181,6 +182,7 @@
                 "name": "x"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-statements/15/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-statements/15/output.json
@@ -112,6 +112,7 @@
                 "name": "foo"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -254,6 +255,7 @@
                 "name": "foo"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-statements/17/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-statements/17/output.json
@@ -112,6 +112,7 @@
                 "name": "a"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -164,6 +165,7 @@
                 "name": "b"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -216,6 +218,7 @@
                 "name": "c"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-statements/7/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-statements/7/output.json
@@ -112,6 +112,7 @@
                 "name": "didAnimate"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/declare-statements/9/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-statements/9/output.json
@@ -228,6 +228,7 @@
                 "name": "x"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/interface-types/basic/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/basic/output.json
@@ -124,6 +124,7 @@
                   "name": "p"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple/output.json
@@ -191,6 +191,7 @@
                   "name": "p"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends/output.json
@@ -158,6 +158,7 @@
                   "name": "p"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/10/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/10/output.json
@@ -162,6 +162,7 @@
                 "name": "x"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -214,6 +215,7 @@
                 "name": "y"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/4/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/4/output.json
@@ -112,6 +112,7 @@
                 "name": "foo"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/5/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/5/output.json
@@ -112,6 +112,7 @@
                 "name": "length"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/identifier-named-static-optional/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/identifier-named-static-optional/output.json
@@ -112,6 +112,7 @@
                 "name": "static"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/01/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/01/output.json
@@ -112,6 +112,7 @@
                 "name": "@@iterator"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/02/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/02/output.json
@@ -112,6 +112,7 @@
                 "name": "@@asyncIterator"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/12/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/12/output.json
@@ -126,6 +126,7 @@
                   "name": "@@iterator"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/13/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/13/output.json
@@ -126,6 +126,7 @@
                   "name": "@@asyncIterator"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/14/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/14/output.json
@@ -112,6 +112,7 @@
                 "name": "@@iterator"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/15/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/15/output.json
@@ -112,6 +112,7 @@
                 "name": "@@asyncIterator"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/object-types/complex-param-types/output.json
+++ b/packages/babel-parser/test/fixtures/flow/object-types/complex-param-types/output.json
@@ -109,6 +109,7 @@
                 "name": "m"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-alias/4/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-alias/4/output.json
@@ -124,6 +124,7 @@
                     "name": "type"
                   },
                   "static": false,
+                  "proto": false,
                   "kind": "init",
                   "method": false,
                   "value": {
@@ -202,6 +203,7 @@
                     "name": "type"
                   },
                   "static": false,
+                  "proto": false,
                   "kind": "init",
                   "method": false,
                   "value": {
@@ -529,6 +531,7 @@
                 "name": "x"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -594,6 +597,7 @@
                           "name": "type"
                         },
                         "static": false,
+                        "proto": false,
                         "kind": "init",
                         "method": false,
                         "value": {
@@ -672,6 +676,7 @@
                           "name": "type"
                         },
                         "static": false,
+                        "proto": false,
                         "kind": "init",
                         "method": false,
                         "value": {
@@ -793,6 +798,7 @@
                 "name": "x"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -858,6 +864,7 @@
                           "name": "type"
                         },
                         "static": false,
+                        "proto": false,
                         "kind": "init",
                         "method": false,
                         "value": {
@@ -936,6 +943,7 @@
                           "name": "type"
                         },
                         "static": false,
+                        "proto": false,
                         "kind": "init",
                         "method": false,
                         "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/108/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/108/output.json
@@ -136,6 +136,7 @@
                         "name": "x"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -188,6 +189,7 @@
                         "name": "y"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -453,6 +455,7 @@
                         "name": "x"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -505,6 +508,7 @@
                         "name": "y"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -871,6 +875,7 @@
                         "name": "a"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -921,6 +926,7 @@
                               "name": "x"
                             },
                             "static": false,
+                            "proto": false,
                             "kind": "init",
                             "method": false,
                             "value": {
@@ -973,6 +979,7 @@
                               "name": "y"
                             },
                             "static": false,
+                            "proto": false,
                             "kind": "init",
                             "method": false,
                             "value": {
@@ -1033,6 +1040,7 @@
                         "name": "b"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -1401,6 +1409,7 @@
                         "name": "a"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -1451,6 +1460,7 @@
                               "name": "x"
                             },
                             "static": false,
+                            "proto": false,
                             "kind": "init",
                             "method": false,
                             "value": {
@@ -1503,6 +1513,7 @@
                               "name": "y"
                             },
                             "static": false,
+                            "proto": false,
                             "kind": "init",
                             "method": false,
                             "value": {
@@ -1563,6 +1574,7 @@
                         "name": "b"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/110/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/110/output.json
@@ -109,6 +109,7 @@
                 "name": "p"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/111/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/111/output.json
@@ -109,6 +109,7 @@
                 "name": "p"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/136/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/136/output.json
@@ -109,6 +109,7 @@
                 "name": "p"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/32/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/32/output.json
@@ -136,6 +136,7 @@
                         "name": "numVal"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/33/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/33/output.json
@@ -136,6 +136,7 @@
                         "name": "numVal"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/34/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/34/output.json
@@ -136,6 +136,7 @@
                         "name": "numVal"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/35/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/35/output.json
@@ -150,6 +150,7 @@
                           "name": "numVal"
                         },
                         "static": false,
+                        "proto": false,
                         "kind": "init",
                         "method": false,
                         "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/36/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/36/output.json
@@ -136,6 +136,7 @@
                         "name": "numVal"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -188,6 +189,7 @@
                         "name": "strVal"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/37/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/37/output.json
@@ -136,6 +136,7 @@
                         "name": "subObj"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -186,6 +187,7 @@
                               "name": "strVal"
                             },
                             "static": false,
+                            "proto": false,
                             "kind": "init",
                             "method": false,
                             "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/38/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/38/output.json
@@ -136,6 +136,7 @@
                         "name": "subObj"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -200,6 +201,7 @@
                                 "name": "strVal"
                               },
                               "static": false,
+                              "proto": false,
                               "kind": "init",
                               "method": false,
                               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/39/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/39/output.json
@@ -136,6 +136,7 @@
                         "name": "param1"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -188,6 +189,7 @@
                         "name": "param2"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/40/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/40/output.json
@@ -136,6 +136,7 @@
                         "name": "param1"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -188,6 +189,7 @@
                         "name": "param2"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/42/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/42/output.json
@@ -136,6 +136,7 @@
                         "name": "add"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": true,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/43/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/43/output.json
@@ -136,6 +136,7 @@
                         "name": "id"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": true,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/60/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/60/output.json
@@ -191,6 +191,7 @@
                         "name": "x"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/61/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/61/output.json
@@ -191,6 +191,7 @@
                         "name": "x"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/63/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/63/output.json
@@ -196,6 +196,7 @@
                       "name": "x"
                     },
                     "static": false,
+                    "proto": false,
                     "kind": "init",
                     "method": false,
                     "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/98/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/98/output.json
@@ -136,6 +136,7 @@
                         "name": "param1"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -188,6 +189,7 @@
                         "name": "param2"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {
@@ -240,6 +242,7 @@
                         "name": "param3"
                       },
                       "static": false,
+                      "proto": false,
                       "kind": "init",
                       "method": false,
                       "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/object-type-method/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/object-type-method/output.json
@@ -109,6 +109,7 @@
                 "name": "a"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -233,6 +234,7 @@
                 "name": "a"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": false,
               "value": {
@@ -390,6 +392,7 @@
                 "name": "a"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -513,6 +516,7 @@
                 "name": "a"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -978,6 +982,7 @@
                 "name": "foo"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -1104,6 +1109,7 @@
                 "name": "foo"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-exports/interface/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-exports/interface/output.json
@@ -129,6 +129,7 @@
                   "name": "p"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {
@@ -304,6 +305,7 @@
                   "name": "p"
                 },
                 "static": false,
+                "proto": false,
                 "kind": "init",
                 "method": false,
                 "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/output.json
@@ -112,6 +112,7 @@
                 "name": "foobar"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -214,6 +215,7 @@
                 "name": "delete"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -316,6 +318,7 @@
                 "name": "yield"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -418,6 +421,7 @@
                 "name": "do"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -520,6 +524,7 @@
                 "name": "foobar"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -622,6 +627,7 @@
                 "name": "delete"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -724,6 +730,7 @@
                 "name": "yield"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -826,6 +833,7 @@
                 "name": "do"
               },
               "static": true,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/output.json
@@ -112,6 +112,7 @@
                 "name": "foobar"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -214,6 +215,7 @@
                 "name": "delete"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -316,6 +318,7 @@
                 "name": "yield"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -418,6 +421,7 @@
                 "name": "do"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/output.json
@@ -112,6 +112,7 @@
                 "name": "foobar"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -214,6 +215,7 @@
                 "name": "delete"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -316,6 +318,7 @@
                 "name": "yield"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -418,6 +421,7 @@
                 "name": "do"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/output.json
@@ -109,6 +109,7 @@
                 "name": "foobar"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -211,6 +212,7 @@
                 "name": "delete"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -313,6 +315,7 @@
                 "name": "yield"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {
@@ -415,6 +418,7 @@
                 "name": "do"
               },
               "static": false,
+              "proto": false,
               "kind": "init",
               "method": true,
               "value": {

--- a/packages/babel-parser/test/fixtures/flow/typecasts/2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/typecasts/2/output.json
@@ -246,6 +246,7 @@
                     "name": "xxx"
                   },
                   "static": false,
+                  "proto": false,
                   "kind": "init",
                   "method": false,
                   "value": {
@@ -298,6 +299,7 @@
                     "name": "yyy"
                   },
                   "static": false,
+                  "proto": false,
                   "kind": "init",
                   "method": false,
                   "value": {

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -1634,7 +1634,7 @@ Aliases: `Flow`, `UserWhitespacable`
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)
  - `optional`: `boolean` (default: `null`)
- - `proto`: `proto` (default: `null`)
+ - `proto`: `boolean` (default: `null`)
  - `static`: `boolean` (default: `null`)
 
 ---

--- a/packages/babel-types/README.md
+++ b/packages/babel-types/README.md
@@ -1634,6 +1634,7 @@ Aliases: `Flow`, `UserWhitespacable`
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)
  - `optional`: `boolean` (default: `null`)
+ - `proto`: `proto` (default: `null`)
  - `static`: `boolean` (default: `null`)
 
 ---

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -321,6 +321,7 @@ defineType("ObjectTypeProperty", {
     value: validateType("FlowType"),
     kind: validate(assertOneOf("init", "get", "set")),
     static: validate(assertValueType("boolean")),
+    proto: validate(assertValueType("proto")),
     optional: validate(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),
   },

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -321,7 +321,7 @@ defineType("ObjectTypeProperty", {
     value: validateType("FlowType"),
     kind: validate(assertOneOf("init", "get", "set")),
     static: validate(assertValueType("boolean")),
-    proto: validate(assertValueType("proto")),
+    proto: validate(assertValueType("boolean")),
     optional: validate(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),
   },

--- a/packages/babylon/test/fixtures/flow/proto-props/declare-class/input.js
+++ b/packages/babylon/test/fixtures/flow/proto-props/declare-class/input.js
@@ -1,0 +1,11 @@
+declare class A {
+  proto: T;
+}
+
+declare class B {
+  proto x: T;
+}
+
+declare class C {
+  proto +x: T;
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/declare-class/output.json
+++ b/packages/babylon/test/fixtures/flow/proto-props/declare-class/output.json
@@ -1,0 +1,433 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 102,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 102,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareClass",
+        "start": 0,
+        "end": 31,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 14,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 16,
+          "end": 31,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 20,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 10
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 20,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "identifierName": "proto"
+                },
+                "name": "proto"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "GenericTypeAnnotation",
+                "start": 27,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 27,
+                  "end": 28,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "identifierName": "T"
+                  },
+                  "name": "T"
+                }
+              },
+              "variance": null,
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 33,
+        "end": 66,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 47,
+          "end": 48,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 14
+            },
+            "end": {
+              "line": 5,
+              "column": 15
+            },
+            "identifierName": "B"
+          },
+          "name": "B"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 49,
+          "end": 66,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 16
+            },
+            "end": {
+              "line": 7,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 53,
+              "end": 63,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 2
+                },
+                "end": {
+                  "line": 6,
+                  "column": 12
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 59,
+                "end": 60,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 9
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "proto": true,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "GenericTypeAnnotation",
+                "start": 62,
+                "end": 63,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 12
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 62,
+                  "end": 63,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 12
+                    },
+                    "identifierName": "T"
+                  },
+                  "name": "T"
+                }
+              },
+              "variance": null,
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 68,
+        "end": 102,
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 0
+          },
+          "end": {
+            "line": 11,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 82,
+          "end": 83,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 14
+            },
+            "end": {
+              "line": 9,
+              "column": 15
+            },
+            "identifierName": "C"
+          },
+          "name": "C"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 84,
+          "end": 102,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 16
+            },
+            "end": {
+              "line": 11,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 88,
+              "end": 99,
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 2
+                },
+                "end": {
+                  "line": 10,
+                  "column": 13
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 95,
+                "end": 96,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 10
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "proto": true,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "GenericTypeAnnotation",
+                "start": 98,
+                "end": 99,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 13
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 98,
+                  "end": 99,
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 13
+                    },
+                    "identifierName": "T"
+                  },
+                  "name": "T"
+                }
+              },
+              "variance": {
+                "type": "Variance",
+                "start": 94,
+                "end": 95,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 9
+                  }
+                },
+                "kind": "plus"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/interface/input.js
+++ b/packages/babylon/test/fixtures/flow/proto-props/interface/input.js
@@ -1,0 +1,3 @@
+interface I {
+  proto p: string;
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/interface/options.json
+++ b/packages/babylon/test/fixtures/flow/proto-props/interface/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \":\" (2:8)"
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/object/input.js
+++ b/packages/babylon/test/fixtures/flow/proto-props/object/input.js
@@ -1,0 +1,1 @@
+type T = { proto p: string }

--- a/packages/babylon/test/fixtures/flow/proto-props/object/options.json
+++ b/packages/babylon/test/fixtures/flow/proto-props/object/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \":\" (1:17)"
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/proto-static/input.js
+++ b/packages/babylon/test/fixtures/flow/proto-props/proto-static/input.js
@@ -1,0 +1,3 @@
+declare class C {
+  proto static p: T;
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/proto-static/options.json
+++ b/packages/babylon/test/fixtures/flow/proto-props/proto-static/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \":\" (2:15)"
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/static-proto/input.js
+++ b/packages/babylon/test/fixtures/flow/proto-props/static-proto/input.js
@@ -1,0 +1,3 @@
+declare class C {
+  static proto p: T;
+}

--- a/packages/babylon/test/fixtures/flow/proto-props/static-proto/options.json
+++ b/packages/babylon/test/fixtures/flow/proto-props/static-proto/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token, expected \":\" (2:15)"
+}

--- a/scripts/tests/flow/flow_tests_whitelist.txt
+++ b/scripts/tests/flow/flow_tests_whitelist.txt
@@ -37,4 +37,3 @@ numbers/underscored_float_whole.js
 numbers/underscored_hex.js
 numbers/underscored_number.js
 numbers/underscored_oct.js
-types/declare_class/proto.js


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

See https://github.com/facebook/flow/commit/eb815be907eeae9f4851ff154087ebf079510d18 for more information about this feature.
    
The proto modifier indicates that a property declared using `x: T` syntax is actually present on the prototype object of the class, rather than an own property.
    
The proto and static modifiers are mutually exclusive, as class declarations don't simultaneously define the static prototype object, as they do the instance prototype.
    
This syntax is only supported on declared classes, not object types, interfaces, or runtime class declarations, and as such should only appear in library definitions.