### PR TITLE
Bumped lodash to 4.17.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lerna": "^2.11.0",
     "lerna-changelog": "^0.5.0",
     "lint-staged": "^6.0.1",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "merge-stream": "^1.0.1",
     "output-file-sync": "^2.0.0",
     "prettier": "^1.13.7",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -20,7 +20,7 @@
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^1.0.0",
     "glob": "^7.0.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "output-file-sync": "^2.0.0",
     "slash": "^1.0.0",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -40,7 +40,7 @@
     "convert-source-map": "^1.1.0",
     "debug": "^3.1.0",
     "json5": "^0.5.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@babel/types": "7.0.0-beta.54",
     "jsesc": "^2.5.1",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "source-map": "^0.5.0",
     "trim-right": "^1.0.1"
   },

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "@babel/helper-function-name": "7.0.0-beta.54",
     "@babel/types": "7.0.0-beta.54",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   }
 }

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "semver": "^5.3.0",
     "try-resolve": "^1.0.0"
   }

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "7.0.0-beta.54",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.54"

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -13,6 +13,6 @@
     "@babel/helper-split-export-declaration": "7.0.0-beta.54",
     "@babel/template": "7.0.0-beta.54",
     "@babel/types": "7.0.0-beta.54",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   }
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   }
 }

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "@babel/template": "7.0.0-beta.54",
     "@babel/types": "7.0.0-beta.54",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -14,7 +14,7 @@
     "@babel/polyfill": "7.0.0-beta.54",
     "jest": "^22.4.2",
     "jest-diff": "^22.4.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "resolve": "^1.3.2",
     "source-map": "^0.5.0"
   }

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -20,7 +20,7 @@
     "@babel/register": "7.0.0-beta.54",
     "commander": "^2.8.1",
     "fs-readdir-recursive": "^1.0.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "output-file-sync": "^2.0.0",
     "v8flags": "^3.1.1"
   },

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-plugin-utils": "7.0.0-beta.54",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,7 +13,7 @@
     "core-js": "^2.5.7",
     "find-cache-dir": "^1.0.0",
     "home-or-tmp": "^3.0.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "pirates": "^4.0.0",
     "source-map-support": "^0.4.2"

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -11,6 +11,6 @@
     "@babel/code-frame": "7.0.0-beta.54",
     "@babel/parser": "7.0.0-beta.54",
     "@babel/types": "7.0.0-beta.54",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   }
 }

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -16,7 +16,7 @@
     "@babel/types": "7.0.0-beta.54",
     "debug": "^3.1.0",
     "globals": "^11.1.0",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "7.0.0-beta.54"

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -10,7 +10,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "esutils": "^2.0.2",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "to-fast-properties": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Resolve #8368
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes (`lodash`)
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I bumped `lodash` in `devDependency` from 4.17.5 to 4.17.10, which is less vulnerable to issues but might require another bump once they release a new patched version; the issue was raised to them [here](https://github.com/lodash/lodash/issues/3882).