### PR TITLE
 Do not unpack array patterns that update a referenced binding

### DIFF
--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -44,13 +44,23 @@ export default declare((api, options) => {
     return false;
   }
 
-  const arrayUnpackVisitor = {
-    ReferencedIdentifier(path, state) {
-      if (state.bindings[path.node.name]) {
-        state.deopt = true;
-        path.stop();
-      }
-    },
+  const STOP_TRAVERSAL = {};
+
+  // NOTE: This visitor is meant to be used via t.traverse
+  const arrayUnpackVisitor = (node, ancestors, state) => {
+    if (!ancestors.length) {
+      // Top-level node: this is the array literal.
+      return;
+    }
+
+    if (
+      t.isIdentifier(node) &&
+      t.isReferenced(node, ancestors[ancestors.length - 1]) &&
+      state.bindings[node.name]
+    ) {
+      state.deopt = true;
+      throw STOP_TRAVERSAL;
+    }
   };
 
   class DestructuringTransformer {
@@ -282,7 +292,13 @@ export default declare((api, options) => {
       // deopt on reference to left side identifiers
       const bindings = t.getBindingIdentifiers(pattern);
       const state = { deopt: false, bindings };
-      this.scope.traverse(arr, arrayUnpackVisitor, state);
+
+      try {
+        t.traverse(arr, arrayUnpackVisitor, state);
+      } catch (e) {
+        if (e !== STOP_TRAVERSAL) throw e;
+      }
+
       return !state.deopt;
     }
 

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/regression/8528/input.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/regression/8528/input.js
@@ -1,0 +1,4 @@
+function isBetween(x, a, b) {
+  if (a > b) [a, b] = [b, a];
+  return x > a && x < b;
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/regression/8528/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/regression/8528/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-destructuring"]
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/regression/8528/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/regression/8528/output.js
@@ -1,0 +1,9 @@
+function isBetween(x, a, b) {
+  if (a > b) {
+    var _ref = [b, a];
+    a = _ref[0];
+    b = _ref[1];
+  }
+
+  return x > a && x < b;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8528 
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> Do not unpack array patterns that update a referenced binding
>
> We used this.scope.traverse to check if the array initializer referenced
> a binding which is present in the array pattern. It doesn't work because,
> in order to check if an identifier is a reference, we need to check its
> parent.
> this.scope.binding can't set the correct `parentPath`, because the only
> path that it knows is the root scope's (e.g. the function path).
> Use `t.traverse` which gives the correct parent.

This regression has been brought to the surface by 29d249e3b700e9bff9d3b6e47f7a8ba9c69612cc because it made the `isReferenced` check stricter, but it is unrelated.