### PR TITLE
[class-properties] Remove unnecessary return and temp variable

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -379,7 +379,7 @@ export default declare((api, options) => {
             if (isDerived) {
               newConstructor.params = [t.restElement(t.identifier("args"))];
               newConstructor.body.body.push(
-                t.returnStatement(
+                t.expressionStatement(
                   t.callExpression(t.super(), [
                     t.spreadElement(t.identifier("args")),
                   ]),

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
@@ -18,13 +18,15 @@ function (_Foo) {
   babelHelpers.inherits(Bar, _Foo);
 
   function Bar(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, Bar);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args)), Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _prop2, {
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
+    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _prop2, {
       writable: true,
       value: "bar"
-    }), _temp));
+    });
+    return _this;
   }
 
   return Bar;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -16,10 +16,14 @@ function (_Foo) {
   babelHelpers.inherits(Bar, _Foo);
 
   function Bar(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, Bar);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args)), _prop2.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar"), _temp));
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
+
+    _prop2.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar");
+
+    return _this;
   }
 
   return Bar;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -24,10 +24,14 @@ function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), _foo.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))), _temp));
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
+
+    _foo.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
+
+    return _this;
   }
 
   return B;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
@@ -6,10 +6,12 @@ function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args)), _this.bar = "foo", _temp));
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args));
+    _this.bar = "foo";
+    return _this;
   }
 
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -24,10 +24,12 @@ function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)), _temp));
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
+    _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    return _this;
   }
 
   return B;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -6,10 +6,12 @@ function (_Bar) {
   babelHelpers.inherits(Foo, _Bar);
 
   function Foo(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo"), _temp));
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args));
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo");
+    return _this;
   }
 
   return Foo;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -24,10 +24,12 @@ function (_A) {
   babelHelpers.inherits(B, _A);
 
   function B(...args) {
-    var _temp, _this;
+    var _this;
 
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(_this, (_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))), _temp));
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
+    return _this;
   }
 
   return B;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -35,7 +35,7 @@ var Test = function Test() {
     function Other() {
       var _getPrototypeOf2;
 
-      var _temp, _this;
+      var _this;
 
       _classCallCheck(this, Other);
 
@@ -43,9 +43,13 @@ var Test = function Test() {
         args[_key] = arguments[_key];
       }
 
-      return _possibleConstructorReturn(_this, (_temp = _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args))), _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "a", function () {
+      _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args)));
+
+      _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "a", function () {
         return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));
-      }), _temp));
+      });
+
+      return _this;
     }
 
     return Other;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-call-only-allowed-in-derived-constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-call-only-allowed-in-derived-constructor/output.js
@@ -1,0 +1,9 @@
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+let Foo = function Foo() {
+  "use strict";
+
+  _classCallCheck(this, Foo);
+
+  super();
+};

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -39,7 +39,7 @@ function (_Component) {
   function App() {
     var _getPrototypeOf2;
 
-    var _temp, _this;
+    var _this;
 
     _classCallCheck(this, App);
 
@@ -47,7 +47,11 @@ function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _possibleConstructorReturn(_this, (_temp = _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args))), _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "exportType", ''), _temp));
+    _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args)));
+
+    _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "exportType", '');
+
+    return _this;
   }
 
   _createClass(App, [{

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/class-assign-unreferenced-param-deopt/output.mjs
@@ -6,17 +6,19 @@ var _ref =
 
 class BugReport extends React.Component {
   constructor(...args) {
-    var _temp;
+    super(...args);
 
-    return _temp = super(...args), this.thisWontWork = ({
+    this.thisWontWork = ({
       color
     }) => data => {
       return <div color={color}>does not reference data</div>;
-    }, this.thisWorks = ({
+    };
+
+    this.thisWorks = ({
       color
     }) => data => {
       return <div color={color}>{data}</div>;
-    }, _temp;
+    };
   }
 
   render() {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression-this/output.js
@@ -4,13 +4,15 @@ var _ref =
 
 class Component extends React.Component {
   constructor(...args) {
-    var _temp;
+    super(...args);
+
+    this.subComponent = () => _ref;
 
     var _ref2 =
     /*#__PURE__*/
     <this.subComponent />;
 
-    return _temp = super(...args), this.subComponent = () => _ref, this.render = () => _ref2, _temp;
+    this.render = () => _ref2;
   }
 
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/member-expression/output.js
@@ -12,9 +12,9 @@ var _ref2 =
 
 class Component extends React.Component {
   constructor(...args) {
-    var _temp;
+    super(...args);
 
-    return _temp = super(...args), this.render = () => _ref2, _temp;
+    this.render = () => _ref2;
   }
 
 }


### PR DESCRIPTION
`super()` is already implicitly returned, so we don't need the return statement.

Input:

```js
class A extends B {
  foo = 2;
}
```

Before:
```js
class A extends B {
  constructor(...args) {
    var _temp;

    return _temp = super(...args), _defineProperty(this, "foo", 2), _temp;
  }

}
```

After:
```js
class A extends B {
  constructor(...args) {
    super(...args);
    _defineProperty(this, "foo", 2);
  }

}
```