### PR TITLE
remove regression to support output of full directory hierarchy with --out-dir

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -21,6 +21,7 @@
     "fs-readdir-recursive": "^1.0.0",
     "glob": "^7.0.0",
     "lodash": "^4.17.5",
+    "mkdirp": "^0.5.1",
     "output-file-sync": "^2.0.0",
     "slash": "^1.0.0",
     "source-map": "^0.5.0"

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -1,5 +1,6 @@
 import defaults from "lodash/defaults";
 import outputFileSync from "output-file-sync";
+import { sync as mkdirpSync } from "mkdirp";
 import slash from "slash";
 import path from "path";
 import fs from "fs";
@@ -71,19 +72,6 @@ export default async function({ cliOptions, babelOptions }) {
     return path.join(cliOptions.outDir, filename);
   }
 
-  function outputDestFolder(outDir) {
-    const outDirPath = path.resolve(outDir);
-
-    try {
-      fs.mkdirSync(outDirPath);
-    } catch (err) {
-      // Testing for the directory and then creating it can lead to race
-      // conditions if there are multiple processes, so we try to create it
-      // and bail if it already exists.
-      if (err.code !== "EEXIST") throw err;
-    }
-  }
-
   async function handleFile(src, base) {
     const written = await write(src, base);
 
@@ -128,7 +116,7 @@ export default async function({ cliOptions, babelOptions }) {
       util.deleteDir(cliOptions.outDir);
     }
 
-    outputDestFolder(cliOptions.outDir);
+    mkdirpSync(cliOptions.outDir);
 
     let compiledFiles = 0;
     for (const filename of cliOptions.filenames) {


### PR DESCRIPTION
fixes: #8182 

@loganfsmyth, I have made the replacement of `outputDestFolder` with `mkdirp`. However, I have no idea whatsoever of how to try out whether these changes do the job.

One way I had tried to check whether the code changes worked or not was by trying to install the local copy of the newly built `babel-cli` plugin and then type in the command in the shell to see whether it works or not. But I have no idea of how to install this newly built local copy of the `babel-cli` plugin so that I can use it.

P.S. by the local copy of `babel-cli` I mean the one generated after running `make build`

Also the `make build` cmd takes too much of time. Is there any other way to only build the specific files