### PR TITLE
Correctly update bindings of decorated class declarations

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer-legacy.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-legacy.ts
@@ -325,6 +325,14 @@ const visitor: Visitor<PluginPass> = {
     const replacement = decoratedClassToExpression(path);
     if (replacement) {
       path.replaceWith(replacement);
+
+      const decl = path.get("declarations.0");
+      const { id } = decl.node;
+
+      // TODO: Maybe add this logic to @babel/traverse
+      const binding = path.scope.getOwnBinding(id.name);
+      binding.identifier = id;
+      binding.path = decl;
     }
   },
   ClassExpression(path, state) {

--- a/packages/babel-plugin-proposal-decorators/src/transformer-legacy.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-legacy.ts
@@ -324,10 +324,10 @@ const visitor: Visitor<PluginPass> = {
   ClassDeclaration(path) {
     const replacement = decoratedClassToExpression(path);
     if (replacement) {
-      path.replaceWith(replacement);
+      const [newPath] = path.replaceWith(replacement);
 
-      const decl = path.get("declarations.0");
-      const { id } = decl.node;
+      const decl = newPath.get("declarations.0");
+      const id = decl.node.id as t.Identifier;
 
       // TODO: Maybe add this logic to @babel/traverse
       const binding = path.scope.getOwnBinding(id.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/input.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/input.mjs
@@ -1,0 +1,12 @@
+import {autobind} from 'core-decorators';
+
+export default function wrap() {
+	return function() {
+		class Foo {
+			@autobind
+			method() {}
+		}
+
+		return Foo;
+	};
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    ["proposal-decorators", { "legacy": true }]
+  ],
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": 8
+      }
+    }]
+  ]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/options.json
@@ -1,12 +1,7 @@
 {
+  "targets": { "node": 8 },
   "plugins": [
-    ["proposal-decorators", { "legacy": true }]
+    ["proposal-decorators", { "version": "legacy" }]
   ],
-  "presets": [
-    ["env", {
-      "targets": {
-        "node": 8
-      }
-    }]
-  ]
+  "presets": ["env"]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/output.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = wrap;
+
+var _coreDecorators = require("core-decorators");
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
+
+function wrap() {
+  return function () {
+    var _class;
+
+    let Foo = (_class = class Foo {
+      method() {}
+
+    }, (_applyDecoratedDescriptor(_class.prototype, "method", [_coreDecorators.autobind], Object.getOwnPropertyDescriptor(_class.prototype, "method"), _class.prototype)), _class);
+    return Foo;
+  };
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/8559/output.js
@@ -7,8 +7,6 @@ exports.default = wrap;
 
 var _coreDecorators = require("core-decorators");
 
-function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
-
 function wrap() {
   return function () {
     var _class;
@@ -16,7 +14,7 @@ function wrap() {
     let Foo = (_class = class Foo {
       method() {}
 
-    }, (_applyDecoratedDescriptor(_class.prototype, "method", [_coreDecorators.autobind], Object.getOwnPropertyDescriptor(_class.prototype, "method"), _class.prototype)), _class);
+    }, (babelHelpers.applyDecoratedDescriptor(_class.prototype, "method", [_coreDecorators.autobind], Object.getOwnPropertyDescriptor(_class.prototype, "method"), _class.prototype)), _class);
     return Foo;
   };
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8559 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> This commit adds a small utility (Scope#updateOwnBinding) which
> should be used whenever you replace a declaration with a new
> delaration which defines the same binding (e.g. `class Foo {}` ->
> `let Foo = class Foo {}`). Since our scope system isn't currently
> synchrinized with the AST, doing this automatically would add too
> much overhead to the `replaceWith*` functions.
>
> That function probably needs to be used in many more places, but we
> can add them when users find bugs related to non-updated bingins.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/8566"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

