### PR TITLE
Allow babel-plugin/preset prefix to not be a prefix, when used in a scope.

### DIFF
--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -15,8 +15,8 @@ const BABEL_PLUGIN_PREFIX_RE = /^(?!@|module:|[^/]+\/|babel-plugin-)/;
 const BABEL_PRESET_PREFIX_RE = /^(?!@|module:|[^/]+\/|babel-preset-)/;
 const BABEL_PLUGIN_ORG_RE = /^(@babel\/)(?!plugin-|[^/]+\/)/;
 const BABEL_PRESET_ORG_RE = /^(@babel\/)(?!preset-|[^/]+\/)/;
-const OTHER_PLUGIN_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?!babel-plugin(?:-|\/|$)|[^/]+\/)/;
-const OTHER_PRESET_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?!babel-preset(?:-|\/|$)|[^/]+\/)/;
+const OTHER_PLUGIN_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?![^/]*babel-plugin(?:-|\/|$)|[^/]+\/)/;
+const OTHER_PRESET_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?![^/]*babel-preset(?:-|\/|$)|[^/]+\/)/;
 const OTHER_ORG_DEFAULT_RE = /^(@(?!babel$)[^/]+)$/;
 
 export function resolvePlugin(name: string, dirname: string): string | null {

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing-babel-plugin/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing-babel-plugin/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing-babel-preset/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing-babel-preset/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing.babel-plugin-convert/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing.babel-plugin-convert/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing.babel-preset-convert/index.js
+++ b/packages/babel-core/test/fixtures/resolution/foo-org-paths/node_modules/@foo/thing.babel-preset-convert/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -134,6 +134,46 @@ describe("addon resolution", function() {
     });
   });
 
+  it("should find @foo scoped presets with an inner babel-preset", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      presets: ["@foo/thing.babel-preset-convert"],
+    });
+  });
+
+  it("should find @foo scoped plugins with an inner babel-plugin", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      plugins: ["@foo/thing.babel-plugin-convert"],
+    });
+  });
+
+  it("should find @foo scoped presets with an babel-preset suffix", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      presets: ["@foo/thing-babel-preset"],
+    });
+  });
+
+  it("should find @foo scoped plugins with an babel-plugin suffix", function() {
+    process.chdir("foo-org-paths");
+
+    babel.transform("", {
+      filename: "filename.js",
+      babelrc: false,
+      plugins: ["@foo/thing-babel-plugin"],
+    });
+  });
+
   it("should find @foo scoped presets with an existing prefix", function() {
     process.chdir("foo-org-paths");
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8236
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

In 7.x, in the top-level npm registry scope, we require "babel-plugin-" or "babel-preset-" to be a prefix on plugins/preset names, and if it is not detected, we auto-insert it at the beginning of the package name. Similarly, we auto-inject that prefix for packages used in a scope too, e.g. `@foo/something` will become `@foo/babel-plugin-something`. 

What this PR does is make it so that, if there is a scope and "babel-plugin" is _anywhere_ in the package name (after the scope name anyway), we will skip inserting the prefix. See #8236 for an example usecase.