### PR TITLE
[babel-types] Fix isNodesEquivalent() behavior for TemplateElements

### DIFF
--- a/packages/babel-types/src/validators/isNodesEquivalent.js
+++ b/packages/babel-types/src/validators/isNodesEquivalent.js
@@ -1,5 +1,5 @@
 // @flow
-import { NODE_FIELDS } from "../definitions";
+import { NODE_FIELDS, VISITOR_KEYS } from "../definitions";
 
 /**
  * Check if two nodes are equivalent
@@ -19,6 +19,7 @@ export default function isNodesEquivalent(a: any, b: any): boolean {
   }
 
   const fields = Object.keys(NODE_FIELDS[a.type] || a.type);
+  const visitorKeys = VISITOR_KEYS[a.type];
 
   for (const field of fields) {
     if (typeof a[field] !== typeof b[field]) {
@@ -35,6 +36,18 @@ export default function isNodesEquivalent(a: any, b: any): boolean {
 
       for (let i = 0; i < a[field].length; i++) {
         if (!isNodesEquivalent(a[field][i], b[field][i])) {
+          return false;
+        }
+      }
+      continue;
+    }
+
+    if (
+      typeof a[field] === "object" &&
+      (!visitorKeys || !visitorKeys.includes(field))
+    ) {
+      for (const key in a[field]) {
+        if (a[field][key] !== b[field][key]) {
           return false;
         }
       }

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -26,6 +26,14 @@ describe("validators", function() {
       expect(t.isNodesEquivalent(parse(program), parse(program2))).toBe(false);
     });
 
+    it("should handle nodes with object properties", function() {
+      const original = t.templateElement({ raw: "\\'a", cooked: "'a" }, true);
+      const identical = t.templateElement({ raw: "\\'a", cooked: "'a" }, true);
+      const different = t.templateElement({ raw: "'a", cooked: "'a" }, true);
+      expect(t.isNodesEquivalent(original, identical)).toBe(true);
+      expect(t.isNodesEquivalent(original, different)).toBe(false);
+    });
+
     it("rejects 'await' as an identifier", function() {
       expect(t.isValidIdentifier("await")).toBe(false);
     });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8163 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | ✅
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> ## Bug Report
> 
> **Current Behavior**
> Attempting to run `t.isNodesEquivalent()` on any node that contains a `TemplateElement` node somewhere in its subtree will throw an error.
> 
> **Input Code**
> - REPL or Repo link if applicable: https://runkit.com/embed/o7tn287ktlay
> 
> ```js
> const t = require("babel-types");
> 
> const node = t.templateElement({ raw: 'foo', cooked: 'foo' }, true);
> 
> t.isNodesEquivalent(node, node);
> // TypeError: Cannot convert undefined or null to object
> //     at keys (<anonymous>)
> //     at isNodesEquivalent (babel-types/lib/validators.js:223:35)
> ```

**Solution**

This error occurs because according to the `NODE_FIELDS` registry, `TemplateElement` defines a [`value`](https://github.com/babel/babel/blob/master/packages/babel-types/src/definitions/es2015.js#L520) property, which according to [the ESTree spec](https://github.com/estree/estree/blob/master/es2015.md#templateelement) is an object with `{ raw, cooked }` properties – *not* a babel AST node.

The `isNodesEquivalent()` algorithm incorrectly assumes that any object properties must themselves be AST nodes, which is not the case here, causing the error.

As far as I can tell, the `VISITOR_KEYS` registry seems to be used elsewhere to determine which properties refer to sub-nodes of any given node. This means that the `isNodesEquivalent()` algorithm could potentially use this information to determine whether to compare the property values as AST nodes (i.e. recursively compare the values using `isNodesEquivalent()`) or as raw JS objects (i.e. compare the two objects via a shallow equality check).

**Questions**

- I'm not hugely familiar with the `babel-types` source – is `VISITOR_KEYS` definitely the correct source of truth to use here? i.e. I've assumed that any property that is *not* present in the `VISITOR_KEYS` array will *not* contain an AST node. Is this a valid assumption?