### PR TITLE
Remove preset-env outdated test

### DIFF
--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -114,21 +114,6 @@ describe("getTargets", () => {
         android: "4.0.0",
       });
     });
-
-    it("ignores invalid", () => {
-      expect(
-        getTargets({
-          browsers: 59,
-          chrome: "49",
-          firefox: "55",
-          ie: "11",
-        }),
-      ).toEqual({
-        chrome: "49.0.0",
-        firefox: "55.0.0",
-        ie: "11.0.0",
-      });
-    });
   });
 
   describe("esmodules", () => {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

Remove outdated test from babel preset-env that was previously removed in commit https://github.com/babel/babel/commit/3de053cc6c94be9411deb213cfc53c1392b5f6eb#diff-7b0b52f2e5e913ba850f9511c986b459L59 and then accidentally added back to master.
