### PR TITLE
Upgrade upath to avoid yarn failure on node 10

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8403,8 +8403,8 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | N/A
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


upath 1.0.4 doesn't support node 10, and this was fixed in later versions
( https://github.com/anodynos/upath/pull/15 ), but Babel's yarn.lock pinned the
version to 1.0.4. Normal Babel builds use `yarn --ignore-engines` to work around
this, but I have a script that clones and builds a number of repositories
(including Babel) and assumes that all of them can run `yarn` after cloning
without error. Upgrading upath fixes plain `yarn` on node 10 so I don't need to
add a special case when cloning/building Babel.

As described in https://github.com/yarnpkg/yarn/issues/4986#issuecomment-395036563 ,
I did this by deleting the yarn.lock entry and re-running `yarn`. (It's a little
tricky to upgrade since it's an indirect dependency.)

I believe this means that it should be safe to remove `--ignore-engines` from
travis.yml and Makefile, but I left those alone since arguably `--ignore-engines`
is nice in that it protects against future similar issues.