### PR TITLE
Flatten TokenType class hierarchy

### DIFF
--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -66,18 +66,12 @@ export class TokenType {
   }
 }
 
-class KeywordTokenType extends TokenType {
-  constructor(name: string, options: TokenOptions = {}) {
-    options.keyword = name;
-
-    super(name, options);
-  }
+function KeywordTokenType(keyword: string, options: TokenOptions = {}) {
+  return new TokenType(keyword, { ...options, keyword });
 }
 
-export class BinopTokenType extends TokenType {
-  constructor(name: string, prec: number) {
-    super(name, { beforeExpr, binop: prec });
-  }
+function BinopTokenType(name: string, binop: number) {
+  return new TokenType(name, { beforeExpr, binop });
 }
 
 export const types: { [name: string]: TokenType } = {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Technically? I removed an exported `BinopTokenType` class.
| Minor: New Feature?      |
| Tests Added + Pass?      | No changes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

`KeywordTokenType` and `BinopTokenType` were just meant to be factory
helpers, there's no reason for a class hierarchy.