### PR TITLE
Remove parenthesizedArgument

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -287,9 +287,7 @@ export default class ExpressionParser extends LValParser {
         if (
           operator === "**" &&
           left.type === "UnaryExpression" &&
-          left.extra &&
-          !left.extra.parenthesizedArgument &&
-          !left.extra.parenthesized
+          !(left.extra && left.extra.parenthesized)
         ) {
           this.raise(
             left.argument.start,
@@ -364,15 +362,7 @@ export default class ExpressionParser extends LValParser {
       }
       this.next();
 
-      const argType = this.state.type;
       node.argument = this.parseMaybeUnary();
-
-      this.addExtra(
-        node,
-        "parenthesizedArgument",
-        argType === tt.parenL &&
-          (!node.argument.extra || !node.argument.extra.parenthesized),
-      );
 
       if (refShorthandDefaultPos && refShorthandDefaultPos.start) {
         this.unexpected(refShorthandDefaultPos.start);

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0000/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0000/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0001/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0001/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0002/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0002/output.json
@@ -30,8 +30,5 @@
       "identifierName": "eval"
     },
     "name": "eval"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0003/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0003/output.json
@@ -30,8 +30,5 @@
       "identifierName": "eval"
     },
     "name": "eval"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0004/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0004/output.json
@@ -30,8 +30,5 @@
       "identifierName": "arguments"
     },
     "name": "arguments"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0005/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0005/output.json
@@ -30,8 +30,5 @@
       "identifierName": "arguments"
     },
     "name": "arguments"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0006/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0006/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0007/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0007/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0008/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0008/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0009/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0009/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0010/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0010/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0011/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0011/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0012/output.json
+++ b/packages/babel-parser/test/expressions/esprima/expression-unary/migrated_0012/output.json
@@ -30,8 +30,5 @@
       "identifierName": "x"
     },
     "name": "x"
-  },
-  "extra": {
-    "parenthesizedArgument": false
   }
 }

--- a/packages/babel-parser/test/fixtures/core/categorized/06-regex/output.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/06-regex/output.json
@@ -138,9 +138,6 @@
                   "body": [],
                   "directives": []
                 }
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             },
             "operator": "/",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/138/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/138/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/139/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/139/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/140/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/140/output.json
@@ -75,9 +75,6 @@
               "identifierName": "eval"
             },
             "name": "eval"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/141/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/141/output.json
@@ -75,9 +75,6 @@
               "identifierName": "eval"
             },
             "name": "eval"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/142/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/142/output.json
@@ -75,9 +75,6 @@
               "identifierName": "arguments"
             },
             "name": "arguments"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/143/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/143/output.json
@@ -75,9 +75,6 @@
               "identifierName": "arguments"
             },
             "name": "arguments"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/144/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/144/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/145/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/145/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/146/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/146/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/147/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/147/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/148/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/148/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/149/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/149/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/150/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/150/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/300/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/300/output.json
@@ -122,9 +122,6 @@
                   "identifierName": "y"
                 },
                 "name": "y"
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             }
           }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/301/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/301/output.json
@@ -122,9 +122,6 @@
                   "identifierName": "y"
                 },
                 "name": "y"
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             }
           }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/329/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/329/output.json
@@ -88,9 +88,6 @@
                 }
               },
               "properties": []
-            },
-            "extra": {
-              "parenthesizedArgument": false
             }
           },
           "operator": "/",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/339/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/339/output.json
@@ -106,9 +106,6 @@
                 },
                 "name": "x"
               }
-            },
-            "extra": {
-              "parenthesizedArgument": false
             }
           },
           "operator": "/",

--- a/packages/babel-parser/test/fixtures/es2015/for-in/nonstrict-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/for-in/nonstrict-initializer/output.json
@@ -327,9 +327,6 @@
                         "identifierName": "effects"
                       },
                       "name": "effects"
-                    },
-                    "extra": {
-                      "parenthesizedArgument": false
                     }
                   },
                   {
@@ -367,9 +364,6 @@
                         "raw": "1"
                       },
                       "value": 1
