### PR TITLE
Lerna: remove exact [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ publish:
 	make clone-license
 	# not using lerna independent mode atm, so only update packages that have changed since we use ^
 	# --only-explicit-updates
-	./node_modules/.bin/lerna publish --force-publish=* --exact --skip-temp-tag
+	./node_modules/.bin/lerna publish --force-publish=* --skip-temp-tag
 	make clean
 
 bootstrap: clean-all


### PR DESCRIPTION
We only wanted all the dependencies to be exact in the pre-release because of breaking changes. This will make it use the default `^`