### PR TITLE
Update readme in plugin-unicode-property-regex [skip ci]

### DIFF
--- a/packages/babel-plugin-proposal-unicode-property-regex/README.md
+++ b/packages/babel-plugin-proposal-unicode-property-regex/README.md
@@ -15,5 +15,17 @@ npm install --save @babel/plugin-proposal-unicode-property-regex
 or using yarn:
 
 ```sh
-yarn add --save @babel/plugin-proposal-unicode-property-regex
+yarn add @babel/plugin-proposal-unicode-property-regex
+```
+
+Add to your babel plugin list:
+
+```
+{
+  "babel": {
+    "plugins": [
+      "@babel/plugin-proposal-unicode-property-regex"
+    ]
+  }
+}
 ```


### PR DESCRIPTION
yarn doesn't have `--save` flag (save is default functionality)

| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

<!-- Describe your changes below in as much detail as possible -->
