### PR TITLE
Typescript: Avoid stripping class properties when a decorator is set

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -157,10 +157,6 @@ export default declare((api, { jsxPragma = "React" }) => {
 
       ClassProperty(path) {
         const { node } = path;
-        if (!node.value) {
-          path.remove();
-          return;
-        }
 
         if (node.accessibility) node.accessibility = null;
         if (node.abstract) node.abstract = null;
@@ -196,7 +192,10 @@ export default declare((api, { jsxPragma = "React" }) => {
         path.get("body.body").forEach(child => {
           if (child.isClassProperty()) {
             child.node.typeAnnotation = null;
-            if (!child.node.value) child.remove();
+
+            if (!child.node.value && !child.node.decorators) {
+              child.remove();
+            }
           }
         });
       },

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/input.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/input.js
@@ -2,4 +2,6 @@ class C {
     public a?: number;
     private b: number = 0;
     readonly c!: number = 1;
+    @foo d: number;
+    @foo e: number = 3;
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-typescript",
+    ["syntax-decorators", { "legacy": true }]
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/properties/output.js
@@ -1,4 +1,8 @@
 class C {
   b = 0;
   c = 1;
+  @foo
+  d;
+  @foo
+  e = 3;
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

**Current behavior:**
The `babel-plugin-transform-typescript` removes class properties without value regardless if decorators are assigned to it or not.

```ts
// Original
class C {
  @foo
  d;
  @foo
  e = 3;
}

// Transformed
class C {
  // <-- Missing `d` field
  @foo
  e = 3;
}
```


**Expected behavior:**
The `babel-plugin-transform-typescript` should only remove a class property if it has no value and no decorators.

```ts
// Original
class C {
  @foo
  d;
  @foo
  e = 3;
}

// Transformed
class C {
  @foo
  d;
  @foo
  e = 3;
}
```

[REPL example](http://babeljs.io/repl/#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEASCmIQHtoG8BQ1pgNxegCNoBeaARn2wAEAzZVYK6Oh6AE1IvwF8g&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&sourceType=module&lineWrap=false&presets=typescript&prettier=true&targets=Node-8&version=7.0.0-beta.35&envVersion=)
