### PR TITLE
Refactor async-to-generator transform

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/output.js
@@ -1,36 +1,39 @@
 function f() {
   var _this = this;
 
-  let g =
-  /*#__PURE__*/
-  function () {
-    var _ref = babelHelpers.asyncToGenerator(function* () {
+  function _wrapped() {
+    _wrapped = babelHelpers.asyncToGenerator(function* () {
       _this;
     });
+    return _wrapped.apply(this, arguments);
+  }
 
-    return function g() {
-      return _ref.apply(this, arguments);
+  let g = function () {
+    return _wrapped.apply(this, arguments);
+  };
+}
+
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+    var _this2 = this;
+
+    function _wrapped3() {
+      _wrapped3 = babelHelpers.asyncToGenerator(function* (b) {
+        _this2;
+      });
+      return _wrapped3.apply(this, arguments);
+    }
+
+    var c = function (_x) {
+      return _wrapped3.apply(this, arguments);
     };
-  }();
+  });
+  return _wrapped2.apply(this, arguments);
 }
 
 class Class {
   m() {
-    var _this2 = this;
-
-    return babelHelpers.asyncToGenerator(function* () {
-      var c =
-      /*#__PURE__*/
-      function () {
-        var _ref2 = babelHelpers.asyncToGenerator(function* (b) {
-          _this2;
-        });
-
-        return function c(_x) {
-          return _ref2.apply(this, arguments);
-        };
-      }();
-    })();
+    return _wrapped2.apply(this, arguments);
   }
 
 }

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2765/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2765/output.js
@@ -13,27 +13,27 @@ function f() {
   };
 }
 
