### PR TITLE
Add a 'whitelist' option for the external-helpers plugin to mirror the helper builder.

### DIFF
--- a/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/input.js
+++ b/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/input.js
@@ -1,0 +1,3 @@
+class Foo {
+  method(){}
+}

--- a/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/options.json
+++ b/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["external-helpers", {
+      "whitelist": ["createClass"]
+    }],
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/output.js
+++ b/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/output.js
@@ -1,0 +1,17 @@
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+let Foo =
+/*#__PURE__*/
+function () {
+  "use strict";
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "method",
+    value: function method() {}
+  }]);
+  return Foo;
+}();

--- a/packages/babel-plugin-external-helpers/test/index.js
+++ b/packages/babel-plugin-external-helpers/test/index.js
@@ -1,0 +1,3 @@
+import runner from "@babel/helper-plugin-test-runner";
+
+runner(__dirname);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

The external helper generator in https://github.com/babel/babel/blob/cada040becacb9a1c378763fb2b6e65185fa6d31/packages/babel-core/src/tools/build-external-helpers.js#L146 accepts a whitelist, but the `@babel/plugin-external-helpers` will still insert references to plugins that aren't in the whitelist.

This PR adds a `whitelist` to the plugin as well, so the plugin will fall back to babel-standard behavior of injecting the helper if it isn't included in the whitelist. That way at worse extra code gets injected, instead of having hard-to-diagnose errors about missing helpers.