### PR TITLE
babel-plugin-transform-react-jsx: supoprt @jsxLit annotation

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-distinguish-literals-with-option/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-distinguish-literals-with-option/input.js
@@ -1,0 +1,11 @@
+/** @jsxLit React.literal */
+
+function f(str) {
+  return [
+      <a href="javascript:go()" valueless>Text</a>,
+      // TODO: Should we handle these cases?  Is this an idiom for avoiding HTML decoding?
+      <a href={"javascript:go() // in brackets"}>{"Text in brackets"}</a>,
+      <a href={str} {...({ spreaded: "" })}>{str}</a>,
+      <a href={`${str}`}>Back ticks with an interpolation</a>
+  ];
+}

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-distinguish-literals-with-option/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-distinguish-literals-with-option/output.js
@@ -1,0 +1,16 @@
+/** @jsxLit React.literal */
+function f(str) {
+  return [React.createElement("a", {
+    href: React.literal("javascript:go()", "a[href]"),
+    valueless: true
+  }, React.literal("Text", "#text")), // TODO: Should we handle these cases?  Is this an idiom for avoiding HTML decoding?
+  React.createElement("a", {
+    href: "javascript:go() // in brackets"
+  }, "Text in brackets"), React.createElement("a", babelHelpers.extends({
+    href: str
+  }, {
+    spreaded: ""
+  }), str), React.createElement("a", {
+    href: `${str}`
+  }, React.literal("Back ticks with an interpolation", "#text"))];
+}


### PR DESCRIPTION


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

This change adds an option to *babel-plugin-transform-react-jsx* with a default that is semantics neutral for existing code.

When `options.pragmaLit` or the `@jsxLit` annotation specifies a function name, the plugin now wraps literal attribute and text node values in a call like `functionName("text", "context hint")`.

For background, ["Options for Hardening React &| JSX"](https://gist.github.com/mikesamuel/094d3fe4b1b2f702f543fa0c263ca8ff) discusses ways to address XSS and crafted intents in JSX Frameworks like React and React native.

> Desugar string literals in JSXAttributeValue and JSXText nodes so that they are clearly marked as specified by a trusted developer.

This should allow `ReactDOM` to prevent `javascript:` URLs that reach

```jsx
(<a href={url}>Link</a>)
```

without preventing developers from doing something like

```jsx
(<a href="javascript:doSomethingAwesome()">Link</a>)
```

This is meant to interoperate with the [trusted-types](https://github.com/WICG/trusted-types) polyfill and other schemes for distinguishing strings from trusted sources at runtime.