### PR TITLE
Save full descriptor instead of only value for private fields.

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1016,7 +1016,7 @@ helpers.classPrivateFieldGet = () => template.program.ast`
     if (!privateMap.has(receiver)) {
       throw new TypeError("attempted to get private field on non-instance");
     }
-    return privateMap.get(receiver);
+    return privateMap.get(receiver).value;
   }
 `;
 
@@ -1025,7 +1025,11 @@ helpers.classPrivateFieldSet = () => template.program.ast`
     if (!privateMap.has(receiver)) {
       throw new TypeError("attempted to set private field on non-instance");
     }
-    privateMap.set(receiver, value);
+    var descriptor = privateMap.get(receiver);
+    if (!descriptor.writable) {
+      throw new TypeError("attempted to set read only private field");
+    }
+    descriptor.value = value;
     return value;
   }
 `;

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -201,7 +201,14 @@ export default declare((api, options) => {
 
     // Must be late evaluated in case it references another private field.
     return () =>
-      template.statement`MAP.set(REF, VALUE);`({
+      template.statement`
+        MAP.set(REF, {
+          // configurable is always false for private elements
+          // enumerable is always false for private elements
+          writable: true,
+          value: VALUE
+        });
+      `({
         MAP: map,
         REF: ref,
         VALUE: path.node.value || scope.buildUndefinedNode(),

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/assignment/output.js
@@ -6,7 +6,10 @@ function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
-    _foo.set(this, 0);
+    _foo.set(this, {
+      writable: true,
+      value: 0
+    });
   }
 
   babelHelpers.createClass(Foo, [{

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/call/output.js
@@ -6,8 +6,11 @@ function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
-    _foo.set(this, function () {
-      return this;
+    _foo.set(this, {
+      writable: true,
+      value: function () {
+        return this;
+      }
     });
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
@@ -6,9 +6,15 @@ function () {
   function Point(_x2 = 0, _y2 = 0) {
     babelHelpers.classCallCheck(this, Point);
 
-    _x.set(this, void 0);
+    _x.set(this, {
+      writable: true,
+      value: void 0
+    });
 
-    _y.set(this, void 0);
+    _y.set(this, {
+      writable: true,
+      value: void 0
+    });
 
     babelHelpers.classPrivateFieldSet(this, _x, +_x2);
     babelHelpers.classPrivateFieldSet(this, _y, +_y2);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/constructor-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/constructor-collision/output.js
@@ -5,7 +5,10 @@ var Foo = function Foo() {
 
   babelHelpers.classCallCheck(this, Foo);
 
-  _bar.set(this, foo);
+  _bar.set(this, {
+    writable: true,
+    value: foo
+  });
 
   var _foo = "foo";
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/declaration-order/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/declaration-order/output.js
@@ -4,7 +4,10 @@ var C = function C() {
   babelHelpers.classCallCheck(this, C);
   babelHelpers.defineProperty(this, "y", babelHelpers.classPrivateFieldGet(this, _x));
 
-  _x.set(this, void 0);
+  _x.set(this, {
+    writable: true,
+    value: void 0
+  });
 };
 
 var _x = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -13,11 +13,17 @@ function (_Bar) {
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), "foo");
+      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), {
+        writable: true,
+        value: "foo"
+      });
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), "foo");
+      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), {
+        writable: true,
+        value: "foo"
+      });
     }
 
     return babelHelpers.possibleConstructorReturn(_this);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -3,7 +3,10 @@ var Foo = function Foo() {
 
   babelHelpers.classCallCheck(this, Foo);
 
-  _prop.set(this, "foo");
+  _prop.set(this, {
+    writable: true,
+    value: "foo"
+  });
 };
 
 var _prop = new WeakMap();
@@ -21,7 +24,10 @@ function (_Foo) {
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
 
-    _prop2.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar");
+    _prop2.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+      writable: true,
+      value: "bar"
+    });
 
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/extracted-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/extracted-this/output.js
@@ -5,9 +5,15 @@ var Foo = function Foo(_foo) {
 
   babelHelpers.classCallCheck(this, Foo);
 
-  _bar.set(this, this);
+  _bar.set(this, {
+    writable: true,
+    value: this
+  });
 
-  _baz.set(this, foo);
+  _baz.set(this, {
+    writable: true,
+    value: foo
+  });
 };
 
 var _bar = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
@@ -11,8 +11,11 @@ function (_Parent) {
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
 
-    _scopedFunctionWithThis.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), () => {
-      _this.name = {};
+    _scopedFunctionWithThis.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+      writable: true,
+      value: () => {
+        _this.name = {};
+      }
     });
 
     return _this;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance-undefined/output.js
@@ -3,7 +3,10 @@ var Foo = function Foo() {
 
   babelHelpers.classCallCheck(this, Foo);
 
-  _bar.set(this, void 0);
+  _bar.set(this, {
+    writable: true,
+    value: void 0
+  });
 };
 
 var _bar = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance/output.js
@@ -3,7 +3,10 @@ var Foo = function Foo() {
 
   babelHelpers.classCallCheck(this, Foo);
 
-  _bar.set(this, "foo");
+  _bar.set(this, {
+    writable: true,
+    value: "foo"
+  });
 };
 
 var _bar = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/multiple/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/multiple/output.js
@@ -3,9 +3,15 @@ var Foo = function Foo() {
 
   babelHelpers.classCallCheck(this, Foo);
 
-  _x.set(this, 0);
+  _x.set(this, {
+    writable: true,
+    value: 0
+  });
 
-  _y.set(this, babelHelpers.classPrivateFieldGet(this, _x));
+  _y.set(this, {
+    writable: true,
+    value: babelHelpers.classPrivateFieldGet(this, _x)
+  });
 };
 
 var _x = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
@@ -3,7 +3,10 @@ var Outer = function Outer() {
 
   babelHelpers.classCallCheck(this, Outer);
 
-  _outer.set(this, void 0);
+  _outer.set(this, {
+    writable: true,
+    value: void 0
+  });
 
   var Test =
   /*#__PURE__*/

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reference-in-other-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reference-in-other-property/output.js
@@ -4,13 +4,22 @@ var Foo = function Foo() {
   babelHelpers.classCallCheck(this, Foo);
   babelHelpers.defineProperty(this, "one", babelHelpers.classPrivateFieldGet(this, _private));
 
-  _two.set(this, babelHelpers.classPrivateFieldGet(this, _private));
+  _two.set(this, {
+    writable: true,
+    value: babelHelpers.classPrivateFieldGet(this, _private)
+  });
 
-  _private.set(this, 0);
+  _private.set(this, {
+    writable: true,
+    value: 0
+  });
 
   babelHelpers.defineProperty(this, "three", babelHelpers.classPrivateFieldGet(this, _private));
 
-  _four.set(this, babelHelpers.classPrivateFieldGet(this, _private));
+  _four.set(this, {
+    writable: true,
+    value: babelHelpers.classPrivateFieldGet(this, _private)
+  });
 };
 
 var _two = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/output.mjs
@@ -4,11 +4,18 @@ class MyClass {
   constructor() {
     var _this = this;
 
-    _myAsyncMethod.set(this,
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this);
-    }));
+    _myAsyncMethod.set(this, {
+      writable: true,
+      value: function () {
+        var _ref = babelHelpers.asyncToGenerator(function* () {
+          console.log(_this);
+        });
+
+        return function value() {
+          return _ref.apply(this, arguments);
+        };
+      }()
+    });
   }
 
 }
@@ -19,11 +26,18 @@ _class = class MyClass2 {
   constructor() {
     var _this2 = this;
 
-    _myAsyncMethod2.set(this,
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this2);
-    }));
+    _myAsyncMethod2.set(this, {
+      writable: true,
+      value: function () {
+        var _ref2 = babelHelpers.asyncToGenerator(function* () {
+          console.log(_this2);
+        });
+
+        return function value() {
+          return _ref2.apply(this, arguments);
+        };
+      }()
+    });
   }
 
 };
