### PR TITLE
Allow transform-runtime to insert runtime references with absolute paths.

### DIFF
--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -10,7 +10,8 @@
   ],
   "dependencies": {
     "@babel/helper-module-imports": "7.0.0-rc.1",
-    "@babel/helper-plugin-utils": "7.0.0-rc.1"
+    "@babel/helper-plugin-utils": "7.0.0-rc.1",
+    "resolve": "^1.8.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"
@@ -21,6 +22,7 @@
     "@babel/helpers": "7.0.0-rc.1",
     "@babel/plugin-transform-runtime": "7.0.0-rc.1",
     "@babel/preset-env": "7.0.0-rc.1",
+    "@babel/runtime": "7.0.0-rc.1",
     "@babel/template": "7.0.0-rc.1",
     "@babel/types": "7.0.0-beta.53"
   }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/input.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-classes",
+    ["transform-runtime", { "absoluteRuntime": "./subfolder" }]
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
@@ -1,0 +1,7 @@
+var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/classCallCheck");
+
+let Foo = function Foo() {
+  "use strict";
+
+  _classCallCheck(this, Foo);
+};

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/input.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-classes",
+    ["transform-runtime", { "absoluteRuntime": true }]
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/true/output.js
@@ -1,0 +1,7 @@
+var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/classCallCheck");
+
+let Foo = function Foo() {
+  "use strict";
+
+  _classCallCheck(this, Foo);
+};


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes feature request in https://github.com/babel/babel/pull/8266#issuecomment-411069941 for runtime transform
| Patch: Bug Fix?          |
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Tests Added + Pass?      |
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This allows users to run `transform-runtime` broadly across a whole project. By default, `transform-runtime` imports from `@babel/runtime/foo` directly, but that only works if `@babel/runtime` is in the node modules of the file that is being compiled. This can be problematic for nested node modules, or npm-linked modules, among other cases. To avoid worrying about how the runtime module's location, this allows users to resolve the runtime once up front, and then insert absolute paths to the runtime into the output code.

Using absolute paths is not desirable if files are compiled for use at a later time, but in contexts where a file is compiled and then immediately consumed, they can be quite helpful.

This PR exposes two approaches for resolving the runtime:

* `absoluteRuntime: true` - Resolve the runtime:
  * relative to Babel's `cwd` if the `transform-runtime` plugin is passed as a programmatic arg to Babel
  * relative to the config file, if `transform-runtime` is enabled via a config file
* `absoluteRuntime: '/projects/thing/src'`
  * Resolve the runtime relative to some specific location, for instance if you wanted to pass the `__dirname` of some general build process script. e.g. will look at
    * `/projects/thing/src/node_modules/@babel/runtime/foo`
    * `/projects/thing/node_modules/@babel/runtime/foo`
    * `/projects/node_modules/@babel/runtime/foo`
    * `/node_modules/@babel/runtime/foo`


cc @insin