### PR TITLE
update micromatch to ^3.1.10

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -42,7 +42,7 @@
     "debug": "^3.1.0",
     "json5": "^0.5.0",
     "lodash": "^4.17.5",
-    "micromatch": "^2.3.11",
+    "micromatch": "^3.1.10",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         | No <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | Yes (micromatch)
| License                  | MIT

`babel-core` depends on `micromatch@2.3.11` that depends on `braces@1.8.5` . That version of braces is affected by a ReDos vulnerability [npm:braces:20180219](https://snyk.io/vuln/npm:braces:20180219). Even if the vulnerability in the babel context is low risk, for [snyk]( users using `babel@7` this convert in a wall of errors as every babel module indirectly depends on braces.
By updating `micromatch` to `3.1.10` that depends on `braces@2.3.1` the issue is resolved.

<!-- Describe your changes below in as much detail as possible -->
<img width="441" alt="screen shot 2018-05-24 at 21 37 58" src="https://user-images.githubusercontent.com/1800988/40512507-f211d038-5f9a-11e8-9eef-b4871a169192.png">