@@ -34,11 +48,18 @@ export default class MyClass3 {
   constructor() {
     var _this3 = this;
 
-    _myAsyncMethod3.set(this,
-    /*#__PURE__*/
-    babelHelpers.asyncToGenerator(function* () {
-      console.log(_this3);
-    }));
+    _myAsyncMethod3.set(this, {
+      writable: true,
+      value: function () {
+        var _ref3 = babelHelpers.asyncToGenerator(function* () {
+          console.log(_this3);
+        });
+
+        return function value() {
+          return _ref3.apply(this, arguments);
+        };
+      }()
+    });
   }
 
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -29,7 +29,10 @@ function (_A) {
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
 
-    _foo.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
+    _foo.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+      writable: true,
+      value: babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))
+    });
 
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
@@ -9,7 +9,10 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "foo"), _temp));
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+      writable: true,
+      value: "foo"
+    }), _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
@@ -11,7 +11,10 @@ function (_Bar) {
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-    _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "foo");
+    _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+      writable: true,
+      value: "foo"
+    });
 
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/update/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/update/output.js
@@ -6,7 +6,10 @@ function () {
   function Foo() {
     babelHelpers.classCallCheck(this, Foo);
 
-    _foo.set(this, 0);
+    _foo.set(this, {
+      writable: true,
+      value: 0
+    });
   }
 
   babelHelpers.createClass(Foo, [{


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Decorators can make private fields non-writable, so we need to store this information smewhere.
The descriptor can also be used to implement private accessors.
