### PR TITLE
Cache individual programmatic descriptors along with the overall list.

### DIFF
--- a/packages/babel-core/src/config/config-descriptors.js
+++ b/packages/babel-core/src/config/config-descriptors.js
@@ -41,6 +41,22 @@ export type UnloadedDescriptor = {
   } | void,
 };
 
+function isEqualDescriptor(
+  a: UnloadedDescriptor,
+  b: UnloadedDescriptor,
+): boolean {
+  return (
+    a.name === b.name &&
+    a.value === b.value &&
+    a.options === b.options &&
+    a.dirname === b.dirname &&
+    a.alias === b.alias &&
+    a.ownPass === b.ownPass &&
+    (a.file && a.file.request) === (b.file && b.file.request) &&
+    (a.file && a.file.resolved) === (b.file && b.file.resolved)
+  );
+}
+
 export type ValidatedFile = {
   filepath: string,
   dirname: string,
@@ -50,7 +66,7 @@ export type ValidatedFile = {
 /**
  * Create a set of descriptors from a given options object, preserving
  * descriptor identity based on the identity of the plugin/preset arrays
- * themselves.
+ * themselves, and potentially on the identity of the plugins/presets + options.
  */
 export function createCachedDescriptors(
   dirname: string,
@@ -113,25 +129,81 @@ export function createUncachedDescriptors(
   };
 }
 
+const PRESET_DESCRIPTOR_CACHE = new WeakMap();
 const createCachedPresetDescriptors = makeWeakCache(
   (items: PluginList, cache: CacheConfigurator<string>) => {
     const dirname = cache.using(dir => dir);
     return makeStrongCache((alias: string) =>
       makeStrongCache((passPerPreset: boolean) =>
-        createPresetDescriptors(items, dirname, alias, passPerPreset),
+        createPresetDescriptors(items, dirname, alias, passPerPreset).map(
+          // Items are cached using the overall preset array identity when
+          // possibly, but individual descriptors are also cached if a match
+          // can be found in the previously-used descriptor lists.
+          desc => loadCachedDescriptor(PRESET_DESCRIPTOR_CACHE, desc),
+        ),
       ),
     );
   },
 );
 
+const PLUGIN_DESCRIPTOR_CACHE = new WeakMap();
 const createCachedPluginDescriptors = makeWeakCache(
   (items: PluginList, cache: CacheConfigurator<string>) => {
     const dirname = cache.using(dir => dir);
     return makeStrongCache((alias: string) =>
-      createPluginDescriptors(items, dirname, alias),
+      createPluginDescriptors(items, dirname, alias).map(
+        // Items are cached using the overall plugin array identity when
+        // possibly, but individual descriptors are also cached if a match
+        // can be found in the previously-used descriptor lists.
+        desc => loadCachedDescriptor(PLUGIN_DESCRIPTOR_CACHE, desc),
+      ),
     );
   },
 );
+
+/**
+ * When no options object is given in a descriptor, this object is used
+ * as a WeakMap key in order to have consistent identity.
+ */
+const DEFAULT_OPTIONS = {};
+
+/**
+ * Given the cache and a descriptor, returns a matching descriptor from the
+ * cache, or else returns the input descriptor and adds it to the cache for
+ * next time.
+ */
+function loadCachedDescriptor(
+  cache: WeakMap<{} | Function, WeakMap<{}, Array<UnloadedDescriptor>>>,
+  desc: UnloadedDescriptor,
+) {
+  const { value, options = DEFAULT_OPTIONS } = desc;
+  if (options === false) return desc;
+
+  let cacheByOptions = cache.get(value);
+  if (!cacheByOptions) {
+    cacheByOptions = new WeakMap();
+    cache.set(value, cacheByOptions);
+  }
+
+  let possibilities = cacheByOptions.get(options);
+  if (!possibilities) {
+    possibilities = [];
+    cacheByOptions.set(options, possibilities);
+  }
+
+  if (possibilities.indexOf(desc) === -1) {
+    const matches = possibilities.filter(possibility =>
+      isEqualDescriptor(possibility, desc),
+    );
+    if (matches.length > 0) {
+      return matches[0];
+    }
+
+    possibilities.push(desc);
+  }
+
+  return desc;
+}
 
 function createPresetDescriptors(
   items: PluginList,

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -29,10 +29,10 @@ describe("@babel/core config loading", () => {
       filename: FILEPATH,
       presets: skipProgrammatic
         ? null
-        : [require("./fixtures/config-loading/preset3")],
+        : [[require("./fixtures/config-loading/preset3"), {}]],
       plugins: skipProgrammatic
         ? null
-        : [require("./fixtures/config-loading/plugin6")],
+        : [[require("./fixtures/config-loading/plugin6"), {}]],
     };
   }
 
@@ -213,7 +213,7 @@ describe("@babel/core config loading", () => {
       }
     });
 
-    it("should invalidate the plugins when given a fresh arrays", () => {
+    it("should not invalidate the plugins when given a fresh arrays", () => {
       const opts = makeOpts();
 
       const options1 = loadConfig(opts).options;
@@ -221,6 +221,38 @@ describe("@babel/core config loading", () => {
       const options2 = loadConfig({
         ...opts,
         plugins: opts.plugins.slice(),
+      }).options;
+      expect(options2.plugins.length).toBe(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        expect(options2.plugins[i]).toBe(options1.plugins[i]);
+      }
+    });
+
+    it("should not invalidate the presets when given a fresh arrays", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      const options2 = loadConfig({
+        ...opts,
+        presets: opts.presets.slice(),
+      }).options;
+      expect(options2.plugins.length).toBe(options1.plugins.length);
+
+      for (let i = 0; i < options2.plugins.length; i++) {
+        expect(options2.plugins[i]).toBe(options1.plugins[i]);
+      }
+    });
+
+    it("should invalidate the plugins when given a fresh options", () => {
+      const opts = makeOpts();
+
+      const options1 = loadConfig(opts).options;
+
+      const options2 = loadConfig({
+        ...opts,
+        plugins: opts.plugins.map(([plg, opt]) => [plg, { ...opt }]),
       }).options;
       expect(options2.plugins.length).toBe(options1.plugins.length);
 
@@ -233,14 +265,14 @@ describe("@babel/core config loading", () => {
       }
     });
 
-    it("should invalidate the presets when given a fresh arrays", () => {
+    it("should invalidate the presets when given a fresh options", () => {
       const opts = makeOpts();
 
       const options1 = loadConfig(opts).options;
 
       const options2 = loadConfig({
         ...opts,
-        presets: opts.presets.slice(),
+        presets: opts.presets.map(([plg, opt]) => [plg, { ...opt }]),
       }).options;
       expect(options2.plugins.length).toBe(options1.plugins.length);
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

We added caching for presets early on for Babel 7. These caches affect how often a plugin/preset's overall function is re-executed, and come in three flavors:

* Programmatic plugins/presets
* Config-file based plugins/presets
* Preset-based plugins/presets

Invalidation, and thus re-execution of these functions, has been managed differently for each of these. Up until this PR, invalidation of programmatic options has been purely based on the identity of the array itself, so if you did

```
const presets = ['@babel/preset-env'];

babel.transformFile("tmp.js", { presets });
babel.transformFile("tmp.js", { presets });
```
it would only evaluate the env preset's function a single time.

```
const presets = ['@babel/preset-env'];

babel.transformFile("tmp.js", { presets: presets.slice() });
babel.transformFile("tmp.js", { presets: presets.slice() });
```
then each call would have a different array, even though the contents were identical, and the preset function would be evaluated twice.

This PR changes the second case to still only evaluate the preset a single time, even in the second case. When I originally wrote the caching, I was on the fence about how aggressive to be here, and how much power to give to users. Over the course of 7.x's beta, I've come to the conclusion that expected usage will mean that the behavior without this PR would result in too many re-executions of the plugins/presets, and thus reduced performance.

With this PR, we preserve the old behavior, so if you give exactly the same array, it will still be the fastest, but if you give two different arrays, we'll still do our best to recognize that it is actually exactly the same preset both times, and avoid re-executing the preset.

Note, this still relies on object identity for the preset/plugin and the options object, so if you do

```
babel.transformFile("tmp.js", { presets: [['@babel/preset-env', {}]] });
babel.transformFile("tmp.js", { presets: [['@babel/preset-env', {}]] });
```
this _will_ still run the preset twice, because it has gotten two entirely different options objects. I think that is acceptable and more along the lines of what a user might actually expect, so I don't think it's too bad. It seems too aggressive to actually try to deep-compare the options objects themselves, since that could incur a bit of a performance hit. 