### PR TITLE
Fix code generation for async generator methods for babel@6.x

### DIFF
--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -20,12 +20,6 @@ export function _method(node: Object) {
   const kind = node.kind;
   const key  = node.key;
 
-  if (kind === "method" || kind === "init") {
-    if (node.generator) {
-      this.token("*");
-    }
-  }
-
   if (kind === "get" || kind === "set") {
     this.word(kind);
     this.space();
@@ -34,6 +28,12 @@ export function _method(node: Object) {
   if (node.async) {
     this.word("async");
     this.space();
+  }
+
+  if (kind === "method" || kind === "init") {
+    if (node.generator) {
+      this.token("*");
+    }
   }
 
   if (node.computed) {

--- a/packages/babel-generator/test/fixtures/edgecase/async-generator/actual.js
+++ b/packages/babel-generator/test/fixtures/edgecase/async-generator/actual.js
@@ -1,0 +1,19 @@
+function a() {}
+function *b() {}
+async function c() {}
+async function *d() {}
+var e = function () {};
+var f = function *() {};
+var g = async function () {};
+var h = async function *() {};
+
+class A {
+  a() {}
+  *b() {}
+  async c() {}
+  async *d() {}
+  e = () => {};
+  // f = () =>* {};
+  g = async () => {};
+  // h = async () =>* {};
+}

--- a/packages/babel-generator/test/fixtures/edgecase/async-generator/expected.js
+++ b/packages/babel-generator/test/fixtures/edgecase/async-generator/expected.js
@@ -1,0 +1,19 @@
+function a() {}
+function* b() {}
+async function c() {}
+async function* d() {}
+var e = function () {};
+var f = function* () {};
+var g = async function () {};
+var h = async function* () {};
+
+class A {
+  a() {}
+  *b() {}
+  async c() {}
+  async *d() {}
+  e = () => {};
+  // f = () =>* {};
+  g = async () => {};
+  // h = async () =>* {};
+}

--- a/packages/babel-generator/test/fixtures/edgecase/async-generator/options.json
+++ b/packages/babel-generator/test/fixtures/edgecase/async-generator/options.json
@@ -1,0 +1,1 @@
+{ "plugins": ["asyncGenerators", "classProperties"] }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #8382
| Patch: Bug Fix?          |  Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

babel-generator is writing async generator methods as `*async methodName() {}` instead of `async *methodName() {}`. This puts the `*` in the right place.

This is a port of PR: #6998 for `babel@6.x`