-                    },
-                    "extra": {
-                      "parenthesizedArgument": false
                     }
                   }
                 ],
@@ -692,9 +686,6 @@
                     "identifierName": "iterations"
                   },
                   "name": "iterations"
-                },
-                "extra": {
-                  "parenthesizedArgument": false
                 }
               }
             }

--- a/packages/babel-parser/test/fixtures/es2015/modules/xml-comment-in-module/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/xml-comment-in-module/output.json
@@ -123,13 +123,7 @@
                   "identifierName": "bar"
                 },
                 "name": "bar"
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
-            },
-            "extra": {
-              "parenthesizedArgument": false
             }
           }
         }

--- a/packages/babel-parser/test/fixtures/es2015/yield/function-name-function-expression/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/function-name-function-expression/output.json
@@ -110,9 +110,6 @@
               "body": [],
               "directives": []
             }
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/2/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/2/output.json
@@ -118,9 +118,6 @@
               "parenthesized": true,
               "parenStart": 1
             }
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/7/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/7/output.json
@@ -127,9 +127,6 @@
                   "raw": "1"
                 },
                 "value": 1
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             },
             "extra": {

--- a/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/8/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/8/output.json
@@ -127,9 +127,6 @@
                   "raw": "1"
                 },
                 "value": 1
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             }
           },

--- a/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/9/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/9/output.json
@@ -94,7 +94,6 @@
               "value": 5
             },
             "extra": {
-              "parenthesizedArgument": false,
               "parenthesized": true,
               "parenStart": 0
             }

--- a/packages/babel-parser/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0000/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0000/output.json
@@ -122,9 +122,6 @@
                   "identifierName": "y"
                 },
                 "name": "y"
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             }
           }

--- a/packages/babel-parser/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0001/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/automatic-semicolon-insertion/migrated_0001/output.json
@@ -122,9 +122,6 @@
                   "identifierName": "y"
                 },
                 "name": "y"
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             }
           }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0000/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0000/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0001/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0001/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0002/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0002/output.json
@@ -75,9 +75,6 @@
               "identifierName": "eval"
             },
             "name": "eval"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0003/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0003/output.json
@@ -75,9 +75,6 @@
               "identifierName": "eval"
             },
             "name": "eval"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0004/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0004/output.json
@@ -75,9 +75,6 @@
               "identifierName": "arguments"
             },
             "name": "arguments"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0005/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0005/output.json
@@ -75,9 +75,6 @@
               "identifierName": "arguments"
             },
             "name": "arguments"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0006/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0006/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0007/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0007/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0008/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0008/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0009/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0009/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0010/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0010/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0011/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0011/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0012/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/expression-unary/migrated_0012/output.json
@@ -75,9 +75,6 @@
               "identifierName": "x"
             },
             "name": "x"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/experimental/class-private-methods/async-generator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-methods/async-generator/output.json
@@ -386,9 +386,6 @@
                                 "name": "EOF"
                               },
                               "computed": false
-                            },
-                            "extra": {
-                              "parenthesizedArgument": false
                             }
                           },
                           "body": {

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/nested/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/nested/output.json
@@ -494,9 +494,6 @@
                             "identifierName": "x"
                           },
                           "name": "x"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }
@@ -625,9 +622,6 @@
                             "identifierName": "y"
                           },
                           "name": "y"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }
@@ -1158,9 +1152,6 @@
                                             "identifierName": "x"
                                           },
                                           "name": "x"
-                                        },
-                                        "extra": {
-                                          "parenthesizedArgument": false
                                         }
                                       }
                                     }
@@ -1289,9 +1280,6 @@
                                             "identifierName": "y"
                                           },
                                           "name": "y"
-                                        },
-                                        "extra": {
-                                          "parenthesizedArgument": false
                                         }
                                       }
                                     }
@@ -1630,9 +1618,6 @@
                                             "identifierName": "value"
                                           },
                                           "name": "value"
-                                        },
-                                        "extra": {
-                                          "parenthesizedArgument": false
                                         }
                                       }
                                     }