-function _wrapped2() {
-  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+function _m() {
+  _m = babelHelpers.asyncToGenerator(function* m() {
     var _this2 = this;
 
-    function _wrapped3() {
-      _wrapped3 = babelHelpers.asyncToGenerator(function* (b) {
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* (b) {
         _this2;
       });
-      return _wrapped3.apply(this, arguments);
+      return _wrapped2.apply(this, arguments);
     }
 
     var c = function (_x) {
-      return _wrapped3.apply(this, arguments);
+      return _wrapped2.apply(this, arguments);
     };
   });
-  return _wrapped2.apply(this, arguments);
+  return _m.apply(this, arguments);
 }
 
 class Class {
   m() {
-    return _wrapped2.apply(this, arguments);
+    return _m.apply(this, arguments);
   }
 
 }

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-2892/output.js
@@ -17,6 +17,27 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _bar() {
+  _bar = _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function bar() {
+    var baz;
+    return regeneratorRuntime.wrap(function bar$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            baz = 0;
+
+          case 1:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, bar, this);
+  }));
+  return _bar.apply(this, arguments);
+}
+
 var Foo =
 /*#__PURE__*/
 function () {
@@ -26,29 +47,9 @@ function () {
 
   _createClass(Foo, [{
     key: "bar",
-    value: function () {
-      var _bar = _asyncToGenerator(
-      /*#__PURE__*/
-      regeneratorRuntime.mark(function _callee() {
-        var baz;
-        return regeneratorRuntime.wrap(function _callee$(_context) {
-          while (1) {
-            switch (_context.prev = _context.next) {
-              case 0:
-                baz = 0;
-
-              case 1:
-              case "end":
-                return _context.stop();
-            }
-          }
-        }, _callee, this);
-      }));
-
-      return function bar() {
-        return _bar.apply(this, arguments);
-      };
-    }()
+    value: function bar() {
+      return _bar.apply(this, arguments);
+    }
   }]);
 
   return Foo;
@@ -56,51 +57,50 @@ function () {
 
 exports.default = Foo;
 
-function foo() {
-  return _foo.apply(this, arguments);
+function _bar2() {
+  _bar2 = _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function bar() {
+    var baz;
+    return regeneratorRuntime.wrap(function bar$(_context3) {
+      while (1) {
+        switch (_context3.prev = _context3.next) {
+          case 0:
+            baz = {};
+
+          case 1:
+          case "end":
+            return _context3.stop();
+        }
+      }
+    }, bar, this);
+  }));
+  return _bar2.apply(this, arguments);
 }
 
 function _foo() {
   _foo = _asyncToGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
-    var bar, _bar2;
-
-    return regeneratorRuntime.wrap(function _callee3$(_context3) {
+  regeneratorRuntime.mark(function foo() {
+    var bar;
+    return regeneratorRuntime.wrap(function foo$(_context2) {
       while (1) {
-        switch (_context3.prev = _context3.next) {
+        switch (_context2.prev = _context2.next) {
           case 0:
-            _bar2 = function _ref2() {
-              _bar2 = _asyncToGenerator(
-              /*#__PURE__*/
-              regeneratorRuntime.mark(function _callee2() {
-                var baz;
-                return regeneratorRuntime.wrap(function _callee2$(_context2) {
-                  while (1) {
-                    switch (_context2.prev = _context2.next) {
-                      case 0:
-                        baz = {};
-
-                      case 1:
-                      case "end":
-                        return _context2.stop();
-                    }
-                  }
-                }, _callee2, this);
-              }));
-              return _bar2.apply(this, arguments);
-            };
-
             bar = function _ref() {
               return _bar2.apply(this, arguments);
             };
 
-          case 2:
+          case 1:
           case "end":
-            return _context3.stop();
+            return _context2.stop();
         }
       }
-    }, _callee3, this);
+    }, foo, this);
   }));
+  return _foo.apply(this, arguments);
+}
+
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-annotate-as-pure": "7.0.0-beta.51",
     "@babel/helper-wrap-function": "7.0.0-beta.51",
     "@babel/template": "7.0.0-beta.51",
     "@babel/traverse": "7.0.0-beta.51",

--- a/packages/babel-helper-remap-async-to-generator/src/index.js
+++ b/packages/babel-helper-remap-async-to-generator/src/index.js
@@ -2,7 +2,6 @@
 
 import type { NodePath } from "@babel/traverse";
 import wrapFunction from "@babel/helper-wrap-function";
-import annotateAsPure from "@babel/helper-annotate-as-pure";
 import * as t from "@babel/types";
 
 const awaitVisitor = {
@@ -36,50 +35,8 @@ export default function(
     wrapAwait: helpers.wrapAwait,
   });
 
-  const isIIFE = checkIsIIFE(path);
-
   path.node.async = false;
-  path.node.generator = true;
+  path.node.generator = false;
 
   wrapFunction(path, t.cloneNode(helpers.wrapAsync));
-
-  const isProperty =
-    path.isObjectMethod() ||
-    path.isClassMethod() ||
-    path.parentPath.isObjectProperty() ||
-    path.parentPath.isClassProperty();
-
-  if (!isProperty && !isIIFE && path.isExpression()) {
-    annotateAsPure(path);
-  }
-
-  function checkIsIIFE(path: NodePath) {
-    if (path.parentPath.isCallExpression({ callee: path.node })) {
-      return true;
-    }
-
-    // try to catch calls to Function#bind, as emitted by arrowFunctionToExpression in spec mode
-    // this may also catch .bind(this) written by users, but does it matter? 🤔
-    const { parentPath } = path;
-    if (
-      parentPath.isMemberExpression() &&
-      t.isIdentifier(parentPath.node.property, { name: "bind" })
-    ) {
-      const { parentPath: bindCall } = parentPath;
-
-      // (function () { ... }).bind(this)()
-
-      return (
-        // first, check if the .bind is actually being called
-        bindCall.isCallExpression() &&
-        // and whether its sole argument is 'this'
-        bindCall.node.arguments.length === 1 &&
-        t.isThisExpression(bindCall.node.arguments[0]) &&
-        // and whether the result of the .bind(this) is being called
-        bindCall.parentPath.isCallExpression({ callee: bindCall.node })
-      );
-    }
-
-    return false;
-  }
 }

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/helper-function-name": "7.0.0-beta.51",
     "@babel/template": "7.0.0-beta.51",
     "@babel/traverse": "7.0.0-beta.51",
     "@babel/types": "7.0.0-beta.51"

--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -1,114 +1,62 @@
 import type { NodePath } from "@babel/traverse";
-import nameFunction from "@babel/helper-function-name";
 import template from "@babel/template";
 import * as t from "@babel/types";
 
-const buildExpressionWrapper = template.expression(`
-  (function () {
-    var REF = FUNCTION;
-    return function NAME(PARAMS) {
-      return REF.apply(this, arguments);
-    };
-  })()
-`);
-
-const buildDeclarationWrapper = template(`
-  function NAME(PARAMS) { return REF.apply(this, arguments); }
-  function REF() {
-    REF = FUNCTION;
-    return REF.apply(this, arguments);
+function buildParams(params, scope) {
+  const dummies = [];
+  for (const param of params) {
+    if (t.isAssignmentPattern(param) || t.isRestElement(param)) {
+      break;
+    }
+    dummies.push(scope.generateUidIdentifier("x"));
   }
-`);
+  return dummies;
+}
 
 function classOrObjectMethod(path: NodePath, callId: Object) {
-  const node = path.node;
-  const body = node.body;
+  const { node } = path;
+  const { body } = node;
 
-  const container = t.functionExpression(
-    null,
-    [],
-    t.blockStatement(body.body),
-    true,
-  );
-  body.body = [
-    t.returnStatement(
-      t.callExpression(t.callExpression(callId, [container]), []),
-    ),
-  ];
+  const params = node.params.map(t.cloneNode);
+  const container = t.functionExpression(null, params, t.cloneNode(body));
 
-  // Regardless of whether or not the wrapped function is a an async method
-  // or generator the outer function should not be
-  node.async = false;
-  node.generator = false;
-
-  // Unwrap the wrapper IIFE's environment so super and this and such still work.
   path
-    .get("body.body.0.argument.callee.arguments.0")
-    .unwrapFunctionEnvironment();
+    .get("body")
+    .replaceWith(t.blockStatement([t.expressionStatement(container)]));
+
+  const fn = path.get("body.body.0.expression");
+  plainFunction(fn, callId);
+  path.get("body").replaceWith(t.cloneNode(fn.node.body));
 }
 
 function plainFunction(path: NodePath, callId: Object) {
-  const node = path.node;
-  const isDeclaration = path.isFunctionDeclaration();
+  const { node } = path;
   const functionId = node.id;
-  const wrapper = isDeclaration
-    ? buildDeclarationWrapper
-    : buildExpressionWrapper;
 
   if (path.isArrowFunctionExpression()) {
     path.arrowFunctionToExpression();
   }
 
-  node.id = null;
+  const name = functionId ? functionId.name : "wrapped";
+  const ref = path.scope.generateUidIdentifier(name);
+  const fn = t.cloneNode(node);
+  fn.type = "FunctionExpression";
+  fn.generator = true;
 
-  if (isDeclaration) {
-    node.type = "FunctionExpression";
-  }
-
-  const built = t.callExpression(callId, [node]);
-  const container = wrapper({
-    NAME: functionId || null,
-    REF: path.scope.generateUidIdentifier(functionId ? functionId.name : "ref"),
-    FUNCTION: built,
-    PARAMS: node.params.reduce(
-      (acc, param) => {
-        acc.done =
-          acc.done || t.isAssignmentPattern(param) || t.isRestElement(param);
-
-        if (!acc.done) {
-          acc.params.push(path.scope.generateUidIdentifier("x"));
-        }
-
-        return acc;
-      },
-      {
-        params: [],
-        done: false,
-      },
-    ).params,
-  });
-
-  if (isDeclaration) {
-    path.replaceWith(container[0]);
-    path.insertAfter(container[1]);
-  } else {
-    const retFunction = container.callee.body.body[1].argument;
-    if (!functionId) {
-      nameFunction({
-        node: retFunction,
-        parent: path.parent,
-        scope: path.scope,
-      });
+  const caller = template.statement.ast`
+    return ${ref}.apply(this, arguments);
+  `;
+  const wrapper = template.statement.ast`
+    function ${ref}() {
+      ${ref} = ${callId}(${fn});
+      ${caller}
     }
+  `;
 
-    if (!retFunction || retFunction.id || node.params.length) {
-      // we have an inferred function id or params so we need this wrapper
-      path.replaceWith(container);
-    } else {
-      // we can omit this wrapper as the conditions it protects for do not apply
-      path.replaceWith(built);
-    }
-  }
+  node.params = buildParams(node.params, path.scope);
+
+  path.get("body").replaceWith(t.blockStatement([caller, wrapper]));
+  path.get("body.body.1").hoist();
 }
 
 export default function wrapFunction(path: NodePath, callId: Object) {

--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -18,13 +18,11 @@ function classOrObjectMethod(path: NodePath, callId: Object) {
   const { body } = node;
 
   const params = node.params.map(t.cloneNode);
-  const container = t.functionExpression(null, params, t.cloneNode(body));
+  const container = t.functionDeclaration(null, params, t.cloneNode(body));
 
-  path
-    .get("body")
-    .replaceWith(t.blockStatement([t.expressionStatement(container)]));
+  path.get("body").replaceWith(t.blockStatement([container]));
 
-  const fn = path.get("body.body.0.expression");
+  const fn = path.get("body.body.0");
   plainFunction(fn, callId);
   path.get("body").replaceWith(t.cloneNode(fn.node.body));
   node.params = fn.node.params;

--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -27,6 +27,7 @@ function classOrObjectMethod(path: NodePath, callId: Object) {
   const fn = path.get("body.body.0.expression");
   plainFunction(fn, callId);
   path.get("body").replaceWith(t.cloneNode(fn.node.body));
+  node.params = fn.node.params;
 }
 
 function plainFunction(path: NodePath, callId: Object) {

--- a/packages/babel-helper-wrap-function/src/index.js
+++ b/packages/babel-helper-wrap-function/src/index.js
@@ -13,22 +13,40 @@ function buildParams(params, scope) {
   return dummies;
 }
 
+const superPropVisitor = {
+  MemberExpression(path) {
+    if (path.get("object").isSuper()) {
+      this.hasSuperProp = true;
+      path.stop();
+    }
+  },
+};
+
 function classOrObjectMethod(path: NodePath, callId: Object) {
   const { node } = path;
-  const { body } = node;
+  const { body, key } = node;
 
+  const id =
+    node.computed || !t.isIdentifier(key) || !t.isValidES3Identifier(key.name)
+      ? null
+      : t.cloneNode(node.key);
   const params = node.params.map(t.cloneNode);
-  const container = t.functionDeclaration(null, params, t.cloneNode(body));
+  const container = t.functionDeclaration(id, params, t.cloneNode(body));
 
   path.get("body").replaceWith(t.blockStatement([container]));
 
   const fn = path.get("body.body.0");
-  plainFunction(fn, callId);
+
+  const state = { hasSuperProp: false };
+  fn.traverse(superPropVisitor, state);
+  const hasSuperProp = state.hasSuperProp;
+
+  plainFunction(fn, callId, hasSuperProp);
   path.get("body").replaceWith(t.cloneNode(fn.node.body));
   node.params = fn.node.params;
 }
 
-function plainFunction(path: NodePath, callId: Object) {
+function plainFunction(path: NodePath, callId: Object, hasSuperProp = false) {
   const { node } = path;
   const functionId = node.id;
 
@@ -42,20 +60,31 @@ function plainFunction(path: NodePath, callId: Object) {
   fn.type = "FunctionExpression";
   fn.generator = true;
 
-  const caller = template.statement.ast`
-    return ${ref}.apply(this, arguments);
-  `;
-  const wrapper = template.statement.ast`
-    function ${ref}() {
-      ${ref} = ${callId}(${fn});
-      ${caller}
-    }
-  `;
+  if (hasSuperProp) {
+    const caller = template.statement.ast`
+      return ${callId}(${fn})();
+    `;
 
-  node.params = buildParams(node.params, path.scope);
+    path.get("body").replaceWith(t.blockStatement([caller]));
+    // Unwrap the wrapper IIFE's environment so super and this and such still work.
+    path
+      .get("body.body.0.argument.callee.arguments.0")
+      .unwrapFunctionEnvironment();
+  } else {
+    const caller = template.statement.ast`
+      return ${ref}.apply(this, arguments);
+    `;
+    const wrapper = template.statement.ast`
+      function ${ref}() {
+        ${ref} = ${callId}(${fn});
+        ${caller}
+      }
+    `;
 
-  path.get("body").replaceWith(t.blockStatement([caller, wrapper]));
-  path.get("body.body.1").hoist();
+    path.get("body").replaceWith(t.blockStatement([caller, wrapper]));
+    node.params = buildParams(node.params, path.scope);
+    path.get("body.body.1").hoist();
+  }
 }
 
 export default function wrapFunction(path: NodePath, callId: Object) {

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-method/output.js
@@ -1,16 +1,16 @@
-function _wrapped() {
-  _wrapped = babelHelpers.wrapAsyncGenerator(function* () {
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
-  return _wrapped.apply(this, arguments);
+  return _g.apply(this, arguments);
 }
 
 class C {
   g() {
-    return _wrapped.apply(this, arguments);
+    return _g.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/class-method/output.js
@@ -1,13 +1,16 @@
+function _wrapped() {
+  _wrapped = babelHelpers.wrapAsyncGenerator(function* () {
+    this;
+    yield babelHelpers.awaitAsyncGenerator(1);
+    yield 2;
+    return 3;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 class C {
   g() {
-    var _this = this;
-
-    return babelHelpers.wrapAsyncGenerator(function* () {
-      _this;
-      yield babelHelpers.awaitAsyncGenerator(1);
-      yield 2;
-      return 3;
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/declaration/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/declaration/output.js
@@ -1,13 +1,13 @@
-function agf() {
-  return _agf.apply(this, arguments);
-}
-
 function _agf() {
-  _agf = babelHelpers.wrapAsyncGenerator(function* () {
+  _agf = babelHelpers.wrapAsyncGenerator(function* agf() {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
+  return _agf.apply(this, arguments);
+}
+
+function agf() {
   return _agf.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/expression/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/expression/output.js
@@ -1,13 +1,13 @@
-/*#__PURE__*/
-(function () {
-  var _agf = babelHelpers.wrapAsyncGenerator(function* () {
+function _agf() {
+  _agf = babelHelpers.wrapAsyncGenerator(function* agf() {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
+  return _agf.apply(this, arguments);
+}
 
-  return function agf() {
-    return _agf.apply(this, arguments);
-  };
-})();
+(function agf() {
+  return _agf.apply(this, arguments);
+});

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/object-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/object-method/output.js
@@ -1,16 +1,16 @@
-function _wrapped() {
-  _wrapped = babelHelpers.wrapAsyncGenerator(function* () {
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
-  return _wrapped.apply(this, arguments);
+  return _g.apply(this, arguments);
 }
 
 ({
   g() {
-    return _wrapped.apply(this, arguments);
+    return _g.apply(this, arguments);
   }
 
 });

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/object-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/object-method/output.js
@@ -1,13 +1,16 @@
+function _wrapped() {
+  _wrapped = babelHelpers.wrapAsyncGenerator(function* () {
+    this;
+    yield babelHelpers.awaitAsyncGenerator(1);
+    yield 2;
+    return 3;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 ({
   g() {
-    var _this = this;
-
-    return babelHelpers.wrapAsyncGenerator(function* () {
-      _this;
-      yield babelHelpers.awaitAsyncGenerator(1);
-      yield 2;
-      return 3;
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 });

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/static-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/static-method/output.js
@@ -1,13 +1,16 @@
+function _wrapped() {
+  _wrapped = babelHelpers.wrapAsyncGenerator(function* () {
+    this;
+    yield babelHelpers.awaitAsyncGenerator(1);
+    yield 2;
+    return 3;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 class C {
   static g() {
-    var _this = this;
-
-    return babelHelpers.wrapAsyncGenerator(function* () {
-      _this;
-      yield babelHelpers.awaitAsyncGenerator(1);
-      yield 2;
-      return 3;
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/static-method/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/static-method/output.js
@@ -1,16 +1,16 @@
-function _wrapped() {
-  _wrapped = babelHelpers.wrapAsyncGenerator(function* () {
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
     this;
     yield babelHelpers.awaitAsyncGenerator(1);
     yield 2;
     return 3;
   });
-  return _wrapped.apply(this, arguments);
+  return _g.apply(this, arguments);
 }
 
 class C {
   static g() {
-    return _wrapped.apply(this, arguments);
+    return _g.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/yield-star/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/async-generators/yield-star/output.js
@@ -1,11 +1,11 @@
-function g() {
-  return _g.apply(this, arguments);
-}
-
 function _g() {
-  _g = babelHelpers.wrapAsyncGenerator(function* () {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
     yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator([1, 2, 3]), babelHelpers.awaitAsyncGenerator);
     yield* babelHelpers.asyncGeneratorDelegate(babelHelpers.asyncIterator(iterable), babelHelpers.awaitAsyncGenerator);
   });
+  return _g.apply(this, arguments);
+}
+
+function g() {
   return _g.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-arrow/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-arrow/output.js
@@ -1,27 +1,33 @@
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
-  var _iteratorNormalCompletion = true;
-  var _didIteratorError = false;
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
 
-  var _iteratorError;
+    var _iteratorError;
 
-  try {
-    for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
-      let x = _value;
-      f(x);
-    }
-  } catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-  } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
-        yield _iterator.return();
+      for (var _iterator = babelHelpers.asyncIterator(y), _step, _value; _step = yield _iterator.next(), _iteratorNormalCompletion = _step.done, _value = yield _step.value, !_iteratorNormalCompletion; _iteratorNormalCompletion = true) {
+        let x = _value;
+        f(x);
       }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
     } finally {
-      if (_didIteratorError) {
-        throw _iteratorError;
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return != null) {
+          yield _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
       }
     }
-  }
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
 });

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-function/output.js
@@ -1,9 +1,5 @@
-function f() {
-  return _f.apply(this, arguments);
-}
-
 function _f() {
-  _f = babelHelpers.asyncToGenerator(function* () {
+  _f = babelHelpers.asyncToGenerator(function* f() {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
 
@@ -29,5 +25,9 @@ function _f() {
       }
     }
   });
+  return _f.apply(this, arguments);
+}
+
+function f() {
   return _f.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/async-generator/output.js
@@ -1,9 +1,5 @@
-function g() {
-  return _g.apply(this, arguments);
-}
-
 function _g() {
-  _g = babelHelpers.wrapAsyncGenerator(function* () {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
 
@@ -29,5 +25,9 @@ function _g() {
       }
     }
   });
+  return _g.apply(this, arguments);
+}
+
+function g() {
   return _g.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/for-await/destructuring/output.js
@@ -1,9 +1,5 @@
-function f() {
-  return _f.apply(this, arguments);
-}
-
 function _f() {
-  _f = babelHelpers.asyncToGenerator(function* () {
+  _f = babelHelpers.asyncToGenerator(function* f() {
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
 
@@ -32,5 +28,9 @@ function _f() {
       }
     }
   });
+  return _f.apply(this, arguments);
+}
+
+function f() {
   return _f.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/arrows-in-declaration/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/arrows-in-declaration/output.js
@@ -1,9 +1,5 @@
-function g() {
-  return _g.apply(this, arguments);
-}
-
 function _g() {
-  _g = babelHelpers.wrapAsyncGenerator(function* () {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
     var _this = this;
 
     () => this;
@@ -12,12 +8,23 @@ function _g() {
       () => this;
     }
 
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      _this;
-      yield 1;
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* () {
+        _this;
+        yield 1;
+      });
+      return _wrapped.apply(this, arguments);
+    }
+
+    (function () {
+      return _wrapped.apply(this, arguments);
     });
+
     yield babelHelpers.awaitAsyncGenerator(1);
   });
+  return _g.apply(this, arguments);
+}
+
+function g() {
   return _g.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/async-in-params/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/async-in-params/output.js
@@ -1,15 +1,20 @@
-function g() {
-  return _g.apply(this, arguments);
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    yield 1;
+  });
+  return _wrapped.apply(this, arguments);
 }
 
 function _g() {
-  _g = babelHelpers.wrapAsyncGenerator(function* (x =
-  /*#__PURE__*/
-  babelHelpers.asyncToGenerator(function* () {
-    yield 1;
-  })) {
+  _g = babelHelpers.wrapAsyncGenerator(function* g(x = function () {
+    return _wrapped.apply(this, arguments);
+  }) {
     yield babelHelpers.awaitAsyncGenerator(2);
     yield 3;
   });
+  return _g.apply(this, arguments);
+}
+
+function g() {
   return _g.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/generator-in-async/output.js
+++ b/packages/babel-plugin-proposal-async-generator-functions/test/fixtures/nested/generator-in-async/output.js
@@ -1,22 +1,22 @@
-function f() {
-  return _f.apply(this, arguments);
+function _g() {
+  _g = babelHelpers.wrapAsyncGenerator(function* g() {
+    yield babelHelpers.awaitAsyncGenerator(2);
+    yield 3;
+  });
+  return _g.apply(this, arguments);
 }
 
 function _f() {
-  _f = babelHelpers.asyncToGenerator(function* () {
+  _f = babelHelpers.asyncToGenerator(function* f() {
     yield 1;
 
     function g() {
       return _g.apply(this, arguments);
     }
-
-    function _g() {
-      _g = babelHelpers.wrapAsyncGenerator(function* () {
-        yield babelHelpers.awaitAsyncGenerator(2);
-        yield 3;
-      });
-      return _g.apply(this, arguments);
-    }
   });
+  return _f.apply(this, arguments);
+}
+
+function f() {
   return _f.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/output.mjs
@@ -4,11 +4,16 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    _myAsyncMethod.set(this,
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this);
-    }));
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this);
+      });
+      return _wrapped.apply(this, arguments);
+    }
+
+    _myAsyncMethod.set(this, function () {
+      return _wrapped.apply(this, arguments);
+    });
   }
 
 }
@@ -19,11 +24,16 @@ _class = class MyClass2 {
   constructor() {
     var _this2 = this;
 
-    _myAsyncMethod2.set(this,
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this2);
-    }));
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this2);
+      });
+      return _wrapped2.apply(this, arguments);
+    }
+
+    _myAsyncMethod2.set(this, function () {
+      return _wrapped2.apply(this, arguments);
+    });
   }
 
 };
@@ -34,11 +44,16 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    _myAsyncMethod3.set(this,
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this3);
-    }));
+    function _wrapped3() {
+      _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this3);
+      });
+      return _wrapped3.apply(this, arguments);
+    }
+
+    _myAsyncMethod3.set(this, function () {
+      return _wrapped3.apply(this, arguments);
+    });
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T7364/output.mjs
@@ -2,11 +2,16 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this);
-    });
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this);
+      });
+      return _wrapped.apply(this, arguments);
+    }
+
+    this.myAsyncMethod = function () {
+      return _wrapped.apply(this, arguments);
+    };
   }
 
 }
@@ -15,11 +20,16 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this2);
-    });
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this2);
+      });
+      return _wrapped2.apply(this, arguments);
+    }
+
+    this.myAsyncMethod = function () {
+      return _wrapped2.apply(this, arguments);
+    };
   }
 
 });
@@ -28,11 +38,16 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this3);
-    });
+    function _wrapped3() {
+      _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this3);
+      });
+      return _wrapped3.apply(this, arguments);
+    }
+
+    this.myAsyncMethod = function () {
+      return _wrapped3.apply(this, arguments);
+    };
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T7364/output.mjs
@@ -2,11 +2,16 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    babelHelpers.defineProperty(this, "myAsyncMethod",
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this);
-    }));
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this);
+      });
+      return _wrapped.apply(this, arguments);
+    }
+
+    babelHelpers.defineProperty(this, "myAsyncMethod", function () {
+      return _wrapped.apply(this, arguments);
+    });
   }
 
 }
