### PR TITLE
Adds JSXFragment to plugin-transform-typescript check for the presence of jsx

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -276,7 +276,10 @@ export default declare((api, { jsxPragma = "React" }) => {
     // "React" or the JSX pragma is referenced as a value if there are any JSX elements in the code.
     let sourceFileHasJsx = false;
     programPath.traverse({
-      JSX() {
+      JSXElement() {
+        sourceFileHasJsx = true;
+      },
+      JSXFragment() {
         sourceFileHasJsx = true;
       },
     });

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -276,10 +276,7 @@ export default declare((api, { jsxPragma = "React" }) => {
     // "React" or the JSX pragma is referenced as a value if there are any JSX elements in the code.
     let sourceFileHasJsx = false;
     programPath.traverse({
-      JSXElement() {
-        sourceFileHasJsx = true;
-      },
-      JSXFragment() {
+      JSX() {
         sourceFileHasJsx = true;
       },
     });

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -279,6 +279,9 @@ export default declare((api, { jsxPragma = "React" }) => {
       JSXElement() {
         sourceFileHasJsx = true;
       },
+      JSXFragment() {
+        sourceFileHasJsx = true;
+      },
     });
     return !sourceFileHasJsx;
   }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/input.mjs
@@ -1,3 +1,3 @@
 // Don't elide React if a JSX fragment appears somewhere.
-import React from "react";
-<></>
+import * as React from "react";
+<></>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/input.mjs
@@ -1,0 +1,3 @@
+// Don't elide React if a JSX fragment appears somewhere.
+import React from "react";
+<></>

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/options.json
@@ -1,0 +1,3 @@
+{
+    "plugins": ["syntax-jsx", "transform-typescript"]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/output.mjs
@@ -1,3 +1,3 @@
 // Don't elide React if a JSX fragment appears somewhere.
-import React from "react";
-<></>
+import * as React from "react";
+<></>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react-no-3/output.mjs
@@ -1,0 +1,3 @@
+// Don't elide React if a JSX fragment appears somewhere.
+import React from "react";
+<></>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7979
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR Adds `JSXFragment` to plugin-transform-typescript check for type imports.