### PR TITLE
throwOnUninitializedRead option for babel-plugin-transform-modules-common-js

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.js
@@ -28,6 +28,7 @@ export default declare((api, options) => {
     strictMode,
     noInterop,
     lazy = false,
+    throwOnUninitializedRead = false,
     // Defaulting to 'true' for now. May change before 7.x major.
     allowCommonJSExports = true,
   } = options;
@@ -152,6 +153,7 @@ export default declare((api, options) => {
               allowTopLevelThis,
               noInterop,
               lazy,
+              throwOnUninitializedRead,
               esNamespaceOnly:
                 typeof state.filename === "string" &&
                 /\.mjs$/.test(state.filename)

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/throw-on-uninitialized-read/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/throw-on-uninitialized-read/input.mjs
@@ -1,0 +1,9 @@
+const foo = require('foo');
+
+export const x = "Hello world";
+
+export function bar() {
+  return 42;
+}
+
+export const y = "Goodbye world";

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/throw-on-uninitialized-read/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/throw-on-uninitialized-read/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    ["transform-modules-commonjs", { "throwOnUninitializedRead": true }]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/throw-on-uninitialized-read/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/throw-on-uninitialized-read/output.js
@@ -1,0 +1,62 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.bar = bar;
+
+var _x_storage,
+    _x_set = false;
+
+Object.defineProperty(exports, "x", {
+  get: function () {
+    if (_x_set === false) {
+      throw new Error("Cannot access uninitialized export x");
+    }
+
+    return _x_storage;
+  },
+  set: function (_v) {
+    if (_x_set) {
+      throw new Error("Cannot reassign exported value x");
+    }
+
+    _x_set = true;
+    _x_storage = _v;
+  },
+  enumerable: true
+});
+
+var _y_storage,
+    _y_set = false;
+
+Object.defineProperty(exports, "y", {
+  get: function () {
+    if (_y_set === false) {
+      throw new Error("Cannot access uninitialized export y");
+    }
+
+    return _y_storage;
+  },
+  set: function (_v) {
+    if (_y_set) {
+      throw new Error("Cannot reassign exported value y");
+    }
+
+    _y_set = true;
+    _y_storage = _v;
+  },
+  enumerable: true
+});
+
+const foo = require('foo');
+
+const x = "Hello world";
+exports.x = x;
+
+function bar() {
+  return 42;
+}
+
+const y = "Goodbye world";
+exports.y = y;


### PR DESCRIPTION
If you use ES6 modules with `require` and trigger a circular dependency, what should happen? Currently you receive `undefined`; this adds an off-by-default option to throw instead.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
