### PR TITLE
Pass missing caller metadata for .babelrc.js files.

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -190,6 +190,7 @@ export function buildRootChain(
     ({ ignore: ignoreFile, config: babelrcFile } = findRelativeConfig(
       pkgData,
       context.envName,
+      context.caller,
     ));
 
     if (


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Added this argument in https://github.com/babel/babel/pull/8485/files#diff-83f25d98662c0f8e8ad7cc7d1ed06f8eR30 but it didn't get passed down to this function, accidentally.

`.bablerc.js` files would always get `undefined` caller metadata from `api.caller(dat => {})` without this.