### PR TITLE
Do not quote JSX attribute keys for IdentifierName

### DIFF
--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -89,14 +89,14 @@ You can turn on the 'throwIfNamespace' flag to bypass this warning.`,
       }
     }
 
-    if (t.isValidIdentifier(node.name.name)) {
+    if (t.isJSXNamespacedName(node.name)) {
+      node.name = t.stringLiteral(
+        node.name.namespace.name + ":" + node.name.name.name,
+      );
+    } else if (esutils.keyword.isIdentifierNameES6(node.name.name)) {
       node.name.type = "Identifier";
     } else {
-      node.name = t.stringLiteral(
-        t.isJSXNamespacedName(node.name)
-          ? node.name.namespace.name + ":" + node.name.name.name
-          : node.name.name,
-      );
+      node.name = t.stringLiteral(node.name.name);
     }
 
     return t.inherits(t.objectProperty(node.name, value), node);

--- a/packages/babel-plugin-transform-react-inline-elements/test/fixtures/regressions/6276/output.js
+++ b/packages/babel-plugin-transform-react-inline-elements/test/fixtures/regressions/6276/output.js
@@ -1,3 +1,3 @@
 var test = babelHelpers.jsx(T, {
-  "default": " some string "
+  default: " some string "
 });

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-add-quotes-es3/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-add-quotes-es3/input.js
@@ -1,0 +1,1 @@
+var es3 = <F aaa new const var default foo-bar/>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-add-quotes-es3/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-add-quotes-es3/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-react-jsx", "transform-property-literals"]
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-add-quotes-es3/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-add-quotes-es3/output.js
@@ -1,0 +1,8 @@
+var es3 = React.createElement(F, {
+  aaa: true,
+  "new": true,
+  "const": true,
+  "var": true,
+  "default": true,
+  "foo-bar": true
+});

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-add-quotes-to-identifier-names/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-add-quotes-to-identifier-names/input.js
@@ -1,0 +1,1 @@
+var e = <F aaa new const var default foo-bar/>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-add-quotes-to-identifier-names/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-not-add-quotes-to-identifier-names/output.js
@@ -1,0 +1,8 @@
+var e = React.createElement(F, {
+  aaa: true,
+  new: true,
+  const: true,
+  var: true,
+  default: true,
+  "foo-bar": true
+});


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Bug fix
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Given the following

```js
a = <F new/>
```

We used to generate:

```js
a = React.createElement(F, {"new": true})
```

but now we generate

```js
a = React.createElement(F, {new: true})
```

If you need to quote these (for ES3  for example, you can use transform-property-literals)
