### PR TITLE
Validate @babel/preset-env options

### DIFF
--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -166,3 +166,9 @@ declare module "convert-source-map" {
     generateMapFileComment(path: string, options?: ?{ multiline: boolean }): string,
   };
 }
+
+declare module "js-levenshtein" {
+  declare module.exports: {
+    (string, string): number,
+  };
+}

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -49,6 +49,7 @@
     "@babel/plugin-transform-unicode-regex": "7.0.0-beta.49",
     "browserslist": "^3.0.0",
     "invariant": "^2.2.2",
+    "js-levenshtein": "^1.1.3",
     "semver": "^5.3.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -7,29 +7,18 @@ import { defaultWebIncludes } from "./default-includes";
 import moduleTransformations from "./module-transformations";
 import { findSuggestion } from "./utils";
 import pluginsList from "../data/plugins.json";
+import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
 import type { Targets, Options, ModuleOption, BuiltInsOption } from "./types";
-
-const topLevelOptions = [
-  "configPath",
-  "debug",
-  "exclude",
-  "forceAllTransforms",
-  "ignoreBrowserslistConfig",
-  "include",
-  "loose",
-  "modules",
-  "shippedProposals",
-  "spec",
-  "targets",
-  "useBuiltIns",
-];
 
 const validateTopLevelOptions = (options: Options) => {
   for (const option in options) {
     invariant(
-      topLevelOptions.includes(option),
+      TopLevelOptions[option],
       `Invalid Option: ${option} is not a valid top-level option.
-      Maybe you meant to use '${findSuggestion(topLevelOptions, option)}'?`,
+      Maybe you meant to use '${findSuggestion(
+        Object.values(TopLevelOptions),
+        option,
+      )}'?`,
     );
   }
 };
