### PR TITLE
remove emojis from cli output

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -124,7 +124,7 @@ export default async function({ cliOptions, babelOptions }) {
     }
 
     console.log(
-      `🎉  Successfully compiled ${compiledFiles} ${
+      `Successfully compiled ${compiledFiles} ${
         compiledFiles !== 1 ? "files" : "file"
       } with Babel.`,
     );

--- a/packages/babel-cli/test/fixtures/babel/--copy-files --include-dotfiles with ignore/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--copy-files --include-dotfiles with ignore/stdout.txt
@@ -1,2 +1,2 @@
 src/index.js -> lib/index.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--copy-files --include-dotfiles with only/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--copy-files --include-dotfiles with only/stdout.txt
@@ -1,3 +1,3 @@
 src/foo/.foo.js -> lib/foo/.foo.js
 src/foo/bar.js -> lib/foo/bar.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--copy-files --include-dotfiles/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--copy-files --include-dotfiles/stdout.txt
@@ -1,4 +1,4 @@
 src/.foo.js -> lib/.foo.js
 src/bar/index.js -> lib/bar/index.js
 src/foo/foo.js -> lib/foo/foo.js
-🎉  Successfully compiled 3 files with Babel.
+Successfully compiled 3 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--copy-files with ignore/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--copy-files with ignore/stdout.txt
@@ -1,2 +1,2 @@
 src/index.js -> lib/index.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--copy-files with only/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--copy-files with only/stdout.txt
@@ -1,2 +1,2 @@
 src/foo/bar.js -> lib/foo/bar.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--copy-files/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--copy-files/stdout.txt
@@ -1,3 +1,3 @@
 src/bar/index.js -> lib/bar/index.js
 src/foo/foo.js -> lib/foo/foo.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--ignore complete/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--ignore complete/stdout.txt
@@ -1,2 +1,2 @@
 src/foobar/foo.js -> lib/foobar/foo.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--ignore glob/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--ignore glob/stdout.txt
@@ -2,4 +2,4 @@ src/a.js -> lib/a.js
 src/b.js -> lib/b.js
 src/baz/c.js -> lib/baz/c.js
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 4 files with Babel.
+Successfully compiled 4 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--ignore/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--ignore/stdout.txt
@@ -1,2 +1,2 @@
 src/bar/index.js -> lib/bar/index.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--only glob/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--only glob/stdout.txt
@@ -1,3 +1,3 @@
 src/a.foo.js -> lib/a.foo.js
 src/baz/b.foo.js -> lib/baz/b.foo.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/--only/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/--only/stdout.txt
@@ -1,2 +1,2 @@
 src/bar/index.js -> lib/bar/index.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --copy-files/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --copy-files/stdout.txt
@@ -1,2 +1,2 @@
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --keep-file-extension/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --keep-file-extension/stdout.txt
@@ -1,3 +1,3 @@
 src/bar.mjs -> lib/bar.mjs
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --relative/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --relative/stdout.txt
@@ -2,4 +2,4 @@ package1/src/bar/bar1.js -> package1/lib/bar/bar1.js
 package1/src/foo1.js -> package1/lib/foo1.js
 package2/src/bar/bar2.js -> package2/lib/bar/bar2.js
 package2/src/foo2.js -> package2/lib/foo2.js
-🎉  Successfully compiled 4 files with Babel.
+Successfully compiled 4 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --source-maps inline/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --source-maps inline/stdout.txt
@@ -1,3 +1,3 @@
 src/bar/bar.js -> lib/bar/bar.js
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --source-maps/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --source-maps/stdout.txt
@@ -1,3 +1,3 @@
 src/bar/bar.js -> lib/bar/bar.js
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir --verbose/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir --verbose/stdout.txt
@@ -1,3 +1,3 @@
 src/bar/bar.js -> lib/bar/bar.js
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/dir --out-dir/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/dir --out-dir/stdout.txt
@@ -1,1 +1,1 @@
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/empty dir --out-dir/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/empty dir --out-dir/stdout.txt
@@ -1,1 +1,1 @@
-🎉  Successfully compiled 0 files with Babel.
+Successfully compiled 0 files with Babel.

--- a/packages/babel-cli/test/fixtures/babel/filename --out-dir --relative/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/filename --out-dir --relative/stdout.txt
@@ -1,2 +1,2 @@
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-cli/test/fixtures/babel/filename --out-dir/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/filename --out-dir/stdout.txt
@@ -1,2 +1,2 @@
 src/foo.js -> lib/foo.js
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
@@ -147,4 +147,4 @@ Using polyfills with `entry` option:
   web.timers { "android":"4" }
   web.immediate { "android":"4" }
   web.dom.iterable { "android":"4" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
@@ -21,4 +21,4 @@ Using plugins:
 Using polyfills with `entry` option:
 
 [<CWD>/src/in.js] `import '@babel/polyfill'` was not found.
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
@@ -53,4 +53,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"55" }
   web.immediate { "chrome":"55" }
   web.dom.iterable { "chrome":"55" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
@@ -163,4 +163,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"54", "ie":"10", "node":"6" }
   web.immediate { "chrome":"54", "ie":"10", "node":"6" }
   web.dom.iterable { "chrome":"54", "ie":"10", "node":"6" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
@@ -123,4 +123,4 @@ Using polyfills with `entry` option:
   web.timers { "electron":"0.36" }
   web.immediate { "electron":"0.36" }
   web.dom.iterable { "electron":"0.36" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
@@ -50,4 +50,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"55" }
   web.immediate { "chrome":"55" }
   web.dom.iterable { "chrome":"55" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
@@ -26,4 +26,4 @@ Using plugins:
   proposal-unicode-property-regex { "firefox":"52", "node":"7.4" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
@@ -27,4 +27,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"60" }
   web.immediate { "chrome":"60" }
   web.dom.iterable { "chrome":"60" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
@@ -181,4 +181,4 @@ Using polyfills with `entry` option:
   web.timers {}
   web.immediate {}
   web.dom.iterable {}
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -167,4 +167,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   web.immediate { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   web.dom.iterable { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
@@ -41,4 +41,4 @@ Using polyfills with `usage` option:
 [<CWD>/src/in.js] Based on your code and targets, none were added.
 
 [<CWD>/src/in2.js] Based on your code and targets, none were added.
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
@@ -16,4 +16,4 @@ Using plugins:
 Using polyfills with `usage` option:
 
 [<CWD>/src/in.js] Based on your code and targets, none were added.
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
@@ -47,4 +47,4 @@ Using polyfills with `usage` option:
 [<CWD>/src/in2.js] Added following polyfills:
   regenerator-runtime { "chrome":"52", "firefox":"50", "ie":"11" }
   web.dom.iterable { "chrome":"52", "firefox":"50", "ie":"11" }
-🎉  Successfully compiled 2 files with Babel.
+Successfully compiled 2 files with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
@@ -193,4 +193,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   web.immediate { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   web.dom.iterable { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
@@ -163,4 +163,4 @@ Using polyfills with `entry` option:
   web.timers { "chrome":"54", "ie":"10", "node":"6.10" }
   web.immediate { "chrome":"54", "ie":"10", "node":"6.10" }
   web.dom.iterable { "chrome":"54", "ie":"10", "node":"6.10" }
-🎉  Successfully compiled 1 file with Babel.
+Successfully compiled 1 file with Babel.


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8243 
| Patch: Bug Fix?          |  no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added + Pass?      | Yes
| Documentation PR         | no
| Any Dependency Changes?  | no
| License                  | MIT

These changes fix display issues on some terminals caused by the use of emojis in output. emojis have been removed from cli package as well as preset-env package
