### PR TITLE
Remove Stage presets

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-4855/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-4855/options.json
@@ -1,7 +1,10 @@
 {
   "compact": false,
   "presets": [
-    "env",
-    ["stage-2", { "decoratorsLegacy": true }]
+    "env"
+  ],
+  "plugins": [
+    "external-helpers",
+    "proposal-object-rest-spread"
   ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/options.json
@@ -1,6 +1,5 @@
 {
   "presets": [
-    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }],
     "env"
   ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
@@ -1,7 +1,6 @@
 {
   "plugins": ["external-helpers", ["proposal-class-properties", {"loose": true}]],
   "presets": [
-    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }],
     "env"
   ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/options.json
@@ -1,7 +1,6 @@
 {
   "plugins": ["external-helpers", "proposal-class-properties"],
   "presets": [
-    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }],
     "env"
   ]
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/options.json
@@ -1,6 +1,8 @@
 {
   "presets": [
-    "env",
-    ["stage-2", { "decoratorsLegacy": true }]
+    "env"
+  ],
+  "plugins": [
+    "proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/options.json
@@ -1,6 +1,5 @@
 {
   "presets": [
-    "env",
-    ["stage-0", { "decoratorsLegacy": true, "pipelineProposal": "minimal" }]
+    "env"
   ]
 }

--- a/packages/babel-preset-stage-0/README.md
+++ b/packages/babel-preset-stage-0/README.md
@@ -1,19 +1,33 @@
 # @babel/preset-stage-0
 
-> Babel preset for stage 0 plugins
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
+If you want the same configuration as before, you can use this configuration,
+although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
 
-See our website [@babel/preset-stage-0](https://babeljs.io/docs/en/next/babel-preset-stage-0.html) for more information.
-
-## Install
-
-Using npm:
-
-```sh
-npm install --save-dev @babel/preset-stage-0
+```json
+{
+  "presets": [
+    [
+      "@babel/preset-stage-1", { 
+        "loose": false,
+        "useBuiltIns": false,
+        "decoratorsLegacy": true,
+        "pipelineProposal": "minimal"
+      }
+    ]
+  ],
+  "plugins": ["@babel/plugin-proposal-function-bind"]
+}
 ```
 
-or using yarn:
-
-```sh
-yarn add @babel/preset-stage-0 --dev
-```
+This will be the last publish of "@babel/preset-stage-0", and it won't be
+in the final release.
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.

--- a/packages/babel-preset-stage-0/README.md
+++ b/packages/babel-preset-stage-0/README.md
@@ -1,15 +1,17 @@
 # @babel/preset-stage-0
 
-As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.52, we've decided to remove
 the official Babel Stage presets. You can find more information
-at issue #7770: https://github.com/babel/babel/issues/7770, but
+at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
 that they didn't intend to.
-If you want the same configuration as before, you can use this configuration,
-although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
+
+---
+
+If you want the same configuration as before, you can use this configuration, although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
 
 ```json
 {
@@ -24,6 +26,45 @@ although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
     ]
   ],
   "plugins": ["@babel/plugin-proposal-function-bind"]
+}
+```
+
+And without reference to any Stage preset:
+
+```json
+{
+  "plugins": [
+    // Stage 0
+    "@babel/plugin-proposal-function-bind",
+
+    // Stage 1
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
+    "@babel/plugin-proposal-do-expressions",
+
+    // Stage 2
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+
+    // Stage 3
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-async-generator-functions",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings",
+    ["@babel/plugin-proposal-object-rest-spread", {
+      "loose": false,
+      "useBuiltIns": false
+    }],
+    "@babel/plugin-proposal-optional-catch-binding",
+    "@babel/plugin-proposal-unicode-property-regex",
+  ]
 }
 ```
 

--- a/packages/babel-preset-stage-0/README.md
+++ b/packages/babel-preset-stage-0/README.md
@@ -55,15 +55,8 @@ And without reference to any Stage preset:
     // Stage 3
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-async-generator-functions",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
-    "@babel/plugin-proposal-json-strings",
-    ["@babel/plugin-proposal-object-rest-spread", {
-      "loose": false,
-      "useBuiltIns": false
-    }],
-    "@babel/plugin-proposal-optional-catch-binding",
-    "@babel/plugin-proposal-unicode-property-regex",
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 ```

--- a/packages/babel-preset-stage-0/README.md
+++ b/packages/babel-preset-stage-0/README.md
@@ -1,6 +1,6 @@
 # @babel/preset-stage-0
 
-> As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
@@ -44,15 +44,21 @@ If you want the same configuration as before:
 }
 ```
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 ```js
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
 ```

--- a/packages/babel-preset-stage-0/README.md
+++ b/packages/babel-preset-stage-0/README.md
@@ -7,29 +7,12 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-0"
 
 ---
 
-If you want the same configuration as before, you can use this configuration, although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
-
-```json
-{
-  "presets": [
-    [
-      "@babel/preset-stage-1", { 
-        "loose": false,
-        "useBuiltIns": false,
-        "decoratorsLegacy": true,
-        "pipelineProposal": "minimal"
-      }
-    ]
-  ],
-  "plugins": ["@babel/plugin-proposal-function-bind"]
-}
-```
-
-And without reference to any Stage preset:
+If you want the same configuration as before:
 
 ```json
 {
@@ -61,7 +44,15 @@ And without reference to any Stage preset:
 }
 ```
 
-This will be the last publish of "@babel/preset-stage-0", and it won't be
-in the final release.
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+
+```js
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
+```

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -6,16 +6,5 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-0",
-  "main": "lib/index.js",
-  "dependencies": {
-    "@babel/helper-plugin-utils": "7.0.0-beta.54",
-    "@babel/plugin-proposal-function-bind": "7.0.0-beta.54",
-    "@babel/preset-stage-1": "7.0.0-beta.54"
-  },
-  "peerDependencies": {
-    "@babel/core": ">=7.0.0-beta.50 <7.0.0-rc.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.0.0-beta.54"
-  }
+  "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -1,39 +1,31 @@
-import { declare } from "@babel/helper-plugin-utils";
-import presetStage1 from "@babel/preset-stage-1";
+export default function() {
+  throw new Error(`
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-import transformFunctionBind from "@babel/plugin-proposal-function-bind";
+If you want the same configuration as before, you can use this configuration,
+although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
 
-export default declare((api, opts = {}) => {
-  api.assertVersion(7);
-
-  const {
-    loose = false,
-    useBuiltIns = false,
-    decoratorsLegacy = true,
-    pipelineProposal = "minimal",
-  } = opts;
-
-  if (typeof loose !== "boolean") {
-    throw new Error("@babel/preset-stage-0 'loose' option must be a boolean.");
-  }
-  if (typeof useBuiltIns !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-0 'useBuiltIns' option must be a boolean.",
-    );
-  }
-  if (typeof decoratorsLegacy !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-0 'decoratorsLegacy' option must be a boolean.",
-    );
-  }
-
-  return {
-    presets: [
-      [
-        presetStage1,
-        { loose, useBuiltIns, decoratorsLegacy, pipelineProposal },
-      ],
+{
+  presets: [
+    [
+      "@babel/preset-stage-1",
+      { loose, useBuiltIns, decoratorsLegacy, pipelineProposal },
     ],
-    plugins: [transformFunctionBind],
-  };
-});
+  ],
+  plugins: ["@babel/plugin-proposal-function-bind"],
+}
+
+This will be the last publish of "@babel/preset-stage-0", and it won't be
+in the final release.
+
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.
+  `);
+}

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -1,6 +1,6 @@
 export default function() {
   throw new Error(`
