### PR TITLE
make isReferenced() recognise ObjectTypeProperty

### DIFF
--- a/packages/babel-types/src/validators.js
+++ b/packages/babel-types/src/validators.js
@@ -154,6 +154,12 @@ export function isReferenced(node: Object, parent: Object): boolean {
     case "ObjectPattern":
     case "ArrayPattern":
       return false;
+
+    // yes: type X = { somePropert: NODE }
+    // no: type X = { NODE: OtherType }
+    case "ObjectTypeProperty":
+      return parent.key !== node;
+
   }
 
   return true;

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -55,4 +55,20 @@ suite("validators", function () {
       assert(t.isNodesEquivalent(pattern, pattern) === true);
     });
   });
+
+  suite("isReferenced", function () {
+    it("ObjectTypeProperty key is not a reference", function () {
+      const node = t.identifier("a");
+      const parent = t.objectTypeProperty(node, t.numberTypeAnnotation());
+
+      assert(t.isReferenced(node, parent) === false);
+    });
+
+    it("ObjectTypeProperty value is a reference", function () {
+      const node = t.identifier("a");
+      const parent = t.objectTypeProperty(t.identifier("someKey"), node);
+
+      assert(t.isReferenced(node, parent) === true);
+    });
+  });
 });


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | fixes #8057
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

The `isReferenced()` validator mistakenly treats `ObjectTypeProperty` node as a reference. This leads to the `program.scope.globals` to get populated with Flow object type properties and maybe also to some minor bugs in variable renaming as the `collectorVisitor` from babel-travers thinks that there is a variable and adds it to `references` array.

What makes this issue a bit more important is that having Flow types removed via `transform-flow-strip-types` plugin the entry in `program.scope.globals` stays and may cause a bug.

Here is a [PR for v7.x](https://github.com/babel/babel/pull/8060)