### PR TITLE
Fixes for the wrapNativeSuper helper

### DIFF
--- a/packages/babel-helpers/README.md
+++ b/packages/babel-helpers/README.md
@@ -38,7 +38,7 @@ export default {
 
 ## Defining Helpers
 
-> **NOTE**: This package is only meant to be used by the packages inluded in this repository. There is currently no way for third-party plugins to define an helper.
+> **NOTE**: This package is only meant to be used by the packages inluded in this repository. There is currently no way for third-party plugins to define a helper.
 
 Helpers are defined in the `src/helpers.js` file, and they must be valid modules which follow these guidelines:
  - They must have a default export, which is their entry-point.
@@ -48,7 +48,9 @@ Helpers are defined in the `src/helpers.js` file, and they must be valid modules
 ```js
 helpers.customHelper = defineHelper(`
   import dep from "dependency";
+
   const foo = 2;
+
   export default function getFooTimesDepPlusX(x) {
     return foo * dep() + x;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -1,6 +1,8 @@
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
-function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null) return null; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+var _cache = typeof Map === "function" ? new Map() : undefined;
+
+function _wrapNativeSuper(Class) { if (Class === null) return null; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }
 
 function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/overwritten-null/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/overwritten-null/exec.js
@@ -2,7 +2,7 @@ var env = {
   Array: null,
 };
 
-// Wee need to use "with" to avoid leaking the modified Array to other tests.
+// We need to use "with" to avoid leaking the modified Array to other tests.
 with (env) {
   class List extends Array {}
   expect(List.prototype.__proto__).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/reuse-wrapper-class/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/reuse-wrapper-class/exec.js
@@ -1,0 +1,43 @@
+// confirm the external wrapNativeSuper helper works
+// and that it caches/reuses the shim/wrapper class
+
+class Test1 extends Array {
+  name() {
+    return 'test1';
+  }
+}
+
+class Test2 extends Array {
+  name() {
+    return 'test2';
+  }
+}
+
+// return an array of an object's own class and superclasses
+// e.g. [Test1, Wrapper, Array, Object]
+function classes(value) {
+  var result = [];
+  var target = Object.getPrototypeOf(value);
+
+  while (target) {
+    result.push(target.constructor);
+    target = Object.getPrototypeOf(target);
+  }
+
+  return result;
+}
+
+var t1 = new Test1();
+var t2 = new Test2();
+
+expect(t1).not.toBe(t2);
+expect(t1.name()).toBe('test1');
+expect(t2.name()).toBe('test2');
+
+var c1 = classes(t1);
+var c2 = classes(t2);
+var wrapper = c1[1];
+
+expect(c1[1]).toBe(c2[1]); // same (i.e. cached/reused) shim class
+expect(c1).toEqual([Test1, wrapper, Array, Object]);
+expect(c2).toEqual([Test2, wrapper, Array, Object]);

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/reuse-wrapper-class/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/reuse-wrapper-class/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-classes","transform-block-scoping","external-helpers"]
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -6,7 +6,9 @@ function _assertThisInitialized(self) { if (self === void 0) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
-function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null) return null; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+var _cache = typeof Map === "function" ? new Map() : undefined;
+
+function _wrapNativeSuper(Class) { if (Class === null) return null; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }
 
 function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/super-called/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/super-called/exec.js
@@ -6,7 +6,7 @@ var env = {
   }
 };
 
-// Wee need to use "with" to avoid leaking the modified Array to other tests.
+// We need to use "with" to avoid leaking the modified Array to other tests.
 with (env) {
   class List extends Array {};
   new List();

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -10,7 +10,9 @@ function _assertThisInitialized(self) { if (self === void 0) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
-function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null) return null; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+var _cache = typeof Map === "function" ? new Map() : undefined;
+
+function _wrapNativeSuper(Class) { if (Class === null) return null; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }
 
 function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8061, reverts #7188
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

This PR:
  
1\) fixes a ReferenceError caused by a typo (`_construct` instead of `construct`) in the external `wrapNativeSuper` helper. (The typo doesn't usually cause an error in inline helpers because `_construct` happens to be the default name given to the `construct` helper function.)

2\) fixes caching of the shim/wrapper class in external helpers

Extending builtins in ES5 requires the use of a shim class between the subclass and the builtin. This class can be (and should be) reused for each builtin e.g. extensions of Array should all extend the same "ArrayShim" class:

    MyArray1 < ArrayShim < Array < Object
    MyArray2 < ArrayShim < Array < Object

The reuse of this class is handled by a cache, but the current implementation restricts the scope of this cache to the body of the `wrapNativeSuper` function for ["tree-shakeability"](https://github.com/babel/babel/pull/7188). However, in addition to making the code less clear, this also breaks caching because it relies on the redefinition of the `wrapNativeSuper` function, which (by default) [doesn't work with external helpers](https://github.com/babel/babel/issues/8087#issuecomment-393622260).