-As of v7.0.0-beta.52, we've decided to remove
+As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue #7770: https://github.com/babel/babel/issues/7770, but
 the TL;DR is that it's causing more harm than convenience in that
@@ -40,14 +40,20 @@ If you want the same configuration as before:
   ]
 }
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
   `);

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -13,13 +13,17 @@ If you want the same configuration as before, you can use this configuration,
 although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
 
 {
-  presets: [
+  "presets": [
     [
-      "@babel/preset-stage-1",
-      { loose, useBuiltIns, decoratorsLegacy, pipelineProposal },
-    ],
+      "@babel/preset-stage-1", { 
+        "loose": false,
+        "useBuiltIns": false,
+        "decoratorsLegacy": true,
+        "pipelineProposal": "minimal"
+      }
+    ]
   ],
-  plugins: ["@babel/plugin-proposal-function-bind"],
+  "plugins": ["@babel/plugin-proposal-function-bind"]
 }
 
 This will be the last publish of "@babel/preset-stage-0", and it won't be

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -7,29 +7,48 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-0"
 
-If you want the same configuration as before, you can use this configuration,
-although keep in mind that Stage 0 contains Stage 1 which is also deprecated.
+If you want the same configuration as before:
 
 {
-  "presets": [
-    [
-      "@babel/preset-stage-1", { 
-        "loose": false,
-        "useBuiltIns": false,
-        "decoratorsLegacy": true,
-        "pipelineProposal": "minimal"
-      }
-    ]
-  ],
-  "plugins": ["@babel/plugin-proposal-function-bind"]
+  "plugins": [
+    // Stage 0
+    "@babel/plugin-proposal-function-bind",
+
+    // Stage 1
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
+    "@babel/plugin-proposal-do-expressions",
+
+    // Stage 2
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+
+    // Stage 3
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings"
+  ]
 }
 
-This will be the last publish of "@babel/preset-stage-0", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
   `);
 }

--- a/packages/babel-preset-stage-1/README.md
+++ b/packages/babel-preset-stage-1/README.md
@@ -7,35 +7,12 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-1"
 
 ---
 
-
-If you want the same configuration as before, you can use this configuration,
-although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
-
-```json
-{
-  "presets": [
-    ["@babel/preset-stage-2", {
-      "loose": false,
-      "useBuiltIns": false,
-      "decoratorsLegacy": true
-    }]
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-proposal-logical-assignment-operators",
-    ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
-    ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
-    "@babel/plugin-proposal-do-expressions"
-  ]
-}
-```
-
-And without reference to any Stage preset:
+If you want the same configuration as before:
 
 ```json
 {
@@ -64,9 +41,15 @@ And without reference to any Stage preset:
 }
 ```
 
-This will be the last publish of "@babel/preset-stage-1", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
-
+```js
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
+```

--- a/packages/babel-preset-stage-1/README.md
+++ b/packages/babel-preset-stage-1/README.md
@@ -1,19 +1,40 @@
 # @babel/preset-stage-1
 
