### PR TITLE
Remove option-filtering options from the final options results.

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -500,11 +500,15 @@ function normalizeOptions(opts: ValidatedOptions): ValidatedOptions {
   };
   delete options.extends;
   delete options.env;
+  delete options.overrides;
   delete options.plugins;
   delete options.presets;
   delete options.passPerPreset;
   delete options.ignore;
   delete options.only;
+  delete options.test;
+  delete options.include;
+  delete options.exclude;
 
   // "sourceMap" is just aliased to sourceMap, so copy it over as
   // we merge the options together.

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -899,6 +899,23 @@ describe("buildConfigChain", function() {
 
       expect(opts.comments).toBe(true);
     });
+
+    it("should remove the overrides and filtering fields from the options", () => {
+      const opts = loadOptions({
+        cwd: fixture("nonexistant-fake"),
+        filename: fixture("nonexistant-fake", "src.js"),
+        babelrc: false,
+        overrides: [],
+        test: /^/,
+        include: /^/,
+        exclude: [],
+      });
+
+      expect(opts.overrides).toBeUndefined();
+      expect(opts.test).toBeUndefined();
+      expect(opts.include).toBeUndefined();
+      expect(opts.exclude).toBeUndefined();
+    });
   });
 
   describe("config files", () => {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel-loader/issues/642
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Since these were getting left in, things that loaded the config, and then passed in back to Babel would get `test` and such _twice_, which could lead to either bad configuration merging, or no configuration at all if the patterns were relative to different directories, as was the case in https://github.com/babel/babel-loader/issues/642.