### PR TITLE
babel/parser: test helpers: write expected throw message to options.json ~ complete `jest -u` functionality

### DIFF
--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -1,4 +1,6 @@
 import { multiple as getFixtures } from "@babel/helper-fixtures";
+import fs from "fs";
+import path from "path";
 
 export function runFixtureTests(fixturesPath, parseFunction) {
   const fixtures = getFixtures(fixturesPath);
@@ -7,8 +9,6 @@ export function runFixtureTests(fixturesPath, parseFunction) {
     fixtures[name].forEach(function(testSuite) {
       testSuite.tests.forEach(function(task) {
         const testFn = task.disabled ? it.skip : it;
-        const fs = require("fs");
-        const path = require("path");
 
         testFn(name + "/" + testSuite.title + "/" + task.title, function() {
           try {


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | -
| Patch: Bug Fix?          | -
| Major: Breaking Change?  | -
| Minor: New Feature?      | 👍 (parser test rig)
| Tests Added + Pass?      | Yes
| Documentation PR         | -
| Any Dependency Changes?  | -
| License                  | MIT

babel/parser: test helpers: when test fails with an exception and both reference output file and options.json file do not exist, write a simple options.json with the error message to expect when such a file doesn't exist yet. This completes the `jest -u` capability for new tests which are expected to *fail*.

(In my own fork I added tests which are expected to fail and `jest -u` updates the snapshot files quite nicely, yet the error-throwing test cases still had to be updated by hand, which was a chore. This code checks if the options.json exists and it not, writes the exception message in there. This code *only does that when there's no output reference file present*, i.e. this code does *not* patch/write the options.json file when the output reference file (`expects.code`) already tells us this test is **not expected to fail**. This prevents the test runner from acting up when tests actually *fail* *unexpectedly*.

