### PR TITLE
passes the jsxPragma options from preset-typescript to plugin-transform-typescript

### DIFF
--- a/packages/babel-preset-typescript/README.md
+++ b/packages/babel-preset-typescript/README.md
@@ -54,6 +54,8 @@ require("@babel/core").transform("code", {
 });
 ```
 
+## Options
+
 ### `jsxPragma`
 
 `string`

--- a/packages/babel-preset-typescript/README.md
+++ b/packages/babel-preset-typescript/README.md
@@ -53,3 +53,11 @@ require("@babel/core").transform("code", {
   presets: ["@babel/preset-typescript"]
 });
 ```
+
+### `jsxPragma`
+
+`string`
+
+Replace the function used when compiling JSX expressions.
+
+This is so that we know that the import is not a type import, and should not be removed

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformTypeScript from "@babel/plugin-transform-typescript";
 
-export default declare((api, { jsxPragma = "React" }) => {
+export default declare((api, { jsxPragma }) => {
   api.assertVersion(7);
 
   return {

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -1,10 +1,10 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformTypeScript from "@babel/plugin-transform-typescript";
 
-export default declare(api => {
+export default declare((api, { jsxPragma = "React" }) => {
   api.assertVersion(7);
 
   return {
-    plugins: [transformTypeScript],
+    plugins: [[transformTypeScript, { jsxPragma }]],
   };
 });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #7989, Fixes #7979
| Patch: Bug Fix?          |  yes
| Tests Added + Pass?      | yes
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


Jsx pragmas were being ignored by preset-typescript. I've simply passed the jsxPragma option to the plugin-transform-typescript.
