### PR TITLE
Clone id before mutating in babel-helpers-function-name

### DIFF
--- a/packages/babel-helper-function-name/src/index.js
+++ b/packages/babel-helper-function-name/src/index.js
@@ -141,7 +141,7 @@ export default function ({ node, parent, scope, id }) {
       const binding = scope.parent.getBinding(id.name);
       if (binding && binding.constant && scope.getBinding(id.name) === binding) {
         // always going to reference this method
-        node.id = id;
+        node.id = t.clone(id);
         node.id[t.NOT_LOCAL_BINDING] = true;
         return;
       }


### PR DESCRIPTION
This appears to already be resolved in 7, but I'd like to get it back ported to 6.x if possible. Without this, both the variable declaration and function name identifiers will get `NOT_LOCAL_BINDING` set on them instead of just the function name since they reference the same object when processing code like below. That causes subsequent renaming of the variable to also affect the function name, which messes with scope analysis as well.

```javascript
let foo = function () {};
```

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
