### PR TITLE
add access public to all packages [skip ci]

### DIFF
--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -4,6 +4,9 @@
   "description": "Transforms Object.assign into object spread syntax",
   "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-object-assign-to-object-spread",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "@babel/codemod",

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -4,6 +4,9 @@
   "description": "Remove unused catch bindings",
   "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-remove-unused-catch-binding",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "@babel/codemod",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-cli",
   "keywords": [
     "6to5",

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -6,6 +6,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-core",
   "keywords": [
     "6to5",

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-generator",
   "main": "lib/index.js",
   "files": [

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to annotate paths and nodes with #__PURE__ comment",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.0.0"

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to bindify decorators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/traverse": "^7.0.0",

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to build binary assignment operator visitors",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-explode-assignable-expression": "^7.0.0",

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to build react jsx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.0.0",

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to call delegate",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-hoist-variables": "^7.0.0",

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to define a map",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-function-name": "^7.0.0",

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to explode an assignable expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/traverse": "^7.0.0",

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to explode class",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-bindify-decorators": "^7.0.0",

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to support fixtures",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to change the property 'name' of every function",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-get-function-arity": "^7.0.0",

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to get function arity",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.0.0"

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to hoist variables",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.0.0"

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to replace certain member expressions with function calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "author": "Justin Ridgewell <justin@ridgewell.name>",
   "dependencies": {

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -5,6 +5,9 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -5,6 +5,9 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to optimise call expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.0.0"

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to support test runner",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-transform-fixture-test-runner": "^7.0.0"

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -5,6 +5,9 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils",
   "main": "lib/index.js"
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to check for literal RegEx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "lodash": "^4.17.10"

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to remap async functions to generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-annotate-as-pure": "^7.0.0",

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -4,6 +4,9 @@
   "description": "Helper function to replace supers",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-member-expression-to-functions": "^7.0.0",

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -5,6 +5,9 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/types": "^7.0.0"

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-transform-fixture-test-runner",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -4,6 +4,9 @@
   "description": "Helper to wrap functions inside a function call.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-function-name": "^7.0.0",

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helpers",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -5,6 +5,9 @@
   "author": "suchipi <me@suchipi.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-highlight",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-node",
   "keywords": [
     "6to5",

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "babel",
     "javascript",

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin contains helper functions that’ll be placed at the top of the generated code",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -4,6 +4,9 @@
   "description": "Turn async generator functions into ES2015 generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin transforms static class properties as well as properties declared with the property initializer syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -3,6 +3,9 @@
   "version": "7.0.0",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Compile class and object decorators to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-decorators",
   "main": "lib/index.js",

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -4,6 +4,9 @@
   "description": "Compile do expressions to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -4,6 +4,9 @@
   "description": "Compile export default to ES2015",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -4,6 +4,9 @@
   "description": "Compile export namespace to ES2015",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace-from",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -4,6 +4,9 @@
   "description": "Compile function bind operator to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -4,6 +4,9 @@
   "description": "Compile the function.sent meta propety to valid ES2015 code",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -4,6 +4,9 @@
   "description": "Escape U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in JS strings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -4,6 +4,9 @@
   "description": "Transforms logical assignment operators into short-circuited assignments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -4,6 +4,9 @@
   "description": "Remove nullish coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-nullish-coalescing-opearator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -4,6 +4,9 @@
   "description": "Remove numeric separators from Decimal, Binary, Hex and Octal literals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -4,6 +4,9 @@
   "description": "Compile object rest and spread to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -4,6 +4,9 @@
   "description": "Compile optional catch bindings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -4,6 +4,9 @@
   "description": "Transform optional chaining operators into a series of nil checks",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -4,6 +4,9 @@
   "description": "Transform pipeline operator into call expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -4,6 +4,9 @@
   "description": "Wraps Throw Expressions in an IIFE",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -4,6 +4,9 @@
   "description": "Compile Unicode property escapes in Unicode regular expressions to ES5.",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "engines": {
     "node": ">=4"

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of async generator functions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-bigint/package.json
+++ b/packages/babel-plugin-syntax-bigint/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of BigInt literals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-bigint",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of class properties",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of decorators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of do expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-dynamic-import/package.json
+++ b/packages/babel-plugin-syntax-dynamic-import/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of import()",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of export default from",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-export-namespace-from/package.json
+++ b/packages/babel-plugin-syntax-export-namespace-from/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of export namespace from",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of the flow syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of function bind",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of the function.sent meta property",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-import-meta/package.json
+++ b/packages/babel-plugin-syntax-import-meta/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of import.meta",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-meta",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-json-strings/package.json
+++ b/packages/babel-plugin-syntax-json-strings/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of the U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in JS strings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of jsx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of the logical assignment operators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of the nullish-coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of Decimal, Binary, Hex and Octal literals that contain a Numeric Literal Separator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of object rest/spread",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-optional-catch-binding/package.json
+++ b/packages/babel-plugin-syntax-optional-catch-binding/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of optional catch bindings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-optional-chaining/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of optional properties",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of the pipeline operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of Throw Expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -4,6 +4,9 @@
   "description": "Allow parsing of TypeScript syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin",

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 arrow functions to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -4,6 +4,9 @@
   "description": "Turn async functions into ES2015 generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -4,6 +4,9 @@
   "description": "Babel plugin to ensure function declarations at the block level are block scoped",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 block scoping (const and let) to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 classes to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-annotate-as-pure": "^7.0.0",

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 computed properties to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 destructuring to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -4,6 +4,9 @@
   "description": "Compile regular expressions using the `s` (`dotAll`) flag to ES5.",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "engines": {
     "node": ">=4"

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -4,6 +4,9 @@
   "description": "Compile objects with duplicate keys to valid strict ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -4,6 +4,9 @@
   "description": "Compile exponentiation operator to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -4,6 +4,9 @@
   "description": "Turn flow type annotations into comments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -4,6 +4,9 @@
   "description": "Strip flow type annotations from your output code.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 for...of to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -4,6 +4,9 @@
   "description": "Apply ES2015 function.name semantics to all functions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin transforms all the ES2015 'instanceof' methods",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-instanceof",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -4,6 +4,9 @@
   "description": "Babel plugin to fix buggy JScript named function expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jscript",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 unicode string and number literals to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -4,6 +4,9 @@
   "description": "Ensure that reserved words are quoted in property accesses",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin transforms ES2015 modules to AMD",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "^7.0.0",

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin transforms ES2015 modules to CommonJS",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "^7.0.0",

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin transforms ES2015 modules to SystemJS",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-hoist-variables": "^7.0.0",

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin transforms ES2015 modules to UMD",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "^7.0.0",

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -4,6 +4,9 @@
   "description": "Transforms new.target meta property",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-assign",
   "author": "Jed Watson",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -4,6 +4,9 @@
   "description": "Turn Object.setPrototypeOf to assignments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-set-prototype-of-to-assign",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 object super to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 default and rest parameters to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-call-delegate": "^7.0.0",

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -4,6 +4,9 @@
   "description": "Ensure that reserved words are quoted in object property keys",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES5 property mutator shorthand syntax to Object.defineProperty",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-mutators",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -4,6 +4,9 @@
   "description": "Babel plugin for turning __proto__ into a shallow property clone",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -4,6 +4,9 @@
   "description": "Treat React JSX elements as value types and hoist them to the highest scope",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-constant-elements",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -4,6 +4,9 @@
   "description": "Add displayName to React.createClass calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -4,6 +4,9 @@
   "description": "Turn JSX elements into exploded React objects",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-inline-elements",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -4,6 +4,9 @@
   "description": "Turn JSX into React Pre-0.12 function calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-compat",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -4,6 +4,9 @@
   "description": "Add a __self prop to all JSX Elements",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -4,6 +4,9 @@
   "description": "Add a __source prop to all JSX Elements",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -4,6 +4,9 @@
   "description": "Turn JSX into React function calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -10,6 +10,9 @@
     "regenerator-transform": "^0.13.3"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"
   },

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -4,6 +4,9 @@
   "description": "Ensure that no reserved words are used.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -4,6 +4,9 @@
   "description": "Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 shorthand properties to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 spread to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 sticky regex to an ES5 RegExp constructor",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -4,6 +4,9 @@
   "description": "This plugin places a 'use strict'; directive at the top of all files to enable strict mode",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 template literals to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-annotate-as-pure": "^7.0.0",

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -4,6 +4,9 @@
   "description": "This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -4,6 +4,9 @@
   "description": "Transform TypeScript into ES.next",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin",

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -4,6 +4,9 @@
   "description": "Compile ES2015 Unicode regex to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-polyfill",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-preset-env-standalone/package.json
+++ b/packages/babel-preset-env-standalone/package.json
@@ -25,6 +25,9 @@
     "transpiler"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/babel/babel/issues"
   },

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -5,6 +5,9 @@
   "author": "Henry Zhu <hi@henryzoo.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-env",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -5,6 +5,9 @@
   "author": "James Kyle <me@thejameskyle.com>",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-preset",

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-0",
   "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-1",
   "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-2",
   "main": "lib/index.js"
 }

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-stage-3",
   "main": "lib/index.js"
 }

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -4,6 +4,9 @@
   "description": "Babel preset for TypeScript.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "keywords": [
     "babel-preset",

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -3,6 +3,9 @@
   "version": "7.0.0",
   "description": "babel require hook",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-register",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "main": "lib/index.js",

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -3,6 +3,9 @@
   "version": "7.0.0",
   "description": "babel's modular runtime helpers with core-js@2 polyfilling",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime-corejs2",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -3,6 +3,9 @@
   "version": "7.0.0",
   "description": "babel's modular runtime helpers",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -105,6 +105,9 @@
   ],
   "author": "Daniel Lo Nigro <daniel@dan.cx> (http://dan.cx/)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/babel/babel-standalone/issues"
   },

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-template",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -5,6 +5,9 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-traverse",
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Not necessary https://docs.npmjs.com/cli/access, as once you publish as public it will be public but if people copy paste to make an new package they might miss this and we will get a publish error later so figured we should.