### PR TITLE
Fix type annotation properties assigning to undefined. (#8417)

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -6,6 +6,9 @@ import { environmentVisitor } from "@babel/helper-replace-supers";
 import memberExpressionToFunctions from "@babel/helper-member-expression-to-functions";
 import optimiseCall from "@babel/helper-optimise-call-expression";
 
+const isNoInitialTypeAnnotationProp = o =>
+  o.has("typeAnnotation") && !o.has("value");
+
 export default declare((api, options) => {
   api.assertVersion(7);
 
@@ -366,6 +369,9 @@ export default declare((api, options) => {
 
         let p = 0;
         for (const prop of props) {
+          // Check property is an type annotation, and skip it
+          if (isNoInitialTypeAnnotationProp(prop)) continue;
+
           if (prop.node.static) {
             staticNodes.push(buildClassProperty(t.cloneNode(ref), prop, state));
           } else if (prop.isPrivate()) {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/exec.js
@@ -1,0 +1,75 @@
+function test(x) {
+
+  class B {
+    name: string = x
+    fn() {
+      return x
+    }
+    dispatchTransaction() {
+      return x
+    }
+  }
+
+  class Foo extends B {
+
+    // static fields -------------
+    static FOO: string
+    static BAR: string = 'BAR'
+
+    // instance fields -------------
+
+    name: string
+    noInitial: boolean
+
+    log: { error: boolean } = {
+      error: x
+    };
+
+    fn: Function
+    dispatchTransaction: Function = this.dispatchTransaction.bind(this);
+
+    get silent(): boolean {
+      return x;
+    }
+
+    // to be assigned later
+    f1: Function
+
+    constructor() {
+      super();
+      this.f1 = this.f1.bind(this);
+
+      expect(this.name).toBe(x);
+      expect(this).not.toHaveProperty('noInitial');
+      expect(this.fn()).toBe(x)
+      expect(this.f1()).toBe(x)
+
+      this.end = 1
+    }
+
+    f1 = () => x
+
+    test() {
+      expect(this.name).toBe(x);
+      expect(this).not.toHaveProperty('noInitial');
+      expect(this.fn()).toBe(x);
+      expect(this.f1()).toBe(x)
+
+      expect(this).toHaveProperty('log.error', x);
+      expect(this.dispatchTransaction()).toBe(x);
+      expect(this.silent).toBe(x);
+    }
+
+    static test() {
+      expect(Foo.BAR).toBe('BAR')
+      expect(Foo).not.toHaveProperty('FOO')
+    }
+  }
+
+  // run tests
+  Foo.test();
+  (new Foo(x)).test();
+
+}
+
+test('foo');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/input.js
@@ -1,0 +1,47 @@
+function test(x) {
+
+  class B {
+    name: string = x
+    fn() {
+      return x
+    }
+    dispatchTransaction() {
+      return x
+    }
+  }
+
+  class Foo extends B {
+
+    // static fields -------------
+    static FOO: string
+    static BAR: string = 'BAR'
+
+    // instance fields -------------
+
+    name: string
+    noInitial: boolean
+
+    log: { error: boolean } = {
+      error: x
+    };
+
+    fn: Function
+    dispatchTransaction: Function = this.dispatchTransaction.bind(this);
+
+    get silent(): boolean {
+      return x;
+    }
+
+    // to be assigned later
+    f1: Function
+
+    constructor() {
+      super();
+      this.f1 = this.f1.bind(this);
+
+      this.end = 1
+    }
+
+    f1 = () => x
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/options.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    "env",
+    "flow"
+  ],
+  "plugins": [
+    "external-helpers",
+    ["proposal-class-properties", {"loose": true}],
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/type-annotation-transform/output.js
@@ -1,0 +1,65 @@
+function test(x) {
+  var B =
+  /*#__PURE__*/
+  function () {
+    "use strict";
+
+    function B() {
+      babelHelpers.classCallCheck(this, B);
+      this.name = x;
+    }
+
+    babelHelpers.createClass(B, [{
+      key: "fn",
+      value: function fn() {
+        return x;
+      }
+    }, {
+      key: "dispatchTransaction",
+      value: function dispatchTransaction() {
+        return x;
+      }
+    }]);
+    return B;
+  }();
+
+  var Foo =
+  /*#__PURE__*/
+  function (_B) {
+    "use strict";
+
+    babelHelpers.inherits(Foo, _B);
+    babelHelpers.createClass(Foo, [{
+      key: "silent",
+      // static fields -------------
+      // instance fields -------------
+      get: function get() {
+        return x;
+      } // to be assigned later
+
+    }]);
+
+    function Foo() {
+      var _this;
+
+      babelHelpers.classCallCheck(this, Foo);
+      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this.log = {
+        error: x
+      };
+      _this.dispatchTransaction = _this.dispatchTransaction.bind(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)));
+
+      _this.f1 = function () {
+        return x;
+      };
+
+      _this.f1 = _this.f1.bind(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)));
+      _this.end = 1;
+      return _this;
+    }
+
+    return Foo;
+  }(B);
+
+  Foo.BAR = 'BAR';
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/exec.js
@@ -1,0 +1,75 @@
+function test(x) {
+
+  class B {
+    name: string = x
+    fn() {
+      return x
+    }
+    dispatchTransaction() {
+      return x
+    }
+  }
+
+  class Foo extends B {
+
+    // static fields -------------
+    static FOO: string
+    static BAR: string = 'BAR'
+
+    // instance fields -------------
+
+    name: string
+    noInitial: boolean
+
+    log: { error: boolean } = {
+      error: x
+    };
+
+    fn: Function
+    dispatchTransaction: Function = this.dispatchTransaction.bind(this);
+
+    get silent(): boolean {
+      return x;
+    }
+
+    // to be assigned later
+    f1: Function
+
+    constructor() {
+      super();
+      this.f1 = this.f1.bind(this);
+
+      expect(this.name).toBe(x);
+      expect(this).not.toHaveProperty('noInitial');
+      expect(this.fn()).toBe(x)
+      expect(this.f1()).toBe(x)
+
+      this.end = 1
+    }
+
+    f1 = () => x
+
+    test() {
+      expect(this.name).toBe(x);
+      expect(this).not.toHaveProperty('noInitial');
+      expect(this.fn()).toBe(x);
+      expect(this.f1()).toBe(x)
+
+      expect(this).toHaveProperty('log.error', x);
+      expect(this.dispatchTransaction()).toBe(x);
+      expect(this.silent).toBe(x);
+    }
+
+    static test() {
+      expect(Foo.BAR).toBe('BAR')
+      expect(Foo).not.toHaveProperty('FOO')
+    }
+  }
+
+  // run tests
+  Foo.test();
+  (new Foo(x)).test();
+
+}
+
+test('foo');

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/input.js
@@ -1,0 +1,47 @@
+function test(x) {
+
+  class B {
+    name: string = x
+    fn() {
+      return x
+    }
+    dispatchTransaction() {
+      return x
+    }
+  }
+
+  class Foo extends B {
+
+    // static fields -------------
+    static FOO: string
+    static BAR: string = 'BAR'
+
+    // instance fields -------------
+
+    name: string
+    noInitial: boolean
+
+    log: { error: boolean } = {
+      error: x
+    };
+
+    fn: Function
+    dispatchTransaction: Function = this.dispatchTransaction.bind(this);
+
+    get silent(): boolean {
+      return x;
+    }
+
+    // to be assigned later
+    f1: Function
+
+    constructor() {
+      super();
+      this.f1 = this.f1.bind(this);
+
+      this.end = 1
+    }
+
+    f1 = () => x
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/options.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    "env",
+    "flow"
+  ],
+  "plugins": [
+    "external-helpers",
+    "proposal-class-properties",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/type-annotation-transform/output.js
@@ -1,0 +1,63 @@
+function test(x) {
+  var B =
+  /*#__PURE__*/
+  function () {
+    "use strict";
+
+    function B() {
+      babelHelpers.classCallCheck(this, B);
+      babelHelpers.defineProperty(this, "name", x);
+    }
+
+    babelHelpers.createClass(B, [{
+      key: "fn",
+      value: function fn() {
+        return x;
+      }
+    }, {
+      key: "dispatchTransaction",
+      value: function dispatchTransaction() {
+        return x;
+      }
+    }]);
+    return B;
+  }();
+
+  var Foo =
+  /*#__PURE__*/
+  function (_B) {
+    "use strict";
+
+    babelHelpers.inherits(Foo, _B);
+    babelHelpers.createClass(Foo, [{
+      key: "silent",
+      // static fields -------------
+      // instance fields -------------
+      get: function get() {
+        return x;
+      } // to be assigned later
+
+    }]);
+
+    function Foo() {
+      var _this;
+
+      babelHelpers.classCallCheck(this, Foo);
+      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "log", {
+        error: x
+      });
+      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "dispatchTransaction", _this.dispatchTransaction.bind(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))));
+      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "f1", function () {
+        return x;
+      });
+      _this.f1 = _this.f1.bind(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)));
+      _this.end = 1;
+      return _this;
+    }
+
+    return Foo;
+  }(B);
+
+  babelHelpers.defineProperty(Foo, "BAR", 'BAR');
+}

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/output.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/class-prop-values-3/output.js
@@ -2,7 +2,6 @@ class X {
   constructor() {
     this.a = 2;
     this.b = '3';
-    this.c = void 0;
   }
 
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8417  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Add a helper `declareNilProps (obj, props);` to @babel/babel-helpers
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->