### PR TITLE
Add initial AppVeyor support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <p align="center">
   <a href="https://travis-ci.org/babel/babel"><img alt="Travis Status" src="https://img.shields.io/travis/babel/babel/master.svg?label=travis&maxAge=43200"></a>
+  <a href="https://ci.appveyor.com/project/babel/babel"><img alt="AppVeyor Status" src="https://img.shields.io/appveyor/ci/babel/babel/master.svg?label=AppVeyor%20build&maxAge=43200"></a>
   <a href="https://circleci.com/gh/babel/babel"><img alt="CircleCI Status" src="https://img.shields.io/circleci/project/github/babel/babel/master.svg?label=circle&maxAge=43200"></a>
   <a href="https://codecov.io/github/babel/babel"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/babel/babel/master.svg?maxAge=43200"></a>
   <a href="https://slack.babeljs.io/"><img alt="Slack Status" src="https://slack.babeljs.io/badge.svg"></a>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+version: "{build}"
+
+clone_depth: 5
+
+environment:
+  PLATFORM: "x64"
+  matrix:
+    # check the current Node.js release and the minimum supported one
+    - NODEJS_VERSION: "10"
+    - NODEJS_VERSION: "6"
+
+install:
+  - ps: Install-Product node $env:NODEJS_VERSION $env:PLATFORM
+  - yarn install --ignore-engines
+
+test_script:
+  # make MSYS2 utils available like `make`
+  - set PATH=C:\msys64\usr\bin;%PATH%
+  - node -v
+  - yarn -v
+  - make test-ci
+
+matrix:
+  fast_finish: true
+
+build: off
+
+cache:
+  # cache the Yarn folder and invalidate the cache if one
+  # of the files right to the arrow changes
+  - '%LOCALAPPDATA%/Yarn -> appveyor.yml,package.json,yarn.lock'

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -59,7 +59,7 @@ const assertTest = function(stdout, stderr, opts, cwd) {
   stderr = replacePaths(stderr, cwd);
 
   const expectStderr = opts.stderr.trim();
-  stderr = stderr.trim();
+  stderr = stderr.trim().replace(/\\/g, "/");
 
   if (opts.stderr) {
     if (opts.stderrContains) {


### PR DESCRIPTION
Things to do:

- [x] Add AppVeyor to the repo and then I'll change the badge link
- [x] **Make sure you check the option to skip builds if `appveyor.yml` is missing in AppVeyor project settings**
- [x] Should we use `.appveyor.yml` or the default `appveyor.yml`?
- [x] Should we run all tests? Currently I only run `make test-ci`
- [x] Which Node.js versions should we test?
- [x] Which platforms? x86/x64/both? I went with x64 for now.
- [ ] Notifications? Same as Travis? Someone should take care of this themselves since we can't disable notifications via the config file.
- [ ] Fix tests to be cross-platform

/CC @xtuc @hzoo 