### PR TITLE
Require v1.1.0 so that correct filter params are passed.

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "convert-source-map": "^1.1.0",
-    "fs-readdir-recursive": "^1.0.0",
+    "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.0.0",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #8431
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

PR #8418 introduced some new logic that uses the third parameter of `fs-readdir-recursive`'s `filter` option, the current directory, but missed that our dependencies only required `^1.0.0`, while that parameter was actually added in `1.1.0`. This means that if some other dependency forced a downgrade in the version to satisfy some range, or the user already had 1.0.0 module installed locally, it could cause problems,