@@ -134,17 +123,17 @@ export const validateIgnoreBrowserslistConfig = (
   ignoreBrowserslistConfig: boolean,
 ) =>
   validateBoolOption(
-    "ignoreBrowserslistConfig",
+    TopLevelOptions.ignoreBrowserslistConfig,
     ignoreBrowserslistConfig,
     false,
   );
 
 export const validateModulesOption = (
-  modulesOpt: ModuleOption = "commonjs",
+  modulesOpt: ModuleOption = ModulesOption.commonjs,
 ) => {
   invariant(
-    modulesOpt === false ||
-      Object.keys(moduleTransformations).indexOf(modulesOpt) > -1,
+    ModulesOption[modulesOpt] ||
+      ModulesOption[modulesOpt] === ModulesOption.false,
     `Invalid Option: The 'modules' option must be either 'false' to indicate no modules, or a
     module type which can be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'.`,
   );
@@ -166,7 +155,8 @@ export const validateUseBuiltInsOption = (
   builtInsOpt: BuiltInsOption = false,
 ): BuiltInsOption => {
   invariant(
-    builtInsOpt === "usage" || builtInsOpt === false || builtInsOpt === "entry",
+    UseBuiltInsOption[builtInsOpt] ||
+      UseBuiltInsOption[builtInsOpt] === UseBuiltInsOption.false,
     `Invalid Option: The 'useBuiltIns' option must be either
     'false' (default) to indicate no polyfill,
     '"entry"' to indicate replacing the entry polyfill, or
@@ -179,8 +169,14 @@ export const validateUseBuiltInsOption = (
 export default function normalizeOptions(opts: Options) {
   validateTopLevelOptions(opts);
 
-  const include = expandIncludesAndExcludes(opts.include, "include");
-  const exclude = expandIncludesAndExcludes(opts.exclude, "exclude");
+  const include = expandIncludesAndExcludes(
+    opts.include,
+    TopLevelOptions.include,
+  );
+  const exclude = expandIncludesAndExcludes(
+    opts.exclude,
+    TopLevelOptions.exclude,
+  );
 
   checkDuplicateIncludeExcludes(include, exclude);
 
@@ -190,21 +186,21 @@ export default function normalizeOptions(opts: Options) {
     include,
     exclude,
     forceAllTransforms: validateBoolOption(
-      "forceAllTransforms",
+      TopLevelOptions.forceAllTransforms,
       opts.forceAllTransforms,
       false,
     ),
     ignoreBrowserslistConfig: validateIgnoreBrowserslistConfig(
       opts.ignoreBrowserslistConfig,
     ),
-    loose: validateBoolOption("loose", opts.loose, false),
+    loose: validateBoolOption(TopLevelOptions.loose, opts.loose, false),
     modules: validateModulesOption(opts.modules),
     shippedProposals: validateBoolOption(
-      "shippedProposals",
+      TopLevelOptions.shippedProposals,
       opts.shippedProposals,
       false,
     ),
-    spec: validateBoolOption("loose", opts.spec, false),
+    spec: validateBoolOption(TopLevelOptions.spec, opts.spec, false),
     targets: {
       ...opts.targets,
     },

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -5,21 +5,20 @@ import browserslist from "browserslist";
 import builtInsList from "../data/built-ins.json";
 import { defaultWebIncludes } from "./default-includes";
 import moduleTransformations from "./module-transformations";
-import { findSuggestion } from "./utils";
+import { getValues, findSuggestion } from "./utils";
 import pluginsList from "../data/plugins.json";
 import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
 import type { Targets, Options, ModuleOption, BuiltInsOption } from "./types";
 
 const validateTopLevelOptions = (options: Options) => {
   for (const option in options) {
-    invariant(
-      TopLevelOptions[option],
-      `Invalid Option: ${option} is not a valid top-level option.
-      Maybe you meant to use '${findSuggestion(
-        Object.values(TopLevelOptions),
-        option,
-      )}'?`,
-    );
+    if (!TopLevelOptions[option]) {
+      const validOptions = getValues(TopLevelOptions);
+      throw new Error(
+        `Invalid Option: ${option} is not a valid top-level option.
+        Maybe you meant to use '${findSuggestion(validOptions, option)}'?`,
+      );
+    }
   }
 };
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -5,8 +5,34 @@ import browserslist from "browserslist";
 import builtInsList from "../data/built-ins.json";
 import { defaultWebIncludes } from "./default-includes";
 import moduleTransformations from "./module-transformations";
+import { findSuggestion } from "./utils";
 import pluginsList from "../data/plugins.json";
 import type { Targets, Options, ModuleOption, BuiltInsOption } from "./types";
