### PR TITLE
Add missing es7.promise.finally polyfill when using useBuiltIns: usage

### DIFF
--- a/packages/babel-preset-env/src/built-in-definitions.js
+++ b/packages/babel-preset-env/src/built-in-definitions.js
@@ -46,6 +46,7 @@ export const definitions = {
     every: ["es6.array.is-array"],
     fill: ["es6.array.fill"],
     filter: ["es6.array.filter"],
+    finally: ["es7.promise.finally"],
     find: ["es6.array.find"],
     findIndex: ["es6.array.find-index"],
     fixed: ["es6.string.fixed"],

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-finally/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-finally/input.mjs
@@ -1,0 +1,4 @@
+var p = Promise.resolve(0);
+p.finally(() => {
+  alert("OK");
+});

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-finally/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-finally/options.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": {
+          "browsers": ["ie > 10"]
+        },
+        "useBuiltIns": "usage",
+        "modules": false
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-finally/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-finally/output.mjs
@@ -1,0 +1,6 @@
+import "core-js/modules/es7.promise.finally";
+import "core-js/modules/es6.promise";
+var p = Promise.resolve(0);
+p.finally(function () {
+  alert("OK");
+});


### PR DESCRIPTION
Usage of a `finally` instance method should trigger import of the `es7.promise.finally`
polyfill, but it doesn't. This PR adds the missing definition and a test.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None reported
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
