### PR TITLE
Correctly parse interface methods named 'static'

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -463,7 +463,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } while (this.eat(tt.comma));
       }
 
-      node.body = this.flowParseObjectType(true, false, false, isClass);
+      node.body = this.flowParseObjectType(isClass, false, false, isClass);
     }
 
     flowParseInterfaceExtends(): N.FlowInterfaceExtends {
@@ -656,7 +656,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         } while (this.eat(tt.comma));
       }
 
-      node.body = this.flowParseObjectType(true, false, false, false);
+      node.body = this.flowParseObjectType(false, false, false, false);
 
       return this.finishNode(node, "InterfaceTypeAnnotation");
     }

--- a/packages/babel-parser/test/fixtures/flow/interface-types/identifier-named-static-method/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/identifier-named-static-method/input.js
@@ -1,0 +1,1 @@
+type T = interface { static(): number }

--- a/packages/babel-parser/test/fixtures/flow/interface-types/identifier-named-static-method/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/identifier-named-static-method/output.json
@@ -1,0 +1,175 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 39
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 39
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 39
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "InterfaceTypeAnnotation",
+          "start": 9,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 39
+            }
+          },
+          "extends": [],
+          "body": {
+            "type": "ObjectTypeAnnotation",
+            "start": 19,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 39
+              }
+            },
+            "callProperties": [],
+            "properties": [
+              {
+                "type": "ObjectTypeProperty",
+                "start": 21,
+                "end": 37,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 37
+                  }
+                },
+                "key": {
+                  "type": "Identifier",
+                  "start": 21,
+                  "end": 27,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 27
+                    },
+                    "identifierName": "static"
+                  },
+                  "name": "static"
+                },
+                "static": false,
+                "proto": false,
+                "kind": "init",
+                "method": true,
+                "value": {
+                  "type": "FunctionTypeAnnotation",
+                  "start": 21,
+                  "end": 37,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 37
+                    }
+                  },
+                  "params": [],
+                  "rest": null,
+                  "typeParameters": null,
+                  "returnType": {
+                    "type": "NumberTypeAnnotation",
+                    "start": 31,
+                    "end": 37,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 31
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 37
+                      }
+                    }
+                  }
+                },
+                "optional": false
+              }
+            ],
+            "indexers": [],
+            "internalSlots": [],
+            "exact": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/10/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/10/input.js
@@ -1,5 +1,4 @@
 interface IFoo {
   x: boolean;
   static (): void;
-  static y: boolean;
 }

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/10/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/10/output.json
@@ -1,28 +1,28 @@
 {
   "type": "File",
   "start": 0,
-  "end": 72,
+  "end": 51,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 5,
+      "line": 4,
       "column": 1
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 72,
+    "end": 51,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 5,
+        "line": 4,
         "column": 1
       }
     },
@@ -32,14 +32,14 @@
       {
         "type": "InterfaceDeclaration",
         "start": 0,
-        "end": 72,
+        "end": 51,
         "loc": {
           "start": {
             "line": 1,
             "column": 0
           },
           "end": {
-            "line": 5,
+            "line": 4,
             "column": 1
           }
         },
@@ -67,68 +67,18 @@
         "body": {
           "type": "ObjectTypeAnnotation",
           "start": 15,
-          "end": 72,
+          "end": 51,
           "loc": {
             "start": {
               "line": 1,
               "column": 15
             },
             "end": {
-              "line": 5,
+              "line": 4,
               "column": 1
             }
           },
-          "callProperties": [
-            {
-              "type": "ObjectTypeCallProperty",
-              "start": 33,
-              "end": 48,
-              "loc": {
-                "start": {
-                  "line": 3,
-                  "column": 2
-                },
-                "end": {
-                  "line": 3,
-                  "column": 17
-                }
-              },
-              "static": true,
-              "value": {
-                "type": "FunctionTypeAnnotation",
-                "start": 40,
-                "end": 48,
-                "loc": {
-                  "start": {
-                    "line": 3,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 17
-                  }
-                },
-                "params": [],
-                "rest": null,
-                "typeParameters": null,
-                "returnType": {
-                  "type": "VoidTypeAnnotation",
-                  "start": 44,
-                  "end": 48,
-                  "loc": {
-                    "start": {
-                      "line": 3,
-                      "column": 13
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 17
-                    }
-                  }
-                }
-              }
-            }
-          ],
+          "callProperties": [],
           "properties": [
             {
               "type": "ObjectTypeProperty",
@@ -185,55 +135,72 @@
             },
             {
               "type": "ObjectTypeProperty",
-              "start": 52,
-              "end": 69,
+              "start": 33,
+              "end": 48,
               "loc": {
                 "start": {
-                  "line": 4,
+                  "line": 3,
                   "column": 2
                 },
                 "end": {
-                  "line": 4,
-                  "column": 19
+                  "line": 3,
+                  "column": 17
                 }
               },
               "key": {
                 "type": "Identifier",
-                "start": 59,
-                "end": 60,
+                "start": 33,
+                "end": 39,
                 "loc": {
                   "start": {
-                    "line": 4,
-                    "column": 9
+                    "line": 3,
+                    "column": 2
                   },
                   "end": {
-                    "line": 4,
-                    "column": 10
+                    "line": 3,
+                    "column": 8
                   },
-                  "identifierName": "y"
+                  "identifierName": "static"
                 },
-                "name": "y"
+                "name": "static"
               },
-              "static": true,
+              "static": false,
               "proto": false,
               "kind": "init",
-              "method": false,
+              "method": true,
               "value": {
-                "type": "BooleanTypeAnnotation",
-                "start": 62,
-                "end": 69,
+                "type": "FunctionTypeAnnotation",
+                "start": 33,
+                "end": 48,
                 "loc": {
                   "start": {
-                    "line": 4,
-                    "column": 12
+                    "line": 3,
+                    "column": 2
                   },
                   "end": {
-                    "line": 4,
-                    "column": 19
+                    "line": 3,
+                    "column": 17
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 44,
+                  "end": 48,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 17
+                    }
                   }
                 }
               },
-              "variance": null,
               "optional": false
             }
           ],

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/identifier-named-static-method/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/identifier-named-static-method/input.js
@@ -1,0 +1,1 @@
+interface A { static(): number }

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/identifier-named-static-method/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/identifier-named-static-method/output.json
@@ -1,0 +1,162 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 32,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 32
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 32,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 32
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start": 0,
+        "end": 32,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 32
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 10,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 12,
+          "end": 32,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 1,
+              "column": 32
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 14,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 14
+                },
+                "end": {
+                  "line": 1,
+                  "column": 30
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 14,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "identifierName": "static"
+                },
+                "name": "static"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "init",
+              "method": true,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 14,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 30
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 24,
+                  "end": 30,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 30
+                    }
+                  }
+                }
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #8373
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | Arguably? Changes some parses.
| Minor: New Feature?      | n
| Tests Added + Pass?      | y
| Documentation PR Link    | N/A
| Any Dependency Changes?  | n
| License                  | MIT

Flow removed support for `static`s in interfaces a [while ago](https://github.com/facebook/flow/commit/153e4a34633b5e19648e80721ea73e73a5e1b1d2).

The boolean being changed [is](https://github.com/babel/babel/blob/d781e207c80fac6010bc1370e27fbbb54768fbbc/packages/babel-parser/src/plugins/flow.js#L757-L758) `allowStatic`. Flow's parser has [pretty much the same thing](https://github.com/facebook/flow/blob/48673cf7f4c114b0377c97a95167a46998f00d58/src/parser/type_parser.ml#L685-L687) and passes `false` for interfaces, as is done in this PR.