### PR TITLE
Babel standalone type module

### DIFF
--- a/packages/babel-standalone/examples/scriptTag-module.htm
+++ b/packages/babel-standalone/examples/scriptTag-module.htm
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>babel-standalone example - External script</title>
+</head>
+<body>
+  Using Babel <strong id="version"></strong>:
+  <pre id="output">Loading...</pre>
+
+  <script src="../babel.js"></script>
+  <script type="text/babel/module" data-presets='es2016'>
+    import vuid from 'https://unpkg.com/vuid'
+    const doStuff = () => {
+      const name = vuid();
+      document.getElementById('output').innerHTML = `Hello ${name}`;
+      document.getElementById('version').innerHTML = Babel.version;
+    };
+    doStuff();
+  </script>
+</body>
+</html>

--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -55,6 +55,9 @@ function buildBabelOptions(script) {
 function run(transformFn, script) {
   const scriptEl = document.createElement("script");
   scriptEl.text = transformCode(transformFn, script);
+  if (script.module) {
+    scriptEl.type = "module";
+  }
   headEl.appendChild(scriptEl);
 }
 
@@ -132,6 +135,7 @@ function loadScripts(transformFn, scripts) {
       async: script.hasAttribute("async"),
       error: false,
       executed: false,
+      module: script.type.indexOf("module") !== -1,
       plugins: getPluginsOrPresetsFromScript(script, "data-plugins"),
       presets: getPluginsOrPresetsFromScript(script, "data-presets"),
     };


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel-standalone/issues/96
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

I have been building an in browser based dev environment that takes advantage of script `type="module"` with native static `import` statements. Everything worked great until I tried building an app that uses JSX. For that to work in the browser it needs to be transpiled.

I employed `@babel/standalone` to do this for me in the browser. It was at this point that I realised a conflict in script types; I needed `<script type="text/babel">` to flag to babel standalone that the code was to be transpiled but also required `<script type="module">` in order for native imports to work correctly.

I searched the `babel-standalone` repo for similar issues and found this  https://github.com/babel/babel-standalone/issues/96. So I added this comment https://github.com/babel/babel-standalone/issues/96#issuecomment-395994115 questioning wether use of the `type` attribute was required. Some others replied saying they had similar issues but we got no reply for any maintainers and the issue was subsequently archived a week or so later.

So here is my suggestion but in working code. The changes are minimal but have the desired effect; if you mark a script with `type="text/jsx/module"` then babel standalone picks up that the script needs to be transpiled and adds `type="module"` to the resultant script tag which gets appended to the head.

Thanks for your time 🙇