### PR TITLE
Don't regenerate babel-types docs in the readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ build: clean clean-lib
 	# generate flow and typescript typings
 	node scripts/generators/flow.js > ./packages/babel-types/lib/index.js.flow
 	node scripts/generators/typescript.js > ./packages/babel-types/lib/index.d.ts
-	# generate docs
-	node scripts/generators/docs.js > ./packages/babel-types/README.md
 ifneq ("$(BABEL_COVERAGE)", "true")
 	make build-standalone
 	make build-preset-env-standalone


### PR DESCRIPTION
It is super annoying after https://github.com/babel/babel/pull/8108