### PR TITLE
Fixes setter paratemer default value

### DIFF
--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -46,7 +46,7 @@ const iifeVisitor = {
 
 export default function convertFunctionParams(path, loose) {
   const { node, scope } = path;
-  loose = node.kind === "set" ? true : loose;
+
   const state = {
     iife: false,
     scope: scope,
@@ -61,7 +61,7 @@ export default function convertFunctionParams(path, loose) {
     const param = params[i];
 
     const paramIsAssignmentPattern = param.isAssignmentPattern();
-    if (paramIsAssignmentPattern && loose) {
+    if (paramIsAssignmentPattern && (loose || node.kind === "set")) {
       const left = param.get("left");
       const right = param.get("right");
 

--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -46,7 +46,7 @@ const iifeVisitor = {
 
 export default function convertFunctionParams(path, loose) {
   const { node, scope } = path;
-
+  loose = node.kind === "set" ? true : loose;
   const state = {
     iife: false,
     scope: scope,
@@ -60,7 +60,8 @@ export default function convertFunctionParams(path, loose) {
   for (let i = 0; i < params.length; i++) {
     const param = params[i];
 
-    if (param.isAssignmentPattern() && loose) {
+    const paramIsAssignmentPattern = param.isAssignmentPattern();
+    if (paramIsAssignmentPattern && loose) {
       const left = param.get("left");
       const right = param.get("right");
 
@@ -87,13 +88,12 @@ export default function convertFunctionParams(path, loose) {
         );
         param.replaceWith(paramName);
       }
-    } else if (param.isAssignmentPattern()) {
+    } else if (paramIsAssignmentPattern) {
       if (firstOptionalIndex === null) firstOptionalIndex = i;
 
       const left = param.get("left");
       const right = param.get("right");
 
-      //
       if (!state.iife) {
         if (right.isIdentifier() && !isSafeBinding(scope, right.node)) {
           // the right hand side references a parameter

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-setter/exec.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-setter/exec.js
@@ -1,0 +1,9 @@
+const defaultValue = 1;
+const obj = {
+  set field(num = defaultValue) {
+    this.num = num;
+  }
+};
+obj.field = void 0;
+
+expect(obj.num).toBe(defaultValue);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-setter/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-setter/input.js
@@ -1,0 +1,5 @@
+const obj = {
+  set field(num = 1) {
+    this.num = num;
+  }
+};

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-setter/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-setter/output.js
@@ -1,0 +1,10 @@
+var obj = {
+  set field(num) {
+    if (num === void 0) {
+      num = 1;
+    }
+
+    this.num = num;
+  }
+
+};


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #7688
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Forces setter's default parameter to use loose transform