### PR TITLE
Import relative modules based on moduleId if specified.

### DIFF
--- a/packages/babel-plugin-transform-modules-amd/src/index.js
+++ b/packages/babel-plugin-transform-modules-amd/src/index.js
@@ -1,3 +1,4 @@
+import nodePath from "path";
 import { declare } from "@babel/helper-plugin-utils";
 import {
   isModule,
@@ -49,7 +50,14 @@ export default declare((api, options) => {
           }
 
           for (const [source, metadata] of meta.source) {
-            amdArgs.push(t.stringLiteral(source));
+            const newSource = t.stringLiteral(source);
+            if (newSource.value[0] == "." && moduleName) {
+              newSource.value = nodePath.join(
+                nodePath.dirname(moduleName.value),
+                newSource.value,
+              );
+            }
+            amdArgs.push(newSource);
             importNames.push(t.identifier(metadata.name));
 
             if (!isSideEffectImport(metadata)) {

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/input.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/input.js
@@ -1,0 +1,3 @@
+import m from "./module";
+
+foobar();

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/input.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/input.js
@@ -1,3 +1,5 @@
 import m from "./module";
+import sm from "./subfolder/module";
+import d from "../export-specifier-default/input";
 
 foobar();

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/module.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/module.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "moduleIds": true
+}

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/output.js
@@ -1,0 +1,6 @@
+define("amd/module-name-import/input", ["amd/module-name-import/module"], function (_module) {
+  "use strict";
+
+  _module = babelHelpers.interopRequireDefault(_module);
+  foobar();
+});

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/output.js
@@ -1,6 +1,8 @@
-define("amd/module-name-import/input", ["amd/module-name-import/module"], function (_module) {
+define("amd/module-name-import/input", ["amd/module-name-import/module", "amd/module-name-import/subfolder/module", "amd/export-specifier-default/input"], function (_module, _module2, _input) {
   "use strict";
 
   _module = babelHelpers.interopRequireDefault(_module);
+  _module2 = babelHelpers.interopRequireDefault(_module2);
+  _input = babelHelpers.interopRequireDefault(_input);
   foobar();
 });

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/subfolder/module.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/amd/module-name-import/subfolder/module.js
@@ -1,0 +1,1 @@
+export default 43;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8059
| Patch: Bug Fix?          | x
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Details are in #8059, but when using `moduleIds: true` I would have expected the imports to use these `moduleIds` and it is something that is necessary for our use-case as we want as fast as possible dev change turnaround time and for that we simply transform the es6 modules to amd and then concatenate them with a very fast concatenator and serve that in the browser. Also happy to do this in a different/better manner if possible or add a new option if that would be preferred.