-> Babel preset for stage 1 plugins
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-See our website [@babel/preset-stage-1](https://babeljs.io/docs/en/next/babel-preset-stage-1.html) for more information.
+If you want the same configuration as before, you can use this configuration,
+although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
 
-## Install
-
-Using npm:
-
-```sh
-npm install --save-dev @babel/preset-stage-1
+```json
+{
+  "presets": [
+    ["@babel/preset-stage-2", {
+      "loose": false,
+      "useBuiltIns": false,
+      "decoratorsLegacy": true
+    }]
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
+    "@babel/plugin-proposal-do-expressions"
+  ]
+}
 ```
 
-or using yarn:
+This will be the last publish of "@babel/preset-stage-1", and it won't be
+in the final release.
 
-```sh
-yarn add @babel/preset-stage-1 --dev
-```
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.
+

--- a/packages/babel-preset-stage-1/README.md
+++ b/packages/babel-preset-stage-1/README.md
@@ -1,6 +1,6 @@
 # @babel/preset-stage-1
 
-> As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
@@ -41,15 +41,21 @@ If you want the same configuration as before:
 }
 ```
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 ```js
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
 ```

--- a/packages/babel-preset-stage-1/README.md
+++ b/packages/babel-preset-stage-1/README.md
@@ -1,13 +1,16 @@
 # @babel/preset-stage-1
 
-As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.52, we've decided to remove
 the official Babel Stage presets. You can find more information
-at issue #7770: https://github.com/babel/babel/issues/7770, but
+at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
 that they didn't intend to.
+
+---
+
 
 If you want the same configuration as before, you can use this configuration,
 although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
@@ -28,6 +31,42 @@ although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
     ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
     ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
     "@babel/plugin-proposal-do-expressions"
+  ]
+}
+```
+
+And without reference to any Stage preset:
+
+```json
+{
+  "plugins": [
+    // Stage 1
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
+    "@babel/plugin-proposal-do-expressions",
+
+    // Stage 2
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+
+    // Stage 3
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-async-generator-functions",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings",
+    ["@babel/plugin-proposal-object-rest-spread", {
+      "loose": false,
+      "useBuiltIns": false
+    }],
+    "@babel/plugin-proposal-optional-catch-binding",
+    "@babel/plugin-proposal-unicode-property-regex",
   ]
 }
 ```

--- a/packages/babel-preset-stage-1/README.md
+++ b/packages/babel-preset-stage-1/README.md
@@ -58,15 +58,8 @@ And without reference to any Stage preset:
     // Stage 3
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-async-generator-functions",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
-    "@babel/plugin-proposal-json-strings",
-    ["@babel/plugin-proposal-object-rest-spread", {
-      "loose": false,
-      "useBuiltIns": false
-    }],
-    "@babel/plugin-proposal-optional-catch-binding",
-    "@babel/plugin-proposal-unicode-property-regex",
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 ```

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -6,21 +6,5 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
-  "main": "lib/index.js",
-  "dependencies": {
-    "@babel/helper-plugin-utils": "7.0.0-beta.54",
-    "@babel/plugin-proposal-do-expressions": "7.0.0-beta.54",
-    "@babel/plugin-proposal-export-default-from": "7.0.0-beta.54",
-    "@babel/plugin-proposal-logical-assignment-operators": "7.0.0-beta.54",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "7.0.0-beta.54",
-    "@babel/plugin-proposal-optional-chaining": "7.0.0-beta.54",
-    "@babel/plugin-proposal-pipeline-operator": "7.0.0-beta.54",
-    "@babel/preset-stage-2": "7.0.0-beta.54"
-  },
-  "peerDependencies": {
-    "@babel/core": ">=7.0.0-beta.50 <7.0.0-rc.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.0.0-beta.54"
-  }
+  "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -1,6 +1,6 @@
 export default function() {
   throw new Error(`
-As of v7.0.0-beta.52, we've decided to remove
+As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue #7770: https://github.com/babel/babel/issues/7770, but
 the TL;DR is that it's causing more harm than convenience in that
@@ -37,14 +37,20 @@ If you want the same configuration as before:
   ]
 }
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
 `);

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -13,16 +13,20 @@ If you want the same configuration as before, you can use this configuration,
 although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
 
 {
-  presets: [
-    ["@babel/preset-stage-2", { loose, useBuiltIns, decoratorsLegacy }]
+  "presets": [
+    ["@babel/preset-stage-2", {
+      "loose": false,
+      "useBuiltIns": false,
+      "decoratorsLegacy": true
+    }]
   ],
-  plugins: [
+  "plugins": [
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-logical-assignment-operators",
-    ["@babel/plugin-proposal-optional-chaining", { loose }],
-    ["@babel/plugin-proposal-pipeline-operator", { proposal: pipelineProposal }],
-    ["@babel/plugin-proposal-nullish-coalescing-operator", { loose }],
-    "@babel/plugin-proposal-do-expressions",
+    ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
+    "@babel/plugin-proposal-do-expressions"
   ]
 }
 

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -1,46 +1,35 @@
-import { declare } from "@babel/helper-plugin-utils";
-import presetStage2 from "@babel/preset-stage-2";
+export default function() {
+  throw new Error(`
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-import transformExportDefaultFrom from "@babel/plugin-proposal-export-default-from";
-import transformLogicalAssignmentOperators from "@babel/plugin-proposal-logical-assignment-operators";
-import transformOptionalChaining from "@babel/plugin-proposal-optional-chaining";
-import transformPipelineOperator from "@babel/plugin-proposal-pipeline-operator";
-import transformNullishCoalescingOperator from "@babel/plugin-proposal-nullish-coalescing-operator";
-import transformDoExpressions from "@babel/plugin-proposal-do-expressions";
+If you want the same configuration as before, you can use this configuration,
+although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
 
-export default declare((api, opts = {}) => {
-  api.assertVersion(7);
+{
+  presets: [
+    ["@babel/preset-stage-2", { loose, useBuiltIns, decoratorsLegacy }]
+  ],
+  plugins: [
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    ["@babel/plugin-proposal-optional-chaining", { loose }],
+    ["@babel/plugin-proposal-pipeline-operator", { proposal: pipelineProposal }],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { loose }],
+    "@babel/plugin-proposal-do-expressions",
+  ]
+}
 
-  const {
-    loose = false,
-    useBuiltIns = false,
-    decoratorsLegacy = true,
-    pipelineProposal = "minimal",
-  } = opts;
+This will be the last publish of "@babel/preset-stage-1", and it won't be
+in the final release.
 
-  if (typeof loose !== "boolean") {
-    throw new Error("@babel/preset-stage-1 'loose' option must be a boolean.");
-  }
-  if (typeof useBuiltIns !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-1 'useBuiltIns' option must be a boolean.",
-    );
-  }
-  if (typeof decoratorsLegacy !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-1 'decoratorsLegacy' option must be a boolean.",
-    );
-  }
-
-  return {
-    presets: [[presetStage2, { loose, useBuiltIns, decoratorsLegacy }]],
-    plugins: [
-      transformExportDefaultFrom,
-      transformLogicalAssignmentOperators,
-      [transformOptionalChaining, { loose }],
-      [transformPipelineOperator, { proposal: pipelineProposal }],
-      [transformNullishCoalescingOperator, { loose }],
-      transformDoExpressions,
-    ],
-  };
-});
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.
+`);
+}

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -7,33 +7,45 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-1"
 
-If you want the same configuration as before, you can use this configuration,
-although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
+If you want the same configuration as before:
 
 {
-  "presets": [
-    ["@babel/preset-stage-2", {
-      "loose": false,
-      "useBuiltIns": false,
-      "decoratorsLegacy": true
-    }]
-  ],
   "plugins": [
+    // Stage 1
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-logical-assignment-operators",
     ["@babel/plugin-proposal-optional-chaining", { "loose": false }],
     ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
     ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
-    "@babel/plugin-proposal-do-expressions"
+    "@babel/plugin-proposal-do-expressions",
+
+    // Stage 2
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+
+    // Stage 3
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 
-This will be the last publish of "@babel/preset-stage-1", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
 `);
 }

--- a/packages/babel-preset-stage-2/README.md
+++ b/packages/babel-preset-stage-2/README.md
@@ -7,32 +7,12 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-2"
 
 ---
 
-If you want the same configuration as before, you can use this configuration,
-although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
-
-```json
-{
-  "presets": [
-    ["@babel/preset-stage-3", {
-    "loose": false,
-      "useBuiltIns": false
-    }]
-  ],
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    "@babel/plugin-proposal-function-sent",
-    "@babel/plugin-proposal-export-namespace-from",
-    "@babel/plugin-proposal-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions"
-  ]
-}
-```
-
-And without reference to any Stage preset:
+If you want the same configuration as before:
 
 ```json
 {
@@ -53,8 +33,15 @@ And without reference to any Stage preset:
 }
 ```
 
-This will be the last publish of "@babel/preset-stage-2", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+```js
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
+

--- a/packages/babel-preset-stage-2/README.md
+++ b/packages/babel-preset-stage-2/README.md
@@ -1,19 +1,37 @@
 # @babel/preset-stage-2
 
-> Babel preset for stage 2 plugins
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-See our website [@babel/preset-stage-2](https://babeljs.io/docs/en/next/babel-preset-stage-2.html) for more information.
+If you want the same configuration as before, you can use this configuration,
+although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
 
-## Install
-
-Using npm:
-
-```sh
-npm install --save-dev @babel/preset-stage-2
+```json
+{
+  "presets": [
+    ["@babel/preset-stage-3", {
+    "loose": false,
+      "useBuiltIns": false
+    }]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions"
+  ]
+}
 ```
 
-or using yarn:
+This will be the last publish of "@babel/preset-stage-2", and it won't be
+in the final release.
 
-```sh
-yarn add @babel/preset-stage-2 --dev
-```
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.

--- a/packages/babel-preset-stage-2/README.md
+++ b/packages/babel-preset-stage-2/README.md
@@ -1,6 +1,6 @@
 # @babel/preset-stage-2
 
-> As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
@@ -33,15 +33,21 @@ If you want the same configuration as before:
 }
 ```
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 ```js
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
-
+```

--- a/packages/babel-preset-stage-2/README.md
+++ b/packages/babel-preset-stage-2/README.md
@@ -1,13 +1,15 @@
 # @babel/preset-stage-2
 
-As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.52, we've decided to remove
 the official Babel Stage presets. You can find more information
-at issue #7770: https://github.com/babel/babel/issues/7770, but
+at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
 that they didn't intend to.
+
+---
 
 If you want the same configuration as before, you can use this configuration,
 although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
@@ -26,6 +28,34 @@ although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-numeric-separator",
     "@babel/plugin-proposal-throw-expressions"
+  ]
+}
+```
+
+And without reference to any Stage preset:
+
+```json
+{
+  "plugins": [
+    // Stage 2
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+
+    // Stage 3
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-async-generator-functions",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings",
+    ["@babel/plugin-proposal-object-rest-spread", {
+      "loose": false,
+      "useBuiltIns": false
+    }],
+    "@babel/plugin-proposal-optional-catch-binding",
+    "@babel/plugin-proposal-unicode-property-regex",
   ]
 }
 ```

--- a/packages/babel-preset-stage-2/README.md
+++ b/packages/babel-preset-stage-2/README.md
@@ -47,15 +47,8 @@ And without reference to any Stage preset:
     // Stage 3
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-async-generator-functions",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
-    "@babel/plugin-proposal-json-strings",
-    ["@babel/plugin-proposal-object-rest-spread", {
-      "loose": false,
-      "useBuiltIns": false
-    }],
-    "@babel/plugin-proposal-optional-catch-binding",
-    "@babel/plugin-proposal-unicode-property-regex",
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 ```

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -6,20 +6,5 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
-  "main": "lib/index.js",
-  "dependencies": {
-    "@babel/helper-plugin-utils": "7.0.0-beta.54",
-    "@babel/plugin-proposal-decorators": "7.0.0-beta.54",
-    "@babel/plugin-proposal-export-namespace-from": "7.0.0-beta.54",
-    "@babel/plugin-proposal-function-sent": "7.0.0-beta.54",
-    "@babel/plugin-proposal-numeric-separator": "7.0.0-beta.54",
-    "@babel/plugin-proposal-throw-expressions": "7.0.0-beta.54",
-    "@babel/preset-stage-3": "7.0.0-beta.54"
-  },
-  "peerDependencies": {
-    "@babel/core": ">=7.0.0-beta.50 <7.0.0-rc.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.0.0-beta.54"
-  }
+  "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -13,13 +13,18 @@ If you want the same configuration as before, you can use this configuration,
 although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
 
 {
-  presets: [["@babel/preset-stage-3", { loose, useBuiltIns }]],
-  plugins: [
-   ["@babel/plugin-proposal-decorators", { legacy: decoratorsLegacy }],
+  "presets": [
+    ["@babel/preset-stage-3", {
+    "loose": false,
+      "useBuiltIns": false
+    }]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions",
+    "@babel/plugin-proposal-throw-expressions"
   ]
 }
 

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -7,31 +7,37 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-2"
 
-If you want the same configuration as before, you can use this configuration,
-although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
+If you want the same configuration as before:
 
 {
-  "presets": [
-    ["@babel/preset-stage-3", {
-    "loose": false,
-      "useBuiltIns": false
-    }]
-  ],
   "plugins": [
+    // Stage 2
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions"
+    "@babel/plugin-proposal-throw-expressions",
+
+    // Stage 3
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 
-This will be the last publish of "@babel/preset-stage-2", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
 `);
 }

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -1,6 +1,6 @@
 export default function() {
   throw new Error(`
-As of v7.0.0-beta.52, we've decided to remove
+As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue #7770: https://github.com/babel/babel/issues/7770, but
 the TL;DR is that it's causing more harm than convenience in that
@@ -29,14 +29,20 @@ If you want the same configuration as before:
   ]
 }
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
 `);

--- a/packages/babel-preset-stage-2/src/index.js
+++ b/packages/babel-preset-stage-2/src/index.js
@@ -1,39 +1,32 @@
-import { declare } from "@babel/helper-plugin-utils";
-import presetStage3 from "@babel/preset-stage-3";
+export default function() {
+  throw new Error(`
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-import transformDecorators from "@babel/plugin-proposal-decorators";
-import transformFunctionSent from "@babel/plugin-proposal-function-sent";
-import transformExportNamespaceFrom from "@babel/plugin-proposal-export-namespace-from";
-import transformNumericSeparator from "@babel/plugin-proposal-numeric-separator";
-import transformThrowExpressions from "@babel/plugin-proposal-throw-expressions";
+If you want the same configuration as before, you can use this configuration,
+although keep in mind that Stage 1 contains Stage 2 which is also deprecated.
 
-export default declare((api, opts = {}) => {
-  api.assertVersion(7);
+{
+  presets: [["@babel/preset-stage-3", { loose, useBuiltIns }]],
+  plugins: [
+   ["@babel/plugin-proposal-decorators", { legacy: decoratorsLegacy }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+  ]
+}
 
-  const { loose = false, useBuiltIns = false, decoratorsLegacy = true } = opts;
+This will be the last publish of "@babel/preset-stage-2", and it won't be
+in the final release.
 
-  if (typeof loose !== "boolean") {
-    throw new Error("@babel/preset-stage-2 'loose' option must be a boolean.");
-  }
-  if (typeof useBuiltIns !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-2 'useBuiltIns' option must be a boolean.",
-    );
-  }
-  if (typeof decoratorsLegacy !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-2 'decoratorsLegacy' option must be a boolean.",
-    );
-  }
-
-  return {
-    presets: [[presetStage3, { loose, useBuiltIns }]],
-    plugins: [
-      [transformDecorators, { legacy: decoratorsLegacy }],
-      transformFunctionSent,
-      transformExportNamespaceFrom,
-      transformNumericSeparator,
-      transformThrowExpressions,
-    ],
-  };
-});
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.
+`);
+}

--- a/packages/babel-preset-stage-3/README.md
+++ b/packages/babel-preset-stage-3/README.md
@@ -1,19 +1,36 @@
 # @babel/preset-stage-3
 
-> Babel preset for stage 3 plugins
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-See our website [@babel/preset-stage-3](https://babeljs.io/docs/en/next/babel-preset-stage-3.html) for more information.
+If you want the same configuration as before, you can use this configuration.
 
-## Install
-
-Using npm:
-
-```sh
-npm install --save-dev @babel/preset-stage-3
+```json
+{
+  "plugins": [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-async-generator-functions",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
+    "@babel/plugin-proposal-json-strings",
+    ["@babel/plugin-proposal-object-rest-spread", {
+      "loose": false,
+      "useBuiltIns": false
+    }],
+    "@babel/plugin-proposal-optional-catch-binding",
+    "@babel/plugin-proposal-unicode-property-regex",
+  ]
+}
 ```
 
-or using yarn:
+This will be the last publish of "@babel/preset-stage-3", and it won't be
+in the final release.
 
-```sh
-yarn add @babel/preset-stage-3 --dev
-```
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.

--- a/packages/babel-preset-stage-3/README.md
+++ b/packages/babel-preset-stage-3/README.md
@@ -7,11 +7,12 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-3"
 
 ---
 
-If you want the same configuration as before, you can use this configuration.
+If you want the same configuration as before:
 
 ```json
 {
@@ -24,8 +25,13 @@ If you want the same configuration as before, you can use this configuration.
 }
 ```
 
-This will be the last publish of "@babel/preset-stage-3", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};

--- a/packages/babel-preset-stage-3/README.md
+++ b/packages/babel-preset-stage-3/README.md
@@ -1,13 +1,15 @@
 # @babel/preset-stage-3
 
-As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.52, we've decided to remove
 the official Babel Stage presets. You can find more information
-at issue #7770: https://github.com/babel/babel/issues/7770, but
+at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
 that they didn't intend to.
+
+---
 
 If you want the same configuration as before, you can use this configuration.
 

--- a/packages/babel-preset-stage-3/README.md
+++ b/packages/babel-preset-stage-3/README.md
@@ -18,15 +18,8 @@ If you want the same configuration as before, you can use this configuration.
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-async-generator-functions",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
-    "@babel/plugin-proposal-json-strings",
-    ["@babel/plugin-proposal-object-rest-spread", {
-      "loose": false,
-      "useBuiltIns": false
-    }],
-    "@babel/plugin-proposal-optional-catch-binding",
-    "@babel/plugin-proposal-unicode-property-regex",
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 ```

--- a/packages/babel-preset-stage-3/README.md
+++ b/packages/babel-preset-stage-3/README.md
@@ -1,6 +1,6 @@
 # @babel/preset-stage-3
 
-> As of v7.0.0-beta.52, we've decided to remove
+> As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue [#7770](https://github.com/babel/babel/issues/7770), but
 the TL;DR is that it's causing more harm than convenience in that
@@ -25,13 +25,21 @@ If you want the same configuration as before:
 }
 ```
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
+```js
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
+```

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -6,22 +6,5 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-3",
-  "main": "lib/index.js",
-  "dependencies": {
-    "@babel/helper-plugin-utils": "7.0.0-beta.54",
-    "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.54",
-    "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
-    "@babel/plugin-proposal-json-strings": "7.0.0-beta.54",
-    "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.54",
-    "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.54",
-    "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.54",
-    "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.54",
-    "@babel/plugin-syntax-import-meta": "7.0.0-beta.54"
-  },
-  "peerDependencies": {
-    "@babel/core": ">=7.0.0-beta.50 <7.0.0-rc.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.0.0-beta.54"
-  }
+  "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -7,9 +7,10 @@ the TL;DR is that it's causing more harm than convenience in that
 the preset is always out of date, each change is usually going to
 require a major version bump and thus people will be behind,
 and it encouraged too many people to opt-in to too many proposals
-that they didn't intend to.
+that they didn't intend to. This is intended to be the last publish
+of "@babel/preset-stage-3"
 
-If you want the same configuration as before, you can use this configuration.
+If you want the same configuration as before:
 
 {
   "plugins": [
@@ -20,10 +21,15 @@ If you want the same configuration as before, you can use this configuration.
   ]
 }
 
-This will be the last publish of "@babel/preset-stage-3", and it won't be
-in the final release.
+We recommend that make your own presets to use across projects for
+reusability. This can be as simple as exporting a function that returns your config/array of plugins.
 
-If it's a hassle to maintain, you can certainly make your own preset to use
-across projects, or there might be one in the community to use.
+module.exports = function() {
+  return {
+    plugins: [
+      // ...
+    ]
+  };
+};
 `);
 }

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -15,15 +15,8 @@ If you want the same configuration as before, you can use this configuration.
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-async-generator-functions",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
-    "@babel/plugin-proposal-json-strings",
-    ["@babel/plugin-proposal-object-rest-spread", {
-      "loose": false,
-      "useBuiltIns": false
-    }],
-    "@babel/plugin-proposal-optional-catch-binding",
-    "@babel/plugin-proposal-unicode-property-regex",
+    "@babel/plugin-proposal-json-strings"
   ]
 }
 

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -1,43 +1,33 @@
-import { declare } from "@babel/helper-plugin-utils";
-import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
-import syntaxImportMeta from "@babel/plugin-syntax-import-meta";
-import transformAsyncGeneratorFunctions from "@babel/plugin-proposal-async-generator-functions";
-import transformClassProperties from "@babel/plugin-proposal-class-properties";
-import transformJsonStrings from "@babel/plugin-proposal-json-strings";
-import transformObjectRestSpread from "@babel/plugin-proposal-object-rest-spread";
-import transformOptionalCatchBinding from "@babel/plugin-proposal-optional-catch-binding";
-import transformUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
+export default function() {
+  throw new Error(`
+As of v7.0.0-beta.52, we've decided to remove
+the official Babel Stage presets. You can find more information
+at issue #7770: https://github.com/babel/babel/issues/7770, but
+the TL;DR is that it's causing more harm than convenience in that
+the preset is always out of date, each change is usually going to
+require a major version bump and thus people will be behind,
+and it encouraged too many people to opt-in to too many proposals
+that they didn't intend to.
 
-export default declare((api, opts) => {
-  api.assertVersion(7);
+If you want the same configuration as before, you can use this configuration.
 
-  let loose = false;
-  let useBuiltIns = false;
+{
+  plugins: [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-async-generator-functions",
+    ["@babel/plugin-proposal-class-properties", { loose }],
+    "@babel/plugin-proposal-json-strings",
+    ["@babel/plugin-proposal-object-rest-spread", { loose, useBuiltIns }],
+    "@babel/plugin-proposal-optional-catch-binding",
+    "@babel/plugin-proposal-unicode-property-regex",
+  ]
+}
 
-  if (opts !== undefined) {
-    if (opts.loose !== undefined) loose = opts.loose;
-    if (opts.useBuiltIns !== undefined) useBuiltIns = opts.useBuiltIns;
-  }
+This will be the last publish of "@babel/preset-stage-3", and it won't be
+in the final release.
 
-  if (typeof loose !== "boolean") {
-    throw new Error("@babel/preset-stage-3 'loose' option must be a boolean.");
-  }
-  if (typeof useBuiltIns !== "boolean") {
-    throw new Error(
-      "@babel/preset-stage-3 'useBuiltIns' option must be a boolean.",
-    );
-  }
-
-  return {
-    plugins: [
-      syntaxDynamicImport,
-      syntaxImportMeta,
-      transformAsyncGeneratorFunctions,
-      [transformClassProperties, { loose }],
-      transformJsonStrings,
-      [transformObjectRestSpread, { loose, useBuiltIns }],
-      transformOptionalCatchBinding,
-      transformUnicodePropertyRegex,
-    ],
-  };
-});
+If it's a hassle to maintain, you can certainly make your own preset to use
+across projects, or there might be one in the community to use.
+`);
+}

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -12,13 +12,16 @@ that they didn't intend to.
 If you want the same configuration as before, you can use this configuration.
 
 {
-  plugins: [
+  "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
     "@babel/plugin-proposal-async-generator-functions",
-    ["@babel/plugin-proposal-class-properties", { loose }],
+    ["@babel/plugin-proposal-class-properties", { "loose": false }],
     "@babel/plugin-proposal-json-strings",
-    ["@babel/plugin-proposal-object-rest-spread", { loose, useBuiltIns }],
+    ["@babel/plugin-proposal-object-rest-spread", {
+      "loose": false,
+      "useBuiltIns": false
+    }],
     "@babel/plugin-proposal-optional-catch-binding",
     "@babel/plugin-proposal-unicode-property-regex",
   ]

--- a/packages/babel-preset-stage-3/src/index.js
+++ b/packages/babel-preset-stage-3/src/index.js
@@ -1,6 +1,6 @@
 export default function() {
   throw new Error(`
-As of v7.0.0-beta.52, we've decided to remove
+As of v7.0.0-beta.54, we've decided to remove
 the official Babel Stage presets. You can find more information
 at issue #7770: https://github.com/babel/babel/issues/7770, but
 the TL;DR is that it's causing more harm than convenience in that
@@ -21,14 +21,21 @@ If you want the same configuration as before:
   ]
 }
 
