### PR TITLE
jest binary is a bash shell script, not a nodeJS file.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,4 +23,4 @@ if [ -n "$TEST_ONLY" ]; then
   jestArgs+=("(packages|codemods)/.*$TEST_ONLY.*/test")
 fi
 
-$node node_modules/.bin/jest "${jestArgs[@]}"
+node_modules/.bin/jest "${jestArgs[@]}"


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | 👍 (Windows: fail to run jest as bash is *not* default SHELL; invoking jest via `node` should be handled by the active shell, wich *is* bash.)
| Patch: Bug Fix?          | -
| Major: Breaking Change?  | -
| Minor: New Feature?      | -
| Tests Added + Pass?      | Yes
| Documentation PR         | -
| Any Dependency Changes?  |
| License                  | MIT

Fixes failure to run tests on Windows platform as there bash is not the default shell, hence invoking shell scripts via node is not going to work as expected.

node_modules/.bin/jest *is* a sh/bash shell script, hence invoking that script via the `node` executable is is done without this patch, is begging for trouble on Windows boxes at least and superfluous on unix boxes.