### PR TITLE
Fix stage-0/1 import of pipeline proposals array

### DIFF
--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -9,8 +9,8 @@ export default declare((api, opts = {}) => {
   const {
     loose = false,
     useBuiltIns = false,
-    decoratorsLegacy = false,
-    pipelineProposal,
+    decoratorsLegacy = true,
+    pipelineProposal = "minimal",
   } = opts;
 
   if (typeof loose !== "boolean") {
@@ -24,23 +24,6 @@ export default declare((api, opts = {}) => {
   if (typeof decoratorsLegacy !== "boolean") {
     throw new Error(
       "@babel/preset-stage-0 'decoratorsLegacy' option must be a boolean.",
-    );
-  }
-
-  if (decoratorsLegacy !== true) {
-    throw new Error(
-      "The new decorators proposal is not supported yet." +
-        ' You must pass the `"decoratorsLegacy": true` option to' +
-        " @babel/preset-stage-0",
-    );
-  }
-
-  if (typeof pipelineProposal !== "string") {
-    throw new Error(
-      "The pipeline operator requires a proposal set." +
-        " You must pass 'pipelineProposal' option to" +
-        " @babel/preset-stage-0 whose value must be one of: " +
-        ["minimal"].join(", "),
     );
   }
 

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import presetStage1 from "@babel/preset-stage-1";
 
 import transformFunctionBind from "@babel/plugin-proposal-function-bind";
-import { proposals } from "@babel/plugin-proposal-pipeline-operator";
+import { proposals } from "@babel/plugin-syntax-pipeline-operator";
 
 export default declare((api, opts = {}) => {
   api.assertVersion(7);

--- a/packages/babel-preset-stage-0/src/index.js
+++ b/packages/babel-preset-stage-0/src/index.js
@@ -2,7 +2,6 @@ import { declare } from "@babel/helper-plugin-utils";
 import presetStage1 from "@babel/preset-stage-1";
 
 import transformFunctionBind from "@babel/plugin-proposal-function-bind";
-import { proposals } from "@babel/plugin-syntax-pipeline-operator";
 
 export default declare((api, opts = {}) => {
   api.assertVersion(7);
@@ -41,7 +40,7 @@ export default declare((api, opts = {}) => {
       "The pipeline operator requires a proposal set." +
         " You must pass 'pipelineProposal' option to" +
         " @babel/preset-stage-0 whose value must be one of: " +
-        proposals.join(", "),
+        ["minimal"].join(", "),
     );
   }
 

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -8,8 +8,6 @@ import transformPipelineOperator from "@babel/plugin-proposal-pipeline-operator"
 import transformNullishCoalescingOperator from "@babel/plugin-proposal-nullish-coalescing-operator";
 import transformDoExpressions from "@babel/plugin-proposal-do-expressions";
 
-import { proposals } from "@babel/plugin-syntax-pipeline-operator";
-
 export default declare((api, opts = {}) => {
   api.assertVersion(7);
 
@@ -47,7 +45,7 @@ export default declare((api, opts = {}) => {
       "The pipeline operator requires a proposal set." +
         " You must pass 'pipelineProposal' option to" +
         " @babel/preset-stage-1 whose value must be one of: " +
-        proposals.join(", "),
+        ["minimal"].join(", "),
     );
   }
 

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -4,11 +4,11 @@ import presetStage2 from "@babel/preset-stage-2";
 import transformExportDefaultFrom from "@babel/plugin-proposal-export-default-from";
 import transformLogicalAssignmentOperators from "@babel/plugin-proposal-logical-assignment-operators";
 import transformOptionalChaining from "@babel/plugin-proposal-optional-chaining";
-import transformPipelineOperator, {
-  proposals,
-} from "@babel/plugin-proposal-pipeline-operator";
+import transformPipelineOperator from "@babel/plugin-proposal-pipeline-operator";
 import transformNullishCoalescingOperator from "@babel/plugin-proposal-nullish-coalescing-operator";
 import transformDoExpressions from "@babel/plugin-proposal-do-expressions";
+
+import { proposals } from "@babel/plugin-syntax-pipeline-operator";
 
 export default declare((api, opts = {}) => {
   api.assertVersion(7);

--- a/packages/babel-preset-stage-1/src/index.js
+++ b/packages/babel-preset-stage-1/src/index.js
@@ -14,8 +14,8 @@ export default declare((api, opts = {}) => {
   const {
     loose = false,
     useBuiltIns = false,
-    decoratorsLegacy = false,
-    pipelineProposal,
+    decoratorsLegacy = true,
+    pipelineProposal = "minimal",
   } = opts;
 
   if (typeof loose !== "boolean") {
@@ -29,23 +29,6 @@ export default declare((api, opts = {}) => {
   if (typeof decoratorsLegacy !== "boolean") {
     throw new Error(
       "@babel/preset-stage-1 'decoratorsLegacy' option must be a boolean.",
-    );
-  }
-
-  if (decoratorsLegacy !== true) {
-    throw new Error(
-      "The new decorators proposal is not supported yet." +
-        ' You must pass the `"decoratorsLegacy": true` option to' +
-        " @babel/preset-stage-1",
-    );
-  }
-
-  if (typeof pipelineProposal !== "string") {
-    throw new Error(
-      "The pipeline operator requires a proposal set." +
-        " You must pass 'pipelineProposal' option to" +
-        " @babel/preset-stage-1 whose value must be one of: " +
-        ["minimal"].join(", "),
     );
   }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8307
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

The proposals array is exported from the syntax plugin, so it must be imported from there as well.