### PR TITLE
Remove LICENSE email and refer to other contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2018 Sebastian McKenzie <sebmck@gmail.com>
+Copyright (c) 2014-2018 Sebastian McKenzie and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Been years since I've been involved in Babel, so I feel like referencing other contributors is more appropriate now.

Also removed my email address. I constantly get emails from random people because they find my email in the licenses of random software and think I'm responsible for their problems.
