### PR TITLE
[static private] Use explicit descriptors instead of an object

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1055,24 +1055,26 @@ helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
 `;
 
 helpers.classStaticPrivateFieldSpecGet = helper("7.0.1")`
-  export default function _classStaticPrivateFieldSpecGet(
-    receiver, classConstructor, privateClass, privateId
-  ) {
+  export default function _classStaticPrivateFieldSpecGet(receiver, classConstructor, descriptor) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
     }
-    return privateClass[privateId];
+    return descriptor.value;
   }
 `;
 
 helpers.classStaticPrivateFieldSpecSet = helper("7.0.1")`
-  export default function _classStaticPrivateFieldSpecSet(
-    receiver, classConstructor, privateClass, privateId, value
-  ) {
+  export default function _classStaticPrivateFieldSpecSet(receiver, classConstructor, descriptor, value) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
     }
-    privateClass[privateId] = value;
+    if (!descriptor.writable) {
+      // This should only throw in strict mode, but class bodies are
+      // always strict and private fields can only be used inside
+      // class bodies.
+      throw new TypeError("attempted to set read only private field");
+    }
+    descriptor.value = value;
     return value;
   }
 `;

--- a/packages/babel-plugin-proposal-class-properties/src/index.js
+++ b/packages/babel-plugin-proposal-class-properties/src/index.js
@@ -295,8 +295,7 @@ export default declare((api, options) => {
       state,
     );
 
-    const staticNodesToAdd = [keyDecl, buildInit()];
-    return [staticNodesToAdd];
+    return [keyDecl, buildInit()];
   }
 
   function buildClassStaticPrivatePropertySpec(ref, path, state) {
@@ -312,7 +311,7 @@ export default declare((api, options) => {
       ...staticPrivatePropertyHandlerSpec,
     });
 
-    const staticNodesToAdd = [
+    return [
       template.statement.ast`
         var ${privateId} = {
           // configurable is always false for private elements
@@ -322,8 +321,6 @@ export default declare((api, options) => {
         }
       `,
     ];
-
-    return [staticNodesToAdd];
   }
 
   const buildClassProperty = loose
@@ -433,21 +430,16 @@ export default declare((api, options) => {
           }
         }
         let p = 0;
-        let privateClassId;
         for (const prop of props) {
           if (prop.node.static) {
             if (prop.isPrivate()) {
-              let staticNodesToAdd;
-              [
-                staticNodesToAdd,
-                privateClassId,
-              ] = buildClassStaticPrivateProperty(
-                t.cloneNode(ref),
-                prop,
-                state,
-                privateClassId,
+              staticNodes.push(
+                ...buildClassStaticPrivateProperty(
+                  t.cloneNode(ref),
+                  prop,
+                  state,
+                ),
               );
-              staticNodes.push(...staticNodesToAdd);
             } else {
               staticNodes.push(
                 buildClassProperty(t.cloneNode(ref), prop, state),

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/native-classes/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/native-classes/output.js
@@ -7,7 +7,7 @@ class Foo {
   }
 
   static test() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _FooStatics, "foo");
+    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _foo);
   }
 
   test() {
@@ -16,8 +16,9 @@ class Foo {
 
 }
 
-var _FooStatics = Object.create(null);
-
-babelHelpers.defineProperty(_FooStatics, "foo", "foo");
+var _foo = {
+  writable: true,
+  value: "foo"
+};
 
 var _bar = new WeakMap();

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/non-block-arrow-func/output.mjs
@@ -1,20 +1,16 @@
 export default (param => {
-  var _class, _temp;
+  var _class, _temp, _props;
 
-  return function () {
-    _temp = _class = class App {
-      getParam() {
-        return param;
-      }
+  return _temp = _class = class App {
+    getParam() {
+      return param;
+    }
 
-    };
-
-    var _classStatics = Object.create(null);
-
-    babelHelpers.defineProperty(_classStatics, "props", {
+  }, _props = {
+    writable: true,
+    value: {
       prop1: 'prop1',
       prop2: 'prop2'
-    });
-    return _temp;
-  }();
+    }
+  }, _temp;
 });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/output.js
@@ -1,38 +1,32 @@
 function classFactory() {
-  var _class, _temp;
+  var _class, _temp, _foo, _bar;
 
-  return function () {
-    _temp = _class = class Foo {
-      constructor() {
-        _foo.set(this, {
-          writable: true,
-          value: "foo"
-        });
-      }
+  return _temp = _class = class Foo {
+    constructor() {
+      _foo.set(this, {
+        writable: true,
+        value: "foo"
+      });
+    }
 
-      instance() {
-        return babelHelpers.classPrivateFieldGet(this, _foo);
-      }
+    instance() {
+      return babelHelpers.classPrivateFieldGet(this, _foo);
+    }
 
-      static() {
-        return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _classStatics, "bar");
-      }
+    static() {
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _bar);
+    }
 
-      static instance(inst) {
-        return babelHelpers.classPrivateFieldGet(inst, _foo);
-      }
+    static instance(inst) {
+      return babelHelpers.classPrivateFieldGet(inst, _foo);
+    }
 
-      static static() {
-        return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _classStatics, "bar");
-      }
+    static static() {
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _bar);
+    }
 
-    };
-
-    var _foo = new WeakMap();
-
-    var _classStatics = Object.create(null);
-
-    babelHelpers.defineProperty(_classStatics, "bar", "bar");
-    return _temp;
-  }();
+  }, _foo = new WeakMap(), _bar = {
+    writable: true,
+    value: "bar"
+  }, _temp;
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T2983/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T2983/output.mjs
@@ -1,16 +1,12 @@
-var _class, _temp;
+var _class, _temp, _test;
 
-call(function () {
-  _temp = _class = class {};
-
-  var _classStatics = Object.create(null);
-
-  babelHelpers.defineProperty(_classStatics, "test", true);
-  return _temp;
-}());
+call((_temp = _class = class {}, _test = {
+  writable: true,
+  value: true
+}, _temp));
 export default class _class2 {}
-
-var _class2Statics = Object.create(null);
-
-babelHelpers.defineProperty(_class2Statics, "test", true);
+var _test2 = {
+  writable: true,
+  value: true
+};
 ;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T6719/output.js
@@ -1,18 +1,14 @@
 function withContext(ComposedComponent) {
-  var _class, _temp;
+  var _class, _temp, _propTypes;
 
-  return function () {
-    _temp = _class = class WithContext extends Component {};
-
-    var _classStatics = Object.create(null);
-
-    babelHelpers.defineProperty(_classStatics, "propTypes", {
+  return _temp = _class = class WithContext extends Component {}, _propTypes = {
+    writable: true,
+    value: {
       context: PropTypes.shape({
         addCss: PropTypes.func,
         setTitle: PropTypes.func,
         setMeta: PropTypes.func
       })
-    });
-    return _temp;
-  }();
+    }
+  }, _temp;
 }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-call/output.js
@@ -10,14 +10,15 @@ function () {
   babelHelpers.createClass(Foo, [{
     key: "test",
     value: function test(x) {
-      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _FooStatics, "foo").call(Foo, x);
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _foo).call(Foo, x);
     }
   }]);
   return Foo;
 }();
 
-var _FooStatics = Object.create(null);
-
-babelHelpers.defineProperty(_FooStatics, "foo", function (x) {
-  return x;
-});
+var _foo = {
+  writable: true,
+  value: function (x) {
+    return x;
+  }
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-export/output.mjs
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-export/output.mjs
@@ -1,10 +1,10 @@
 export class MyClass {}
-
-var _MyClassStatics = Object.create(null);
-
-babelHelpers.defineProperty(_MyClassStatics, "property", value);
+var _property = {
+  writable: true,
+  value: value
+};
 export default class MyClass2 {}
-
-var _MyClass2Statics = Object.create(null);
-
-babelHelpers.defineProperty(_MyClass2Statics, "property", value);
+var _property2 = {
+  writable: true,
+  value: value
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-infer-name/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-infer-name/output.js
@@ -1,10 +1,6 @@
-var _class, _temp;
+var _class, _temp, _num;
 
-var Foo = function () {
-  _temp = _class = class Foo {};
-
-  var _classStatics = Object.create(null);
-
-  babelHelpers.defineProperty(_classStatics, "num", 0);
-  return _temp;
-}();
+var Foo = (_temp = _class = class Foo {}, _num = {
+  writable: true,
+  value: 0
+}, _temp);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-inherited/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-inherited/output.js
@@ -1,35 +1,37 @@
 class Base {
   static getThis() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, Base, _BaseStatics, "foo");
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, Base, _foo);
   }
 
   static updateThis(val) {
-    return babelHelpers.classStaticPrivateFieldSpecSet(this, Base, _BaseStatics, "foo", val);
+    return babelHelpers.classStaticPrivateFieldSpecSet(this, Base, _foo, val);
   }
 
   static getClass() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(Base, Base, _BaseStatics, "foo");
+    return babelHelpers.classStaticPrivateFieldSpecGet(Base, Base, _foo);
   }
 
   static updateClass(val) {
-    return babelHelpers.classStaticPrivateFieldSpecSet(Base, Base, _BaseStatics, "foo", val);
+    return babelHelpers.classStaticPrivateFieldSpecSet(Base, Base, _foo, val);
   }
 
 }
 
-var _BaseStatics = Object.create(null);
-
-babelHelpers.defineProperty(_BaseStatics, "foo", 1);
+var _foo = {
+  writable: true,
+  value: 1
+};
 
 class Sub1 extends Base {
   static update(val) {
-    return babelHelpers.classStaticPrivateFieldSpecSet(this, Sub1, _Sub1Statics, "foo", val);
+    return babelHelpers.classStaticPrivateFieldSpecSet(this, Sub1, _foo2, val);
   }
 
 }
 
-var _Sub1Statics = Object.create(null);
-
-babelHelpers.defineProperty(_Sub1Statics, "foo", 2);
+var _foo2 = {
+  writable: true,
+  value: 2
+};
 
 class Sub2 extends Base {}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-undefined/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-undefined/output.js
@@ -1,14 +1,15 @@
 class Foo {
   static test() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _FooStatics, "bar");
+    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
   }
 
   test() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _FooStatics, "bar");
+    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
   }
 
 }
 
-var _FooStatics = Object.create(null);
-
-babelHelpers.defineProperty(_FooStatics, "bar", void 0);
+var _bar = {
+  writable: true,
+  value: void 0
+};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static/output.js
@@ -1,17 +1,18 @@
 class Foo {
   static test() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _FooStatics, "bar");
+    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
   }
 
   test() {
-    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _FooStatics, "bar");
+    return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
   }
 
 }
 
-var _FooStatics = Object.create(null);
-
-babelHelpers.defineProperty(_FooStatics, "bar", "foo");
+var _bar = {
+  writable: true,
+  value: "foo"
+};
 expect("bar" in Foo).toBe(false);
 expect(Foo.test()).toBe("foo");
 expect(Foo.test()).toBe("foo");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> This is similar to ec69b4bb1256c061ac76f53dfed09c4283ec6a31 (#8318), which was about private instance fields.
>
> Private properties can be non-writable (thanks to decorators), or have
get/set accessors. If we stored this information on the `privateClass`
object, we would need to always use `Object.getOwnPropertyDescriptor`
before reading or writing a property because accessors need to be called
with the correct `this` context (it should be the actual class, not the
object hat stores the private properties). This commit simplifies that
operation a bit by removing the container object.
>
> It also have another advantage, which instance fields already have
thanks to the use of separate weakmaps: unused private static fields
can be tree-shaken away or garbage-collected, while properties of an
object can't. Also, they can be easilier minified.

This isn't strictly required, but it makes the transform a little bit simpler.

cc @rricard @jridgewell 