### PR TITLE
Add missing parameters to ast creators

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -383,6 +383,7 @@ export const patternLikeCommon = {
       assertValueType("array"),
       assertEach(assertNodeType("Decorator")),
     ),
+    optional: true,
   },
 };
 
@@ -538,10 +539,12 @@ defineType("Program", {
   // Note: We explicitly leave 'interpreter' out here because it is
   // conceptually comment-like, and Babel does not traverse comments either.
   visitor: ["directives", "body"],
-  builder: ["body", "directives", "sourceType", "interpreter"],
+  builder: ["body", "directives", "sourceType", "interpreter", "sourceFile"],
   fields: {
     sourceFile: {
       validate: assertValueType("string"),
+      default: null,
+      optional: true,
     },
     sourceType: {
       validate: assertOneOf("script", "module"),
@@ -585,7 +588,7 @@ defineType("ObjectExpression", {
 });
 
 defineType("ObjectMethod", {
-  builder: ["kind", "key", "params", "body", "computed"],
+  builder: ["kind", "key", "params", "body", "computed", "async", "generator"],
   fields: {
     ...functionCommon,
     ...functionTypeAnnotationCommon,
@@ -620,6 +623,7 @@ defineType("ObjectMethod", {
         assertValueType("array"),
         assertEach(assertNodeType("Decorator")),
       ),
+      optional: true,
     },
     body: {
       validate: assertNodeType("BlockStatement"),

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -13,7 +13,7 @@ import {
 } from "./core";
 
 defineType("AssignmentPattern", {
-  visitor: ["left", "right"],
+  visitor: ["left", "right", "decorators", "typeAnnotation"],
   builder: ["left", "right"],
   aliases: ["Pattern", "PatternLike", "LVal"],
   fields: {
@@ -24,17 +24,11 @@ defineType("AssignmentPattern", {
     right: {
       validate: assertNodeType("Expression"),
     },
-    decorators: {
-      validate: chain(
-        assertValueType("array"),
-        assertEach(assertNodeType("Decorator")),
-      ),
-    },
   },
 });
 
 defineType("ArrayPattern", {
-  visitor: ["elements", "typeAnnotation"],
+  visitor: ["elements", "decorators", "typeAnnotation"],
   builder: ["elements"],
   aliases: ["Pattern", "PatternLike", "LVal"],
   fields: {
@@ -45,17 +39,11 @@ defineType("ArrayPattern", {
         assertEach(assertNodeType("PatternLike")),
       ),
     },
-    decorators: {
-      validate: chain(
-        assertValueType("array"),
-        assertEach(assertNodeType("Decorator")),
-      ),
-    },
   },
 });
 
 defineType("ArrowFunctionExpression", {
-  builder: ["params", "body", "async"],
+  builder: ["params", "body", "async", "generator", "expression"],
   visitor: ["params", "body", "returnType", "typeParameters"],
   aliases: [
     "Scopable",
@@ -69,8 +57,9 @@ defineType("ArrowFunctionExpression", {
     ...functionCommon,
     ...functionTypeAnnotationCommon,
     expression: {
-      // https://github.com/babel/babylon/issues/505
+      // use to differentiate between `() => true` and `() => { true }`
       validate: assertValueType("boolean"),
+      default: false,
     },
     body: {
       validate: assertNodeType("BlockStatement", "Expression"),
@@ -277,6 +266,7 @@ defineType("ExportSpecifier", {
 
 defineType("ForOfStatement", {
   visitor: ["left", "right", "body"],
+  builder: ["left", "right", "body", "await"],
   aliases: [
     "Scopable",
     "Statement",
@@ -357,6 +347,7 @@ defineType("ImportSpecifier", {
     importKind: {
       // Handle Flowtype's extension "import {typeof foo} from"
       validate: assertOneOf(null, "type", "typeof"),
+      optional: true,
     },
   },
 });
@@ -452,7 +443,16 @@ export const classMethodOrDeclareMethodCommon = {
 
 defineType("ClassMethod", {
   aliases: ["Function", "Scopable", "BlockParent", "FunctionParent", "Method"],
-  builder: ["kind", "key", "params", "body", "computed", "static"],
+  builder: [
+    "kind",
+    "key",
+    "params",
+    "body",
+    "computed",
+    "static",
+    "async",
+    "generator",
+  ],
   visitor: [
     "key",
     "params",
@@ -471,7 +471,7 @@ defineType("ClassMethod", {
 });
 
 defineType("ObjectPattern", {
-  visitor: ["properties", "typeAnnotation"],
+  visitor: ["properties", "decorators", "typeAnnotation"],
   builder: ["properties"],
   aliases: ["Pattern", "PatternLike", "LVal"],
   fields: {

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -14,7 +14,14 @@ const defineInterfaceishType = (
   typeParameterType: string = "TypeParameterDeclaration",
 ) => {
   defineType(name, {
-    builder: ["id", "typeParameters", "extends", "body"],
+    builder: [
+      "id",
+      "typeParameters",
+      "extends",
+      "body",
+      "implements",
+      "mixins",
+    ],
     visitor: [
       "id",
       "typeParameters",
@@ -76,6 +83,7 @@ defineInterfaceishType("DeclareClass", "TypeParameterInstantiation");
 
 defineType("DeclareFunction", {
   visitor: ["id"],
+  builder: ["id", "predicate"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     id: validateType("Identifier"),
@@ -134,6 +142,7 @@ defineType("DeclareVariable", {
 
 defineType("DeclareExportDeclaration", {
   visitor: ["declaration", "specifiers", "source"],
+  builder: ["declaration", "specifiers", "source", "default"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     declaration: validateOptionalType("Flow"),
@@ -146,7 +155,7 @@ defineType("DeclareExportDeclaration", {
 });
 
 defineType("DeclareExportAllDeclaration", {
-  visitor: ["source"],
+  visitor: ["source", "exportKind"],
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     source: validateType("StringLiteral"),
@@ -179,6 +188,7 @@ defineType("FunctionTypeAnnotation", {
 
 defineType("FunctionTypeParam", {
   visitor: ["name", "typeAnnotation"],
+  builder: ["name", "typeAnnotation", "optional"],
   aliases: ["Flow"],
   fields: {
     name: validateOptionalType("Identifier"),
@@ -303,26 +313,28 @@ defineType("ObjectTypeCallProperty", {
 
 defineType("ObjectTypeIndexer", {
   visitor: ["id", "key", "value", "variance"],
+  builder: ["id", "key", "value", "variance"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     id: validateOptionalType("Identifier"),
     key: validateType("FlowType"),
     value: validateType("FlowType"),
-    static: validate(assertValueType("boolean")),
+    static: validateOptional(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),
   },
 });
 
 defineType("ObjectTypeProperty", {
   visitor: ["key", "value", "variance"],
+  builder: ["key", "value", "variance", "kind", "optional", "proto", "static"],
   aliases: ["Flow", "UserWhitespacable"],
   fields: {
     key: validateType(["Identifier", "StringLiteral"]),
     value: validateType("FlowType"),
-    kind: validate(assertOneOf("init", "get", "set")),
-    static: validate(assertValueType("boolean")),
-    proto: validate(assertValueType("boolean")),
-    optional: validate(assertValueType("boolean")),
+    kind: validateOptional(assertOneOf("init", "get", "set")),
+    static: validateOptional(assertValueType("boolean")),
+    proto: validateOptional(assertValueType("boolean")),
+    optional: validateOptional(assertValueType("boolean")),
     variance: validateOptionalType("Variance"),
   },
 });
@@ -417,6 +429,7 @@ defineType("TypeCastExpression", {
 defineType("TypeParameter", {
   aliases: ["Flow"],
   visitor: ["bound", "default", "variance"],
+  builder: ["name", "bound", "default", "variance"],
   fields: {
     name: validate(assertValueType("string")),
     bound: validateOptionalType("TypeAnnotation"),


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Sorry, didn't create an additional issue
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No _dramatic_ breaking changes (see below)
| Minor: New Feature?      | This will allow users of the package to create nodes with all allowed kinds of fields! ✨ 
| Tests Added + Pass?      | No new tests but I fixed the old ones (see below)
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

Hey Babel team,

first, thanks for the awesome package _@babel/types_. The package has been making so much progress in the last 6 month. It is so useful when generating code and I rely heavily on it in my project.

A while ago I already fixed a small problem regarding arguments of creator functions (#7697). Some of the creator functions in @babel/types have less arguments than they have fields. This makes it possible to verify nodes of that type but not possible to create new nodes with these properties using the functions from the package.
I added the missing arguments to a bunch of functions by either introducing the `builder` property or adding more values to it. Furthermore I made sure that all additional parameters that are now available for these functions are optional (see exception below). This should prevent them from breaking for users that are relying on these functions.

#### Scope of the change:

I went through the documentation and changed all the functions that have less arguments than fields to match the arguments with the fields. I did not do that for the typescript functions (I tried to keep the scope size comfortable for me) but could maybe do this in another PR later.

~I also removed an optimisation in the `cloneNode` function (first change in the diff). It was only copying the `name` property but _ Identifiers_ can have all sorts of fields these days. My change broke the test because it did not copy over all of the new fields (which are initialised as null when not provided).~ _Edit: Removed from this PR_

#### Breaking changes

As I said I tried to not make any breaking changes. I think two things are technically breaking:
- I added the `name` argument to `TypeParameter` as the first argument (and therefore changed the arguments) but I am not sure how a type parameter without a name would work since the field is required.
- ~In `ArrayPattern` I inserted the `decorators` argument in between the existing arguments to make it consistent in ordering with all the other functions expecting `decorators` and `typeAnnotation`.~ _Edit: Removed from this PR_