+
+const topLevelOptions = [
+  "configPath",
+  "debug",
+  "exclude",
+  "forceAllTransforms",
+  "ignoreBrowserslistConfig",
+  "include",
+  "loose",
+  "modules",
+  "shippedProposals",
+  "spec",
+  "targets",
+  "useBuiltIns",
+];
+
+const validateTopLevelOptions = (options: Options) => {
+  for (const option in options) {
+    invariant(
+      topLevelOptions.includes(option),
+      `Invalid Option: ${option} is not a valid top-level option.
+      Maybe you meant to use '${findSuggestion(topLevelOptions, option)}'?`,
+    );
+  }
+};
 
 const validIncludesAndExcludes = new Set([
   ...Object.keys(pluginsList),
@@ -151,6 +177,8 @@ export const validateUseBuiltInsOption = (
 };
 
 export default function normalizeOptions(opts: Options) {
+  validateTopLevelOptions(opts);
+
   const include = expandIncludesAndExcludes(opts.include, "include");
   const exclude = expandIncludesAndExcludes(opts.exclude, "exclude");
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -182,7 +182,7 @@ export default function normalizeOptions(opts: Options) {
 
   return {
     configPath: validateConfigPathOption(opts.configPath),
-    debug: opts.debug,
+    debug: validateBoolOption(TopLevelOptions.debug, opts.debug, false),
     include,
     exclude,
     forceAllTransforms: validateBoolOption(

--- a/packages/babel-preset-env/src/options.js
+++ b/packages/babel-preset-env/src/options.js
@@ -1,0 +1,44 @@
+export const TopLevelOptions = {
+  configPath: "configPath",
+  debug: "debug",
+  exclude: "exclude",
+  forceAllTransforms: "forceAllTransforms",
+  ignoreBrowserslistConfig: "ignoreBrowserslistConfig",
+  include: "include",
+  loose: "loose",
+  modules: "modules",
+  shippedProposals: "shippedProposals",
+  spec: "spec",
+  targets: "targets",
+  useBuiltIns: "useBuiltIns",
+};
+
+export const ModulesOption = {
+  false: false,
+  amd: "amd",
+  commonjs: "commonjs",
+  cjs: "cjs",
+  systemjs: "systemjs",
+  umd: "umd",
+};
+
+export const UseBuiltInsOption = {
+  false: false,
+  entry: "entry",
+  usage: "usage",
+};
+
+export const TargetNames = {
+  esmodules: "esmodules",
+  node: "node",
+  browsers: "browsers",
+  chrome: "chrome",
+  opera: "opera",
+  edge: "edge",
+  firefox: "firefox",
+  safari: "safari",
+  ie: "ie",
+  ios: "ios",
+  android: "android",
+  electron: "electron",
+};

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -7,6 +7,7 @@ import {
   semverify,
   isUnreleasedVersion,
   getLowestUnreleased,
+  getValues,
   findSuggestion,
 } from "./utils";
 import { objectToBrowserslist } from "./normalize-options";
@@ -14,16 +15,15 @@ import browserModulesData from "../data/built-in-modules.json";
 import { TargetNames } from "./options";
 import type { Targets } from "./types";
 
-const validateTargetNames = targets => {
+const validateTargetNames = (validTargets, targets) => {
   for (const target in targets) {
-    invariant(
-      TargetNames[target],
-      `Invalid Option: '${target}' is not a valid target
-      Maybe you meant to use '${findSuggestion(
-        Object.values(TargetNames),
-        target,
-      )}'?`,
-    );
+    if (!TargetNames[target]) {
+      const validOptions = getValues(TargetNames);
+      throw new Error(
+        `Invalid Option: '${target}' is not a valid target
+        Maybe you meant to use '${findSuggestion(validOptions, target)}'?`,
+      );
+    }
   }
 };
 

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -11,29 +11,18 @@ import {
 } from "./utils";
 import { objectToBrowserslist } from "./normalize-options";
 import browserModulesData from "../data/built-in-modules.json";
+import { TargetNames } from "./options";
 import type { Targets } from "./types";
-
-const validTargetNames = [
-  "esmodules",
-  "node",
-  "browsers",
-  "chrome",
-  "opera",
-  "edge",
-  "firefox",
-  "safari",
-  "ie",
-  "ios",
-  "android",
-  "electron",
-];
 
 const validateTargetNames = targets => {
   for (const target in targets) {
     invariant(
-      validTargetNames.includes(target),
+      TargetNames[target],
       `Invalid Option: '${target}' is not a valid target
-      Maybe you meant to use '${findSuggestion(validTargetNames, target)}'?`,
+      Maybe you meant to use '${findSuggestion(
+        Object.values(TargetNames),
+        target,
+      )}'?`,
     );
   }
 };
@@ -66,7 +55,7 @@ export const semverMin = (first: ?string, second: string): string => {
 
 const mergeBrowsers = (fromQuery: Targets, fromTarget: Targets) => {
   return Object.keys(fromTarget).reduce((queryObj, targKey) => {
-    if (targKey !== "browsers") {
+    if (targKey !== TargetNames.browsers) {
       queryObj[targKey] = fromTarget[targKey];
     }
     return queryObj;
@@ -183,11 +172,11 @@ const getTargets = (targets: Object = {}, options: Object = {}): Targets => {
 
   // Parse remaining targets
   const parsed = Object.keys(targets)
-    .filter(value => value !== "esmodules")
+    .filter(value => value !== TargetNames.esmodules)
     .sort()
     .reduce(
       (results: ParsedResult, target: string): ParsedResult => {
-        if (target !== "browsers") {
+        if (target !== TargetNames.browsers) {
           const value = targets[target];
 
           // Warn when specifying minor/patch as a decimal

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -1,27 +1,17 @@
 //@flow
 
+import { TargetNames, ModulesOption, UseBuiltInsOption } from "./options";
+
 // Targets
-export type Target =
-  | "esmodules"
-  | "node"
-  | "browsers"
-  | "chrome"
-  | "opera"
-  | "edge"
-  | "firefox"
-  | "safari"
-  | "ie"
-  | "ios"
-  | "android"
-  | "electron";
+export type Target = $Keys<typeof TargetNames>;
 export type Targets = {
   [target: Target]: string,
 };
 
 // Options
 // Use explicit modules to prevent typo errors.
-export type ModuleOption = false | "amd" | "commonjs" | "systemjs" | "umd";
-export type BuiltInsOption = false | "entry" | "usage";
+export type ModuleOption = $Values<typeof ModulesOption>;
+export type BuiltInsOption = $Values<typeof UseBuiltInsOption>;
 
 export type Options = {
   configPath: string,

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -1,9 +1,21 @@
 //@flow
 
 // Targets
-export type Target = string;
+export type Target =
+  | "esmodules"
+  | "node"
+  | "browsers"
+  | "chrome"
+  | "opera"
+  | "edge"
+  | "firefox"
+  | "safari"
+  | "ie"
+  | "ios"
+  | "android"
+  | "electron";
 export type Targets = {
-  [target: string]: Target,
+  [target: Target]: string,
 };
 
 // Options

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -31,6 +31,9 @@ export const semverify = (version: string | number): string => {
   return split.join(".");
 };
 
+export const getValues = (object: Object) =>
+  Object.keys(object).map(key => object[key]);
+
 export const findSuggestion = (options: Array<string>, option: string) => {
   let levenshteinValue = Infinity;
   return options.reduce((suggestion, validOption) => {

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import semver from "semver";
+import levenshtein from "js-levenshtein";
 import { addSideEffect } from "@babel/helper-module-imports";
 import unreleasedLabels from "../data/unreleased-labels";
 import { semverMin } from "./targets-parser";
@@ -19,6 +20,18 @@ export const semverify = (version: string | number): string => {
   }
 
   return split.join(".");
+};
+
+export const findSuggestion = (options: Array<string>, option: string) => {
+  let levenshteinValue = Infinity;
+  return options.reduce((suggestion, validOption) => {
+    const value = levenshtein(validOption, option);
+    if (value < levenshteinValue) {
+      levenshteinValue = value;
+      return validOption;
+    }
+    return suggestion;
+  }, undefined);
 };
 
 export const prettifyVersion = (version: string): string => {

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -31,7 +31,7 @@ export const semverify = (version: string | number): string => {
   return split.join(".");
 };
 
-export const getValues = (object: Object) =>
+export const getValues = (object: Object): Array<any> =>
   Object.keys(object).map(key => object[key]);
 
 export const findSuggestion = (options: Array<string>, option: string) => {

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -1,4 +1,6 @@
 // @flow
+
+import invariant from "invariant";
 import semver from "semver";
 import levenshtein from "js-levenshtein";
 import { addSideEffect } from "@babel/helper-module-imports";
@@ -6,19 +8,26 @@ import unreleasedLabels from "../data/unreleased-labels";
 import { semverMin } from "./targets-parser";
 import type { Targets } from "./types";
 
+const versionRegExp = /^(\d+|\d+.\d+)$/;
+
 // Convert version to a semver value.
 // 2.5 -> 2.5.0; 1 -> 1.0.0;
 export const semverify = (version: string | number): string => {
-  if (typeof version === "string" && semver.valid(version)) {
+  const isString = typeof version === "string";
+
+  if (isString && semver.valid(version)) {
     return version;
   }
 
-  const split = version.toString().split(".");
+  invariant(
+    typeof version === "number" || (isString && versionRegExp.test(version)),
+    `'${version}' is not a valid version`,
+  );
 
+  const split = version.toString().split(".");
   while (split.length < 3) {
     split.push("0");
   }
-
   return split.join(".");
 };
 

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -36,6 +36,15 @@ describe("normalize-options", () => {
     });
   });
 
+  describe("Config format validation", () => {
+    it("should throw if top-level option not found", () => {
+      const unknownTopLevelOption = () => {
+        normalizeOptions({ unknown: "option" });
+      };
+      expect(unknownTopLevelOption).toThrow();
+    });
+  });
+
   describe("RegExp include/exclude", () => {
     it("should not allow invalid plugins in `include` and `exclude`", () => {
       const normalizeWithNonExistingPlugin = () => {

--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -19,6 +19,35 @@ describe("getTargets", () => {
     });
   });
 
+  describe("validation", () => {
+    it("throws on invalid target name", () => {
+      const invalidTargetName = () => {
+        getTargets({
+          unknown: "unknown",
+        });
+      };
+      expect(invalidTargetName).toThrow();
+    });
+
+    it("throws on invalid browsers target", () => {
+      const invalidBrowsersTarget = () => {
+        getTargets({
+          browsers: 59,
+        });
+      };
+      expect(invalidBrowsersTarget).toThrow();
+    });
+
+    it("throws on invalid target version", () => {
+      const invalidTargetVersion = () => {
+        getTargets({
+          chrome: "unknown",
+        });
+      };
+      expect(invalidTargetVersion).toThrow();
+    });
+  });
+
   describe("browser", () => {
     it("merges browser key targets", () => {
       expect(
@@ -53,21 +82,6 @@ describe("getTargets", () => {
         }),
       ).toEqual({
         safari: "tp",
-      });
-    });
-
-    it("ignores invalid", () => {
-      expect(
-        getTargets({
-          browsers: 59,
-          chrome: "49",
-          firefox: "55",
-          ie: "11",
-        }),
-      ).toEqual({
-        chrome: "49.0.0",
-        firefox: "55.0.0",
-        ie: "11.0.0",
       });
     });
   });

--- a/packages/babel-preset-env/test/utils.spec.js
+++ b/packages/babel-preset-env/test/utils.spec.js
@@ -2,7 +2,7 @@
 
 const utils = require("../lib/utils");
 
-const { prettifyTargets, prettifyVersion, semverify } = utils;
+const { prettifyTargets, prettifyVersion, semverify, findSuggestion } = utils;
 
 describe("utils", () => {
   describe("semverify", () => {
@@ -41,6 +41,14 @@ describe("utils", () => {
         electron: "1.6",
         node: "0.12",
       });
+    });
+  });
+
+  describe("findSuggestion", () => {
+    it("returns", () => {
+      const options = ["one", "two", "three"];
+      expect(findSuggestion(options, "onr")).toEqual("one");
+      expect(findSuggestion(options, "tree")).toEqual("three");
     });
   });
 });

--- a/packages/babel-preset-env/test/utils.spec.js
+++ b/packages/babel-preset-env/test/utils.spec.js
@@ -13,6 +13,13 @@ describe("utils", () => {
       expect(semverify(1)).toBe("1.0.0");
       expect(semverify(1.2)).toBe("1.2.0");
     });
+
+    it("throws", () => {
+      const invalidSemver = () => {
+        semverify("invalid");
+      };
+      expect(invalidSemver).toThrow();
+    });
   });
 
   describe("prettifyVersion", () => {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #7445, Fixes #7541
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | Yes
| License                  | MIT

This PR adds validation for [@babel/preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env) options.
Also I've added [js-levenshtein](https://www.npmjs.com/package/js-levenshtein) to display suggestions in case of typo / error for some options.