### PR TITLE
Preserve arguments for @callable(...)-style decorators.

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-constructors/decorator-with-arguments/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-constructors/decorator-with-arguments/exec.js
@@ -1,0 +1,10 @@
+function addStaticProperty(name, value) {
+  return function (cls) {
+    cls[name] = value;
+  };
+}
+
+@addStaticProperty("foo", 42)
+class C {}
+
+expect(C.foo).toBe(42);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/meteor/meteor/issues/9895
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

Reported [here](https://github.com/babel/babel/pull/7719#issuecomment-391551435).

Although #7719 updated the parser to produce `decorator.arguments` when a decorator is called with arguments, the legacy `@babel/plugin-proposal-decorators` implementation was not updated to respect this new property.

This fix is loosely modeled after [similar functionality](https://github.com/nicolo-ribaudo/babel/blob/f6239a6c8f1cf3eaf76a66c40de08aa3305d1d1a/packages/babel-plugin-proposal-decorators/src/transformer.js#L33-L41) in the [non-legacy decorators PR](https://github.com/babel/babel/pull/7976) by @nicolo-ribaudo.