### PR TITLE
Optimize async to generator

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
@@ -7,7 +7,9 @@ exports.default = void 0;
 
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
@@ -7,9 +7,9 @@ exports.default = void 0;
 
 function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return right[Symbol.hasInstance](left); } else { return left instanceof right; } }
 
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -238,7 +238,7 @@ helpers.asyncGeneratorDelegate = () => template.program.ast`
 `;
 
 helpers.asyncToGenerator = () => template.program.ast`
-  function step(gen, resolve, reject, _next, _throw, key, arg) {
+  function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
     try {
       var info = gen[key](arg);
       var value = info.value;
@@ -260,10 +260,10 @@ helpers.asyncToGenerator = () => template.program.ast`
       return new Promise(function (resolve, reject) {
         var gen = fn.apply(self, args);
         function _next(value) {
-          step(gen, resolve, reject, _next, _throw, "next", value);
+          asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
         }
         function _throw(err) {
-          step(gen, resolve, reject, _next, _throw, "throw", err);
+          asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
         }
 
         _next(undefined);

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -238,30 +238,35 @@ helpers.asyncGeneratorDelegate = () => template.program.ast`
 `;
 
 helpers.asyncToGenerator = () => template.program.ast`
+  function step(gen, resolve, reject, _next, _throw, key, arg) {
+    try {
+      var info = gen[key](arg);
+      var value = info.value;
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    if (info.done) {
+      resolve(value);
+    } else {
+      Promise.resolve(value).then(_next, _throw);
+    }
+  }
+
   export default function _asyncToGenerator(fn) {
     return function () {
       var self = this, args = arguments;
       return new Promise(function (resolve, reject) {
         var gen = fn.apply(self, args);
-        function step(key, arg) {
-          try {
-            var info = gen[key](arg);
-            var value = info.value;
-          } catch (error) {
-            reject(error);
-            return;
-          }
-
-          if (info.done) {
-            resolve(value);
-          } else {
-            Promise.resolve(value).then(_next, _throw);
-          }
+        function _next(value) {
+          step(gen, resolve, reject, _next, _throw, "next", value);
         }
-        function _next(value) { step("next", value); }
-        function _throw(err) { step("throw", err); }
+        function _throw(err) {
+          step(gen, resolve, reject, _next, _throw, "throw", err);
+        }
 
-        _next();
+        _next(undefined);
       });
     };
   }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/output.mjs
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/output.mjs
@@ -1,4 +1,6 @@
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 import _Promise from 'somewhere';
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/output.mjs
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/output.mjs
@@ -1,6 +1,6 @@
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 import _Promise from 'somewhere';
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/output.js
@@ -1,6 +1,6 @@
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 let _Promise;
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/output.js
@@ -1,4 +1,6 @@
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 let _Promise;
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/output.js
@@ -1,6 +1,6 @@
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 let _Promise;
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/output.js
@@ -1,4 +1,6 @@
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 let _Promise;
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/output.js
@@ -1,6 +1,8 @@
 "use strict";
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/output.js
@@ -1,8 +1,8 @@
 "use strict";
 
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
@@ -1,4 +1,6 @@
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 export default {
   function(name) {

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
@@ -1,6 +1,6 @@
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 export default {
   function(name) {

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/output.mjs
@@ -1,9 +1,9 @@
 import "regenerator-runtime/runtime";
 import "core-js/modules/es6.promise";
 
-function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function a() {
   return _a.apply(this, arguments);

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/output.mjs
@@ -1,7 +1,9 @@
 import "regenerator-runtime/runtime";
 import "core-js/modules/es6.promise";
 
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } } function _next(value) { step("next", value); } function _throw(err) { step("throw", err); } _next(); }); }; }
+function step(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { step(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { step(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function a() {
   return _a.apply(this, arguments);


### PR DESCRIPTION
We can reuse the step function, avoiding a closure on every invocation.