-We recommend that make your own presets to use across projects for
-reusability. This can be as simple as exporting a function that returns your config/array of plugins.
+
+If you're using the same configuration across many separate projects,
+keep in mind that you can also create your own custom presets with
+whichever plugins and presets you're looking to use.
 
 module.exports = function() {
   return {
     plugins: [
+      require("@babel/plugin-syntax-dynamic-import"),
+      [require("@babel/plugin-proposal-decorators"), { "legacy": true }],
+      [require("@babel/plugin-proposal-class-properties"), { "loose": false }],
+    ],
+    presets: [
       // ...
-    ]
+    ],
   };
 };
 `);

--- a/packages/babel-standalone/src/index.js
+++ b/packages/babel-standalone/src/index.js
@@ -233,10 +233,10 @@ registerPresets({
     };
   },
   react: require("@babel/preset-react"),
-  "stage-0": require("@babel/preset-stage-0"),
-  "stage-1": require("@babel/preset-stage-1"),
-  "stage-2": require("@babel/preset-stage-2"),
-  "stage-3": require("@babel/preset-stage-3"),
+  "stage-0": require("./preset-stage-0"),
+  "stage-1": require("./preset-stage-1"),
+  "stage-2": require("./preset-stage-2"),
+  "stage-3": require("./preset-stage-3"),
   "es2015-loose": {
     presets: [[require("./preset-es2015"), { loose: true }]],
   },

--- a/packages/babel-standalone/src/preset-es2015.js
+++ b/packages/babel-standalone/src/preset-es2015.js
@@ -24,7 +24,6 @@ import transformES2015Instanceof from "@babel/plugin-transform-instanceof";
 import transformRegenerator from "@babel/plugin-transform-regenerator";
 
 export default (_, opts) => {
-  const moduleTypes = ["commonjs", "cjs", "amd", "umd", "systemjs"];
   let loose = false;
   let modules = "commonjs";
   let spec = false;
@@ -33,19 +32,6 @@ export default (_, opts) => {
     if (opts.loose !== undefined) loose = opts.loose;
     if (opts.modules !== undefined) modules = opts.modules;
     if (opts.spec !== undefined) spec = opts.spec;
-  }
-
-  if (typeof loose !== "boolean") {
-    throw new Error("Preset es2015 'loose' option must be a boolean.");
-  }
-  if (typeof spec !== "boolean") {
-    throw new Error("Preset es2015 'spec' option must be a boolean.");
-  }
-  if (modules !== false && moduleTypes.indexOf(modules) === -1) {
-    throw new Error(
-      "Preset es2015 'modules' option must be 'false' to indicate no modules\n" +
-        "or a module type which be be one of: 'commonjs' (default), 'amd', 'umd', 'systemjs'",
-    );
   }
 
   // be DRY

--- a/packages/babel-standalone/src/preset-stage-0.js
+++ b/packages/babel-standalone/src/preset-stage-0.js
@@ -7,7 +7,7 @@ export default (_, opts = {}) => {
     loose = false,
     useBuiltIns = false,
     decoratorsLegacy = false,
-    pipelineProposal,
+    pipelineProposal = "minimal",
   } = opts;
 
   return {

--- a/packages/babel-standalone/src/preset-stage-0.js
+++ b/packages/babel-standalone/src/preset-stage-0.js
@@ -1,0 +1,22 @@
+import presetStage1 from "./preset-stage-1";
+
+import transformFunctionBind from "@babel/plugin-proposal-function-bind";
+
+export default (_, opts = {}) => {
+  const {
+    loose = false,
+    useBuiltIns = false,
+    decoratorsLegacy = false,
+    pipelineProposal,
+  } = opts;
+
+  return {
+    presets: [
+      [
+        presetStage1,
+        { loose, useBuiltIns, decoratorsLegacy, pipelineProposal },
+      ],
+    ],
+    plugins: [transformFunctionBind],
+  };
+};

--- a/packages/babel-standalone/src/preset-stage-1.js
+++ b/packages/babel-standalone/src/preset-stage-1.js
@@ -12,7 +12,7 @@ export default (_, opts = {}) => {
     loose = false,
     useBuiltIns = false,
     decoratorsLegacy = false,
-    pipelineProposal,
+    pipelineProposal = "minimal",
   } = opts;
 
   return {

--- a/packages/babel-standalone/src/preset-stage-1.js
+++ b/packages/babel-standalone/src/preset-stage-1.js
@@ -1,0 +1,29 @@
+import presetStage2 from "./preset-stage-2";
+
+import transformExportDefaultFrom from "@babel/plugin-proposal-export-default-from";
+import transformLogicalAssignmentOperators from "@babel/plugin-proposal-logical-assignment-operators";
+import transformOptionalChaining from "@babel/plugin-proposal-optional-chaining";
+import transformPipelineOperator from "@babel/plugin-proposal-pipeline-operator";
+import transformNullishCoalescingOperator from "@babel/plugin-proposal-nullish-coalescing-operator";
+import transformDoExpressions from "@babel/plugin-proposal-do-expressions";
+
+export default (_, opts = {}) => {
+  const {
+    loose = false,
+    useBuiltIns = false,
+    decoratorsLegacy = false,
+    pipelineProposal,
+  } = opts;
+
+  return {
+    presets: [[presetStage2, { loose, useBuiltIns, decoratorsLegacy }]],
+    plugins: [
+      transformExportDefaultFrom,
+      transformLogicalAssignmentOperators,
+      [transformOptionalChaining, { loose }],
+      [transformPipelineOperator, { proposal: pipelineProposal }],
+      [transformNullishCoalescingOperator, { loose }],
+      transformDoExpressions,
+    ],
+  };
+};

--- a/packages/babel-standalone/src/preset-stage-2.js
+++ b/packages/babel-standalone/src/preset-stage-2.js
@@ -1,0 +1,22 @@
+import presetStage3 from "./preset-stage-3";
+
+import transformDecorators from "@babel/plugin-proposal-decorators";
+import transformFunctionSent from "@babel/plugin-proposal-function-sent";
+import transformExportNamespaceFrom from "@babel/plugin-proposal-export-namespace-from";
+import transformNumericSeparator from "@babel/plugin-proposal-numeric-separator";
+import transformThrowExpressions from "@babel/plugin-proposal-throw-expressions";
+
+export default (_, opts = {}) => {
+  const { loose = false, useBuiltIns = false, decoratorsLegacy = false } = opts;
+
+  return {
+    presets: [[presetStage3, { loose, useBuiltIns }]],
+    plugins: [
+      [transformDecorators, { legacy: decoratorsLegacy }],
+      transformFunctionSent,
+      transformExportNamespaceFrom,
+      transformNumericSeparator,
+      transformThrowExpressions,
+    ],
+  };
+};

--- a/packages/babel-standalone/src/preset-stage-3.js
+++ b/packages/babel-standalone/src/preset-stage-3.js
@@ -1,31 +1,21 @@
 import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
 import syntaxImportMeta from "@babel/plugin-syntax-import-meta";
-import transformAsyncGeneratorFunctions from "@babel/plugin-proposal-async-generator-functions";
 import transformClassProperties from "@babel/plugin-proposal-class-properties";
 import transformJsonStrings from "@babel/plugin-proposal-json-strings";
-import transformObjectRestSpread from "@babel/plugin-proposal-object-rest-spread";
-import transformOptionalCatchBinding from "@babel/plugin-proposal-optional-catch-binding";
-import transformUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
 
 export default (_, opts) => {
   let loose = false;
-  let useBuiltIns = false;
 
   if (opts !== undefined) {
     if (opts.loose !== undefined) loose = opts.loose;
-    if (opts.useBuiltIns !== undefined) useBuiltIns = opts.useBuiltIns;
   }
 
   return {
     plugins: [
       syntaxDynamicImport,
       syntaxImportMeta,
-      transformAsyncGeneratorFunctions,
       [transformClassProperties, { loose }],
       transformJsonStrings,
-      [transformObjectRestSpread, { loose, useBuiltIns }],
-      transformOptionalCatchBinding,
-      transformUnicodePropertyRegex,
     ],
   };
 };

--- a/packages/babel-standalone/src/preset-stage-3.js
+++ b/packages/babel-standalone/src/preset-stage-3.js
@@ -1,0 +1,31 @@
+import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
+import syntaxImportMeta from "@babel/plugin-syntax-import-meta";
+import transformAsyncGeneratorFunctions from "@babel/plugin-proposal-async-generator-functions";
+import transformClassProperties from "@babel/plugin-proposal-class-properties";
+import transformJsonStrings from "@babel/plugin-proposal-json-strings";
+import transformObjectRestSpread from "@babel/plugin-proposal-object-rest-spread";
+import transformOptionalCatchBinding from "@babel/plugin-proposal-optional-catch-binding";
+import transformUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
+
+export default (_, opts) => {
+  let loose = false;
+  let useBuiltIns = false;
+
+  if (opts !== undefined) {
+    if (opts.loose !== undefined) loose = opts.loose;
+    if (opts.useBuiltIns !== undefined) useBuiltIns = opts.useBuiltIns;
+  }
+
+  return {
+    plugins: [
+      syntaxDynamicImport,
+      syntaxImportMeta,
+      transformAsyncGeneratorFunctions,
+      [transformClassProperties, { loose }],
+      transformJsonStrings,
+      [transformObjectRestSpread, { loose, useBuiltIns }],
+      transformOptionalCatchBinding,
+      transformUnicodePropertyRegex,
+    ],
+  };
+};

--- a/scripts/generators/readmes.js
+++ b/scripts/generators/readmes.js
@@ -84,4 +84,6 @@ packages
 
     // write
     writeFileSync(readmePath, readme);
+
+    console.log("OK", id);
   });

--- a/scripts/generators/readmes.js
+++ b/scripts/generators/readmes.js
@@ -66,6 +66,7 @@ yarn add ${name} --dev
 
 packages
   .filter(x => x !== "README.md") // ignore root readme
+  .filter(x => x.indexOf("babel-preset-stage-") === -1) // ignore stages
   .forEach(id => {
     const { name, description } = getPackageJson(id);
     const readmePath = join(packageDir, id, "README.md");
@@ -83,6 +84,4 @@ packages
 
     // write
     writeFileSync(readmePath, readme);
-
-    console.log("OK", id);
   });


### PR DESCRIPTION
Sad times 😭, but for the best? Fun because I added them back in originally 😛 

Fixes https://github.com/babel/babel/issues/7770

- [x] Deprecated use of these presets in the last release (beta.52), for an initial warning.
- [x] Throw error with the use in next beta, show the correct config to use otherwise. Optional: Add autofix with https://github.com/babel/babel-upgrade/issues/67
- [x] Update the readme to explain better.
- [x] copy old code to babel-archive: https://github.com/babel/babel-archive/commit/c36fc7ddade1b82c86dba900289c7656c3491c13
- [x] test the Stage options in the REPL works?
- Check the readme and src/index.js of the Stages https://github.com/babel/babel/blob/b2f42e8cb4889e6fbff97e12d3db3dd0be0bfbd5/packages/babel-preset-stage-0/README.md
- [ ] writing a post to explain the changes

We should prob make a better guide on making your own preset