### PR TITLE
Make env preset build-data scripts reproducible

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -60,8 +60,8 @@
     "@babel/core": "7.0.0-beta.52",
     "@babel/helper-fixtures": "7.0.0-beta.52",
     "@babel/helper-plugin-test-runner": "7.0.0-beta.52",
+    "caniuse-db": "1.0.30000851",
     "compat-table": "kangax/compat-table#90d02e486227d179d2ce9b850dbb3f9846443cab",
-    "electron-to-chromium": "^1.3.27",
-    "request": "^2.83.0"
+    "electron-to-chromium": "1.3.48"
   }
 }

--- a/packages/babel-preset-env/scripts/build-modules-support.js
+++ b/packages/babel-preset-env/scripts/build-modules-support.js
@@ -1,77 +1,37 @@
 const path = require("path");
 const fs = require("fs");
-const request = require("request");
 
-// This mapping represents browsers who have shipped ES Modules Support.
-// For more information, checkout the specifications:
-// * https://www.ecma-international.org/ecma-262/6.0/#sec-modules
-// * https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type
-const lastKnown = {
-  chrome: 61,
-  safari: 10.1,
-  ios_saf: 10.3,
-  edge: 16,
-};
+const moduleSupport = require("caniuse-db/features-json/es6-module.json");
 
 const acceptedWithCaveats = {
   safari: true,
   ios_saf: true,
 };
 
-function input() {
-  return new Promise(function(resolve, reject) {
-    request(
-      "https://raw.githubusercontent.com/Fyrd/caniuse/master/features-json/es6-module.json",
-      function(error, response, body) {
-        if (error || response.statusCode !== 200) {
-          return reject(
-            new Error(
-              `Error retrieving es6-module.json. ${
-                error ? error : `statusCode=${response.statusCode}`
-              }`
-            )
-          );
-        }
+const { stats } = moduleSupport;
 
-        try {
-          const { stats } = JSON.parse(body);
-          const allowedBrowsers = {};
+const allowedBrowsers = {};
 
-          Object.keys(stats).forEach(browser => {
-            if (browser !== "and_chr") {
-              const browserVersions = stats[browser];
-              const allowedVersions = Object.keys(browserVersions)
-                .filter(value => {
-                  return acceptedWithCaveats[browser]
-                    ? browserVersions[value][0] === "a"
-                    : browserVersions[value] === "y";
-                })
-                .sort((a, b) => a - b);
+Object.keys(stats).forEach(browser => {
+  if (browser !== "and_chr") {
+    const browserVersions = stats[browser];
+    const allowedVersions = Object.keys(browserVersions)
+      .filter(value => {
+        return acceptedWithCaveats[browser]
+          ? browserVersions[value][0] === "a"
+          : browserVersions[value] === "y";
+      })
+      .sort((a, b) => a - b);
 
-              if (allowedVersions[0] !== undefined) {
-                // Handle cases where caniuse specifies version as: "11.0-11.2"
-                allowedBrowsers[browser] = allowedVersions[0].split("-")[0];
-              }
-            }
-          });
+    if (allowedVersions[0] !== undefined) {
+      // Handle cases where caniuse specifies version as: "11.0-11.2"
+      allowedBrowsers[browser] = allowedVersions[0].split("-")[0];
+    }
+  }
+});
 
-          resolve(allowedBrowsers);
-        } catch (error) {
-          return reject(new Error(`Error parsing es6-module.json.`));
-        }
-      }
-    );
-  });
-}
-
-function output(minVersions) {
-  const dataPath = path.join(__dirname, "../data/built-in-modules.json");
-  const data = {
-    "es6.module": minVersions,
-  };
-  fs.writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`);
-}
-
-Promise.resolve(input())
-  .then(minVersions => output(minVersions))
-  .catch(output(lastKnown));
+const dataPath = path.join(__dirname, "../data/built-in-modules.json");
+const data = {
+  "es6.module": allowedBrowsers,
+};
+fs.writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes, only internal change
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Removed `request` devDep, added devDep on `caniuse-db`, pinned `electron-to-chromium` version
| License                  | MIT

The previous script had a few problems, which means builds are not reproducible:
1. It required internet access
2. It fetched remote data without any versioning

This PR addresses these issues by:
1. Using an explicit version of the `caniuse-db` which is published to npm.
2. Pinning `electron-to-chromium` to the version used the last time the script was run.
