### PR TITLE
remove proposals polyfills from default import [skip ci]

### DIFF
--- a/packages/babel-polyfill/src/index.js
+++ b/packages/babel-polyfill/src/index.js
@@ -1,4 +1,19 @@
-import "core-js/shim";
+// Cover all standardized ES6 APIs.
+import "core-js/es6";
+
+// Standard now
+import "core-js/fn/array/includes";
+import "core-js/fn/string/pad-start";
+import "core-js/fn/string/pad-end";
+import "core-js/fn/symbol/async-iterator";
+import "core-js/fn/object/get-own-property-descriptors";
+import "core-js/fn/object/values";
+import "core-js/fn/object/entries";
+import "core-js/fn/promise/finally";
+
+// Ensure that we polyfill ES6 compat for anything web-related, if it exists.
+import "core-js/web";
+
 import "regenerator-runtime/runtime";
 
 if (global._babelPolyfill && typeof console !== "undefined" && console.warn) {

--- a/packages/babel-polyfill/src/noConflict.js
+++ b/packages/babel-polyfill/src/noConflict.js
@@ -1,2 +1,17 @@
-import "core-js/shim";
+// Cover all standardized ES6 APIs.
+import "core-js/es6";
+
+// Standard now
+import "core-js/fn/array/includes";
+import "core-js/fn/string/pad-start";
+import "core-js/fn/string/pad-end";
+import "core-js/fn/symbol/async-iterator";
+import "core-js/fn/object/get-own-property-descriptors";
+import "core-js/fn/object/values";
+import "core-js/fn/object/entries";
+import "core-js/fn/promise/finally";
+
+// Ensure that we polyfill ES6 compat for anything web-related, if it exists.
+import "core-js/web";
+
 import "regenerator-runtime/runtime";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8416
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The default import is replaced with only polyfills that are Stage 4, instead of also including the Stage < 4 polyfills. This should be in alignment with how we have removed the Stage presets. This also would mean we would need to add new imports when necessary.

And it sounds like we desire to also add the polyfill proposals individually? There's a maintenance cost to that too (not that bad) but then I wonder why we aren't just linking to the polyfill to use (that would just mean removing `babel/polyfill` as a package, as people may want to use other polyfills too) since we are just aliasing it. So do we really want to do this?

---

For the proposals in v2:

<details>
```js
// require('../modules/es7.array.includes');
require('../modules/es7.array.flat-map');
require('../modules/es7.array.flatten');
require('../modules/es7.string.at');
// require('../modules/es7.string.pad-start');
// require('../modules/es7.string.pad-end');
require('../modules/es7.string.trim-left');
require('../modules/es7.string.trim-right');
require('../modules/es7.string.match-all');
// require('../modules/es7.symbol.async-iterator');
require('../modules/es7.symbol.observable');
// require('../modules/es7.object.get-own-property-descriptors');
// require('../modules/es7.object.values');
// require('../modules/es7.object.entries');
require('../modules/es7.object.define-getter');
require('../modules/es7.object.define-setter');
require('../modules/es7.object.lookup-getter');
require('../modules/es7.object.lookup-setter');
require('../modules/es7.map.to-json');
require('../modules/es7.set.to-json');
require('../modules/es7.map.of');
require('../modules/es7.set.of');
require('../modules/es7.weak-map.of');
require('../modules/es7.weak-set.of');
require('../modules/es7.map.from');
require('../modules/es7.set.from');
require('../modules/es7.weak-map.from');
require('../modules/es7.weak-set.from');
require('../modules/es7.global');
require('../modules/es7.system.global');
require('../modules/es7.error.is-error');
require('../modules/es7.math.clamp');
require('../modules/es7.math.deg-per-rad');
require('../modules/es7.math.degrees');
require('../modules/es7.math.fscale');
require('../modules/es7.math.iaddh');
require('../modules/es7.math.isubh');
require('../modules/es7.math.imulh');
require('../modules/es7.math.rad-per-deg');
require('../modules/es7.math.radians');
require('../modules/es7.math.scale');
require('../modules/es7.math.umulh');
require('../modules/es7.math.signbit');
// require('../modules/es7.promise.finally');
require('../modules/es7.promise.try');
require('../modules/es7.reflect.define-metadata');
require('../modules/es7.reflect.delete-metadata');
require('../modules/es7.reflect.get-metadata');
require('../modules/es7.reflect.get-metadata-keys');
require('../modules/es7.reflect.get-own-metadata');
require('../modules/es7.reflect.get-own-metadata-keys');
require('../modules/es7.reflect.has-metadata');
require('../modules/es7.reflect.has-own-metadata');
require('../modules/es7.reflect.metadata');
require('../modules/es7.asap');
require('../modules/es7.observable');
```
</details>

from logan:
<details>

```js
// Stage 3
import "core-js/fn/string/trim-left";
import "core-js/fn/string/trim-right";
import "core-js/fn/string/match-all";
import "core-js/fn/array/flat-map";
import "core-js/fn/array/flatten";  // RENAMED
import "core-js/fn/global";

// Stage 1
import "core-js/fn/symbol/observable";
import "core-js/fn/promise/try";
import "core-js/fn/observable";

// Stage 1 Math Extensions
import "core-js/fn/math/clamp";
import "core-js/fn/math/deg-per-rad";
import "core-js/fn/math/degrees";
import "core-js/fn/math/fscale";
import "core-js/fn/math/iaddh";
import "core-js/fn/math/isubh";
import "core-js/fn/math/imulh";
import "core-js/fn/math/rad-per-deg";
import "core-js/fn/math/radians";
import "core-js/fn/math/scale";
import "core-js/fn/math/umulh";
import "core-js/fn/math/signbit";

// Stage 1 "of and from on collection constructors"
import "core-js/fn/map/of";
import "core-js/fn/set/of";
import "core-js/fn/weak-map/of";
import "core-js/fn/weak-set/of";
import "core-js/fn/map/from";
import "core-js/fn/set/from";
import "core-js/fn/weak-map/from";
import "core-js/fn/weak-set/from";

// Stage 0
import "core-js/fn/string/at";

// Nonstandard
import "core-js/fn/object/define-getter";
import "core-js/fn/object/define-setter";
import "core-js/fn/object/lookup-getter";
import "core-js/fn/object/lookup-setter";
// import "core-js/fn/map/to-json"; // Not available standalone
// import "core-js/fn/set/to-json"; // Not available standalone

import "core-js/fn/system/global";
import "core-js/fn/error/is-error";
import "core-js/fn/asap";


// Decorator metadata? Not sure of stage/proposal
import "core-js/fn/reflect/define-metadata";
import "core-js/fn/reflect/delete-metadata";
import "core-js/fn/reflect/get-metadata";
import "core-js/fn/reflect/get-metadata-keys";
import "core-js/fn/reflect/get-own-metadata";
import "core-js/fn/reflect/get-own-metadata-keys";
import "core-js/fn/reflect/has-metadata";
import "core-js/fn/reflect/has-own-metadata";
import "core-js/fn/reflect/metadata";
```
</details>

`write-polyfills.js`

<details>

```js
var a = ["core-js/fn/string/trim-left",
"core-js/fn/string/trim-right",
"core-js/fn/string/match-all",
"core-js/fn/array/flat-map",
"core-js/fn/array/flatten",
"core-js/fn/global",
"core-js/fn/symbol/observable",
"core-js/fn/promise/try",
"core-js/fn/observable",
"core-js/fn/math/clamp",
"core-js/fn/math/deg-per-rad",
"core-js/fn/math/degrees",
"core-js/fn/math/fscale",
"core-js/fn/math/iaddh",
"core-js/fn/math/isubh",
"core-js/fn/math/imulh",
"core-js/fn/math/rad-per-deg",
"core-js/fn/math/radians",
"core-js/fn/math/scale",
"core-js/fn/math/umulh",
"core-js/fn/math/signbit",
"core-js/fn/map/of",
"core-js/fn/set/of",
"core-js/fn/weak-map/of",
"core-js/fn/weak-set/of",
"core-js/fn/map/from",
"core-js/fn/set/from",
"core-js/fn/weak-map/from",
"core-js/fn/weak-set/from",
"core-js/fn/string/at"];

const fse = require('fs-extra');

Promise.all(a.map((file) => {
	return fse.outputFile(`${file.slice(11)}.js`, `import "${file}";`)
	.catch((error) => {
	    console.log(error)
	});
}))
```

</details>
