### PR TITLE
Do not mutate ast

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -2,6 +2,7 @@
 
 import path from "path";
 import buildDebug from "debug";
+import cloneDeep from "lodash/cloneDeep";
 import * as t from "@babel/types";
 import type { PluginPasses } from "../config";
 import convertSourceMap, { typeof Converter } from "convert-source-map";
@@ -75,6 +76,7 @@ export default function normalizeFile(
     } else if (ast.type !== "File") {
       throw new Error("AST root must be a Program or File node");
     }
+    ast = cloneDeep(ast);
   } else {
     // The parser's AST types aren't fully compatible with the types generated
     // by the logic in babel-types.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7987  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | :-1:
| Minor: New Feature?      | :-1:
| Tests Added + Pass?      | :+1:
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | :-1:
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This clones the given ast prior to working on it to avoid mutating the AST given to `transformFromAST`.

This is work in progress and intended as input for review. Some questions I have:

- Is this the intended use for `t.cloneNode`?
- `parse.js` was the easiest place to insert the test. I'm not sure where it should go

Please check inline review comments for context.