@@ -15,11 +20,16 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    babelHelpers.defineProperty(this, "myAsyncMethod",
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this2);
-    }));
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this2);
+      });
+      return _wrapped2.apply(this, arguments);
+    }
+
+    babelHelpers.defineProperty(this, "myAsyncMethod", function () {
+      return _wrapped2.apply(this, arguments);
+    });
   }
 
 });
@@ -28,11 +38,16 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    babelHelpers.defineProperty(this, "myAsyncMethod",
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this3);
-    }));
+    function _wrapped3() {
+      _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this3);
+      });
+      return _wrapped3.apply(this, arguments);
+    }
+
+    babelHelpers.defineProperty(this, "myAsyncMethod", function () {
+      return _wrapped3.apply(this, arguments);
+    });
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T7364/output.mjs
@@ -2,11 +2,16 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this);
-    });
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this);
+      });
+      return _wrapped.apply(this, arguments);
+    }
+
+    this.myAsyncMethod = function () {
+      return _wrapped.apply(this, arguments);
+    };
   }
 
 }
@@ -15,11 +20,16 @@ class MyClass {
   constructor() {
     var _this2 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this2);
-    });
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this2);
+      });
+      return _wrapped2.apply(this, arguments);
+    }
+
+    this.myAsyncMethod = function () {
+      return _wrapped2.apply(this, arguments);
+    };
   }
 
 });
@@ -28,11 +38,16 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    this.myAsyncMethod =
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this3);
-    });
+    function _wrapped3() {
+      _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this3);
+      });
+      return _wrapped3.apply(this, arguments);
+    }
+
+    this.myAsyncMethod = function () {
+      return _wrapped3.apply(this, arguments);
+    };
   }
 
 }

--- a/packages/babel-plugin-proposal-function-sent/src/index.js
+++ b/packages/babel-plugin-proposal-function-sent/src/index.js
@@ -56,6 +56,7 @@ export default declare(api => {
           ]),
         );
 
+        fnPath.node.generator = false;
         wrapFunction(fnPath, state.addHelper("skipFirstGeneratorNext"));
       },
     },

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/basic/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/basic/output.js
@@ -1,14 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function gen() {
-  return _gen.apply(this, arguments);
-}
-
 function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     let sent = _functionSent;
   });
