### PR TITLE
Change decoratorsBeforeExport default to false

### DIFF
--- a/packages/babel-generator/src/index.js
+++ b/packages/babel-generator/src/index.js
@@ -52,10 +52,7 @@ function normalizeOptions(code, opts): Format {
       style: "  ",
       base: 0,
     },
-    decoratorsBeforeExport:
-      opts.decoratorsBeforeExport === undefined
-        ? true
-        : opts.decoratorsBeforeExport,
+    decoratorsBeforeExport: !!opts.decoratorsBeforeExport,
   };
 
   if (format.minified) {

--- a/packages/babel-generator/test/fixtures/types/Decorator/output.js
+++ b/packages/babel-generator/test/fixtures/types/Decorator/output.js
@@ -32,15 +32,15 @@ class Foo {
 
 }
 
-@foo
-export default class Foo {
+export default @foo
+class Foo {
   bar() {
     class Baz {}
   }
 
 }
-@foo
-export class Foo {
+export @foo
+class Foo {
   bar() {
     class Baz {}
   }

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -615,7 +615,9 @@ export default class StatementParser extends ExpressionParser {
 
     const kind = this.state.type.isLoop
       ? "loop"
-      : this.match(tt._switch) ? "switch" : null;
+      : this.match(tt._switch)
+        ? "switch"
+        : null;
     for (let i = this.state.labels.length - 1; i >= 0; i--) {
       const label = this.state.labels[i];
       if (label.statementStart === node.start) {

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -263,8 +263,7 @@ export default class StatementParser extends ExpressionParser {
         this.raise(
           this.state.start,
           "Using the export keyword between a decorator and a class is not allowed. " +
-            "Please use `export @dec class` instead, or set the " +
-            "'decoratorsBeforeExport' option to true.",
+            "Please use `export @dec class` instead.",
         );
       }
     } else if (!this.canHaveLeadingDecorator()) {
@@ -616,9 +615,7 @@ export default class StatementParser extends ExpressionParser {
 
     const kind = this.state.type.isLoop
       ? "loop"
-      : this.match(tt._switch)
-        ? "switch"
-        : null;
+      : this.match(tt._switch) ? "switch" : null;
     for (let i = this.state.labels.length - 1; i >= 0; i--) {
       const label = this.state.labels[i];
       if (label.statementStart === node.start) {

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead, or set the 'decoratorsBeforeExport' option to true. (2:0)"
+  "throws": "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead. (2:0)"
 }

--- a/packages/babel-plugin-syntax-decorators/src/index.js
+++ b/packages/babel-plugin-syntax-decorators/src/index.js
@@ -16,7 +16,7 @@ export default declare((api, options) => {
     );
   }
 
-  let { decoratorsBeforeExport } = options;
+  const { decoratorsBeforeExport } = options;
   if (decoratorsBeforeExport !== undefined) {
     if (legacy) {
       throw new Error(
@@ -26,8 +26,6 @@ export default declare((api, options) => {
     if (typeof decoratorsBeforeExport !== "boolean") {
       throw new Error("'decoratorsBeforeExport' must be a boolean.");
     }
-  } else if (!legacy) {
-    decoratorsBeforeExport = true;
   }
 
   return {

--- a/packages/babel-plugin-syntax-decorators/test/index.js
+++ b/packages/babel-plugin-syntax-decorators/test/index.js
@@ -47,8 +47,8 @@ describe("'decoratorsBeforeExport' option", function() {
   const AFTER = "export @dec class Foo {}";
 
   // These are skipped
-  run(BEFORE, undefined, false);
-  run(AFTER, undefined, true);
+  run(BEFORE, undefined, true);
+  run(AFTER, undefined, false);
   run(BEFORE, true, false);
   run(AFTER, true, true);
   run(BEFORE, false, true);


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | :+1: 
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Ref: https://github.com/babel/babel/pull/7976#discussion_r192599893 (cc @diervo)

I also asked to Daniel, and he said that this option could be removed but

> I am not 100% sure, we will have to confirm, but it could always be added back

Instead of removing the option, this PR changes the default value to false.