### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
   <a href="https://codecov.io/github/babel/babel"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/babel/babel/master.svg?maxAge=43200"></a>
   <a href="https://slack.babeljs.io/"><img alt="Slack Status" src="https://slack.babeljs.io/badge.svg"></a>
   <a href="https://www.npmjs.com/package/babel-core"><img alt="npm Downloads" src="https://img.shields.io/npm/dm/babel-core.svg?maxAge=43200"></a>
+  <a href="https://dependabot.com/compatibility-score.html?dependency-name=babel-core&package-manager=npm_and_yarn&version-scheme=semver">
+    <img src="https://api.dependabot.com/badges/compatibility_score?dependency-name=babel-core&package-manager=npm_and_yarn&version-scheme=semver">
+  </a>
 </p>
 
 <h2 align="center">Supporting Babel</h2>


### PR DESCRIPTION
First of all, thanks for Babel!

Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=babel-core&package-manager=npm_and_yarn&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=babel-core&package-manager=npm_and_yarn&version-scheme=semver)

If you click through then there's a description of how it's calculated - basically it takes all of the relevant updates Dependabot has done for projects that use Babel and checks what percentage of the time specs pass on the upgrade PR.

The score is slightly lower than 100% because some projects have flaky specs, but I'm working on filtering them out from the data, too :octocat:.