### PR TITLE
Treat string ignore/only/test/include/exclude values as paths with only basic pattern matching

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -41,7 +41,6 @@
     "debug": "^3.1.0",
     "json5": "^0.5.0",
     "lodash": "^4.17.5",
-    "micromatch": "^2.3.11",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"

--- a/packages/babel-core/src/config/files/types.js
+++ b/packages/babel-core/src/config/files/types.js
@@ -9,7 +9,7 @@ export type ConfigFile = {
 export type IgnoreFile = {
   filepath: string,
   dirname: string,
-  ignore: Array<string>,
+  ignore: Array<RegExp>,
 };
 
 export type RelativeConfig = {

--- a/packages/babel-core/src/config/pattern-to-regex.js
+++ b/packages/babel-core/src/config/pattern-to-regex.js
@@ -1,0 +1,51 @@
+// @flow
+import path from "path";
+import escapeRegExp from "lodash/escapeRegExp";
+
+const sep = `\\${path.sep}`;
+const endSep = `(?:${sep}|$)`;
+
+const substitution = `[^${sep}]+`;
+
+const starPat = `(?:${substitution}${sep})`;
+const starPatLast = `(?:${substitution}${endSep})`;
+
+const starStarPat = `${starPat}*?`;
+const starStarPatLast = `${starPat}*?${starPatLast}?`;
+
+/**
+ * Implement basic pattern matching that will allow users to do the simple
+ * tests with * and **. If users want full complex pattern matching, then can
+ * always use regex matching, or function validation.
+ */
+export default function pathToPattern(
+  pattern: string,
+  dirname: string,
+): RegExp {
+  const parts = path.resolve(dirname, pattern).split(path.sep);
+
+  return new RegExp(
+    [
+      "^",
+      ...parts.map((part, i) => {
+        const last = i === parts.length - 1;
+
+        // ** matches 0 or more path parts.
+        if (part === "**") return last ? starStarPatLast : starStarPat;
+
+        // * matches 1 path part.
+        if (part === "*") return last ? starPatLast : starPat;
+
+        // *.ext matches a wildcard with an extension.
+        if (part.indexOf("*.") === 0) {
+          return (
+            substitution + escapeRegExp(part.slice(1)) + (last ? endSep : sep)
+          );
+        }
+
+        // Otherwise match the pattern text.
+        return escapeRegExp(part) + (last ? endSep : sep);
+      }),
+    ].join(""),
+  );
+}

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -192,14 +192,14 @@ export function assertBabelrcSearch(
 
   if (Array.isArray(value)) {
     value.forEach((item, i) => {
-      if (typeof item !== "string") {
-        throw new Error(`.${key}[${i}] must be a string.`);
+      if (!checkValidTest(value)) {
+        throw new Error(`.${key}[${i}] must be a string/Function/RegExp.`);
       }
     });
-  } else if (typeof value !== "string") {
+  } else if (!checkValidTest(value)) {
     throw new Error(
-      `.${key} must be a undefined, a boolean, a string, ` +
-        `or an array of strings, got ${JSON.stringify(value)}`,
+      `.${key} must be a undefined, a boolean, a string/Function/RegExp ` +
+        `or an array of those, got ${JSON.stringify(value)}`,
     );
   }
   return (value: any);

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -242,7 +242,7 @@ export type OverridesList = Array<ValidatedOptions>;
 export type ConfigApplicableTest = IgnoreItem | Array<IgnoreItem>;
 
 export type ConfigFileSearch = string | boolean;
-export type BabelrcSearch = boolean | string | Array<string>;
+export type BabelrcSearch = boolean | IgnoreItem | IgnoreList;
 export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -5,11 +5,11 @@ import Plugin from "../lib/config/plugin";
 import generator from "@babel/generator";
 
 function assertIgnored(result) {
-  expect(result).toBeFalsy();
+  expect(result).toBeNull();
 }
 
 function assertNotIgnored(result) {
-  expect(result.ignored).toBeFalsy();
+  expect(result).not.toBeNull();
 }
 
 function transform(code, opts) {
@@ -36,13 +36,11 @@ function transformFileSync(filename, opts) {
   });
 }
 
-// shim
 function transformAsync(code, opts) {
-  return {
-    then: function(resolve) {
-      resolve(transform(code, opts));
-    },
-  };
+  return babel.transformAsync(code, {
+    cwd: __dirname,
+    ...opts,
+  });
 }
 
 describe("parser and generator options", function() {

--- a/packages/babel-register/src/node.js
+++ b/packages/babel-register/src/node.js
@@ -101,7 +101,6 @@ function hookExtensions(exts) {
 
 export function revert() {
   if (piratesRevert) piratesRevert();
-  delete require.cache[require.resolve(__filename)];
 }
 
 register();

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -52,6 +52,7 @@ describe("@babel/register", function() {
   function revertRegister() {
     if (babelRegister) {
       babelRegister.revert();
+      delete require.cache[registerFile];
       babelRegister = null;
     }
   }

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -16,7 +16,6 @@
     "@babel/types": "7.0.0-beta.53",
     "debug": "^3.1.0",
     "globals": "^11.1.0",
-    "invariant": "^2.2.0",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -2,7 +2,6 @@ import type Hub from "../hub";
 import type TraversalContext from "../context";
 import * as virtualTypes from "./lib/virtual-types";
 import buildDebug from "debug";
-import invariant from "invariant";
 import traverse from "../index";
 import Scope from "../scope";
 import * as t from "@babel/types";
@@ -76,7 +75,9 @@ export default class NodePath {
       hub = parentPath.hub;
     }
 
-    invariant(parent, "To get a node path the parent needs to exist");
+    if (!parent) {
+      throw new Error("To get a node path the parent needs to exist");
+    }
 
     const targetNode = container[key];
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8184
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

With #8184 we cannot use micromatch on a general path string to do pattern matching. Rather than screw around trying to make that work, we've decided to treat strings as paths with extremely simple pattern matching abilities, and if users would like more complex pattern matching we'll leave it to them to use regexes, or to pass function that will be called to validate whether a path matches the desired pattern.

~~I've included the two commits from #8201 in this to see how it works, but I'll probably drop them once I see how things look.~~ Still seems to be other issues with that, looks like the tests do need to be tweaked for Windows in general.