### PR TITLE
Ensure preset-env doesn't clobber browserslist defaults

### DIFF
--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -15,6 +15,8 @@ import browserModulesData from "../data/built-in-modules.json";
 import { TargetNames } from "./options";
 import type { Targets } from "./types";
 
+const browserslistDefaults = browserslist.defaults;
+
 const validateTargetNames = (validTargets, targets) => {
   for (const target in targets) {
     if (!TargetNames[target]) {
@@ -178,6 +180,9 @@ const getTargets = (targets: Object = {}, options: Object = {}): Targets => {
     const browsers = browserslist(browsersquery, { path: options.configPath });
     const queryBrowsers = getLowestVersions(browsers);
     targets = mergeBrowsers(queryBrowsers, targets);
+
+    // Reset browserslist defaults
+    browserslist.defaults = browserslistDefaults;
   }
 
   // Parse remaining targets

--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -1,3 +1,4 @@
+import browserslist from "browserslist";
 import getTargets from "../lib/targets-parser";
 
 describe("getTargets", () => {
@@ -17,6 +18,16 @@ describe("getTargets", () => {
       ie: "9.0.0",
       node: "6.10.0",
     });
+  });
+
+  it("does not clobber browserslists defaults", () => {
+    const browserslistDefaults = browserslist.defaults;
+
+    getTargets({
+      browsers: "chrome 56, ie 11, firefox 51, safari 9",
+    });
+
+    expect(browserslist.defaults).toEqual(browserslistDefaults);
   });
 
   describe("validation", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8388
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Makes sure that we reset `browserslist.default` after parsing targets.