@@ -1971,9 +1956,6 @@
                                             "identifierName": "value"
                                           },
                                           "name": "value"
-                                        },
-                                        "extra": {
-                                          "parenthesizedArgument": false
                                         }
                                       }
                                     }
@@ -2992,9 +2974,6 @@
                             "identifierName": "value"
                           },
                           "name": "value"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }
@@ -3333,9 +3312,6 @@
                             "identifierName": "value"
                           },
                           "name": "value"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/pbn-success/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/pbn-success/output.json
@@ -494,9 +494,6 @@
                             "identifierName": "x"
                           },
                           "name": "x"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }
@@ -625,9 +622,6 @@
                             "identifierName": "y"
                           },
                           "name": "y"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }
@@ -966,9 +960,6 @@
                             "identifierName": "value"
                           },
                           "name": "value"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }
@@ -1307,9 +1298,6 @@
                             "identifierName": "value"
                           },
                           "name": "value"
-                        },
-                        "extra": {
-                          "parenthesizedArgument": false
                         }
                       }
                     }

--- a/packages/babel-parser/test/fixtures/experimental/throw-expression/comma/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/throw-expression/comma/output.json
@@ -142,9 +142,6 @@
                         "raw": "1"
                       },
                       "value": 1
-                    },
-                    "extra": {
-                      "parenthesizedArgument": false
                     }
                   },
                   {

--- a/packages/babel-parser/test/fixtures/experimental/throw-expression/expression/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/throw-expression/expression/output.json
@@ -129,7 +129,6 @@
                   "value": 1
                 },
                 "extra": {
-                  "parenthesizedArgument": false,
                   "parenthesized": true,
                   "parenStart": 20
                 }

--- a/packages/babel-parser/test/fixtures/experimental/throw-expression/logical/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/throw-expression/logical/output.json
@@ -158,9 +158,6 @@
                       "raw": "1"
                     },
                     "value": 1
-                  },
-                  "extra": {
-                    "parenthesizedArgument": false
                   }
                 }
               }

--- a/packages/babel-parser/test/fixtures/flow/predicates/2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/predicates/2/output.json
@@ -203,9 +203,6 @@
                       "identifierName": "x"
                     },
                     "name": "x"
-                  },
-                  "extra": {
-                    "parenthesizedArgument": false
                   }
                 },
                 "operator": "===",

--- a/packages/babel-parser/test/fixtures/flow/predicates/3/output.json
+++ b/packages/babel-parser/test/fixtures/flow/predicates/3/output.json
@@ -202,9 +202,6 @@
                       "identifierName": "x"
                     },
                     "name": "x"
-                  },
-                  "extra": {
-                    "parenthesizedArgument": false
                   }
                 },
                 "operator": "===",

--- a/packages/babel-parser/test/fixtures/flow/regression/issue-58/output.json
+++ b/packages/babel-parser/test/fixtures/flow/regression/issue-58/output.json
@@ -5647,13 +5647,7 @@
                           "identifierName": "p"
                         },
                         "name": "p"
-                      },
-                      "extra": {
-                        "parenthesizedArgument": false
                       }
-                    },
-                    "extra": {
-                      "parenthesizedArgument": false
                     }
                   },
                   "consequent": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/negative-number-literal/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/negative-number-literal/output.json
@@ -286,9 +286,6 @@
                   "raw": "1"
                 },
                 "value": 1
-              },
-              "extra": {
-                "parenthesizedArgument": false
               }
             }
           }

--- a/packages/babel-parser/test/fixtures/typescript/cast/null-assertion-false-positive/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/null-assertion-false-positive/output.json
@@ -107,9 +107,6 @@
               "identifierName": "b"
             },
             "name": "b"
-          },
-          "extra": {
-            "parenthesizedArgument": false
           }
         }
       }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7957
| Patch: Bug Fix?          | Cleanup
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

The extra field parenthesizedArgument was never set to true. It was always set to false and the code that read this was incorrectly checking if extra was present.
