### PR TITLE
Expose the Flow 'all' option on the preset too.

### DIFF
--- a/packages/babel-plugin-syntax-flow/src/index.js
+++ b/packages/babel-plugin-syntax-flow/src/index.js
@@ -7,6 +7,10 @@ export default declare((api, options) => {
   // the @flow pragma was provided.
   const { all } = options;
 
+  if (typeof all !== "boolean" && typeof all !== "undefined") {
+    throw new Error(".all must be a boolean, or undefined");
+  }
+
   return {
     manipulateOptions(opts, parserOpts) {
       // If the file has already enabled TS, assume that this is not a

--- a/packages/babel-preset-flow/src/index.js
+++ b/packages/babel-preset-flow/src/index.js
@@ -1,10 +1,10 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
 
-export default declare(api => {
+export default declare((api, { all }) => {
   api.assertVersion(7);
 
   return {
-    plugins: [transformFlowStripTypes],
+    plugins: [[transformFlowStripTypes, { all }]],
   };
 });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

The `all` option landed in https://github.com/babel/babel/pull/7934/files#diff-3a8233bcd2766d2c7d87f23f944f7726R3 but it is only exposed from the plugin, not the preset, so this exposes it there too since the flow preset is what we want people to use.