### PR TITLE
ts generator: allow reserved keywords in interfaces

### DIFF
--- a/scripts/generators/typescript.js
+++ b/scripts/generators/typescript.js
@@ -81,8 +81,12 @@ for (const type in t.NODE_FIELDS) {
       );
     }
 
-    if (t.isValidIdentifier(fieldName)) {
+    const alphaNumeric = /^\w+$/;
+
+    if (t.isValidIdentifier(fieldName) || alphaNumeric.test(fieldName)) {
       struct.push(`${fieldName}: ${typeAnnotation};`);
+    } else {
+      struct.push(`"${fieldName}": ${typeAnnotation};`);
     }
   });
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8607
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | N/Y
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | N
| License                  | MIT

---

We don't seem to have tests for the ts generator script so i didn't add any.

I tried every reserved keyword in an interface and an object, all works fine. So I went ahead and made it so alphanumeric properties go unquoted and those which aren't, will be quoted.