### PR TITLE
Allow @foo/babel-plugin as an unexpanded plugin name, and @foo as a shorthand for it.

### DIFF
--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -15,8 +15,9 @@ const BABEL_PLUGIN_PREFIX_RE = /^(?!@|module:|[^/]+\/|babel-plugin-)/;
 const BABEL_PRESET_PREFIX_RE = /^(?!@|module:|[^/]+\/|babel-preset-)/;
 const BABEL_PLUGIN_ORG_RE = /^(@babel\/)(?!plugin-|[^/]+\/)/;
 const BABEL_PRESET_ORG_RE = /^(@babel\/)(?!preset-|[^/]+\/)/;
-const OTHER_PLUGIN_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?!babel-plugin-|[^/]+\/)/;
-const OTHER_PRESET_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?!babel-preset-|[^/]+\/)/;
+const OTHER_PLUGIN_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?!babel-plugin(?:-|\/|$)|[^/]+\/)/;
+const OTHER_PRESET_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?!babel-preset(?:-|\/|$)|[^/]+\/)/;
+const OTHER_ORG_DEFAULT_RE = /^(@(?!babel$)[^/]+)$/;
 
 export function resolvePlugin(name: string, dirname: string): string | null {
   return resolveStandardizedName("plugin", name, dirname);
@@ -80,6 +81,8 @@ function standardizeName(type: "plugin" | "preset", name: string) {
         isPreset ? OTHER_PRESET_ORG_RE : OTHER_PLUGIN_ORG_RE,
         `$1babel-${type}-`,
       )
+      // @foo -> @foo/babel-preset
+      .replace(OTHER_ORG_DEFAULT_RE, `$1/babel-${type}`)
       // module:mypreset -> mypreset
       .replace(EXACT_RE, "")
   );

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-plugin/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-plugin/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-preset/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/babel-preset/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -154,6 +154,66 @@ describe("addon resolution", function() {
     });
   });
 
+  it("should find @foo/babel-plugin when specified", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      plugins: ["@foo/babel-plugin"],
+    });
+  });
+
+  it("should find @foo/babel-preset when specified", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      presets: ["@foo/babel-preset"],
+    });
+  });
+
+  it("should find @foo/babel-plugin/index when specified", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      plugins: ["@foo/babel-plugin/index"],
+    });
+  });
+
+  it("should find @foo/babel-preset/index when specified", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      presets: ["@foo/babel-preset/index"],
+    });
+  });
+
+  it("should find @foo/babel-plugin when just scope given", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      plugins: ["@foo"],
+    });
+  });
+
+  it("should find @foo/babel-preset when just scope given", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      presets: ["@foo"],
+    });
+  });
+
   it("should find relative path presets", function() {
     process.chdir("relative-paths");
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8091
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

In #5547 we hard-coded the logic to automatically inject `babel-plugin-` prefix, but it's a little aggressive in this case. This PR expands the behavior added in that PR to handle


| Input | Previous behavior | Resolved to
| -------- | --- | ------
| `@foo/babel-plugin` | `@foo/babel-plugin-babel-plugin` | `@foo/babel-plugin`
| `@foo` | `@foo` | `@foo/babel-plugin`