### PR TITLE
System module format hoisting and export refinements

### DIFF
--- a/packages/babel-helper-hoist-variables/src/index.js
+++ b/packages/babel-helper-hoist-variables/src/index.js
@@ -29,7 +29,7 @@ const visitor = {
       }
 
       for (const name in declar.getBindingIdentifiers()) {
-        state.emit(t.identifier(name), name);
+        state.emit(t.identifier(name), name, declar.node.init !== null);
       }
     }
 

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.js
@@ -21,6 +21,81 @@ const buildExportAll = template(`
   }
 `);
 
+function constructExportCall(
+  path,
+  exportIdent,
+  exportNames,
+  exportValues,
+  exportStarTarget,
+) {
+  const statements = [];
+  if (exportNames.length === 1) {
+    statements.push(
+      t.expressionStatement(
+        t.callExpression(exportIdent, [
+          t.stringLiteral(exportNames[0]),
+          exportValues[0],
+        ]),
+      ),
+    );
+  } else if (!exportStarTarget) {
+    const objectProperties = [];
+    for (let i = 0; i < exportNames.length; i++) {
+      const exportName = exportNames[i];
+      const exportValue = exportValues[i];
+      objectProperties.push(
+        t.objectProperty(t.identifier(exportName), exportValue),
+      );
+    }
+    statements.push(
+      t.expressionStatement(
+        t.callExpression(exportIdent, [t.objectExpression(objectProperties)]),
+      ),
+    );
+  } else {
+    const exportObj = path.scope.generateUid("exportObj");
+
+    statements.push(
+      t.variableDeclaration("var", [
+        t.variableDeclarator(t.identifier(exportObj), t.objectExpression([])),
+      ]),
+    );
+
+    statements.push(
+      buildExportAll({
+        KEY: path.scope.generateUidIdentifier("key"),
+        EXPORT_OBJ: t.identifier(exportObj),
+        TARGET: exportStarTarget,
+      }),
+    );
+
+    for (let i = 0; i < exportNames.length; i++) {
+      const exportName = exportNames[i];
+      const exportValue = exportValues[i];
+
+      statements.push(
+        t.expressionStatement(
+          t.assignmentExpression(
+            "=",
+            t.memberExpression(
+              t.identifier(exportObj),
+              t.identifier(exportName),
+            ),
+            exportValue,
+          ),
+        ),
+      );
+    }
+
+    statements.push(
+      t.expressionStatement(
+        t.callExpression(exportIdent, [t.identifier(exportObj)]),
+      ),
+    );
+  }
+  return statements;
+}
+
 const TYPE_IMPORT = "Import";
 
 export default declare((api, options) => {
@@ -35,6 +110,25 @@ export default declare((api, options) => {
       path.node[IGNORE_REASSIGNMENT_SYMBOL] = true;
 
       const arg = path.get(path.isAssignmentExpression() ? "left" : "argument");
+
+      if (arg.isObjectPattern() || arg.isArrayPattern()) {
+        const exprs = [path.node];
+        for (const name in arg.getBindingIdentifiers()) {
+          if (this.scope.getBinding(name) !== path.scope.getBinding(name)) {
+            return;
+          }
+          const exportedNames = this.exports[name];
+          if (!exportedNames) return;
+          for (const exportedName of exportedNames) {
+            exprs.push(
+              this.buildCall(exportedName, t.identifier(name)).expression,
+            );
+          }
+        }
+        path.replaceWith(t.sequenceExpression(exprs));
+        return;
+      }
+
       if (!arg.isIdentifier()) return;
 
       const name = arg.node.name;
@@ -149,17 +243,8 @@ export default declare((api, options) => {
 
           const body: Array<Object> = path.get("body");
 
-          let canHoist = true;
-          for (let path of body) {
-            if (path.isExportDeclaration()) path = path.get("declaration");
-            if (path.isVariableDeclaration() && path.node.kind !== "var") {
-              canHoist = false;
-              break;
-            }
-          }
-
           for (const path of body) {
-            if (canHoist && path.isFunctionDeclaration()) {
+            if (path.isFunctionDeclaration()) {
               beforeBody.push(path.node);
               removedPaths.push(path);
             } else if (path.isImportDeclaration()) {
@@ -192,7 +277,7 @@ export default declare((api, options) => {
                   );
                 }
 
-                if (!canHoist || declar.isClassDeclaration()) {
+                if (declar.isClassDeclaration()) {
                   path.replaceWithMultiple(nodes);
                 } else {
                   beforeBody = beforeBody.concat(nodes);
@@ -207,29 +292,22 @@ export default declare((api, options) => {
               if (declar.node) {
                 path.replaceWith(declar);
 
-                const nodes = [];
-                let bindingIdentifiers;
                 if (path.isFunction()) {
                   const node = declar.node;
                   const name = node.id.name;
-                  if (canHoist) {
-                    addExportName(name, name);
-                    beforeBody.push(node);
-                    beforeBody.push(
-                      buildExportCall(name, t.cloneNode(node.id)),
-                    );
-                    removedPaths.push(path);
-                  } else {
-                    bindingIdentifiers = { [name]: node.id };
-                  }
-                } else {
-                  bindingIdentifiers = declar.getBindingIdentifiers();
-                }
-                for (const name in bindingIdentifiers) {
                   addExportName(name, name);
-                  nodes.push(buildExportCall(name, t.identifier(name)));
+                  beforeBody.push(node);
+                  beforeBody.push(buildExportCall(name, t.cloneNode(node.id)));
+                  removedPaths.push(path);
+                } else if (path.isClass()) {
+                  const name = declar.node.id.name;
+                  addExportName(name, name);
+                  path.insertAfter([buildExportCall(name, t.identifier(name))]);
+                } else {
+                  for (const name in declar.getBindingIdentifiers()) {
+                    addExportName(name, name);
+                  }
                 }
-                path.insertAfter(nodes);
               } else {
                 const specifiers = path.node.specifiers;
                 if (specifiers && specifiers.length) {
@@ -240,12 +318,15 @@ export default declare((api, options) => {
                     const nodes = [];
 
                     for (const specifier of specifiers) {
-                      nodes.push(
-                        buildExportCall(
-                          specifier.exported.name,
-                          specifier.local,
-                        ),
-                      );
+                      // only globals exported this way
+                      if (!path.scope.getBinding(specifier.local.name)) {
+                        nodes.push(
+                          buildExportCall(
+                            specifier.exported.name,
+                            specifier.local,
+                          ),
+                        );
+                      }
                       addExportName(
                         specifier.local.name,
                         specifier.exported.name,
@@ -260,7 +341,7 @@ export default declare((api, options) => {
           }
 
           modules.forEach(function(specifiers) {
-            const setterBody = [];
+            let setterBody = [];
             const target = path.scope.generateUid(specifiers.key);
 
             for (let specifier of specifiers.imports) {
@@ -298,49 +379,30 @@ export default declare((api, options) => {
             }
 
             if (specifiers.exports.length) {
-              const exportObj = path.scope.generateUid("exportObj");
-
-              setterBody.push(
-                t.variableDeclaration("var", [
-                  t.variableDeclarator(
-                    t.identifier(exportObj),
-                    t.objectExpression([]),
-                  ),
-                ]),
-              );
+              const exportNames = [];
+              const exportValues = [];
+              let hasExportStar = false;
 
               for (const node of specifiers.exports) {
                 if (t.isExportAllDeclaration(node)) {
-                  setterBody.push(
-                    buildExportAll({
-                      KEY: path.scope.generateUidIdentifier("key"),
-                      EXPORT_OBJ: t.identifier(exportObj),
-                      TARGET: t.identifier(target),
-                    }),
-                  );
+                  hasExportStar = true;
                 } else if (t.isExportSpecifier(node)) {
-                  setterBody.push(
-                    t.expressionStatement(
-                      t.assignmentExpression(
-                        "=",
-                        t.memberExpression(
-                          t.identifier(exportObj),
-                          node.exported,
-                        ),
-                        t.memberExpression(t.identifier(target), node.local),
-                      ),
-                    ),
+                  exportNames.push(node.exported.name);
+                  exportValues.push(
+                    t.memberExpression(t.identifier(target), node.local),
                   );
                 } else {
                   // todo
                 }
               }
 
-              setterBody.push(
-                t.expressionStatement(
-                  t.callExpression(t.identifier(exportIdent), [
-                    t.identifier(exportObj),
-                  ]),
+              setterBody = setterBody.concat(
+                constructExportCall(
+                  path,
+                  t.identifier(exportIdent),
+                  exportNames,
+                  exportValues,
+                  hasExportStar ? t.identifier(target) : null,
                 ),
               );
             }
@@ -358,15 +420,40 @@ export default declare((api, options) => {
           let moduleName = this.getModuleName();
           if (moduleName) moduleName = t.stringLiteral(moduleName);
 
-          if (canHoist) {
-            hoistVariables(path, id => variableIds.push(id));
-          }
+          const uninitializedVars = [];
+          hoistVariables(
+            path,
+            (id, name, hasInit) => {
+              variableIds.push(id);
+              if (!hasInit) {
+                uninitializedVars.push(name);
+              }
+            },
+            null,
+          );
 
           if (variableIds.length) {
             beforeBody.unshift(
               t.variableDeclaration(
                 "var",
                 variableIds.map(id => t.variableDeclarator(id)),
+              ),
+            );
+          }
+
+          if (uninitializedVars.length) {
+            const undefinedValues = [];
+            const undefinedIdent = path.scope.buildUndefinedNode();
+            for (let i = 0; i < uninitializedVars.length; i++) {
+              undefinedValues[i] = undefinedIdent;
+            }
+            beforeBody = beforeBody.concat(
+              constructExportCall(
+                path,
+                t.identifier(exportIdent),
+                uninitializedVars,
+                undefinedValues,
+                null,
               ),
             );
           }

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-array-default-params/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-array-default-params/output.mjs
@@ -1,14 +1,11 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var foo, bar;
   return {
     setters: [],
     execute: function () {
-      const [foo, bar = 2] = [];
-
-      _export("foo", foo);
-
-      _export("bar", bar);
+      [foo, bar = 2] = [], _export("foo", foo), _export("bar", bar);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-array-rest/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-array-rest/output.mjs
@@ -1,16 +1,11 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var foo, bar, baz;
   return {
     setters: [],
     execute: function () {
-      const [foo, bar, ...baz] = [];
-
-      _export("foo", foo);
-
-      _export("bar", bar);
-
-      _export("baz", baz);
+      [foo, bar, ...baz] = [], _export("foo", foo), _export("bar", bar), _export("baz", baz);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-array/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-array/output.mjs
@@ -1,14 +1,11 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var foo, bar;
   return {
     setters: [],
     execute: function () {
-      const [foo, bar] = [];
-
-      _export("foo", foo);
-
-      _export("bar", bar);
+      [foo, bar] = [], _export("foo", foo), _export("bar", bar);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-deep/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-deep/output.mjs
@@ -1,18 +1,15 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var baz, qux;
   return {
     setters: [],
     execute: function () {
-      const {
+      ({
         foo: {
           bar: [baz, qux]
         }
-      } = {};
-
-      _export("baz", baz);
-
-      _export("qux", qux);
+      } = {}), _export("baz", baz), _export("qux", qux);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-object-default-params/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-object-default-params/output.mjs
@@ -1,17 +1,14 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var foo, bar;
   return {
     setters: [],
     execute: function () {
-      const {
+      ({
         foo,
         bar = 1
-      } = {};
-
-      _export("foo", foo);
-
-      _export("bar", bar);
+      } = {}), _export("foo", foo), _export("bar", bar);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-object-rest/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-object-rest/output.mjs
@@ -1,17 +1,14 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var foo, bar;
   return {
     setters: [],
     execute: function () {
-      const {
+      ({
         foo,
         ...bar
-      } = {};
-
-      _export("foo", foo);
-
-      _export("bar", bar);
+      } = {}), _export("foo", foo), _export("bar", bar);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-object/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-const-destructuring-object/output.mjs
@@ -1,17 +1,14 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var bar, baz;
   return {
     setters: [],
     execute: function () {
-      const {
+      ({
         foo: bar,
         baz
-      } = {};
-
-      _export("bar", bar);
-
-      _export("baz", baz);
+      } = {}), _export("bar", bar), _export("baz", baz);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-2/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-2/output.mjs
@@ -3,10 +3,7 @@ System.register(["foo"], function (_export, _context) {
 
   return {
     setters: [function (_foo) {
-      var _exportObj = {};
-      _exportObj.foo = _foo.foo;
-
-      _export(_exportObj);
+      _export("foo", _foo.foo);
     }],
     execute: function () {}
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-3/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-3/output.mjs
@@ -3,11 +3,10 @@ System.register(["foo"], function (_export, _context) {
 
   return {
     setters: [function (_foo) {
-      var _exportObj = {};
-      _exportObj.foo = _foo.foo;
-      _exportObj.bar = _foo.bar;
-
-      _export(_exportObj);
+      _export({
+        foo: _foo.foo,
+        bar: _foo.bar
+      });
     }],
     execute: function () {}
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-4/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-4/output.mjs
@@ -3,10 +3,7 @@ System.register(["foo"], function (_export, _context) {
 
   return {
     setters: [function (_foo) {
-      var _exportObj = {};
-      _exportObj.bar = _foo.foo;
-
-      _export(_exportObj);
+      _export("bar", _foo.foo);
     }],
     execute: function () {}
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-5/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-5/output.mjs
@@ -3,10 +3,7 @@ System.register(["foo"], function (_export, _context) {
 
   return {
     setters: [function (_foo) {
-      var _exportObj = {};
-      _exportObj.default = _foo.foo;
-
-      _export(_exportObj);
+      _export("default", _foo.foo);
     }],
     execute: function () {}
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-6/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-6/output.mjs
@@ -3,11 +3,10 @@ System.register(["foo"], function (_export, _context) {
 
   return {
     setters: [function (_foo) {
-      var _exportObj = {};
-      _exportObj.default = _foo.foo;
-      _exportObj.bar = _foo.bar;
-
-      _export(_exportObj);
+      _export({
+        default: _foo.foo,
+        bar: _foo.bar
+      });
     }],
     execute: function () {}
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-uninitialized/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-uninitialized/input.mjs
@@ -1,0 +1,1 @@
+export var m;

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-uninitialized/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-uninitialized/output.mjs
@@ -1,11 +1,12 @@
 System.register([], function (_export, _context) {
   "use strict";
 
-  var name;
+  var m;
+
+  _export("m", void 0);
+
   return {
     setters: [],
-    execute: function () {
-      _export("name", name = _context.id);
-    }
+    execute: function () {}
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/exports-variable/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/exports-variable/output.mjs
@@ -1,36 +1,27 @@
 System.register([], function (_export, _context) {
   "use strict";
 
+  var foo, foo2, foo3, foo4, foo5, foo6;
+
+  function foo7() {}
+
+  _export("foo7", foo7);
+
+  _export({
+    foo3: void 0,
+    foo5: void 0
+  });
+
   return {
     setters: [],
     execute: function () {
-      var foo = 1;
+      _export("foo", foo = 1);
 
-      _export("foo", foo);
+      _export("foo2", foo2 = function () {});
 
-      var foo2 = function () {};
+      _export("foo4", foo4 = 2);
 
-      _export("foo2", foo2);
-
-      var foo3;
-
-      _export("foo3", foo3);
-
-      let foo4 = 2;
-
-      _export("foo4", foo4);
-
-      let foo5;
-
-      _export("foo5", foo5);
-
-      const foo6 = 3;
-
-      _export("foo6", foo6);
-
-      function foo7() {}
-
-      _export("foo7", foo7);
+      _export("foo6", foo6 = 3);
 
       class foo8 {}
 

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/hoist-function-exports/output.mjs
@@ -9,14 +9,14 @@ System.register(["./evens"], function (_export, _context) {
 
   _export("nextOdd", nextOdd);
 
+  _export("a", void 0);
+
   return {
     setters: [function (_evens) {
       isEven = _evens.isEven;
     }],
     execute: function () {
       _export("p", p = 5);
-
-      _export("p", p);
 
       for (a in b);
 
@@ -27,8 +27,6 @@ System.register(["./evens"], function (_export, _context) {
           return !isEven(n);
         };
       }(isEven));
-
-      _export("isOdd", isOdd);
     }
   };
 });

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/hoisting-bindings/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/hoisting-bindings/output.mjs
@@ -19,8 +19,6 @@ System.register([], function (_export, _context) {
     execute: function () {
       _export("c", c = 5);
 
-      _export("c", c);
-
       b();
     }
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/overview/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/overview/output.mjs
@@ -14,8 +14,6 @@ System.register(["foo", "foo-bar", "./directory/foo-bar"], function (_export, _c
 
       _export("test2", test2 = 5);
 
-      _export("test2", test2);
-
       _export("default", test);
     }
   };

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/remap/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/remap/output.mjs
@@ -7,8 +7,6 @@ System.register([], function (_export, _context) {
     execute: function () {
       _export("test", test = 2);
 
-      _export("test", test);
-
       _export("test", test = 5);
 
       _export("test", +test + 1), test++;
@@ -21,21 +19,13 @@ System.register([], function (_export, _context) {
 
       _export("a", a = 2);
 
-      _export("a", a);
-
       _export("a", a = 3);
 
       _export("c", b = 2);
 
-      _export("c", b);
-
       _export("c", b = 3);
 
       _export("f", _export("e", d = 3));
-
-      _export("e", d);
-
-      _export("f", d);
 
       _export("f", _export("e", d = 4));
     }


### PR DESCRIPTION
This PR fixes up some issues with hoisting, destructuring assignment and export calls.

Please just let me know if there are any questions here at all, and happy to integrate any feedback.

### Hoisting

As discussed with @loganfsmyth, the goal of hoisting is to support ES module semantics through the system format.

Any code that runs correctly as an ES module, should run correctly through the System format.

As a result, we should always hoist, and not opt out of hoisting when hitting up on let or const declarations.

This does mean we don't catch TDZ errors, but the assumption here is that a working module graph for working code shouldn't need to rely on TDZ errors for proper function in the normal running case.

### Destructuring assignments

Support has been added for cases like `export var p = 5; ({ p } = q);` where previously, the destructured bindings weren't being checked on the assignment expression update.

### Pruning unnecessary export calls

There seem to have been some unnecessary export calls that crept in as well with the destructuring updates, as `export var p = 5` would output two export calls, one for the binding definition, and another for the assignment expression when hoisted. This is fixed by only emitting for the assignment expression and always hoisting.

### Ensuring export calls for uninitialized bindings

To handle the `export var p` case without initialization, a `hasInit` return has been added to the hoisting helper function as a third argument, which when `false` informs the transform that an uninitialized `_export("p", undefined)` is needed at the declaration phase. This also ensures we consistently export for each export name of the module guaranteeing the module object will have the right shape by the end of execution time.

### Combining reexport calls

Reexports of the form `export { p, q } from 'asdf'` would create the an `var exportObj = {}` in the setter, and then assign each export to that. I've separated this process out into a separate `constructExportCall` function which has three cases - single export, multiple exports, and multiple exports with export star. The single export case then becomes `_export("p", asdf.p)`, and the multiple exports case can become `_export({ p: asdf.p, q: asdf.q })` making this a bit cleaner.