### PR TITLE
Don't split an exported class when renaming an inner binding

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/input.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/input.mjs
@@ -1,0 +1,5 @@
+export class Foo extends Bar {
+  static foo = {};
+
+  test = args;
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["external-helpers", "proposal-class-properties"]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/output.mjs
@@ -1,0 +1,9 @@
+export class Foo extends Bar {
+  constructor(..._args2) {
+    var _temp;
+
+    return _temp = super(..._args2), babelHelpers.defineProperty(this, "test", args), _temp;
+  }
+
+}
+babelHelpers.defineProperty(Foo, "foo", {});

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/7951/output.mjs
@@ -1,8 +1,8 @@
 export class Foo extends Bar {
-  constructor(..._args2) {
+  constructor(..._args) {
     var _temp;
 
-    return _temp = super(..._args2), babelHelpers.defineProperty(this, "test", args), _temp;
+    return _temp = super(..._args), babelHelpers.defineProperty(this, "test", args), _temp;
   }
 
 }

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -108,7 +108,12 @@ export default class Renamer {
         path.isClassExpression(),
     );
     if (parentDeclar) {
-      this.maybeConvertFromExportDeclaration(parentDeclar);
+      const bindingIds = parentDeclar.getBindingIdentifiers();
+      if (bindingIds[oldName] === binding.identifier) {
+        // When we are renaming an exported identifier, we need to ensure that
+        // the exported binding keeps the old name.
+        this.maybeConvertFromExportDeclaration(parentDeclar);
+      }
     }
 
     scope.traverse(block || scope.block, renameVisitor, this);


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8062, Fixes #8033, Fixes #7951, Fixes #7843
| Patch: Bug Fix?          | :+1: 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
