### PR TITLE
[static private] Unify loose handling of static and instance props

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1054,15 +1054,6 @@ helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldLooseBase = helper("7.0.1")`
-  export default function _classStaticPrivateFieldLooseBase(receiver, classConstructor) {
-    if (receiver !== classConstructor) {
-      throw new TypeError("Private static access of wrong provenance");
-    }
-    return classConstructor;
-  }
-`;
-
 helpers.classStaticPrivateFieldSpecGet = helper("7.0.1")`
   export default function _classStaticPrivateFieldSpecGet(
     receiver, classConstructor, privateClass, privateId

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/native-classes/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/native-classes/output.js
@@ -7,7 +7,7 @@ class Foo {
   }
 
   static test() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Foo, Foo)._foo;
+    return babelHelpers.classPrivateFieldLooseBase(Foo, _foo)[_foo];
   }
 
   test() {
@@ -16,11 +16,11 @@ class Foo {
 
 }
 
-Object.defineProperty(Foo, "_foo", {
-  value: "foo",
-  enumerable: false,
-  configurable: false,
-  writable: true
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+Object.defineProperty(Foo, _foo, {
+  writable: true,
+  value: "foo"
 });
 
 var _bar = babelHelpers.classPrivateFieldLooseKey("bar");

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
@@ -1,18 +1,16 @@
 export default (param => {
-  var _class, _temp;
+  var _class, _temp, _props;
 
   return _temp = _class = class App {
     getParam() {
       return param;
     }
 
-  }, Object.defineProperty(_class, "_props", {
+  }, _props = babelHelpers.classPrivateFieldLooseKey("props"), Object.defineProperty(_class, _props, {
+    writable: true,
     value: {
       prop1: 'prop1',
       prop2: 'prop2'
-    },
-    enumerable: false,
-    configurable: false,
-    writable: true
+    }
   }), _temp;
 });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/output.js
@@ -1,5 +1,5 @@
 function classFactory() {
-  var _class, _temp, _foo;
+  var _class, _temp, _foo, _bar;
 
   return _temp = _class = class Foo {
     constructor() {
@@ -14,7 +14,7 @@ function classFactory() {
     }
 
     static() {
-      return babelHelpers.classStaticPrivateFieldLooseBase(Foo, _class)._bar;
+      return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
     }
 
     static instance(inst) {
@@ -22,14 +22,12 @@ function classFactory() {
     }
 
     static static() {
-      return babelHelpers.classStaticPrivateFieldLooseBase(Foo, _class)._bar;
+      return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
     }
 
-  }, _foo = babelHelpers.classPrivateFieldLooseKey("foo"), Object.defineProperty(_class, "_bar", {
-    value: "bar",
-    enumerable: false,
-    configurable: false,
-    writable: true
+  }, _foo = babelHelpers.classPrivateFieldLooseKey("foo"), _bar = babelHelpers.classPrivateFieldLooseKey("bar"), Object.defineProperty(_class, _bar, {
+    writable: true,
+    value: "bar"
   }), _temp;
 }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-call/output.js
@@ -10,17 +10,17 @@ function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test(x) {
-      return babelHelpers.classStaticPrivateFieldLooseBase(Foo, Foo)._foo(x);
+      return babelHelpers.classPrivateFieldLooseBase(Foo, _foo)[_foo](x);
     }
   }]);
   return Foo;
 }();
 
-Object.defineProperty(Foo, "_foo", {
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+Object.defineProperty(Foo, _foo, {
+  writable: true,
   value: function (x) {
     return x;
-  },
-  enumerable: false,
-  configurable: false,
-  writable: true
+  }
 });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-export/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-export/output.mjs
@@ -1,14 +1,16 @@
 export class MyClass {}
-Object.defineProperty(MyClass, "_property", {
-  value: value,
-  enumerable: false,
-  configurable: false,
-  writable: true
+
+var _property = babelHelpers.classPrivateFieldLooseKey("property");
+
+Object.defineProperty(MyClass, _property, {
+  writable: true,
+  value: value
 });
 export default class MyClass2 {}
-Object.defineProperty(MyClass2, "_property2", {
-  value: value,
-  enumerable: false,
-  configurable: false,
-  writable: true
+
+var _property2 = babelHelpers.classPrivateFieldLooseKey("property");
+
+Object.defineProperty(MyClass2, _property2, {
+  writable: true,
+  value: value
 });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-infer-name/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-infer-name/output.js
@@ -1,8 +1,6 @@
-var _class, _temp;
+var _class, _temp, _num;
 
-var Foo = (_temp = _class = class Foo {}, Object.defineProperty(_class, "_num", {
-  value: 0,
-  enumerable: false,
-  configurable: false,
-  writable: true
+var Foo = (_temp = _class = class Foo {}, _num = babelHelpers.classPrivateFieldLooseKey("num"), Object.defineProperty(_class, _num, {
+  writable: true,
+  value: 0
 }), _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-inherited/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-inherited/output.js
@@ -1,41 +1,41 @@
 class Base {
   static getThis() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(this, Base)._foo;
+    return babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo];
   }
 
   static updateThis(val) {
-    return babelHelpers.classStaticPrivateFieldLooseBase(this, Base)._foo = val;
+    return babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo] = val;
   }
 
   static getClass() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Base, Base)._foo;
+    return babelHelpers.classPrivateFieldLooseBase(Base, _foo)[_foo];
   }
 
   static updateClass(val) {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Base, Base)._foo = val;
+    return babelHelpers.classPrivateFieldLooseBase(Base, _foo)[_foo] = val;
   }
 
 }
 
-Object.defineProperty(Base, "_foo", {
-  value: 1,
-  enumerable: false,
-  configurable: false,
-  writable: true
+var _foo = babelHelpers.classPrivateFieldLooseKey("foo");
+
+Object.defineProperty(Base, _foo, {
+  writable: true,
+  value: 1
 });
 
 class Sub1 extends Base {
   static update(val) {
-    return babelHelpers.classStaticPrivateFieldLooseBase(this, Sub1)._foo2 = val;
+    return babelHelpers.classPrivateFieldLooseBase(this, _foo2)[_foo2] = val;
   }
 
 }
 
-Object.defineProperty(Sub1, "_foo2", {
-  value: 2,
-  enumerable: false,
-  configurable: false,
-  writable: true
+var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+
+Object.defineProperty(Sub1, _foo2, {
+  writable: true,
+  value: 2
 });
 
 class Sub2 extends Base {}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-undefined/output.js
@@ -1,17 +1,17 @@
 class Foo {
   static test() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Foo, Foo)._bar;
+    return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
   }
 
   test() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Foo, Foo)._bar;
+    return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
   }
 
 }
 
-Object.defineProperty(Foo, "_bar", {
-  value: void 0,
-  enumerable: false,
-  configurable: false,
-  writable: true
+var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+
+Object.defineProperty(Foo, _bar, {
+  writable: true,
+  value: void 0
 });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static/output.js
@@ -1,17 +1,17 @@
 class Foo {
   static test() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Foo, Foo)._bar;
+    return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
   }
 
   test() {
-    return babelHelpers.classStaticPrivateFieldLooseBase(Foo, Foo)._bar;
+    return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
   }
 
 }
 
-Object.defineProperty(Foo, "_bar", {
-  value: "foo",
-  enumerable: false,
-  configurable: false,
-  writable: true
+var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+
+Object.defineProperty(Foo, _bar, {
+  writable: true,
+  value: "foo"
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | y
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Follow up to #8205

<!-- Describe your changes below in as much detail as possible -->
Since both static and instance private props are defined a non-configurable non-enumerable properties on their target, thay can be handled in the same way.

This PR also removes a possible conflict between private and public static properties, by using the `classPrivateFieldLooseKey` helper to generate the key (instead of `"_" + name`). e.g.
```js
class Foo {
  static #bar = 1;
  static _bar = 2;
}
```
cc @rricard @jridgewell 