### PR TITLE
Fix order of optional argument reordering

### DIFF
--- a/packages/babel-core/src/transform-ast.js
+++ b/packages/babel-core/src/transform-ast.js
@@ -31,8 +31,8 @@ export const transformFromAst: TransformFromAst = (function transformFromAst(
   callback,
 ) {
   if (typeof opts === "function") {
-    opts = undefined;
     callback = opts;
+    opts = undefined;
   }
 
   // For backward-compat with Babel 6, we allow sync transformation when


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes. |
| Major: Breaking Change?  | No. |
| Minor: New Feature?      | No. |
| Tests Added + Pass?      | We'll see (minor enough to warrant waiting for CI) |
| Documentation PR Link    | N/A |
| Any Dependency Changes?  | No. ||
| License                  | MIT |

Caught this looking into an unrelated issue with AST transformations. Previously, if the optional `opts` parameter wasn't passed, the _intent_ was to move the function it held into the `callback` parameter and null out the `opts` param - but instead, it was nulling both.