### PR TITLE
Fix ReferenceError in the wrapNativeSuper helper

### DIFF
--- a/packages/babel-helpers/README.md
+++ b/packages/babel-helpers/README.md
@@ -38,7 +38,7 @@ export default {
 
 ## Defining Helpers
 
-> **NOTE**: This package is only meant to be used by the packages inluded in this repository. There is currently no way for third-party plugins to define an helper.
+> **NOTE**: This package is only meant to be used by the packages inluded in this repository. There is currently no way for third-party plugins to define a helper.
 
 Helpers are defined in the `src/helpers.js` file, and they must be valid modules which follow these guidelines:
  - They must have a default export, which is their entry-point.
@@ -48,7 +48,9 @@ Helpers are defined in the `src/helpers.js` file, and they must be valid modules
 ```js
 helpers.customHelper = defineHelper(`
   import dep from "dependency";
+
   const foo = 2;
+
   export default function getFooTimesDepPlusX(x) {
     return foo * dep() + x;
   }

--- a/packages/babel-helpers/README.md
+++ b/packages/babel-helpers/README.md
@@ -38,7 +38,7 @@ export default {
 
 ## Defining Helpers
 
-> **NOTE**: This package is only meant to be used by the packages inluded in this repository. There is currently no way for third-party plugins to define a helper.
+> **NOTE**: This package is only meant to be used by the packages included in this repository. There is currently no way for third-party plugins to define a helper.
 
 Helpers are defined in the `src/helpers.js` file, and they must be valid modules which follow these guidelines:
  - They must have a default export, which is their entry-point.

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -449,7 +449,7 @@ helpers.construct = () => template.program.ast`
     if (Reflect.construct.sham) return false;
 
     // Proxy can't be polyfilled. Every browser implemented
-    // proxies before or at the same time of Reflect.construct,
+    // proxies before or at the same time as Reflect.construct,
     // so if they support Proxy they also support Reflect.construct.
     if (typeof Proxy === "function") return true;
 
@@ -488,8 +488,8 @@ helpers.construct = () => template.program.ast`
 
 // Based on https://github.com/WebReflection/babel-plugin-transform-builtin-classes
 helpers.wrapNativeSuper = () => template.program.ast`
-  import _gPO from "getPrototypeOf";
-  import _sPO from "setPrototypeOf";
+  import getPrototypeOf from "getPrototypeOf";
+  import setPrototypeOf from "setPrototypeOf";
   import construct from "construct";
 
   export default function _wrapNativeSuper(Class) {
@@ -505,7 +505,7 @@ helpers.wrapNativeSuper = () => template.program.ast`
         _cache.set(Class, Wrapper);
       }
       function Wrapper() {
-        return _construct(Class, arguments, _gPO(this).constructor)
+        return construct(Class, arguments, getPrototypeOf(this).constructor)
       }
       Wrapper.prototype = Object.create(Class.prototype, {
         constructor: {
@@ -516,7 +516,7 @@ helpers.wrapNativeSuper = () => template.program.ast`
         }
       });
 
-      return _sPO(Wrapper, Class);
+      return setPrototypeOf(Wrapper, Class);
     }
 
     return _wrapNativeSuper(Class)

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/overwritten-null/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/overwritten-null/exec.js
@@ -2,7 +2,7 @@ var env = {
   Array: null,
 };
 
-// Wee need to use "with" to avoid leaking the modified Array to other tests.
+// We need to use "with" to avoid leaking the modified Array to other tests.
 with (env) {
   class List extends Array {}
   expect(List.prototype.__proto__).toBeUndefined();

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/super-called/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/super-called/exec.js
@@ -6,7 +6,7 @@ var env = {
   }
 };
 
-// Wee need to use "with" to avoid leaking the modified Array to other tests.
+// We need to use "with" to avoid leaking the modified Array to other tests.
 with (env) {
   class List extends Array {};
   new List();

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/wrap-native-super/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/wrap-native-super/exec.js
@@ -1,0 +1,25 @@
+// basic sanity check to confirm the external wrapNativeSuper helper works
+
+class Test1 extends Array {
+  name() {
+    return 'test1';
+  }
+}
+
+class Test2 extends Array {
+  name() {
+    return 'test2';
+  }
+}
+
+var t1 = new Test1();
+var t2 = new Test2();
+
+expect(Test1).not.toBe(Test2);
+expect(t1).not.toBe(t2);
+expect(t1.name()).toBe('test1');
+expect(t2.name()).toBe('test2');
+expect(t1).toBeInstanceOf(Test1);
+expect(t2).toBeInstanceOf(Test2);
+expect(t1).toBeInstanceOf(Array);
+expect(t2).toBeInstanceOf(Array);

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/wrap-native-super/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/wrap-native-super/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-classes","transform-block-scoping","external-helpers"]
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8061
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT
  
Fix a ReferenceError caused by a typo (`_construct` instead of `construct`) in the external `wrapNativeSuper` helper. (The typo doesn't usually cause an error in inline helpers because `_construct` happens to be the default name given to the `construct` helper function.)

Split off from #8083. 