### PR TITLE
Rename exported functions where name conflicts with param.

### DIFF
--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -108,7 +108,7 @@ export default class Renamer {
         path.isClassExpression(),
     );
     if (parentDeclar) {
-      const bindingIds = parentDeclar.getBindingIdentifiers();
+      const bindingIds = parentDeclar.getOuterBindingIdentifiers();
       if (bindingIds[oldName] === binding.identifier) {
         // When we are renaming an exported identifier, we need to ensure that
         // the exported binding keeps the old name.

--- a/packages/babel-traverse/test/fixtures/rename/property-rename-with-export/input.mjs
+++ b/packages/babel-traverse/test/fixtures/rename/property-rename-with-export/input.mjs
@@ -1,0 +1,2 @@
+export function problem(problem) { }
+void { problem: () => problem() };

--- a/packages/babel-traverse/test/fixtures/rename/property-rename-with-export/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/property-rename-with-export/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-function-name"
+  ]
+}

--- a/packages/babel-traverse/test/fixtures/rename/property-rename-with-export/output.mjs
+++ b/packages/babel-traverse/test/fixtures/rename/property-rename-with-export/output.mjs
@@ -1,0 +1,6 @@
+function _problem(problem) {}
+
+export { _problem as problem };
+void {
+  problem: () => _problem()
+};


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8499
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Looks like this was a simple  mistake. The difference between `getBindingIdentifiers` and `getOuterBindingIdentifiers` is pretty confusing as-is, so we were just using the wrong one in this context.