### PR TITLE
Add initial ES2019 and saf12/elec3 support in env

### DIFF
--- a/packages/babel-preset-env-standalone/package.json
+++ b/packages/babel-preset-env-standalone/package.json
@@ -9,6 +9,7 @@
     "src"
   ],
   "devDependencies": {
+    "@babel/plugin-proposal-json-strings": "7.0.0-rc.1",
     "@babel/plugin-transform-new-target": "7.0.0-rc.1",
     "@babel/preset-env": "7.0.0-rc.1",
     "@babel/standalone": "7.0.0-rc.1"

--- a/packages/babel-preset-env-standalone/src/available-plugins.js
+++ b/packages/babel-preset-env-standalone/src/available-plugins.js
@@ -2,6 +2,7 @@ import { availablePlugins, registerPlugin } from "@babel/standalone";
 
 const notIncludedPlugins = {
   "transform-new-target": require("@babel/plugin-transform-new-target"),
+  "proposal-json-strings": require("@babel/plugin-proposal-json-strings"),
 };
 
 Object.keys(notIncludedPlugins).forEach(pluginName => {

--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -206,7 +206,8 @@
     "firefox": "5",
     "safari": "10.1",
     "ie": "9",
-    "ios": "10.3"
+    "ios": "10.3",
+    "electron": "3"
   },
   "es6.array.species": {
     "chrome": "51",
@@ -618,7 +619,8 @@
     "safari": "9",
     "node": "8.10",
     "ios": "9",
-    "opera": "49"
+    "opera": "49",
+    "electron": "3"
   },
   "es7.object.define-setter": {
     "chrome": "62",
@@ -627,7 +629,8 @@
     "safari": "9",
     "node": "8.10",
     "ios": "9",
-    "opera": "49"
+    "opera": "49",
+    "electron": "3"
   },
   "es6.object.define-property": {
     "chrome": "5",
@@ -719,7 +722,8 @@
     "safari": "9",
     "node": "8.10",
     "ios": "9",
-    "opera": "49"
+    "opera": "49",
+    "electron": "3"
   },
   "es7.object.lookup-setter": {
     "chrome": "62",
@@ -727,7 +731,8 @@
     "safari": "9",
     "node": "8.10",
     "ios": "9",
-    "opera": "49"
+    "opera": "49",
+    "electron": "3"
   },
   "es6.object.prevent-extensions": {
     "chrome": "44",
@@ -835,7 +840,8 @@
     "firefox": "58",
     "safari": "11.1",
     "ios": "11.3",
-    "opera": "50"
+    "opera": "50",
+    "electron": "3"
   },
   "es6.reflect.apply": {
     "chrome": "49",
@@ -1052,8 +1058,9 @@
   "es7.symbol.async-iterator": {
     "chrome": "63",
     "firefox": "57",
-    "safari": "tp",
-    "opera": "50"
+    "safari": "12",
+    "opera": "50",
+    "electron": "3"
   },
   "es6.string.anchor": {
     "chrome": "5",
@@ -1430,5 +1437,11 @@
     "ios": "9",
     "opera": "38",
     "electron": "1.2"
+  },
+  "es7.array.flat-map": {
+    "chrome": "69",
+    "firefox": "62",
+    "safari": "12",
+    "opera": "56"
   }
 }

--- a/packages/babel-preset-env/data/plugin-features.js
+++ b/packages/babel-preset-env/data/plugin-features.js
@@ -54,7 +54,7 @@ const es = {
   },
 
   "transform-spread": {
-    features: ["spread (...) operator"],
+    features: "spread syntax for iterable objects",
   },
   "transform-parameters": {
     features: ["default function parameters", "rest parameters"],
@@ -90,6 +90,9 @@ const es = {
   "proposal-async-generator-functions": "Asynchronous Iterators",
   "proposal-object-rest-spread": "object rest/spread properties",
   "proposal-unicode-property-regex": "RegExp Unicode Property Escapes",
+
+  "proposal-json-strings": "", // Awaiting mapping in compat-table
+  "proposal-optional-catch-binding": "optional catch binding",
 };
 
 const proposals = require("./shipped-proposals").features;

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -124,7 +124,8 @@
     "safari": "11.1",
     "node": "8.10",
     "ios": "11.3",
-    "opera": "49"
+    "opera": "49",
+    "electron": "3"
   },
   "transform-unicode-regex": {
     "chrome": "50",
@@ -228,8 +229,9 @@
   "proposal-async-generator-functions": {
     "chrome": "63",
     "firefox": "57",
-    "safari": "tp",
-    "opera": "50"
+    "safari": "12",
+    "opera": "50",
+    "electron": "3"
   },
   "proposal-object-rest-spread": {
     "chrome": "60",
@@ -244,13 +246,16 @@
     "chrome": "64",
     "safari": "11.1",
     "ios": "11.3",
-    "opera": "51"
+    "opera": "51",
+    "electron": "3"
   },
+  "proposal-json-strings": {},
   "proposal-optional-catch-binding": {
     "chrome": "66",
     "firefox": "58",
     "safari": "11.1",
     "ios": "11.3",
-    "opera": "53"
+    "opera": "53",
+    "electron": "3"
   }
 }

--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -1,17 +1,18 @@
 // These mappings represent the builtin/feature proposals that have been
 // shipped by browsers, and are enabled by the `shippedProposals` option.
 
-const builtIns = {};
-
-const features = {
-  "proposal-optional-catch-binding": "optional catch binding",
+const builtIns = {
+  "es7.array.flat-map": "Array.prototype.{flat, flatMap} / Array.prototype.flatMap"
 };
+
+const features = {};
 
 const pluginSyntaxMap = new Map([
   ["proposal-async-generator-functions", "syntax-async-generators"],
   ["proposal-object-rest-spread", "syntax-object-rest-spread"],
   ["proposal-optional-catch-binding", "syntax-optional-catch-binding"],
   ["proposal-unicode-property-regex", null],
+  ["proposal-json-strings", "syntax-json-strings"],
 ]);
 
 module.exports = { builtIns, features, pluginSyntaxMap };

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -14,6 +14,7 @@
     "@babel/helper-module-imports": "7.0.0-rc.1",
     "@babel/helper-plugin-utils": "7.0.0-rc.1",
     "@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
+    "@babel/plugin-proposal-json-strings": "7.0.0-rc.1",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
     "@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.1",
     "@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.1",
@@ -61,7 +62,7 @@
     "@babel/helper-fixtures": "7.0.0-rc.1",
     "@babel/helper-plugin-test-runner": "7.0.0-rc.1",
     "caniuse-db": "1.0.30000851",
-    "compat-table": "kangax/compat-table#90d02e486227d179d2ce9b850dbb3f9846443cab",
-    "electron-to-chromium": "1.3.48"
+    "compat-table": "kangax/compat-table#ce39b436201a8d037cc1b943770a21e07769d684",
+    "electron-to-chromium": "1.3.55"
   }
 }

--- a/packages/babel-preset-env/src/available-plugins.js
+++ b/packages/babel-preset-env/src/available-plugins.js
@@ -4,6 +4,7 @@ export default {
   "syntax-optional-catch-binding": require("@babel/plugin-syntax-optional-catch-binding"),
   "transform-async-to-generator": require("@babel/plugin-transform-async-to-generator"),
   "proposal-async-generator-functions": require("@babel/plugin-proposal-async-generator-functions"),
+  "proposal-json-strings": require("@babel/plugin-proposal-json-strings"),
   "transform-arrow-functions": require("@babel/plugin-transform-arrow-functions"),
   "transform-block-scoped-functions": require("@babel/plugin-transform-block-scoped-functions"),
   "transform-block-scoping": require("@babel/plugin-transform-block-scoping"),

--- a/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
@@ -34,6 +34,8 @@ Using plugins:
   proposal-async-generator-functions { "android":"4" }
   proposal-object-rest-spread { "android":"4" }
   proposal-unicode-property-regex { "android":"4" }
+  proposal-json-strings { "android":"4" }
+  proposal-optional-catch-binding { "android":"4" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-no-import/stdout.txt
@@ -17,6 +17,8 @@ Using plugins:
   proposal-async-generator-functions { "node":"6" }
   proposal-object-rest-spread { "node":"6" }
   proposal-unicode-property-regex { "node":"6" }
+  proposal-json-strings { "node":"6" }
+  proposal-optional-catch-binding { "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins-uglify/stdout.txt
@@ -37,6 +37,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"55" }
   proposal-object-rest-spread { "chrome":"55" }
   proposal-unicode-property-regex { "chrome":"55" }
+  proposal-json-strings { "chrome":"55" }
+  proposal-optional-catch-binding { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
@@ -36,6 +36,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
@@ -29,6 +29,8 @@ Using plugins:
   proposal-async-generator-functions { "electron":"0.36" }
   proposal-object-rest-spread { "electron":"0.36" }
   proposal-unicode-property-regex { "electron":"0.36" }
+  proposal-json-strings { "electron":"0.36" }
+  proposal-optional-catch-binding { "electron":"0.36" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/force-all-transforms/stdout.txt
@@ -34,6 +34,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"55" }
   proposal-object-rest-spread { "chrome":"55" }
   proposal-unicode-property-regex { "chrome":"55" }
+  proposal-json-strings { "chrome":"55" }
+  proposal-optional-catch-binding { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
@@ -24,6 +24,8 @@ Using plugins:
   proposal-async-generator-functions { "firefox":"52", "node":"7.4" }
   proposal-object-rest-spread { "firefox":"52", "node":"7.4" }
   proposal-unicode-property-regex { "firefox":"52", "node":"7.4" }
+  proposal-json-strings { "firefox":"52", "node":"7.4" }
+  proposal-optional-catch-binding { "firefox":"52", "node":"7.4" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
 Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals-chrome60/stdout.txt
@@ -12,6 +12,7 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"60" }
   syntax-object-rest-spread { "chrome":"60" }
   proposal-unicode-property-regex { "chrome":"60" }
+  proposal-json-strings { "chrome":"60" }
   proposal-optional-catch-binding { "chrome":"60" }
 
 Using polyfills with `entry` option:
@@ -24,6 +25,7 @@ Using polyfills with `entry` option:
   es7.object.lookup-setter { "chrome":"60" }
   es7.promise.finally { "chrome":"60" }
   es7.symbol.async-iterator { "chrome":"60" }
+  es7.array.flat-map { "chrome":"60" }
   web.timers { "chrome":"60" }
   web.immediate { "chrome":"60" }
   web.dom.iterable { "chrome":"60" }

--- a/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/shippedProposals/stdout.txt
@@ -32,6 +32,7 @@ Using plugins:
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}
+  proposal-json-strings {}
   proposal-optional-catch-binding {}
 
 Using polyfills with `entry` option:
@@ -178,6 +179,7 @@ Using polyfills with `entry` option:
   es6.typed.float64-array {}
   es6.weak-map {}
   es6.weak-set {}
+  es7.array.flat-map {}
   web.timers {}
   web.immediate {}
   web.dom.iterable {}

--- a/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-none/stdout.txt
@@ -35,6 +35,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stderr.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stderr.txt
@@ -1,2 +1,2 @@
-  When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
+When setting `useBuiltIns: 'usage'`, polyfills are automatically imported when needed.
   Please remove the `import '@babel/polyfill'` call or use `useBuiltIns: 'entry'` instead.

--- a/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-with-import/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"55" }
   proposal-object-rest-spread { "chrome":"55" }
   proposal-unicode-property-regex { "chrome":"55" }
+  proposal-json-strings { "chrome":"55" }
+  proposal-optional-catch-binding { "chrome":"55" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
@@ -35,6 +35,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
@@ -45,6 +45,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
@@ -36,6 +36,8 @@ Using plugins:
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
 
 Using polyfills with `entry` option:
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Ref: https://github.com/babel/babel/issues/8304

Summary:

- Bump compat-table, adjusts mapping for spread syntax, and Safari 12 mappings updated.
- Bump electron-to-chromium, which adds electron 3 mappings.
- Adds initial ES2019 support with `proposal-json-strings` and `proposal-optional-catch-binding`.
- Adds `Array.prototype.flatMap` support to `useShippedProposals`.

I have a big PR for preset-env docs that I'll follow this up with.
