### PR TITLE
Optim constructor cleanup redundant 'assertThisInitialized`, ensure 'this' aliases (#8335)

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -27,14 +27,14 @@ function (_Hello) {
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
 
-    var _babelHelpers$get$cal = babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    var _babelHelpers$get$cal = babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", _this).call(_this);
 
     let Inner = function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, _babelHelpers$get$cal, 'hello');
     };
 
-    return babelHelpers.possibleConstructorReturn(_this, new Inner());
+    return new Inner() || _this;
   }
 
   return Outer;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
@@ -4,17 +4,19 @@ function () {
   "use strict";
 
   function Point(_x2 = 0, _y2 = 0) {
+    var _this = this;
+
     babelHelpers.classCallCheck(this, Point);
-    Object.defineProperty(this, _x, {
+    Object.defineProperty(_this, _x, {
       writable: true,
       value: void 0
     });
-    Object.defineProperty(this, _y, {
+    Object.defineProperty(_this, _y, {
       writable: true,
       value: void 0
     });
-    babelHelpers.classPrivateFieldLooseBase(this, _x)[_x] = +_x2;
-    babelHelpers.classPrivateFieldLooseBase(this, _y)[_y] = +_y2;
+    babelHelpers.classPrivateFieldLooseBase(_this, _x)[_x] = +_x2;
+    babelHelpers.classPrivateFieldLooseBase(_this, _y)[_y] = +_y2;
   }
 
   babelHelpers.createClass(Point, [{

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/declaration-order/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/declaration-order/output.js
@@ -1,9 +1,11 @@
 var C = function C() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, C);
-  this.y = babelHelpers.classPrivateFieldLooseBase(this, _x)[_x];
-  Object.defineProperty(this, _x, {
+  _this.y = babelHelpers.classPrivateFieldLooseBase(_this, _x)[_x];
+  Object.defineProperty(_this, _x, {
     writable: true,
     value: void 0
   });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
@@ -12,13 +12,13 @@ function (_Bar) {
 
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), _bar, {
+      Object.defineProperty(_this, _bar, {
         writable: true,
         value: "foo"
       });
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), _bar, {
+      Object.defineProperty(_this, _bar, {
         writable: true,
         value: "foo"
       });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
@@ -22,7 +22,7 @@ function (_Foo) {
 
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
-    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _prop2, {
+    Object.defineProperty(_this, _prop2, {
       writable: true,
       value: "bar"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/extracted-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/extracted-this/output.js
@@ -3,12 +3,14 @@ var foo = "bar";
 var Foo = function Foo(_foo) {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, _bar, {
+  Object.defineProperty(_this, _bar, {
     writable: true,
-    value: this
+    value: _this
   });
-  Object.defineProperty(this, _baz, {
+  Object.defineProperty(_this, _baz, {
     writable: true,
     value: foo
   });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -10,7 +10,7 @@ function (_Parent) {
 
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
-    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _scopedFunctionWithThis, {
+    Object.defineProperty(_this, _scopedFunctionWithThis, {
       writable: true,
       value: function value() {
         _this.name = {};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/multiple/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/multiple/output.js
@@ -1,14 +1,16 @@
 var Foo = function Foo() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, _x, {
+  Object.defineProperty(_this, _x, {
     writable: true,
     value: 0
   });
-  Object.defineProperty(this, _y, {
+  Object.defineProperty(_this, _y, {
     writable: true,
-    value: babelHelpers.classPrivateFieldLooseBase(this, _x)[_x]
+    value: babelHelpers.classPrivateFieldLooseBase(_this, _x)[_x]
   });
 };
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
@@ -1,8 +1,10 @@
 var Outer = function Outer() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Outer);
-  Object.defineProperty(this, _outer, {
+  Object.defineProperty(_this, _outer, {
     writable: true,
     value: void 0
   });
@@ -18,7 +20,7 @@ var Outer = function Outer() {
     }
 
     return Test;
-  }(babelHelpers.classPrivateFieldLooseBase(this, _outer)[_outer]);
+  }(babelHelpers.classPrivateFieldLooseBase(_this, _outer)[_outer]);
 };
 
 var _outer = babelHelpers.classPrivateFieldLooseKey("outer");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reference-in-other-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reference-in-other-property/output.js
@@ -1,20 +1,22 @@
 var Foo = function Foo() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
-  this.one = babelHelpers.classPrivateFieldLooseBase(this, _private)[_private];
-  Object.defineProperty(this, _two, {
+  _this.one = babelHelpers.classPrivateFieldLooseBase(_this, _private)[_private];
+  Object.defineProperty(_this, _two, {
     writable: true,
-    value: babelHelpers.classPrivateFieldLooseBase(this, _private)[_private]
+    value: babelHelpers.classPrivateFieldLooseBase(_this, _private)[_private]
   });
-  Object.defineProperty(this, _private, {
+  Object.defineProperty(_this, _private, {
     writable: true,
     value: 0
   });
-  this.three = babelHelpers.classPrivateFieldLooseBase(this, _private)[_private];
-  Object.defineProperty(this, _four, {
+  _this.three = babelHelpers.classPrivateFieldLooseBase(_this, _private)[_private];
+  Object.defineProperty(_this, _four, {
     writable: true,
-    value: babelHelpers.classPrivateFieldLooseBase(this, _private)[_private]
+    value: babelHelpers.classPrivateFieldLooseBase(_this, _private)[_private]
   });
 };
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _bar, {
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), Object.defineProperty(_this, _bar, {
       writable: true,
       value: "foo"
     }), _temp));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _bar, {
+    Object.defineProperty(_this, _bar, {
       writable: true,
       value: "foo"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
@@ -4,20 +4,22 @@ function () {
   "use strict";
 
   function Point(_x2 = 0, _y2 = 0) {
+    var _this = this;
+
     babelHelpers.classCallCheck(this, Point);
 
-    _x.set(this, {
+    _x.set(_this, {
       writable: true,
       value: void 0
     });
 
-    _y.set(this, {
+    _y.set(_this, {
       writable: true,
       value: void 0
     });
 
-    babelHelpers.classPrivateFieldSet(this, _x, +_x2);
-    babelHelpers.classPrivateFieldSet(this, _y, +_y2);
+    babelHelpers.classPrivateFieldSet(_this, _x, +_x2);
+    babelHelpers.classPrivateFieldSet(_this, _y, +_y2);
   }
 
   babelHelpers.createClass(Point, [{

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/declaration-order/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/declaration-order/output.js
@@ -1,10 +1,12 @@
 var C = function C() {
   "use strict";
 
-  babelHelpers.classCallCheck(this, C);
-  babelHelpers.defineProperty(this, "y", babelHelpers.classPrivateFieldGet(this, _x));
+  var _this = this;
 
-  _x.set(this, {
+  babelHelpers.classCallCheck(this, C);
+  babelHelpers.defineProperty(_this, "y", babelHelpers.classPrivateFieldGet(_this, _x));
+
+  _x.set(_this, {
     writable: true,
     value: void 0
   });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -13,14 +13,14 @@ function (_Bar) {
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), {
+      _bar.set(_this, {
         writable: true,
         value: "foo"
       });
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), {
+      _bar.set(_this, {
         writable: true,
         value: "foo"
       });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -24,7 +24,7 @@ function (_Foo) {
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
 
-    _prop2.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _prop2.set(_this, {
       writable: true,
       value: "bar"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/extracted-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/extracted-this/output.js
@@ -3,14 +3,16 @@ var foo = "bar";
 var Foo = function Foo(_foo) {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
 
-  _bar.set(this, {
+  _bar.set(_this, {
     writable: true,
-    value: this
+    value: _this
   });
 
-  _baz.set(this, {
+  _baz.set(_this, {
     writable: true,
     value: foo
   });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
@@ -11,7 +11,7 @@ function (_Parent) {
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
 
-    _scopedFunctionWithThis.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _scopedFunctionWithThis.set(_this, {
       writable: true,
       value: () => {
         _this.name = {};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/multiple/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/multiple/output.js
@@ -1,16 +1,18 @@
 var Foo = function Foo() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
 
-  _x.set(this, {
+  _x.set(_this, {
     writable: true,
     value: 0
   });
 
-  _y.set(this, {
+  _y.set(_this, {
     writable: true,
-    value: babelHelpers.classPrivateFieldGet(this, _x)
+    value: babelHelpers.classPrivateFieldGet(_this, _x)
   });
 };
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
@@ -1,9 +1,11 @@
 var Outer = function Outer() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Outer);
 
-  _outer.set(this, {
+  _outer.set(_this, {
     writable: true,
     value: void 0
   });
@@ -19,7 +21,7 @@ var Outer = function Outer() {
     }
 
     return Test;
-  }(babelHelpers.classPrivateFieldGet(this, _outer));
+  }(babelHelpers.classPrivateFieldGet(_this, _outer));
 };
 
 var _outer = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reference-in-other-property/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reference-in-other-property/output.js
@@ -1,24 +1,26 @@
 var Foo = function Foo() {
   "use strict";
 
-  babelHelpers.classCallCheck(this, Foo);
-  babelHelpers.defineProperty(this, "one", babelHelpers.classPrivateFieldGet(this, _private));
+  var _this = this;
 
-  _two.set(this, {
+  babelHelpers.classCallCheck(this, Foo);
+  babelHelpers.defineProperty(_this, "one", babelHelpers.classPrivateFieldGet(_this, _private));
+
+  _two.set(_this, {
     writable: true,
-    value: babelHelpers.classPrivateFieldGet(this, _private)
+    value: babelHelpers.classPrivateFieldGet(_this, _private)
   });
 
-  _private.set(this, {
+  _private.set(_this, {
     writable: true,
     value: 0
   });
 
-  babelHelpers.defineProperty(this, "three", babelHelpers.classPrivateFieldGet(this, _private));
+  babelHelpers.defineProperty(_this, "three", babelHelpers.classPrivateFieldGet(_this, _private));
 
-  _four.set(this, {
+  _four.set(_this, {
     writable: true,
-    value: babelHelpers.classPrivateFieldGet(this, _private)
+    value: babelHelpers.classPrivateFieldGet(_this, _private)
   });
 };
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -29,9 +29,9 @@ function (_A) {
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
 
-    _foo.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _foo.set(_this, {
       writable: true,
-      value: babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))
+      value: babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", _this).call(_this)
     });
 
     return _this;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(_this, {
       writable: true,
       value: "foo"
     }), _temp));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
@@ -11,7 +11,7 @@ function (_Bar) {
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-    _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _bar.set(_this, {
       writable: true,
       value: "foo"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/computed/output.js
@@ -26,16 +26,18 @@ function () {
   "use strict";
 
   function MyClass() {
+    var _this = this;
+
     babelHelpers.classCallCheck(this, MyClass);
-    this[null] = "null";
-    this[_undefined] = "undefined";
-    this[void 0] = "void 0";
-    this[_ref3] = "regex";
-    this[foo] = "foo";
-    this[bar] = "bar";
-    this[_baz] = "baz";
-    this[`template`] = "template";
-    this[_ref4] = "template-with-expression";
+    _this[null] = "null";
+    _this[_undefined] = "undefined";
+    _this[void 0] = "void 0";
+    _this[_ref3] = "regex";
+    _this[foo] = "foo";
+    _this[bar] = "bar";
+    _this[_baz] = "baz";
+    _this[`template`] = "template";
+    _this[_ref4] = "template-with-expression";
   }
 
   babelHelpers.createClass(MyClass, [{

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -28,7 +28,7 @@ function (_A) {
 
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
-    _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", _this).call(_this);
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-with-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-with-collision/output.js
@@ -1,7 +1,9 @@
 var A = function A(_force) {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, A);
-  this.force = force;
-  this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", this).call(this);
+  _this.force = force;
+  _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", _this).call(_this);
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/computed/output.js
@@ -26,16 +26,18 @@ function () {
   "use strict";
 
   function MyClass() {
+    var _this = this;
+
     babelHelpers.classCallCheck(this, MyClass);
-    babelHelpers.defineProperty(this, null, "null");
-    babelHelpers.defineProperty(this, _undefined, "undefined");
-    babelHelpers.defineProperty(this, void 0, "void 0");
-    babelHelpers.defineProperty(this, _ref3, "regex");
-    babelHelpers.defineProperty(this, foo, "foo");
-    babelHelpers.defineProperty(this, bar, "bar");
-    babelHelpers.defineProperty(this, _baz, "baz");
-    babelHelpers.defineProperty(this, `template`, "template");
-    babelHelpers.defineProperty(this, _ref4, "template-with-expression");
+    babelHelpers.defineProperty(_this, null, "null");
+    babelHelpers.defineProperty(_this, _undefined, "undefined");
+    babelHelpers.defineProperty(_this, void 0, "void 0");
+    babelHelpers.defineProperty(_this, _ref3, "regex");
+    babelHelpers.defineProperty(_this, foo, "foo");
+    babelHelpers.defineProperty(_this, bar, "bar");
+    babelHelpers.defineProperty(_this, _baz, "baz");
+    babelHelpers.defineProperty(_this, `template`, "template");
+    babelHelpers.defineProperty(_this, _ref4, "template-with-expression");
   }
 
   babelHelpers.createClass(MyClass, [{

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
@@ -12,10 +12,10 @@ function (_Bar) {
 
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), "bar", "foo");
+      babelHelpers.defineProperty(_this, "bar", "foo");
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), "bar", "foo");
+      babelHelpers.defineProperty(_this, "bar", "foo");
     }
 
     return babelHelpers.possibleConstructorReturn(_this);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo");
+    babelHelpers.defineProperty(_this, "bar", "foo");
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/extracted-this/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/extracted-this/output.js
@@ -3,7 +3,9 @@ var foo = "bar";
 var Foo = function Foo(_foo) {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
-  babelHelpers.defineProperty(this, "bar", this);
-  babelHelpers.defineProperty(this, "baz", foo);
+  babelHelpers.defineProperty(_this, "bar", _this);
+  babelHelpers.defineProperty(_this, "baz", foo);
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
@@ -10,7 +10,7 @@ function (_Parent) {
 
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "scopedFunctionWithThis", function () {
+    babelHelpers.defineProperty(_this, "scopedFunctionWithThis", function () {
       _this.name = {};
     });
     return _this;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/numeric/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/numeric/output.js
@@ -1,7 +1,9 @@
 var Foo = function Foo() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Foo);
-  babelHelpers.defineProperty(this, 0, "foo");
-  babelHelpers.defineProperty(this, 1, "bar");
+  babelHelpers.defineProperty(_this, 0, "foo");
+  babelHelpers.defineProperty(_this, 1, "bar");
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -28,7 +28,7 @@ function (_A) {
 
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
+    babelHelpers.defineProperty(_this, "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", _this).call(_this));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo"), _temp));
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), babelHelpers.defineProperty(_this, "bar", "foo"), _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo");
+    babelHelpers.defineProperty(_this, "bar", "foo");
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-with-collision/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-with-collision/output.js
@@ -1,7 +1,9 @@
 var A = function A(_force) {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, A);
-  babelHelpers.defineProperty(this, "force", force);
-  babelHelpers.defineProperty(this, "foo", babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", this).call(this));
+  babelHelpers.defineProperty(_this, "force", force);
+  babelHelpers.defineProperty(_this, "foo", babelHelpers.get(babelHelpers.getPrototypeOf(A.prototype), "method", _this).call(_this));
 };

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -2,11 +2,11 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -43,8 +43,8 @@ var Test = function Test() {
 
       _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args)));
 
-      _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "a", function () {
-        return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));
+      _defineProperty(_this, "a", function () {
+        return _get(_getPrototypeOf(Other.prototype), "test", _this);
       });
 
       return _this;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/decorator-interop/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/static-property-tdz/decorator-interop/output.js
@@ -20,9 +20,11 @@ function () {
   "use strict";
 
   function A() {
+    var _this = this;
+
     _classCallCheck(this, A);
 
-    _initializerDefineProperty(this, "a", _descriptor, this);
+    _initializerDefineProperty(_this, "a", _descriptor, _this);
   }
 
   _createClass(A, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
@@ -13,14 +13,14 @@ function (_Foo) {
     woops.super.test();
     _this = _Foo.call(this) || this;
 
-    _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
+    _Foo.prototype.test.call(_this);
 
     _this = _Foo.apply(this, arguments) || this;
     _this = _Foo.call.apply(_Foo, [this, "test"].concat(Array.prototype.slice.call(arguments))) || this;
 
-    _Foo.prototype.test.apply(babelHelpers.assertThisInitialized(_this), arguments);
+    _Foo.prototype.test.apply(_this, arguments);
 
-    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));
+    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
@@ -12,7 +12,7 @@ function (_Foo) {
 
     _Foo.prototype.test.whatever();
 
-    _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
+    _Foo.prototype.test.call(_this);
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
@@ -21,7 +21,7 @@ function (_b) {
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(a1).call(this));
 
     _this.x = function () {
-      return babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this));
+      return _this;
     };
 
     return _this;
@@ -42,7 +42,7 @@ function (_b2) {
     _this2 = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(a2).call(this));
 
     _this2.x = function () {
-      return babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this2));
+      return _this2;
     };
 
     return _this2;

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -29,10 +29,10 @@ function (_Point) {
     babelHelpers.classCallCheck(this, ColorPoint);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(ColorPoint).call(this));
     _this.x = 2;
-    babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, babelHelpers.assertThisInitialized(_this), true);
+    babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, _this, true);
     expect(_this.x).toBe(3); // A
 
-    expect(babelHelpers.get(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", babelHelpers.assertThisInitialized(_this))).toBeUndefined(); // B
+    expect(babelHelpers.get(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", _this)).toBeUndefined(); // B
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -13,12 +13,12 @@ function (_Foo) {
     babelHelpers.classCallCheck(this, Test);
     woops.super.test();
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).call(this));
-    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this).call(_this);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).apply(this, arguments));
     _this = babelHelpers.possibleConstructorReturn(this, (_babelHelpers$getProt = babelHelpers.getPrototypeOf(Test)).call.apply(_babelHelpers$getProt, [this, "test"].concat(Array.prototype.slice.call(arguments))));
-    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).apply(babelHelpers.assertThisInitialized(_this), arguments);
+    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this).apply(_this, arguments);
 
-    (_babelHelpers$get = babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this))).call.apply(_babelHelpers$get, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));
+    (_babelHelpers$get = babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this)).call.apply(_babelHelpers$get, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
@@ -10,8 +10,8 @@ function (_Foo) {
 
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).call(this));
-    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this));
-    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).whatever;
+    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this);
+    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this).whatever;
     return _this;
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
@@ -10,8 +10,8 @@ function (_Foo) {
 
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).call(this));
-    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).whatever();
-    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this).whatever();
+    babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", _this).call(_this);
     return _this;
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, () => {
-      _this.test;
+      babelHelpers.assertThisInitialized(_this).test;
     }));
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/exec.js
@@ -5,5 +5,27 @@ class Foo extends Bar {
     if (eval("false")) super();
   }
 }
-
 expect(() => new Foo()).toThrow("this hasn't been initialised");
+
+class Baz extends Bar {
+  constructor() {
+    false && this;
+    this;
+  }
+}
+expect(() => new Baz()).toThrow("this hasn't been initialised");
+
+class Qux extends Bar {
+  constructor() {
+    false && this;
+  }
+}
+expect(() => new Qux()).toThrow("this hasn't been initialised");
+
+class Ok extends Bar {
+  constructor() {
+    false && this;
+    super()
+  }
+}
+expect(() => new Ok()).not.toThrow();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/input.js
@@ -3,3 +3,10 @@ class Foo extends Bar {
     if (eval("false")) super();
   }
 }
+
+class Baz extends Bar {
+  constructor() {
+    false && this;
+    this;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
@@ -15,3 +15,22 @@ function (_Bar) {
 
   return Foo;
 }(Bar);
+
+var Baz =
+/*#__PURE__*/
+function (_Bar2) {
+  "use strict";
+
+  babelHelpers.inherits(Baz, _Bar2);
+
+  function Baz() {
+    var _this2;
+
+    babelHelpers.classCallCheck(this, Baz);
+    false && babelHelpers.assertThisInitialized(_this2);
+    babelHelpers.assertThisInitialized(_this2);
+    return _this2;
+  }
+
+  return Baz;
+}(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -35,7 +35,7 @@ function (_Hello) {
       }
 
       babelHelpers.createClass(Inner, [{
-        key: babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)),
+        key: babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", _this).call(_this),
         value: function value() {
           return 'hello';
         }
@@ -43,7 +43,7 @@ function (_Hello) {
       return Inner;
     }();
 
-    return babelHelpers.possibleConstructorReturn(_this, new Inner());
+    return new Inner() || _this;
   }
 
   return Outer;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -27,12 +27,12 @@ function (_Hello) {
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
     var Inner = {
-      [babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))]() {
+      [babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", _this).call(_this)]() {
         return 'hello';
       }
 
     };
-    return babelHelpers.possibleConstructorReturn(_this, Inner);
+    return Inner || _this;
   }
 
   return Outer;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-function-fallback/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-function-fallback/output.js
@@ -1,6 +1,8 @@
 var Test = function Test() {
   "use strict";
 
+  var _this = this;
+
   babelHelpers.classCallCheck(this, Test);
-  babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "hasOwnProperty", this).call(this, "test");
+  babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "hasOwnProperty", _this).call(_this, "test");
 };

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -26,7 +26,7 @@ function (_Bar) {
 
     _classCallCheck(this, Foo);
 
-    _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_assertThisInitialized(_this), _this = _possibleConstructorReturn(this, _getPrototypeOf(Foo).call(this)));
+    _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_this, _this = _possibleConstructorReturn(this, _getPrototypeOf(Foo).call(this)));
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -26,7 +26,7 @@ function (_Bar) {
 
     _classCallCheck(this, Foo);
 
-    _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_assertThisInitialized(_this));
+    _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_this);
 
     return _this = _possibleConstructorReturn(this, _getPrototypeOf(Foo).call(this));
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
@@ -10,9 +10,9 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(_this);
 
-    babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(_this);
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(_this);
 
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
     t();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(_this);
 
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), (_this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this))).method, babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), (_this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this))).method, babelHelpers.assertThisInitialized(_this)).call(_this);
     return _this;
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))));
+    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, babelHelpers.assertThisInitialized(_this)));
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var fn = () => babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this));
+    var fn = () => babelHelpers.assertThisInitialized(_this);
 
     fn();
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/exec.js
@@ -9,3 +9,13 @@ class Foo extends Bar {
 }
 
 new Foo();
+
+class A extends Bar {
+  constructor() {
+    super();
+    const fn = () => this;
+    fn();
+  }
+}
+
+new A();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/input.js
@@ -5,3 +5,13 @@ class Foo extends Bar {
     fn();
   }
 }
+
+// 'assertThisInitialized` should be cleanup
+class A extends Bar {
+  constructor() {
+    super();
+    const fn = () => this;
+    this;
+    fn();
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var fn = () => babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this));
+    var fn = () => babelHelpers.assertThisInitialized(_this);
 
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
     fn();
@@ -18,4 +18,28 @@ function (_Bar) {
   }
 
   return Foo;
+}(Bar); // 'assertThisInitialized` should be cleanup
+
+
+var A =
+/*#__PURE__*/
+function (_Bar2) {
+  "use strict";
+
+  babelHelpers.inherits(A, _Bar2);
+
+  function A() {
+    var _this2;
+
+    babelHelpers.classCallCheck(this, A);
+    _this2 = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(A).call(this));
+
+    var fn = () => _this2;
+
+    _this2;
+    fn();
+    return _this2;
+  }
+
+  return A;
 }(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
@@ -9,8 +9,8 @@ function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    Foo[babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))];
-    return babelHelpers.possibleConstructorReturn(_this);
+    Foo[babelHelpers.assertThisInitialized(_this)];
+    return _this;
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-6/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-6/exec.js
@@ -1,0 +1,12 @@
+class B {}
+
+class A extends B {
+  constructor() {
+    const a = () => this;
+    const b = () => this;
+    b();
+    super();
+  }
+}
+
+expect(() => new A()).toThrow("this hasn't been initialised");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-6/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-6/input.js
@@ -1,0 +1,12 @@
+class B {}
+
+class A extends B {
+  constructor() {
+    const a = () => this;
+    const b = () => this;
+    b();
+    super();
+  }
+}
+
+new A();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-6/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-6/output.js
@@ -1,0 +1,30 @@
+var B = function B() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, B);
+};
+
+var A =
+/*#__PURE__*/
+function (_B) {
+  "use strict";
+
+  babelHelpers.inherits(A, _B);
+
+  function A() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, A);
+
+    var a = () => babelHelpers.assertThisInitialized(_this);
+
+    var b = () => babelHelpers.assertThisInitialized(_this);
+
+    b();
+    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(A).call(this));
+  }
+
+  return A;
+}(B);
+
+new A();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-7/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-7/exec.js
@@ -1,0 +1,10 @@
+class B {}
+
+class A extends B {
+  constructor() {
+    this;
+    return { foo: 'foo' }
+  }
+}
+
+expect(() => new A()).toThrow("this hasn't been initialised");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-7/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-7/input.js
@@ -1,0 +1,10 @@
+class B {}
+class A extends B {
+  constructor() {
+    this;
+    this.foo = 1
+    return { foo: 'foo' }
+  }
+}
+
+new A

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-7/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-7/output.js
@@ -1,0 +1,28 @@
+var B = function B() {
+  "use strict";
+
+  babelHelpers.classCallCheck(this, B);
+};
+
+var A =
+/*#__PURE__*/
+function (_B) {
+  "use strict";
+
+  babelHelpers.inherits(A, _B);
+
+  function A() {
+    var _this;
+
+    babelHelpers.classCallCheck(this, A);
+    babelHelpers.assertThisInitialized(_this);
+    _this.foo = 1;
+    return {
+      foo: 'foo'
+    } || _this;
+  }
+
+  return A;
+}(B);
+
+new A();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/exec.js
@@ -3,6 +3,7 @@ class Bar {}
 class Foo extends Bar {
   constructor() {
     this.foo = "bar";
+    this.bar = 2
     super();
   }
 }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this.foo = "bar";
+    babelHelpers.assertThisInitialized(_this).foo = "bar";
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
   }
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -19,13 +19,13 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -47,7 +47,7 @@ function (_Component) {
 
     _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args)));
 
-    _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "exportType", '');
+    _defineProperty(_this, "exportType", '');
 
     return _this;
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8335
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