+  return _gen.apply(this, arguments);
+}
+
+function gen() {
   return _gen.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/multiple/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/multiple/output.js
@@ -1,13 +1,20 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-_skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+function _wrapped() {
+  _wrapped = _skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
 
-  const a = _functionSent;
-  const b = _functionSent;
-  _functionSent = yield 4;
-  const c = _functionSent;
-  const d = _functionSent = yield;
-  const e = _functionSent;
-  return [a, b, c, d, e];
+    const a = _functionSent;
+    const b = _functionSent;
+    _functionSent = yield 4;
+    const c = _functionSent;
+    const d = _functionSent = yield;
+    const e = _functionSent;
+    return [a, b, c, d, e];
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
 })();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/yield-function-sent/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/yield-function-sent/output.js
@@ -1,7 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-_skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+function _wrapped() {
+  _wrapped = _skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
 
-  _functionSent = yield _functionSent;
+    _functionSent = yield _functionSent;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
 })();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/async-generator/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/async-generator/output.js
@@ -16,15 +16,22 @@ _AsyncGenerator.prototype.return = function (arg) { return this._invoke("return"
 
 function _AwaitValue(value) { this.wrapped = value; }
 
-function foo() {
-  return _foo.apply(this, arguments);
-}
-
-function _foo() {
-  _foo = _wrapAsyncGenerator(_skipFirstGeneratorNext(function* () {
+function _foo2() {
+  _foo2 = _skipFirstGeneratorNext(function* foo() {
     let _functionSent = yield;
 
     _functionSent = yield _awaitAsyncGenerator(_functionSent);
-  }));
+  });
+  return _foo2.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _wrapAsyncGenerator(function foo() {
+    return _foo2.apply(this, arguments);
+  });
+  return _foo.apply(this, arguments);
+}
+
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/class-method/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/class-method/output.js
@@ -1,12 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
+function _wrapped() {
+  _wrapped = _skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
+
+    return _functionSent;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 class Foo {
   gen() {
-    return _skipFirstGeneratorNext(function* () {
-      let _functionSent = yield;
-
-      return _functionSent;
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/class-method/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/class-method/output.js
@@ -1,17 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function _wrapped() {
-  _wrapped = _skipFirstGeneratorNext(function* () {
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
   });
-  return _wrapped.apply(this, arguments);
+  return _gen.apply(this, arguments);
 }
 
 class Foo {
   gen() {
-    return _wrapped.apply(this, arguments);
+    return _gen.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-anonymous/output.mjs
@@ -1,14 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export default function () {
-  return _ref.apply(this, arguments);
-}
-
-function _ref() {
-  _ref = _skipFirstGeneratorNext(function* () {
+function _wrapped() {
+  _wrapped = _skipFirstGeneratorNext(function* () {
     let _functionSent = yield;
 
     return _functionSent;
   });
-  return _ref.apply(this, arguments);
+  return _wrapped.apply(this, arguments);
+}
+
+export default function () {
+  return _wrapped.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-named/output.mjs
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-named/output.mjs
@@ -1,14 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export default function gen() {
-  return _gen.apply(this, arguments);
-}
-
 function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
   });
+  return _gen.apply(this, arguments);
+}
+
+export default function gen() {
   return _gen.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export/output.mjs
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export/output.mjs
@@ -1,14 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export function gen() {
-  return _gen.apply(this, arguments);
-}
-
 function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
   });
+  return _gen.apply(this, arguments);
+}
+
+export function gen() {
   return _gen.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-anonymous/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-anonymous/output.js
@@ -1,7 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-_skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+function _wrapped() {
+  _wrapped = _skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
 
-  return _functionSent;
+    return _functionSent;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
 })();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-named/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-named/output.js
@@ -1,13 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-const foo = function () {
-  var _gen = _skipFirstGeneratorNext(function* () {
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
   });
+  return _gen.apply(this, arguments);
+}
 
-  return function gen() {
-    return _gen.apply(this, arguments);
-  };
-}();
+const foo = function gen() {
+  return _gen.apply(this, arguments);
+};

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/object-method/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/object-method/output.js
@@ -1,17 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function _wrapped() {
-  _wrapped = _skipFirstGeneratorNext(function* () {
+function _gen() {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
   });
-  return _wrapped.apply(this, arguments);
+  return _gen.apply(this, arguments);
 }
 
 const obj = {
   gen() {
-    return _wrapped.apply(this, arguments);
+    return _gen.apply(this, arguments);
   }
 
 };

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/object-method/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/object-method/output.js
@@ -1,12 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
+function _wrapped() {
+  _wrapped = _skipFirstGeneratorNext(function* () {
+    let _functionSent = yield;
+
+    return _functionSent;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 const obj = {
   gen() {
-    return _skipFirstGeneratorNext(function* () {
-      let _functionSent = yield;
-
-      return _functionSent;
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 };

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/statement/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/statement/output.js
@@ -1,14 +1,14 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function gen() {
-  return _gen.apply(this, arguments);
-}
-
 function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
+  _gen = _skipFirstGeneratorNext(function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
   });
+  return _gen.apply(this, arguments);
+}
+
+function gen() {
   return _gen.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-arrow-in-method/output.js
@@ -4,18 +4,17 @@ let TestClass = {
   testMethodFailure() {
     var _this = this;
 
-    return new Promise(
-    /*#__PURE__*/
-    function () {
-      var _ref = babelHelpers.asyncToGenerator(function* (resolve) {
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* (resolve) {
         console.log(_this);
         setTimeout(resolve, 1000);
       });
+      return _wrapped.apply(this, arguments);
+    }
 
-      return function (_x) {
-        return _ref.apply(this, arguments);
-      };
-    }());
+    return new Promise(function (_x) {
+      return _wrapped.apply(this, arguments);
+    });
   }
 
 };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-default-arguments/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-default-arguments/output.js
@@ -2,17 +2,17 @@ function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);
 }
 
-function foo(_x) {
-  return _foo.apply(this, arguments);
-}
-
 function _foo() {
-  _foo = babelHelpers.asyncToGenerator(function* (_ref) {
+  _foo = babelHelpers.asyncToGenerator(function* foo(_ref) {
     let {
       a,
       b = mandatory("b")
     } = _ref;
     return Promise.resolve(b);
   });
+  return _foo.apply(this, arguments);
+}
+
+function foo(_x) {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator-spec/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator-spec/output.js
@@ -1,43 +1,57 @@
 var _this = this;
 
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee() {
-  return regeneratorRuntime.wrap(function _callee$(_context) {
-    while (1) switch (_context.prev = _context.next) {
-      case 0:
-        _context.next = 2;
-        return 'ok';
-
-      case 2:
-      case "end":
-        return _context.stop();
-    }
-  }, _callee, this);
-}))();
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee2() {
-  return regeneratorRuntime.wrap(function _callee2$(_context2) {
-    while (1) switch (_context2.prev = _context2.next) {
-      case 0:
-        babelHelpers.newArrowCheck(this, _this);
-        _context2.next = 3;
-        return 'ok';
-
-      case 3:
-      case "end":
-        return _context2.stop();
-    }
-  }, _callee2, this);
-})).bind(this)();
-
-/*#__PURE__*/
-(function () {
-  var _notIIFE = babelHelpers.asyncToGenerator(
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
-    return regeneratorRuntime.wrap(function _callee3$(_context3) {
+  regeneratorRuntime.mark(function _callee() {
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 'ok';
+
+        case 2:
+        case "end":
+          return _context.stop();
+      }
+    }, _callee, this);
+  }));
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
+})();
+
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee2() {
+    return regeneratorRuntime.wrap(function _callee2$(_context2) {
+      while (1) switch (_context2.prev = _context2.next) {
+        case 0:
+          babelHelpers.newArrowCheck(this, _this);
+          _context2.next = 3;
+          return 'ok';
+
+        case 3:
+        case "end":
+          return _context2.stop();
+      }
+    }, _callee2, this);
+  }));
+  return _wrapped2.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped2.apply(this, arguments);
+}).bind(this)();
+
+function _notIIFE() {
+  _notIIFE = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function notIIFE() {
+    return regeneratorRuntime.wrap(function notIIFE$(_context3) {
       while (1) switch (_context3.prev = _context3.next) {
         case 0:
           _context3.next = 2;
@@ -47,28 +61,35 @@ regeneratorRuntime.mark(function _callee2() {
         case "end":
           return _context3.stop();
       }
+    }, notIIFE, this);
+  }));
+  return _notIIFE.apply(this, arguments);
+}
+
+(function notIIFE() {
+  return _notIIFE.apply(this, arguments);
+});
+
+function _wrapped3() {
+  _wrapped3 = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee3() {
+    return regeneratorRuntime.wrap(function _callee3$(_context4) {
+      while (1) switch (_context4.prev = _context4.next) {
+        case 0:
+          babelHelpers.newArrowCheck(this, _this);
+          _context4.next = 3;
+          return 'not iife';
+
+        case 3:
+        case "end":
+          return _context4.stop();
+      }
     }, _callee3, this);
   }));
+  return _wrapped3.apply(this, arguments);
+}
 
-  return function notIIFE() {
-    return _notIIFE.apply(this, arguments);
-  };
-})();
-
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee4() {
-  return regeneratorRuntime.wrap(function _callee4$(_context4) {
-    while (1) switch (_context4.prev = _context4.next) {
-      case 0:
-        babelHelpers.newArrowCheck(this, _this);
-        _context4.next = 3;
-        return 'not iife';
-
-      case 3:
-      case "end":
-        return _context4.stop();
-    }
-  }, _callee4, this);
-})).bind(this);
+(function () {
+  return _wrapped3.apply(this, arguments);
+}).bind(this);

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-with-regenerator/output.js
@@ -1,40 +1,54 @@
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee() {
-  return regeneratorRuntime.wrap(function _callee$(_context) {
-    while (1) switch (_context.prev = _context.next) {
-      case 0:
-        _context.next = 2;
-        return 'ok';
-
-      case 2:
-      case "end":
-        return _context.stop();
-    }
-  }, _callee, this);
-}))();
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee2() {
-  return regeneratorRuntime.wrap(function _callee2$(_context2) {
-    while (1) switch (_context2.prev = _context2.next) {
-      case 0:
-        _context2.next = 2;
-        return 'ok';
-
-      case 2:
-      case "end":
-        return _context2.stop();
-    }
-  }, _callee2, this);
-}))();
-
-/*#__PURE__*/
-(function () {
-  var _notIIFE = babelHelpers.asyncToGenerator(
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee3() {
-    return regeneratorRuntime.wrap(function _callee3$(_context3) {
+  regeneratorRuntime.mark(function _callee() {
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 'ok';
+
+        case 2:
+        case "end":
+          return _context.stop();
+      }
+    }, _callee, this);
+  }));
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
+})();
+
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee2() {
+    return regeneratorRuntime.wrap(function _callee2$(_context2) {
+      while (1) switch (_context2.prev = _context2.next) {
+        case 0:
+          _context2.next = 2;
+          return 'ok';
+
+        case 2:
+        case "end":
+          return _context2.stop();
+      }
+    }, _callee2, this);
+  }));
+  return _wrapped2.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped2.apply(this, arguments);
+})();
+
+function _notIIFE() {
+  _notIIFE = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function notIIFE() {
+    return regeneratorRuntime.wrap(function notIIFE$(_context3) {
       while (1) switch (_context3.prev = _context3.next) {
         case 0:
           _context3.next = 2;
@@ -44,27 +58,34 @@ regeneratorRuntime.mark(function _callee2() {
         case "end":
           return _context3.stop();
       }
+    }, notIIFE, this);
+  }));
+  return _notIIFE.apply(this, arguments);
+}
+
+(function notIIFE() {
+  return _notIIFE.apply(this, arguments);
+});
+
+function _wrapped3() {
+  _wrapped3 = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee3() {
+    return regeneratorRuntime.wrap(function _callee3$(_context4) {
+      while (1) switch (_context4.prev = _context4.next) {
+        case 0:
+          _context4.next = 2;
+          return 'not iife';
+
+        case 2:
+        case "end":
+          return _context4.stop();
+      }
     }, _callee3, this);
   }));
