### PR TITLE
preset-env: use Chromium versions for Chromium-based browsers

### DIFF
--- a/packages/babel-preset-env/data/chromium-browsers.js
+++ b/packages/babel-preset-env/data/chromium-browsers.js
@@ -1,0 +1,14 @@
+module.exports = {
+  // Samsung Internet release notes: https://developer.samsung.com/internet/android/releases
+  // Chrome version page (chrome://version) is accessible
+  // Indicated in user agent string as Chrome/XX
+  "samsung 4": 44,
+  "samsung 5": 51,
+  "samsung 6.2": 56,
+  "samsung 7.2": 59,
+  
+  // UC Browser developer edition: https://plus.ucweb.com/download/
+  // Indicated in user agent string as Chrome/XX
+  "and_uc 11.4": 40,
+  "and_uc 11.8": 57,
+};

--- a/packages/babel-preset-env/data/chromium-browsers.js
+++ b/packages/babel-preset-env/data/chromium-browsers.js
@@ -2,13 +2,13 @@ module.exports = {
   // Samsung Internet release notes: https://developer.samsung.com/internet/android/releases
   // Chrome version page (chrome://version) is accessible
   // Indicated in user agent string as Chrome/XX
-  "samsung 4": 44,
-  "samsung 5": 51,
-  "samsung 6.2": 56,
-  "samsung 7.2": 59,
+  "samsung 4": "44",
+  "samsung 5": "51",
+  "samsung 6.2": "56",
+  "samsung 7.2": "59",
   
   // UC Browser developer edition: https://plus.ucweb.com/download/
   // Indicated in user agent string as Chrome/XX
-  "and_uc 11.4": 40,
-  "and_uc 11.8": 57,
+  "and_uc 11.4": "40",
+  "and_uc 11.8": "57",
 };

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -12,6 +12,7 @@ import {
 } from "./utils";
 import { objectToBrowserslist } from "./normalize-options";
 import browserModulesData from "../data/built-in-modules.json";
+import chromiumBrowsersData from "../data/chromium-browsers.js";
 import { TargetNames } from "./options";
 import type { Targets } from "./types";
 
@@ -68,7 +69,12 @@ const mergeBrowsers = (fromQuery: Targets, fromTarget: Targets) => {
 
 const getLowestVersions = (browsers: Array<string>): Targets => {
   return browsers.reduce((all: Object, browser: string): Object => {
-    const [browserName, browserVersion] = browser.split(" ");
+    // get Chromium version for Chromium-based browsers
+    const chromiumVersion = chromiumBrowsersData[browser];
+
+    const [browserName, browserVersion] = chromiumVersion
+      ? ["chrome", chromiumVersion]
+      : browser.split(" ");
     const normalizedBrowserName = browserNameMap[browserName];
 
     if (!normalizedBrowserName) {

--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -166,6 +166,16 @@ describe("getTargets", () => {
         android: "4.0.0",
       });
     });
+
+    it("returns Chrome version for Chromium-based browsers", () => {
+      expect(
+        getTargets({
+          browsers: "Samsung >= 6",
+        }),
+      ).toEqual({
+        chrome: "56.0.0",
+      });
+    });
   });
 
   describe("esmodules", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6602
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 👎
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`@babel/preset-env` only uses `Android`, `Chrome`, `Edge`, `Firefox`, `IE`, `iOS`, `Safari`, `Node` versions for detecting which transforms to include:

https://github.com/babel/babel/blob/e875fc7bc11ffdb8d5176028ae2b336bf7455c6c/packages/babel-preset-env/src/targets-parser.js#L32-L42

and **silently** ignores other browsers:

https://github.com/babel/babel/blob/e875fc7bc11ffdb8d5176028ae2b336bf7455c6c/packages/babel-preset-env/src/targets-parser.js#L72-L76

However, there are local-popular or manufacturer-specific browsers such as Opera Mini, UC browser, QQ browser, Baidu browser, and Samsung Internet. Please see https://github.com/browserslist/browserslist/issues/250 for their importance.

Currently, fortunately, IE 11, Chrome 49 (usage 0.69%) and Android 4.x (4.4 usage 0.58%, 4.4.4 isn't strictly last 2 versions but is in Browserslist default) acts as a stopgap preventing from excluding transform needed for old browsers. However, if user excludes them, they become `dead`, or their usage drops, `preset-env` will recognize as if it targets very modern browsers. Also, user may **explicitly** target them, using Browserslist config.

For Chromium-based browsers, we can use their base Chromium versions to detect features, like [`electron-to-chromium`](https://github.com/Kilian/electron-to-chromium), as a best-effort basis. This PR adds a mapping for Samsung Internet and UC Browser for Android, which is popular in Samsung devices and China, respectively.