### PR TITLE
babel/parser: use charCodes throughout for improved sourcecode readability in tokenizer/parser.

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -1811,7 +1811,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     // ensure that inside flow types, we bypass the jsx parser plugin
     readToken(code: number): void {
       const next = this.input.charCodeAt(this.state.pos + 1);
-      if (this.state.inType && (code === 62 || code === 60)) {
+      if (
+        this.state.inType &&
+        (code === charCodes.greaterThan || code === charCodes.lessThan)
+      ) {
         return this.finishOp(tt.relational, 1);
       } else if (isIteratorStart(code, next)) {
         this.state.isIterator = true;

--- a/packages/babel-parser/src/util/identifier.js
+++ b/packages/babel-parser/src/util/identifier.js
@@ -2,6 +2,8 @@
 
 // @flow
 
+import * as charCodes from "charcodes";
+
 function makePredicate(words: string): (str: string) => boolean {
   const wordsArr = words.split(" ");
   return function(str) {
@@ -75,10 +77,10 @@ function isInAstralSet(code: number, set: $ReadOnlyArray<number>): boolean {
 // Test whether a given character code starts an identifier.
 
 export function isIdentifierStart(code: number): boolean {
-  if (code < 65) return code === 36;
-  if (code < 91) return true;
-  if (code < 97) return code === 95;
-  if (code < 123) return true;
+  if (code < charCodes.uppercaseA) return code === charCodes.dollarSign;
+  if (code <= charCodes.uppercaseZ) return true;
+  if (code < charCodes.lowercaseA) return code === charCodes.underscore;
+  if (code <= charCodes.lowercaseZ) return true;
   if (code <= 0xffff) {
     return (
       code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code))
@@ -87,21 +89,21 @@ export function isIdentifierStart(code: number): boolean {
   return isInAstralSet(code, astralIdentifierStartCodes);
 }
 
-// Test whether a current state character code and next character code  is @
+// Test whether a current state character code and next character code is @
 
 export function isIteratorStart(current: number, next: number): boolean {
-  return current === 64 && next === 64;
+  return current === charCodes.atSign && next === charCodes.atSign;
 }
 
 // Test whether a given character is part of an identifier.
 
 export function isIdentifierChar(code: number): boolean {
-  if (code < 48) return code === 36;
-  if (code < 58) return true;
-  if (code < 65) return false;
-  if (code < 91) return true;
-  if (code < 97) return code === 95;
-  if (code < 123) return true;
+  if (code < charCodes.digit0) return code === charCodes.dollarSign;
+  if (code < charCodes.colon) return true;
+  if (code < charCodes.uppercaseA) return false;
+  if (code <= charCodes.uppercaseZ) return true;
+  if (code < charCodes.lowercaseA) return code === charCodes.underscore;
+  if (code <= charCodes.lowercaseZ) return true;
   if (code <= 0xffff) {
     return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
   }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | -
| Patch: Bug Fix?          | -
| Major: Breaking Change?  | -
| Minor: New Feature?      | -
| Minor: Code cleanup / Typo fixes?      | 👍
| Tests Added + Pass?      | Yes
| Documentation PR         | -
| Any Dependency Changes?  | -
| License                  | MIT

part of the babel/parser code still uses numeric character references, while a large chunk uses charCodes.XYZ named character references.

This pullreq replaces those remaining numeric char code references.

