### PR TITLE
make isReferenced() recognise ObjectTypeProperty

### DIFF
--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -116,6 +116,11 @@ export default function isReferenced(node: Object, parent: Object): boolean {
     // no: NODE.target
     case "MetaProperty":
       return false;
+
+    // yes: type X = { somePropert: NODE }
+    // no: type X = { NODE: OtherType }
+    case "ObjectTypeProperty":
+      return parent.key !== node;
   }
 
   return true;

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -95,4 +95,23 @@ describe("validators", function() {
       expect(t.isNodesEquivalent(pattern, pattern)).toBe(true);
     });
   });
+
+  describe("isReferenced", function() {
+    it("returns false if node is a key of ObjectTypeProperty", function() {
+      const node = t.identifier("a");
+      const parent = t.objectTypeProperty(node, t.numberTypeAnnotation());
+
+      expect(t.isReferenced(node, parent)).toBe(false);
+    });
+
+    it("returns true if node is a value of ObjectTypeProperty", function() {
+      const node = t.identifier("a");
+      const parent = t.objectTypeProperty(
+        t.identifier("someKey"),
+        t.genericTypeAnnotation(node),
+      );
+
+      expect(t.isReferenced(node, parent)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | fixes #8057
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

The `isReferenced()` validator mistakenly treats `ObjectTypeProperty` node as a reference. This leads to the `program.scope.globals` to get populated with Flow object type properties and maybe also to some minor bugs in variable renaming as the `collectorVisitor` from babel-travers thinks that there is a variable and adds it to `references` array.

What makes this issue a bit more important is that having Flow types removed via `transform-flow-strip-types` plugin the entry in `program.scope.globals` stays and may cause a bug.

Here is a [PR for v6.x](https://github.com/babel/babel/pull/8058)