### PR TITLE
Make dir for babel --out-file

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -24,7 +24,7 @@
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.0.0",
     "lodash": "^4.17.13",
-    "mkdirp": "^0.5.1",
+    "make-dir": "^2.1.0",
     "output-file-sync": "^2.0.0",
     "slash": "^2.0.0",
     "source-map": "^0.5.0"

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -2,7 +2,7 @@
 
 import defaults from "lodash/defaults";
 import outputFileSync from "output-file-sync";
-import { sync as mkdirpSync } from "mkdirp";
+import { sync as makeDirSync } from "make-dir";
 import slash from "slash";
 import path from "path";
 import fs from "fs";
@@ -122,7 +122,7 @@ export default async function({
       util.deleteDir(cliOptions.outDir);
     }
 
-    mkdirpSync(cliOptions.outDir);
+    makeDirSync(cliOptions.outDir);
 
     let compiledFiles = 0;
     for (const filename of cliOptions.filenames) {

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -4,6 +4,7 @@ import convertSourceMap from "convert-source-map";
 import defaults from "lodash/defaults";
 import sourceMap from "source-map";
 import slash from "slash";
+import { sync as makeDirSync } from "make-dir";
 import path from "path";
 import fs from "fs";
 
@@ -89,6 +90,8 @@ export default async function({
     const result = buildResult(fileResults);
 
     if (cliOptions.outFile) {
+      makeDirSync(path.dirname(cliOptions.outFile));
+
       // we've requested for a sourcemap to be written to disk
       if (babelOptions.sourceMaps && babelOptions.sourceMaps !== "inline") {
         const mapLoc = cliOptions.outFile + ".map";

--- a/packages/babel-cli/test/fixtures/babel/filename --out-file deep/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/filename --out-file deep/in-files/script.js
@@ -1,0 +1,1 @@
+arr.map(x => x * MULTIPLIER);

--- a/packages/babel-cli/test/fixtures/babel/filename --out-file deep/options.json
+++ b/packages/babel-cli/test/fixtures/babel/filename --out-file deep/options.json
@@ -1,3 +1,3 @@
 {
-  "args": ["script.js", "--out-file", "dist/nested/script.js"]
+  "args": ["script.js", "--out-file", "folder/nested/script.js"]
 }

--- a/packages/babel-cli/test/fixtures/babel/filename --out-file deep/options.json
+++ b/packages/babel-cli/test/fixtures/babel/filename --out-file deep/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["script.js", "--out-file", "dist/nested/script.js"]
+}

--- a/packages/babel-cli/test/fixtures/babel/filename --out-file deep/out-files/folder/nested/script.js
+++ b/packages/babel-cli/test/fixtures/babel/filename --out-file deep/out-files/folder/nested/script.js
@@ -1,0 +1,5 @@
+"use strict";
+
+arr.map(function (x) {
+  return x * MULTIPLIER;
+});

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "find-cache-dir": "^2.0.0",
     "lodash": "^4.17.13",
-    "mkdirp": "^0.5.1",
+    "make-dir": "^2.1.0",
     "pirates": "^4.0.0",
     "source-map-support": "^0.5.9"
   },

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import os from "os";
-import { sync as mkdirpSync } from "mkdirp";
+import { sync as makeDirSync } from "make-dir";
 import * as babel from "@babel/core";
 import findCacheDir from "find-cache-dir";
 
@@ -39,7 +39,7 @@ export function save() {
   }
 
   try {
-    mkdirpSync(path.dirname(FILENAME));
+    makeDirSync(path.dirname(FILENAME));
     fs.writeFileSync(FILENAME, serialised);
   } catch (e) {
     switch (e.code) {


### PR DESCRIPTION
Currently there's unexpected regression after upgrade from babel 6.
On creating file with any depth like dist/index.js the error about
not existing directory is thrown.

In this diff I modified babel-cli to create deep directory for out-file
command.

I also replaced `mkdirp` with more supported `make-dir` package which
also have official promise support.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 6 -> 7 regression fix
| Major: Breaking Change?  | no
| Minor: New Feature?      | maybe
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | yes mkdirp -> make-dir
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