+  return _wrapped3.apply(this, arguments);
+}
 
-  return function notIIFE() {
-    return _notIIFE.apply(this, arguments);
-  };
-})();
-
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(
-/*#__PURE__*/
-regeneratorRuntime.mark(function _callee4() {
-  return regeneratorRuntime.wrap(function _callee4$(_context4) {
-    while (1) switch (_context4.prev = _context4.next) {
-      case 0:
-        _context4.next = 2;
-        return 'not iife';
-
-      case 2:
-      case "end":
-        return _context4.stop();
-    }
-  }, _callee4, this);
-}));
+(function () {
+  return _wrapped3.apply(this, arguments);
+});

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife/output.js
@@ -1,22 +1,43 @@
-babelHelpers.asyncToGenerator(function* () {
-  yield 'ok';
-})();
-babelHelpers.asyncToGenerator(function* () {
-  yield 'ok';
-})();
-
-/*#__PURE__*/
-(function () {
-  var _notIIFE = babelHelpers.asyncToGenerator(function* () {
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
     yield 'ok';
   });
+  return _wrapped.apply(this, arguments);
+}
 
-  return function notIIFE() {
-    return _notIIFE.apply(this, arguments);
-  };
+(function () {
+  return _wrapped.apply(this, arguments);
 })();
 
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
-  yield 'not iife';
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+    yield 'ok';
+  });
+  return _wrapped2.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped2.apply(this, arguments);
+})();
+
+function _notIIFE() {
+  _notIIFE = babelHelpers.asyncToGenerator(function* notIIFE() {
+    yield 'ok';
+  });
+  return _notIIFE.apply(this, arguments);
+}
+
+(function notIIFE() {
+  return _notIIFE.apply(this, arguments);
+});
+
+function _wrapped3() {
+  _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+    yield 'not iife';
+  });
+  return _wrapped3.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped3.apply(this, arguments);
 });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async/output.js
