### PR TITLE
feat(sourcemap): parse external source maps when normalizing

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -28,10 +28,28 @@ export default function normalizeFile(
   let shebang = null;
   let inputMap = null;
   if (options.inputSourceMap !== false) {
+    // Check if sourceMap is inline
     inputMap = convertSourceMap.fromSource(code);
+
+    // Remove inline sourceMap from code
     if (inputMap) {
       code = convertSourceMap.removeComments(code);
-    } else if (typeof options.inputSourceMap === "object") {
+    }
+
+    // if source map is not inline check if it's an external file
+    if (!inputMap) {
+      try {
+        inputMap = convertSourceMap.fromMapFileSource(code);
+      } catch (err) {}
+
+      // remove external sourceMappingUrl from code
+      if (inputMap) {
+        code = convertSourceMap.removeMapFileComments(code);
+      }
+    }
+
+    // If no sourceMap is found and a user provides it use that
+    if (!inputMap && typeof options.inputSourceMap === "object") {
       inputMap = convertSourceMap.fromObject(options.inputSourceMap);
     }
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #4551
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | No (Couldn't figure out where this method was being tested. Can be added if I get some guidance on where to add the unit test)
| Documentation PR         |  None
| Any Dependency Changes?  | No
| License                  | MIT

I use Typescript just for typings and then use babel to transpile down to support older browsers. I ran into an issue where I wasn't getting proper sourcemaps and I noticed it was because we were creating external sourcemaps that babel was not picking up. 

I noted there was already a PR open a while back that was left stale because there was a different approach suggested into how to do this in babel then how the PR was proposed. 
https://github.com/babel/babel/pull/4551#issuecomment-249451109

This implements using @loganfsmyth suggested in that PR. 
