### PR TITLE
Remove unused bindings when excluding keys with rest in loose mode

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/input.js
@@ -1,0 +1,22 @@
+// should not remove when destructuring into existing bindings
+({ a2, ...b2 } = c2);
+
+class Comp extends React.Component {
+  render() {
+    const {
+      excluded,
+      excluded2: excludedRenamed,
+      used,
+      used2: usedRenamed,
+      ...props
+    } = this.props;
+
+    console.log(used, usedRenamed);
+
+    return React.createElement("input", props);
+  }
+}
+
+function smth({ unused, ...rest }) {
+  call(rest);
+}

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/options.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "external-helpers",
+    ["proposal-object-rest-spread", { "loose": true }]
+  ]
+}

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/remove-unused-excluded-keys-loose/output.js
@@ -1,0 +1,26 @@
+// should not remove when destructuring into existing bindings
+var _c = c2;
+({
+  a2
+} = _c);
+b2 = babelHelpers.objectWithoutProperties(_c, ["a2"]);
+_c;
+
+class Comp extends React.Component {
+  render() {
+    const _this$props = this.props,
+          {
+      used,
+      used2: usedRenamed
+    } = _this$props,
+          props = babelHelpers.objectWithoutProperties(_this$props, ["excluded", "excluded2", "used", "used2"]);
+    console.log(used, usedRenamed);
+    return React.createElement("input", props);
+  }
+
+}
+
+function smth(_ref) {
+  let rest = babelHelpers.objectWithoutProperties(_ref, ["unused"]);
+  call(rest);
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | somewhat?
| Minor: New Feature?      | x
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  |
| License                  | MIT

Rest operator is often used as `omit`-like util. It seems to me that knowing that we can remove unused bindings to generate shorter code (in `loose` mode only as in theory there could be some getters on destructured object).