@@ -1,8 +1,13 @@
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    var wat = yield bar();
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 class Foo {
   foo() {
-    return babelHelpers.asyncToGenerator(function* () {
-      var wat = yield bar();
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async/output.js
@@ -1,13 +1,13 @@
-function _wrapped() {
-  _wrapped = babelHelpers.asyncToGenerator(function* () {
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* foo() {
     var wat = yield bar();
   });
-  return _wrapped.apply(this, arguments);
+  return _foo.apply(this, arguments);
 }
 
 class Foo {
   foo() {
-    return _wrapped.apply(this, arguments);
+    return _foo.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/output.js
@@ -1,9 +1,5 @@
-function s(_x) {
-  return _s.apply(this, arguments);
-}
-
 function _s() {
-  _s = babelHelpers.asyncToGenerator(function* (x) {
+  _s = babelHelpers.asyncToGenerator(function* s(x) {
     var _this = this,
         _arguments = arguments;
 
@@ -11,41 +7,43 @@ function _s() {
       args[_key - 1] = arguments[_key];
     }
 
-    let t =
-    /*#__PURE__*/
-    function () {
-      var _ref = babelHelpers.asyncToGenerator(function* (y, a) {
-        let r =
-        /*#__PURE__*/
-        function () {
-          var _ref2 = babelHelpers.asyncToGenerator(function* (z, b) {
-            yield z;
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* (z, b) {
+        yield z;
 
-            for (var _len2 = arguments.length, innerArgs = new Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
-              innerArgs[_key2 - 2] = arguments[_key2];
-            }
+        for (var _len2 = arguments.length, innerArgs = new Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+          innerArgs[_key2 - 2] = arguments[_key2];
+        }
 
-            console.log(_this, innerArgs, _arguments);
-            return _this.x;
-          });
+        console.log(_this, innerArgs, _arguments);
+        return _this.x;
+      });
+      return _wrapped2.apply(this, arguments);
+    }
 
-          return function r(_x4, _x5) {
-            return _ref2.apply(this, arguments);
-          };
-        }();
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* (y, a) {
+        let r = function (_x4, _x5) {
+          return _wrapped2.apply(this, arguments);
+        };
 
         yield r();
         console.log(_this, args, _arguments);
         return _this.g(r);
       });
+      return _wrapped.apply(this, arguments);
+    }
 
-      return function t(_x2, _x3) {
-        return _ref.apply(this, arguments);
-      };
-    }();
+    let t = function (_x2, _x3) {
+      return _wrapped.apply(this, arguments);
+    };
 
     yield t();
     return this.h(t);
   });
+  return _s.apply(this, arguments);
+}
+
+function s(_x) {
   return _s.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/expression/output.js
@@ -1,34 +1,29 @@
-var foo =
-/*#__PURE__*/
-function () {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
-    var wat = yield bar();
-  });
+var foo = function () {
+  return _wrapped.apply(this, arguments);
+};
 
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-}();
-
-var foo2 =
-/*#__PURE__*/
-function () {
-  var _ref2 = babelHelpers.asyncToGenerator(function* () {
-    var wat = yield bar();
-  });
-
-  return function foo2() {
-    return _ref2.apply(this, arguments);
-  };
-}(),
-    bar =
-/*#__PURE__*/
-function () {
-  var _ref3 = babelHelpers.asyncToGenerator(function* () {
+function _wrapped3() {
+  _wrapped3 = babelHelpers.asyncToGenerator(function* () {
     var wat = yield foo();
   });
+  return _wrapped3.apply(this, arguments);
+}
 
-  return function bar() {
-    return _ref3.apply(this, arguments);
-  };
-}();
+var foo2 = function () {
+  return _wrapped2.apply(this, arguments);
+},
+    bar = function () {
+  return _wrapped3.apply(this, arguments);
+},
+    function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+    var wat = yield bar();
+  });
+  return _wrapped2.apply(this, arguments);
+},
+    function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    var wat = yield bar();
+  });
+  return _wrapped.apply(this, arguments);
+};

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/function-arity/output.js
@@ -1,57 +1,57 @@
+function _one() {
+  _one = babelHelpers.asyncToGenerator(function* one(a, b = 1) {});
+  return _one.apply(this, arguments);
+}
+
 function one(_x) {
   return _one.apply(this, arguments);
 }
 
-function _one() {
-  _one = babelHelpers.asyncToGenerator(function* (a, b = 1) {});
-  return _one.apply(this, arguments);
+function _two() {
+  _two = babelHelpers.asyncToGenerator(function* two(a, b, ...c) {});
+  return _two.apply(this, arguments);
 }
 
 function two(_x2, _x3) {
   return _two.apply(this, arguments);
 }
 
-function _two() {
-  _two = babelHelpers.asyncToGenerator(function* (a, b, ...c) {});
-  return _two.apply(this, arguments);
+function _three() {
+  _three = babelHelpers.asyncToGenerator(function* three(a, b = 1, c, d = 3) {});
+  return _three.apply(this, arguments);
 }
 
 function three(_x4) {
   return _three.apply(this, arguments);
 }
 
-function _three() {
-  _three = babelHelpers.asyncToGenerator(function* (a, b = 1, c, d = 3) {});
-  return _three.apply(this, arguments);
+function _four() {
+  _four = babelHelpers.asyncToGenerator(function* four(a, b = 1, c, ...d) {});
+  return _four.apply(this, arguments);
 }
 
 function four(_x5) {
   return _four.apply(this, arguments);
 }
 
-function _four() {
-  _four = babelHelpers.asyncToGenerator(function* (a, b = 1, c, ...d) {});
-  return _four.apply(this, arguments);
+function _five() {
+  _five = babelHelpers.asyncToGenerator(function* five(a, {
+    b
+  }) {});
+  return _five.apply(this, arguments);
 }
 
 function five(_x6, _x7) {
   return _five.apply(this, arguments);
 }
 
-function _five() {
-  _five = babelHelpers.asyncToGenerator(function* (a, {
+function _six() {
+  _six = babelHelpers.asyncToGenerator(function* six(a, {
     b
-  }) {});
-  return _five.apply(this, arguments);
-}
-
-function six(_x8) {
+  } = {}) {});
   return _six.apply(this, arguments);
 }
 
-function _six() {
-  _six = babelHelpers.asyncToGenerator(function* (a, {
-    b
-  } = {}) {});
+function six(_x8) {
   return _six.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/named-expression/output.js
@@ -1,11 +1,10 @@
-var foo =
-/*#__PURE__*/
-function () {
-  var _bar = babelHelpers.asyncToGenerator(function* () {
+function _bar() {
+  _bar = babelHelpers.asyncToGenerator(function* bar() {
     console.log(bar);
   });
+  return _bar.apply(this, arguments);
+}
 
-  return function bar() {
-    return _bar.apply(this, arguments);
-  };
-}();
+var foo = function bar() {
+  return _bar.apply(this, arguments);
+};

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/no-parameters-and-no-id/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/no-parameters-and-no-id/output.js
@@ -1,3 +1,8 @@
-foo(
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {}));
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {});
+  return _wrapped.apply(this, arguments);
+}
+
+foo(function () {
+  return _wrapped.apply(this, arguments);
+});

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-arrows/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-arrows/output.js
@@ -1,35 +1,16 @@
-class Class {
-  method() {
-    var _this = this;
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    this;
 
-    return babelHelpers.asyncToGenerator(function* () {
-      _this;
+    () => this;
 
-      () => _this;
+    () => {
+      this;
 
-      () => {
-        _this;
-
-        () => _this;
-
-        function x() {
-          var _this2 = this;
-
-          this;
-
-          () => {
-            this;
-          };
-
-          /*#__PURE__*/
-          babelHelpers.asyncToGenerator(function* () {
-            _this2;
-          });
-        }
-      };
+      () => this;
 
       function x() {
-        var _this3 = this;
+        var _this = this;
 
         this;
 
@@ -37,12 +18,46 @@ class Class {
           this;
         };
 
-        /*#__PURE__*/
-        babelHelpers.asyncToGenerator(function* () {
-          _this3;
+        function _wrapped2() {
+          _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+            _this;
+          });
+          return _wrapped2.apply(this, arguments);
+        }
+
+        (function () {
+          return _wrapped2.apply(this, arguments);
         });
       }
-    })();
+    };
+
+    function x() {
+      var _this2 = this;
+
+      this;
+
+      () => {
+        this;
+      };
+
+      function _wrapped3() {
+        _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+          _this2;
+        });
+        return _wrapped3.apply(this, arguments);
+      }
+
+      (function () {
+        return _wrapped3.apply(this, arguments);
+      });
+    }
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+class Class {
+  method() {
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-arrows/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-arrows/output.js
@@ -1,5 +1,5 @@
-function _wrapped() {
-  _wrapped = babelHelpers.asyncToGenerator(function* () {
+function _method() {
+  _method = babelHelpers.asyncToGenerator(function* method() {
     this;
 
     () => this;
@@ -18,15 +18,15 @@ function _wrapped() {
           this;
         };
 
-        function _wrapped2() {
-          _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+        function _wrapped() {
+          _wrapped = babelHelpers.asyncToGenerator(function* () {
             _this;
           });
-          return _wrapped2.apply(this, arguments);
+          return _wrapped.apply(this, arguments);
         }
 
         (function () {
-          return _wrapped2.apply(this, arguments);
+          return _wrapped.apply(this, arguments);
         });
       }
     };
@@ -40,24 +40,24 @@ function _wrapped() {
         this;
       };
 
-      function _wrapped3() {
-        _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+      function _wrapped2() {
+        _wrapped2 = babelHelpers.asyncToGenerator(function* () {
           _this2;
         });
-        return _wrapped3.apply(this, arguments);
+        return _wrapped2.apply(this, arguments);
       }
 
       (function () {
-        return _wrapped3.apply(this, arguments);
+        return _wrapped2.apply(this, arguments);
       });
     }
   });
-  return _wrapped.apply(this, arguments);
+  return _method.apply(this, arguments);
 }
 
 class Class {
   method() {
-    return _wrapped.apply(this, arguments);
+    return _method.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
@@ -1,12 +1,15 @@
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    super.method();
+
+    var arrow = () => super.method();
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 class Foo extends class {} {
   method() {
-    var _superprop_callMethod = (..._args) => super.method(..._args);
-
-    return babelHelpers.asyncToGenerator(function* () {
-      _superprop_callMethod();
-
-      var arrow = () => _superprop_callMethod();
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
@@ -1,15 +1,12 @@
-function _wrapped() {
-  _wrapped = babelHelpers.asyncToGenerator(function* () {
-    super.method();
-
-    var arrow = () => super.method();
-  });
-  return _wrapped.apply(this, arguments);
-}
-
 class Foo extends class {} {
   method() {
-    return _wrapped.apply(this, arguments);
+    var _superprop_callMethod = (..._args) => super.method(..._args);
+
+    return babelHelpers.asyncToGenerator(function* method() {
+      _superprop_callMethod();
+
+      var arrow = () => _superprop_callMethod();
+    })();
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/input.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/input.js
@@ -1,6 +1,6 @@
 let obj = {
   a: 123,
   async foo(bar) {
-    return await baz(bar);
+    return await this.baz(bar);
   }
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/input.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/input.js
@@ -1,6 +1,6 @@
 let obj = {
   a: 123,
   async foo(bar) {
-    return await this.baz(bar);
+    return await baz(bar);
   }
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
@@ -1,15 +1,15 @@
-function _wrapped() {
-  _wrapped = babelHelpers.asyncToGenerator(function* (bar) {
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* foo(bar) {
     return yield baz(bar);
   });
-  return _wrapped.apply(this, arguments);
+  return _foo.apply(this, arguments);
 }
 
 let obj = {
   a: 123,
 
   foo(_x) {
-    return _wrapped.apply(this, arguments);
+    return _foo.apply(this, arguments);
   }
 
 };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
@@ -8,7 +8,7 @@ function _wrapped() {
 let obj = {
   a: 123,
 
-  foo(bar) {
+  foo(_x) {
     return _wrapped.apply(this, arguments);
   }
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
@@ -1,6 +1,6 @@
 function _wrapped() {
   _wrapped = babelHelpers.asyncToGenerator(function* (bar) {
-    return yield this.baz(bar);
+    return yield baz(bar);
   });
   return _wrapped.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method/output.js
@@ -1,10 +1,15 @@
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* (bar) {
+    return yield this.baz(bar);
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 let obj = {
   a: 123,
 
   foo(bar) {
-    return babelHelpers.asyncToGenerator(function* () {
-      return yield baz(bar);
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 };

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/parameters/output.js
@@ -1,8 +1,8 @@
-function foo(_x) {
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* foo(bar) {});
   return _foo.apply(this, arguments);
 }
 
-function _foo() {
-  _foo = babelHelpers.asyncToGenerator(function* (bar) {});
+function foo(_x) {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/output.mjs
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-import/output.mjs
@@ -4,13 +4,13 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 import _Promise from 'somewhere';
 
-function foo() {
+function _foo() {
+  _foo = _asyncToGenerator(function* foo() {
+    yield _Promise.resolve();
+  });
   return _foo.apply(this, arguments);
 }
 
-function _foo() {
-  _foo = _asyncToGenerator(function* () {
-    yield _Promise.resolve();
-  });
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise-nested/output.js
@@ -4,25 +4,25 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 let _Promise;
 
-function foo() {
-  return _foo.apply(this, arguments);
-}
-
 function _foo() {
-  _foo = _asyncToGenerator(function* () {
+  _foo = _asyncToGenerator(function* foo() {
     let Promise;
     yield bar();
 
-    function bar() {
-      return _bar.apply(this, arguments);
-    }
-
     function _bar() {
-      _bar = _asyncToGenerator(function* () {
+      _bar = _asyncToGenerator(function* bar() {
         return Promise.resolve();
       });
       return _bar.apply(this, arguments);
     }
+
+    function bar() {
+      return _bar.apply(this, arguments);
+    }
   });
+  return _foo.apply(this, arguments);
+}
+
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/shadowed-promise/output.js
@@ -4,15 +4,15 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 let _Promise;
 
-function foo() {
-  return _foo.apply(this, arguments);
-}
-
 function _foo() {
-  _foo = _asyncToGenerator(function* () {
+  _foo = _asyncToGenerator(function* foo() {
     yield new _Promise(resolve => {
       resolve();
     });
   });
+  return _foo.apply(this, arguments);
+}
+
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/statement/output.js
@@ -1,10 +1,10 @@
-function foo() {
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* foo() {
+    var wat = yield bar();
+  });
   return _foo.apply(this, arguments);
 }
 
-function _foo() {
-  _foo = babelHelpers.asyncToGenerator(function* () {
-    var wat = yield bar();
-  });
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/arrow-function/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/arrow-function/output.js
@@ -1,5 +1,12 @@
 var _coroutine = require("bluebird").coroutine;
 
-_coroutine(function* () {
-  yield foo();
+function _wrapped() {
+  _wrapped = _coroutine(function* () {
+    yield foo();
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
 })();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/class/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/class/output.js
@@ -1,15 +1,15 @@
 var _coroutine = require("bluebird").coroutine;
 
-function _wrapped() {
-  _wrapped = _coroutine(function* () {
+function _foo() {
+  _foo = _coroutine(function* foo() {
     var wat = yield bar();
   });
-  return _wrapped.apply(this, arguments);
+  return _foo.apply(this, arguments);
 }
 
 class Foo {
   foo() {
-    return _wrapped.apply(this, arguments);
+    return _foo.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/class/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/class/output.js
@@ -1,10 +1,15 @@
 var _coroutine = require("bluebird").coroutine;
 
+function _wrapped() {
+  _wrapped = _coroutine(function* () {
+    var wat = yield bar();
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 class Foo {
   foo() {
-    return _coroutine(function* () {
-      var wat = yield bar();
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/expression/output.js
@@ -1,13 +1,12 @@
 var _coroutine = require("bluebird").coroutine;
 
-var foo =
-/*#__PURE__*/
-function () {
-  var _ref = _coroutine(function* () {
+function _wrapped() {
+  _wrapped = _coroutine(function* () {
     var wat = yield bar();
   });
+  return _wrapped.apply(this, arguments);
+}
 
-  return function foo() {
-    return _ref.apply(this, arguments);
-  };
-}();
+var foo = function () {
+  return _wrapped.apply(this, arguments);
+};

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/named-expression/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/named-expression/output.js
@@ -1,13 +1,12 @@
 var _coroutine = require("bluebird").coroutine;
 
-var foo =
-/*#__PURE__*/
-function () {
-  var _bar = _coroutine(function* () {
+function _bar() {
+  _bar = _coroutine(function* bar() {
     console.log(bar);
   });
+  return _bar.apply(this, arguments);
+}
 
-  return function bar() {
-    return _bar.apply(this, arguments);
-  };
-}();
+var foo = function bar() {
+  return _bar.apply(this, arguments);
+};

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/statement/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/bluebird-coroutines/statement/output.js
@@ -1,12 +1,12 @@
 var _coroutine = require("bluebird").coroutine;
 
-function foo() {
+function _foo() {
+  _foo = _coroutine(function* foo() {
+    var wat = yield bar();
+  });
   return _foo.apply(this, arguments);
 }
 
-function _foo() {
-  _foo = _coroutine(function* () {
-    var wat = yield bar();
-  });
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/output.js
@@ -5,10 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _default =
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
-  return yield foo();
-});
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    return yield foo();
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+var _default = function _default() {
+  return _wrapped.apply(this, arguments);
+};
 
 exports.default = _default;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/output.js
@@ -5,11 +5,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = myFunc;
 
-function myFunc() {
+function _myFunc() {
+  _myFunc = babelHelpers.asyncToGenerator(function* myFunc() {});
   return _myFunc.apply(this, arguments);
 }
 
-function _myFunc() {
-  _myFunc = babelHelpers.asyncToGenerator(function* () {});
+function myFunc() {
   return _myFunc.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/output.js
@@ -7,11 +7,11 @@ exports.foo = foo;
 
 var _bar = babelHelpers.interopRequireDefault(require("bar"));
 
-function foo() {
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* foo() {});
   return _foo.apply(this, arguments);
 }
 
-function _foo() {
-  _foo = babelHelpers.asyncToGenerator(function* () {});
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/output.js
@@ -5,11 +5,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.foo = foo;
 
-function foo() {
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(function* foo() {});
   return _foo.apply(this, arguments);
 }
 
-function _foo() {
-  _foo = babelHelpers.asyncToGenerator(function* () {});
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4599/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4599/output.js
@@ -1,9 +1,21 @@
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
-  return yield promise;
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
+    return yield promise;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped.apply(this, arguments);
 });
 
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
-  yield promise;
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+    yield promise;
+  });
+  return _wrapped2.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped2.apply(this, arguments);
 });

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/4943/output.js
@@ -8,16 +8,16 @@ function mandatory(paramName) {
   throw new Error(`Missing parameter: ${paramName}`);
 }
 
-function foo(_x) {
-  return _foo.apply(this, arguments);
-}
-
 function _foo() {
-  _foo = _asyncToGenerator(function* (_ref) {
+  _foo = _asyncToGenerator(function* foo(_ref) {
     let a = _ref.a,
         _ref$b = _ref.b,
         b = _ref$b === void 0 ? mandatory("b") : _ref$b;
     return Promise.resolve(b);
   });
+  return _foo.apply(this, arguments);
+}
+
+function foo(_x) {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/7178/output.js
@@ -1,9 +1,5 @@
 const title = "Neem contact op";
 
-function action() {
-  return _action.apply(this, arguments);
-}
-
 var _ref =
 /*#__PURE__*/
 React.createElement(Contact, {
@@ -11,8 +7,12 @@ React.createElement(Contact, {
 });
 
 function _action() {
-  _action = babelHelpers.asyncToGenerator(function* () {
+  _action = babelHelpers.asyncToGenerator(function* action() {
     return _ref;
   });
+  return _action.apply(this, arguments);
+}
+
+function action() {
   return _action.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/output.js
@@ -1,98 +1,98 @@
-function _wrapped() {
-  _wrapped = babelHelpers.asyncToGenerator(function* () {
+function _method() {
+  _method = babelHelpers.asyncToGenerator(function* method1() {
     var _this = this;
 
     console.log(this);
 
-    function _wrapped5() {
-      _wrapped5 = babelHelpers.asyncToGenerator(function* () {
+    function _wrapped() {
+      _wrapped = babelHelpers.asyncToGenerator(function* () {
         console.log(_this);
       });
-      return _wrapped5.apply(this, arguments);
+      return _wrapped.apply(this, arguments);
     }
 
     setTimeout(function () {
-      return _wrapped5.apply(this, arguments);
+      return _wrapped.apply(this, arguments);
     });
   });
-  return _wrapped.apply(this, arguments);
+  return _method.apply(this, arguments);
 }
 
-function _wrapped2() {
-  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+function _method2() {
+  _method2 = babelHelpers.asyncToGenerator(function* method2() {
     var _this2 = this;
 
     console.log(this);
 
-    function _wrapped6() {
-      _wrapped6 = babelHelpers.asyncToGenerator(function* (arg) {
+    function _wrapped2() {
+      _wrapped2 = babelHelpers.asyncToGenerator(function* (arg) {
         console.log(_this2);
       });
-      return _wrapped6.apply(this, arguments);
+      return _wrapped2.apply(this, arguments);
     }
 
     setTimeout(function (_x) {
-      return _wrapped6.apply(this, arguments);
+      return _wrapped2.apply(this, arguments);
     });
   });
-  return _wrapped2.apply(this, arguments);
+  return _method2.apply(this, arguments);
 }
 
-function _wrapped3() {
-  _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+function _method3() {
+  _method3 = babelHelpers.asyncToGenerator(function* method1() {
     var _this3 = this;
 
     console.log(this);
 
-    function _wrapped7() {
-      _wrapped7 = babelHelpers.asyncToGenerator(function* () {
+    function _wrapped3() {
+      _wrapped3 = babelHelpers.asyncToGenerator(function* () {
         console.log(_this3);
       });
-      return _wrapped7.apply(this, arguments);
+      return _wrapped3.apply(this, arguments);
     }
 
     setTimeout(function () {
-      return _wrapped7.apply(this, arguments);
+      return _wrapped3.apply(this, arguments);
     });
   });
-  return _wrapped3.apply(this, arguments);
+  return _method3.apply(this, arguments);
 }
 
-function _wrapped4() {
-  _wrapped4 = babelHelpers.asyncToGenerator(function* () {
+function _method4() {
+  _method4 = babelHelpers.asyncToGenerator(function* method2() {
     var _this4 = this;
 
     console.log(this);
 
-    function _wrapped8() {
-      _wrapped8 = babelHelpers.asyncToGenerator(function* (arg) {
+    function _wrapped4() {
+      _wrapped4 = babelHelpers.asyncToGenerator(function* (arg) {
         console.log(_this4);
       });
-      return _wrapped8.apply(this, arguments);
+      return _wrapped4.apply(this, arguments);
     }
 
     setTimeout(function (_x2) {
-      return _wrapped8.apply(this, arguments);
+      return _wrapped4.apply(this, arguments);
     });
   });
-  return _wrapped4.apply(this, arguments);
+  return _method4.apply(this, arguments);
 }
 
 class Test {
   static method1() {
-    return _wrapped.apply(this, arguments);
+    return _method.apply(this, arguments);
   }
 
   static method2() {
-    return _wrapped2.apply(this, arguments);
+    return _method2.apply(this, arguments);
   }
 
   method1() {
-    return _wrapped3.apply(this, arguments);
+    return _method3.apply(this, arguments);
   }
 
   method2() {
-    return _wrapped4.apply(this, arguments);
+    return _method4.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7108/output.js
@@ -1,66 +1,98 @@
-class Test {
-  static method1() {
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
     var _this = this;
 
-    return babelHelpers.asyncToGenerator(function* () {
-      console.log(_this);
-      setTimeout(
-      /*#__PURE__*/
-      babelHelpers.asyncToGenerator(function* () {
+    console.log(this);
+
+    function _wrapped5() {
+      _wrapped5 = babelHelpers.asyncToGenerator(function* () {
         console.log(_this);
-      }));
-    })();
+      });
+      return _wrapped5.apply(this, arguments);
+    }
+
+    setTimeout(function () {
+      return _wrapped5.apply(this, arguments);
+    });
+  });
+  return _wrapped.apply(this, arguments);
+}
+
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+    var _this2 = this;
+
+    console.log(this);
+
+    function _wrapped6() {
+      _wrapped6 = babelHelpers.asyncToGenerator(function* (arg) {
+        console.log(_this2);
+      });
+      return _wrapped6.apply(this, arguments);
+    }
+
+    setTimeout(function (_x) {
+      return _wrapped6.apply(this, arguments);
+    });
+  });
+  return _wrapped2.apply(this, arguments);
+}
+
+function _wrapped3() {
+  _wrapped3 = babelHelpers.asyncToGenerator(function* () {
+    var _this3 = this;
+
+    console.log(this);
+
+    function _wrapped7() {
+      _wrapped7 = babelHelpers.asyncToGenerator(function* () {
+        console.log(_this3);
+      });
+      return _wrapped7.apply(this, arguments);
+    }
+
+    setTimeout(function () {
+      return _wrapped7.apply(this, arguments);
+    });
+  });
+  return _wrapped3.apply(this, arguments);
+}
+
+function _wrapped4() {
+  _wrapped4 = babelHelpers.asyncToGenerator(function* () {
+    var _this4 = this;
+
+    console.log(this);
+
+    function _wrapped8() {
+      _wrapped8 = babelHelpers.asyncToGenerator(function* (arg) {
+        console.log(_this4);
+      });
+      return _wrapped8.apply(this, arguments);
+    }
+
+    setTimeout(function (_x2) {
+      return _wrapped8.apply(this, arguments);
+    });
+  });
+  return _wrapped4.apply(this, arguments);
+}
+
+class Test {
+  static method1() {
+    return _wrapped.apply(this, arguments);
   }
 
   static method2() {
-    var _this2 = this;
-
-    return babelHelpers.asyncToGenerator(function* () {
-      console.log(_this2);
-      setTimeout(
-      /*#__PURE__*/
-      function () {
-        var _ref2 = babelHelpers.asyncToGenerator(function* (arg) {
-          console.log(_this2);
-        });
-
-        return function (_x) {
-          return _ref2.apply(this, arguments);
-        };
-      }());
-    })();
+    return _wrapped2.apply(this, arguments);
   }
 
   method1() {
-    var _this3 = this;
-
-    return babelHelpers.asyncToGenerator(function* () {
-      console.log(_this3);
-      setTimeout(
-      /*#__PURE__*/
-      babelHelpers.asyncToGenerator(function* () {
-        console.log(_this3);
-      }));
-    })();
+    return _wrapped3.apply(this, arguments);
   }
 
   method2() {
-    var _this4 = this;
-
-    return babelHelpers.asyncToGenerator(function* () {
-      console.log(_this4);
-      setTimeout(
-      /*#__PURE__*/
-      function () {
-        var _ref4 = babelHelpers.asyncToGenerator(function* (arg) {
-          console.log(_this4);
-        });
-
-        return function (_x2) {
-          return _ref4.apply(this, arguments);
-        };
-      }());
-    })();
+    return _wrapped4.apply(this, arguments);
   }
 
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7194/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7194/output.js
@@ -1,22 +1,33 @@
-function f() {
-  g(
-  /*#__PURE__*/
-  babelHelpers.asyncToGenerator(function* () {
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
     var _this = this;
 
     c(function () {
       return _this;
     });
-  }));
+  });
+  return _wrapped.apply(this, arguments);
 }
 
-/*#__PURE__*/
-babelHelpers.asyncToGenerator(function* () {
-  var _this2 = this;
+function f() {
+  g(function () {
+    return _wrapped.apply(this, arguments);
+  });
+}
 
-  console.log('async wrapper:', this === 'foo');
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
+    var _this2 = this;
 
-  (function () {
-    console.log('nested arrow:', _this2 === 'foo');
-  })();
+    console.log('async wrapper:', this === 'foo');
+
+    (function () {
+      console.log('nested arrow:', _this2 === 'foo');
+    })();
+  });
+  return _wrapped2.apply(this, arguments);
+}
+
+(function () {
+  return _wrapped2.apply(this, arguments);
 }).call('foo');

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/gh-6923/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/gh-6923/output.js
@@ -1,42 +1,42 @@
-function foo() {
-  return _foo.apply(this, arguments);
-}
-
-function _foo() {
-  _foo = babelHelpers.asyncToGenerator(
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee2() {
-    return regeneratorRuntime.wrap(function _callee2$(_context2) {
+  regeneratorRuntime.mark(function _callee(number) {
+    var tmp;
+    return regeneratorRuntime.wrap(function _callee$(_context2) {
       while (1) switch (_context2.prev = _context2.next) {
         case 0:
-          /*#__PURE__*/
-          (function () {
-            var _ref = babelHelpers.asyncToGenerator(
-            /*#__PURE__*/
-            regeneratorRuntime.mark(function _callee(number) {
-              var tmp;
-              return regeneratorRuntime.wrap(function _callee$(_context) {
-                while (1) switch (_context.prev = _context.next) {
-                  case 0:
-                    tmp = number;
-
-                  case 1:
-                  case "end":
-                    return _context.stop();
-                }
-              }, _callee, this);
-            }));
-
-            return function (_x) {
-              return _ref.apply(this, arguments);
-            };
-          })();
+          tmp = number;
 
         case 1:
         case "end":
           return _context2.stop();
       }
-    }, _callee2, this);
+    }, _callee, this);
   }));
+  return _wrapped.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = babelHelpers.asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function foo() {
+    return regeneratorRuntime.wrap(function foo$(_context) {
+      while (1) switch (_context.prev = _context.next) {
+        case 0:
+          (function (_x) {
+            return _wrapped.apply(this, arguments);
+          });
+
+        case 1:
+        case "end":
+          return _context.stop();
+      }
+    }, foo, this);
+  }));
+  return _foo.apply(this, arguments);
+}
+
+function foo() {
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-async-arrow-functions/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-async-arrow-functions/output.js
@@ -1,20 +1,17 @@
-var concat =
-/*#__PURE__*/
-function () {
-  var _ref = babelHelpers.asyncToGenerator(function* () {
+function _wrapped() {
+  _wrapped = babelHelpers.asyncToGenerator(function* () {
     var x = arguments.length <= 0 ? undefined : arguments[0];
     var y = arguments.length <= 1 ? undefined : arguments[1];
   });
+  return _wrapped.apply(this, arguments);
+}
 
-  return function concat() {
-    return _ref.apply(this, arguments);
-  };
-}();
+var concat = function () {
+  return _wrapped.apply(this, arguments);
+};
 
-var x =
-/*#__PURE__*/
-function () {
-  var _ref2 = babelHelpers.asyncToGenerator(function* () {
+function _wrapped2() {
+  _wrapped2 = babelHelpers.asyncToGenerator(function* () {
     if (noNeedToWork) return 0;
 
     for (var _len = arguments.length, rest = new Array(_len), _key = 0; _key < _len; _key++) {
@@ -23,8 +20,9 @@ function () {
 
     return rest;
   });
+  return _wrapped2.apply(this, arguments);
+}
 
-  return function x() {
-    return _ref2.apply(this, arguments);
-  };
-}();
+var x = function () {
+  return _wrapped2.apply(this, arguments);
+};

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
@@ -12,7 +12,7 @@ function _wrapped() {
 }
 
 export default {
-  function(name) {
+  function(_x) {
     return _wrapped.apply(this, arguments);
   }
 

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/async-function/output.mjs
@@ -2,13 +2,18 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
+function _wrapped() {
+  _wrapped = _asyncToGenerator(function* (name) {
+    const uppercasedName = name.upperCase(); // awaits depending on uppercasedName go here
+
+    return <Foo name={uppercasedName} />;
+  });
+  return _wrapped.apply(this, arguments);
+}
+
 export default {
   function(name) {
-    return _asyncToGenerator(function* () {
-      const uppercasedName = name.upperCase(); // awaits depending on uppercasedName go here
-
-      return <Foo name={uppercasedName} />;
-    })();
+    return _wrapped.apply(this, arguments);
   }
 
 };

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/regenerator-used-async/output.mjs
@@ -5,15 +5,11 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-function a() {
-  return _a.apply(this, arguments);
-}
-
 function _a() {
   _a = _asyncToGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+  regeneratorRuntime.mark(function a() {
+    return regeneratorRuntime.wrap(function a$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
@@ -21,7 +17,11 @@ function _a() {
             return _context.stop();
         }
       }
-    }, _callee, this);
+    }, a, this);
   }));
+  return _a.apply(this, arguments);
+}
+
+function a() {
   return _a.apply(this, arguments);
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
@@ -35,15 +35,11 @@ var n = _objectSpread({
   y: y
 }, z);
 
-function agf() {
-  return _agf.apply(this, arguments);
-}
-
 function _agf() {
   _agf = _wrapAsyncGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+  regeneratorRuntime.mark(function agf() {
+    return regeneratorRuntime.wrap(function agf$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
@@ -59,7 +55,11 @@ function _agf() {
             return _context.stop();
         }
       }
-    }, _callee, this);
+    }, agf, this);
   }));
+  return _agf.apply(this, arguments);
+}
+
+function agf() {
   return _agf.apply(this, arguments);
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
@@ -59,15 +59,11 @@ var n = _objectSpread({
   y: y
 }, z);
 
-function agf() {
-  return _agf.apply(this, arguments);
-}
-
 function _agf() {
   _agf = _wrapAsyncGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+  regeneratorRuntime.mark(function agf() {
+    return regeneratorRuntime.wrap(function agf$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
@@ -83,7 +79,11 @@ function _agf() {
             return _context.stop();
         }
       }
-    }, _callee, this);
+    }, agf, this);
   }));
+  return _agf.apply(this, arguments);
+}
+
+function agf() {
   return _agf.apply(this, arguments);
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
@@ -35,15 +35,11 @@ var n = _objectSpread({
   y: y
 }, z);
 
-function agf() {
-  return _agf.apply(this, arguments);
-}
-
 function _agf() {
   _agf = _wrapAsyncGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+  regeneratorRuntime.mark(function agf() {
+    return regeneratorRuntime.wrap(function agf$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
@@ -59,7 +55,11 @@ function _agf() {
             return _context.stop();
         }
       }
-    }, _callee, this);
+    }, agf, this);
   }));
+  return _agf.apply(this, arguments);
+}
+
+function agf() {
   return _agf.apply(this, arguments);
 }

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -236,4 +236,56 @@ describe("modification", function() {
       });
     });
   });
+
+  describe("hoist", function() {
+    describe("function declaration", function() {
+      it("no params", function() {
+        const rootPath = getPath(`
+        function outer() {
+          function inner() {}
+        }`);
+        const path = rootPath.get("body.body.0");
+        path.hoist();
+        expect(generateCode(rootPath)).toBe(
+          "function inner() {}\n\nfunction outer() {}",
+        );
+      });
+
+      it("params", function() {
+        const rootPath = getPath(`
+        function outer() {
+          function inner(a, b, c) {}
+        }`);
+        const path = rootPath.get("body.body.0");
+        path.hoist();
+        expect(generateCode(rootPath)).toBe(
+          "function inner(a, b, c) {}\n\nfunction outer() {}",
+        );
+      });
+
+      it("outer param", function() {
+        const rootPath = getPath(`
+        function outer(a) {
+          function inner() { a; }
+        }`);
+        const path = rootPath.get("body.body.0");
+        path.hoist();
+        expect(generateCode(rootPath)).toBe(
+          "function outer(a) {\n  function inner() {\n    a;\n  }\n}",
+        );
+      });
+
+      it("override outer param", function() {
+        const rootPath = getPath(`
+        function outer(a) {
+          function inner(a) { a; }
+        }`);
+        const path = rootPath.get("body.body.0");
+        path.hoist();
+        expect(generateCode(rootPath)).toBe(
+          "function inner(a) {\n  a;\n}\n\nfunction outer(a) {}",
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
This uses the memoizable function declaration pattern to wrap the call
to `asyncToGenerator` factory. Then, it hoists that function declaration
as high as it'll go.

This should help with performance, and memory pressure, since we won't
be redefining that asyncGenerator wrapper every time we call the async
function.

https://jsbench.github.io/#fe2924043feb9085a27a2edb671ecec0