### PR TITLE
Require proposal flag for pipeline plugin

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/options.json
@@ -1,3 +1,6 @@
 {
-  "presets": [["stage-0", { "decoratorsLegacy": true }], "es2015"]
+  "presets": [
+    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }],
+    "es2015"
+  ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
@@ -1,7 +1,7 @@
 {
   "plugins": ["external-helpers", ["proposal-class-properties", {"loose": true}]],
   "presets": [
-    ["stage-0", { "decoratorsLegacy": true }],
+    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }],
     "es2015"
   ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/options.json
@@ -1,7 +1,7 @@
 {
   "plugins": ["external-helpers", "proposal-class-properties"],
   "presets": [
-    ["stage-0", { "decoratorsLegacy": true }],
+    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }],
     "es2015"
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/options.json
@@ -1,6 +1,6 @@
 {
   "presets": [
     "es2015",
-    ["stage-0", { "decoratorsLegacy": true }]
+    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }]
   ]
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/pipeline-operator/options.json
@@ -1,3 +1,5 @@
 {
-  "plugins": ["proposal-pipeline-operator"]
+  "plugins": [
+    ["proposal-pipeline-operator", { "proposal": "minimal" }]
+  ]
 }

--- a/packages/babel-plugin-syntax-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-syntax-pipeline-operator/src/index.js
@@ -1,11 +1,17 @@
 import { declare } from "@babel/helper-plugin-utils";
 
-export default declare(api => {
+const proposals = ["minimal"];
+
+export default declare((api, { proposal }) => {
   api.assertVersion(7);
+
+  if (typeof proposal !== "string" || !proposals.includes(proposal)) {
+    throw new Error("'proposal' must be one of: " + proposals.join(", "));
+  }
 
   return {
     manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push("pipelineOperator");
+      parserOpts.plugins.push(["pipelineOperator", { proposal }]);
     },
   };
 });

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -6,7 +6,12 @@ import transformFunctionBind from "@babel/plugin-proposal-function-bind";
 export default declare((api, opts = {}) => {
   api.assertVersion(7);
 
-  const { loose = false, useBuiltIns = false, decoratorsLegacy = false } = opts;
+  const {
+    loose = false,
+    useBuiltIns = false,
+    decoratorsLegacy = false,
+    pipelineProposal,
+  } = opts;
 
   if (typeof loose !== "boolean") {
     throw new Error("@babel/preset-stage-0 'loose' option must be a boolean.");
@@ -30,8 +35,21 @@ export default declare((api, opts = {}) => {
     );
   }
 
+  if (typeof pipelineProposal !== "string") {
+    throw new Error(
+      "The pipeline operator requires a proposal set." +
+        " You must pass the 'pipelineProposal' option to" +
+        " @babel/preset-stage-0",
+    );
+  }
+
   return {
-    presets: [[presetStage1, { loose, useBuiltIns, decoratorsLegacy }]],
+    presets: [
+      [
+        presetStage1,
+        { loose, useBuiltIns, decoratorsLegacy, pipelineProposal },
+      ],
+    ],
     plugins: [transformFunctionBind],
   };
 });

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -11,7 +11,12 @@ import transformDoExpressions from "@babel/plugin-proposal-do-expressions";
 export default declare((api, opts = {}) => {
   api.assertVersion(7);
 
-  const { loose = false, useBuiltIns = false, decoratorsLegacy = false } = opts;
+  const {
+    loose = false,
+    useBuiltIns = false,
+    decoratorsLegacy = false,
+    pipelineProposal,
+  } = opts;
 
   if (typeof loose !== "boolean") {
     throw new Error("@babel/preset-stage-1 'loose' option must be a boolean.");
@@ -35,13 +40,21 @@ export default declare((api, opts = {}) => {
     );
   }
 
+  if (typeof pipelineProposal !== "string") {
+    throw new Error(
+      "The pipeline operator requires a proposal set." +
+        " You must pass 'pipelineProposal' option to" +
+        " @babel/preset-stage-1",
+    );
+  }
+
   return {
     presets: [[presetStage2, { loose, useBuiltIns, decoratorsLegacy }]],
     plugins: [
       transformExportDefaultFrom,
       transformLogicalAssignmentOperators,
       [transformOptionalChaining, { loose }],
-      transformPipelineOperator,
+      [transformPipelineOperator, { proposal: pipelineProposal }],
       [transformNullishCoalescingOperator, { loose }],
       transformDoExpressions,
     ],


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/proposals/issues/29
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

I'm opening this now to get feedback early. I'm not sure if the logic should live in the proposal plugin, the syntax plugin, or the parser? (or all three?)

Is `proposal` an acceptable flag name?

Also, this breaks the current stage-0 plugin as well, which I don't know if you're going to keep. Is that going to be an issue?

* [x] Implement validation logic in all required places
* [x] Update README