### PR TITLE
preset-env: fix `opera` from `esmodules` target and Browserslist not used

### DIFF
--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -38,6 +38,7 @@ const browserNameMap = {
   ie: "ie",
   ios_saf: "ios",
   safari: "safari",
+  opera: "opera",
   node: "node",
 };
 

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -102,7 +102,7 @@ const getLowestVersions = (browsers: Array<string>): Targets => {
       } else if (!isUnreleased && !isSplitUnreleased) {
         const parsedBrowserVersion = semverify(splitVersion);
 
-        all[normalizedBrowserName] = semverMin(version, parsedBrowserVersion);f
+        all[normalizedBrowserName] = semverMin(version, parsedBrowserVersion);
       }
     } catch (e) {}
 

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -30,16 +30,16 @@ const validateTargetNames = (validTargets, targets) => {
 };
 
 const browserNameMap = {
+  and_chr: "chrome",
   android: "android",
   chrome: "chrome",
-  and_chr: "chrome",
   edge: "edge",
   firefox: "firefox",
   ie: "ie",
   ios_saf: "ios",
-  safari: "safari",
-  opera: "opera",
   node: "node",
+  opera: "opera",
+  safari: "safari",
 };
 
 export const isBrowsersQueryValid = (
@@ -102,7 +102,7 @@ const getLowestVersions = (browsers: Array<string>): Targets => {
       } else if (!isUnreleased && !isSplitUnreleased) {
         const parsedBrowserVersion = semverify(splitVersion);
 
-        all[normalizedBrowserName] = semverMin(version, parsedBrowserVersion);
+        all[normalizedBrowserName] = semverMin(version, parsedBrowserVersion);f
       }
     } catch (e) {}
 

--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -7,6 +7,7 @@ describe("getTargets", () => {
       getTargets({
         chrome: 49,
         firefox: "55",
+        opera: "36",
         ie: "9",
         node: "6.10",
         electron: "1.6",
@@ -17,6 +18,7 @@ describe("getTargets", () => {
       firefox: "55.0.0",
       ie: "9.0.0",
       node: "6.10.0",
+      opera: "36.0.0",
     });
   });
 

--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -7,7 +7,6 @@ describe("getTargets", () => {
       getTargets({
         chrome: 49,
         firefox: "55",
-        opera: "36",
         ie: "9",
         node: "6.10",
         electron: "1.6",
@@ -18,7 +17,6 @@ describe("getTargets", () => {
       firefox: "55.0.0",
       ie: "9.0.0",
       node: "6.10.0",
-      opera: "36.0.0",
     });
   });
 
@@ -101,11 +99,12 @@ describe("getTargets", () => {
     it("works with current node version and string type browsers", () => {
       expect(
         getTargets({
-          browsers: "current node, chrome 55",
+          browsers: "current node, chrome 55, opera 42",
         }),
       ).toEqual({
         node: process.versions.node,
         chrome: "55.0.0",
+        opera: "42.0.0",
       });
     });
 
@@ -180,6 +179,7 @@ describe("getTargets", () => {
         chrome: "61.0.0",
         safari: "10.1.0",
         firefox: "60.0.0",
+        opera: "48.0.0",
         ios: "10.3.0",
         edge: "16.0.0",
       });
@@ -195,6 +195,7 @@ describe("getTargets", () => {
         chrome: "61.0.0",
         safari: "10.1.0",
         firefox: "60.0.0",
+        opera: "48.0.0",
         ios: "10.3.0",
         edge: "16.0.0",
       });
@@ -210,6 +211,7 @@ describe("getTargets", () => {
         chrome: "61.0.0",
         safari: "10.1.0",
         firefox: "60.0.0",
+        opera: "48.0.0",
         ios: "10.3.0",
         ie: "11.0.0",
         edge: "16.0.0",
@@ -230,6 +232,7 @@ describe("getTargets", () => {
         ie: "11.0.0",
         edge: "16.0.0",
         firefox: "60.0.0",
+        opera: "48.0.0",
       });
     });
   });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/website/pull/1774#issuecomment-416285651
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    | N/A
| Any Dependency Changes?  | 👎
| License                  | MIT

* Added `opera` to `browserNameMap`