### PR TITLE
Bump `js-tokens` in `@babel/highlight`.

### DIFF
--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "chalk": "^2.0.0",
     "esutils": "^2.0.2",
-    "js-tokens": "^3.0.0"
+    "js-tokens": "^4.0.0"
   },
   "devDependencies": {
     "strip-ansi": "^4.0.0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Possibly.
| Minor: New Feature?      |
| Tests Added + Pass?      | None added.
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`@babel/highlight` is using an older version of `js-tokens`.  This should let regular expressions handle the dotAll flag.  I don't think it's breaking for this use case, but you might want to take a look at it.