### PR TITLE
[static private] Use correct min version in helpers

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1054,7 +1054,7 @@ helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldLooseBase = helper("7.1.0")`
+helpers.classStaticPrivateFieldLooseBase = helper("7.0.1")`
   export default function _classStaticPrivateFieldLooseBase(receiver, classConstructor) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
@@ -1063,7 +1063,7 @@ helpers.classStaticPrivateFieldLooseBase = helper("7.1.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldSpecGet = helper("7.1.0")`
+helpers.classStaticPrivateFieldSpecGet = helper("7.0.1")`
   export default function _classStaticPrivateFieldSpecGet(
     receiver, classConstructor, privateClass, privateId
   ) {
@@ -1074,7 +1074,7 @@ helpers.classStaticPrivateFieldSpecGet = helper("7.1.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldSpecSet = helper("7.1.0")`
+helpers.classStaticPrivateFieldSpecSet = helper("7.0.1")`
   export default function _classStaticPrivateFieldSpecSet(
     receiver, classConstructor, privateClass, privateId, value
   ) {

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1054,7 +1054,7 @@ helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldLooseBase = helper("7.0.0-beta.0")`
+helpers.classStaticPrivateFieldLooseBase = helper("7.1.0")`
   export default function _classStaticPrivateFieldLooseBase(receiver, classConstructor) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
@@ -1063,7 +1063,7 @@ helpers.classStaticPrivateFieldLooseBase = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldSpecGet = helper("7.0.0-beta.0")`
+helpers.classStaticPrivateFieldSpecGet = helper("7.1.0")`
   export default function _classStaticPrivateFieldSpecGet(
     receiver, classConstructor, privateClass, privateId
   ) {
@@ -1074,7 +1074,7 @@ helpers.classStaticPrivateFieldSpecGet = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldSpecSet = helper("7.0.0-beta.0")`
+helpers.classStaticPrivateFieldSpecSet = helper("7.1.0")`
   export default function _classStaticPrivateFieldSpecSet(
     receiver, classConstructor, privateClass, privateId, value
   ) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Update the min version of `@babel/runtime` that support the helpers introduced by #8205, so that newer version of Babel can be used with old versions of `@babel/runtime`.

cc @rricard @jridgewell 