### PR TITLE
[6.x] Properly verify that decorators actually exist.

### DIFF
--- a/packages/babel-plugin-transform-decorators/src/index.js
+++ b/packages/babel-plugin-transform-decorators/src/index.js
@@ -50,18 +50,22 @@ export default function ({ types: t }) {
     return nodes;
   }
 
+  function nodeHasDecorators(node) {
+    return node.decorators && node.decorators.length > 0;
+  }
+
   function hasDecorators(path) {
     if (path.isClass()) {
-      if (path.node.decorators) return true;
+      if (nodeHasDecorators(path.node)) return true;
 
       for (const method of (path.node.body.body: Array<Object>)) {
-        if (method.decorators) {
+        if (nodeHasDecorators(method)) {
           return true;
         }
       }
     } else if (path.isObjectExpression()) {
       for (const prop of (path.node.properties: Array<Object>)) {
-        if (prop.decorators) {
+        if (nodeHasDecorators(prop)) {
           return true;
         }
       }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Mentioned in https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy/pull/80 but it seems like fixing it in core makes the most sense.

Since that other module already has a fix in place, I don't know that I'll publish right away, but figured it's small enough to just throw in there.

cc @sirrodgepodge