### PR TITLE
Build InterfaceTypeAnnotation generated type code

### DIFF
--- a/packages/babel-types/src/asserts/generated/index.js
+++ b/packages/babel-types/src/asserts/generated/index.js
@@ -414,6 +414,12 @@ export function assertInterfaceDeclaration(
 ): void {
   assert("InterfaceDeclaration", node, opts);
 }
+export function assertInterfaceTypeAnnotation(
+  node: Object,
+  opts?: Object = {},
+): void {
+  assert("InterfaceTypeAnnotation", node, opts);
+}
 export function assertIntersectionTypeAnnotation(
   node: Object,
   opts?: Object = {},

--- a/packages/babel-types/src/builders/generated/index.js
+++ b/packages/babel-types/src/builders/generated/index.js
@@ -393,6 +393,10 @@ export function InterfaceDeclaration(...args: Array<any>): Object {
   return builder("InterfaceDeclaration", ...args);
 }
 export { InterfaceDeclaration as interfaceDeclaration };
+export function InterfaceTypeAnnotation(...args: Array<any>): Object {
+  return builder("InterfaceTypeAnnotation", ...args);
+}
+export { InterfaceTypeAnnotation as interfaceTypeAnnotation };
 export function IntersectionTypeAnnotation(...args: Array<any>): Object {
   return builder("IntersectionTypeAnnotation", ...args);
 }

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -1387,6 +1387,23 @@ export function isInterfaceDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
+export function isInterfaceTypeAnnotation(
+  node: Object,
+  opts?: Object,
+): boolean {
+  if (!node) return false;
+
+  const nodeType = node.type;
+  if (nodeType === "InterfaceTypeAnnotation") {
+    if (typeof opts === "undefined") {
+      return true;
+    } else {
+      return shallowEqual(node, opts);
+    }
+  }
+
+  return false;
+}
 export function isIntersectionTypeAnnotation(
   node: Object,
   opts?: Object,
@@ -3840,6 +3857,7 @@ export function isFlow(node: Object, opts?: Object): boolean {
     "InferredPredicate" === nodeType ||
     "InterfaceExtends" === nodeType ||
     "InterfaceDeclaration" === nodeType ||
+    "InterfaceTypeAnnotation" === nodeType ||
     "IntersectionTypeAnnotation" === nodeType ||
     "MixedTypeAnnotation" === nodeType ||
     "EmptyTypeAnnotation" === nodeType ||
@@ -3892,6 +3910,7 @@ export function isFlowType(node: Object, opts?: Object): boolean {
     "ExistsTypeAnnotation" === nodeType ||
     "FunctionTypeAnnotation" === nodeType ||
     "GenericTypeAnnotation" === nodeType ||
+    "InterfaceTypeAnnotation" === nodeType ||
     "IntersectionTypeAnnotation" === nodeType ||
     "MixedTypeAnnotation" === nodeType ||
     "EmptyTypeAnnotation" === nodeType ||


### PR DESCRIPTION
Looks like the PR that introduced it forgot to rebuild babel-types.