### PR TITLE
Allow patterns as argument of RestElement

### DIFF
--- a/packages/babel-plugin-transform-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-parameters/src/rest.js
@@ -228,9 +228,19 @@ export default function convertFunctionRest(path) {
   const { node, scope } = path;
   if (!hasRest(node)) return false;
 
-  const rest = node.params.pop().argument;
+  let rest = node.params.pop().argument;
 
   const argsId = t.identifier("arguments");
+
+  if (t.isPattern(rest)) {
+    const pattern = rest;
+    rest = scope.generateUidIdentifier("ref");
+
+    const declar = t.variableDeclaration("let", [
+      t.variableDeclarator(pattern, rest),
+    ]);
+    node.body.body.unshift(declar);
+  }
 
   // check and optimise for extremely common cases
   const state = {

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/exec.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/exec.js
@@ -1,0 +1,5 @@
+function foo(...{ length }) {
+  return length;
+}
+
+expect(foo(1, 2, 3)).toEqual(3);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/input.js
@@ -1,0 +1,1 @@
+function foo(...[a]) {}

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-patterns/output.js
@@ -1,0 +1,7 @@
+function foo() {
+  for (var _len = arguments.length, _ref = new Array(_len), _key = 0; _key < _len; _key++) {
+    _ref[_key] = arguments[_key];
+  }
+
+  var a = _ref[0];
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8396, fixes #5673  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Patterns as arguments to `RestElement`s were apparently removed back in https://github.com/babel/babel/commit/9a97d92217dffcf6478611067c1525fa4004fce4 when, as mentioned there, they were not part of es6. They're part of the standard now, so this PR adds them back in.

```js
function foo(...[a]) {}
```

will now get converted to:

```js
function foo() {
  for (var _len = arguments.length, _ref = new Array(_len), _key = 0; _key < _len; _key++) {
    _ref[_key] = arguments[_key];
  }

  var [a] = _ref;
}

```

letting the destructuring plugin handle it from there (`[a] = _ref` => `a = _ref[0]`).

Note that this does not make any of the optimizations that are otherwise made when the argument is an identifier - e.g. even though `a` is not referenced inside the function it will still be made available. If any optimizations are possible I think they can be added in other PRs?

~~I'll try to make a backport for v6 as well.~~ EDIT: Don't think it's possible to change babylon 6.x anymore.