### PR TITLE
Allow an Array for `babelrcRoots`.

### DIFF
--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -192,7 +192,7 @@ export function assertBabelrcSearch(
 
   if (Array.isArray(value)) {
     value.forEach((item, i) => {
-      if (!checkValidTest(value)) {
+      if (!checkValidTest(item)) {
         throw new Error(`.${key}[${i}] must be a string/Function/RegExp.`);
       }
     });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `babelrcRoots` was throwing if it was an Array.
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://github.com/babel/babel/pull/8327 changed a check from each element in an Array to the whole Array, so validation was failing when `babelrcRoots` was an Array.