### PR TITLE
Expose opt-in useESModules:"auto" from transform-runtime to toggle based on 'supportsStaticESM'

### DIFF
--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/input.js
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/options.json
@@ -1,0 +1,7 @@
+{
+  "caller": {
+    "name": "babel-test",
+    "supportsStaticESM": true
+  },
+  "plugins": [["transform-runtime", { "useESModules": "auto" }], "transform-classes"]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
@@ -1,0 +1,23 @@
+var _classCallCheck = require("@babel/runtime/helpers/classCallCheck");
+
+var _possibleConstructorReturn = require("@babel/runtime/helpers/possibleConstructorReturn");
+
+var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
+
+var _inherits = require("@babel/runtime/helpers/inherits");
+
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
+  "use strict";
+
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/options.json
@@ -1,3 +1,7 @@
 {
+  "caller": {
+    "name": "babel-test",
+    "supportsStaticESM": true
+  },
   "plugins": [["transform-runtime", { "useESModules": true }], "transform-classes"]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/input.mjs
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/options.json
@@ -1,0 +1,7 @@
+{
+  "caller": {
+    "name": "babel-test",
+    "supportsStaticESM": true
+  },
+  "plugins": [["transform-runtime", { "useESModules": "auto" }], "transform-classes"]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/output.mjs
@@ -1,0 +1,18 @@
+import _classCallCheck from "@babel/runtime/helpers/esm/classCallCheck";
+import _possibleConstructorReturn from "@babel/runtime/helpers/esm/possibleConstructorReturn";
+import _getPrototypeOf from "@babel/runtime/helpers/esm/getPrototypeOf";
+import _inherits from "@babel/runtime/helpers/esm/inherits";
+
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs/options.json
@@ -1,3 +1,7 @@
 {
+  "caller": {
+    "name": "babel-test",
+    "supportsStaticESM": true
+  },
   "plugins": [["transform-runtime", { "useESModules": true }], "transform-classes"]
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Refs #8516
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This doesn't make the behavior the _default_, but it does implement the automatic behavior requested in #8516, if you opt into it.

See https://github.com/babel/babel/issues/8516#issuecomment-415579817 for my concerns about making this the default.