### PR TITLE
output aliased types in typescript declarations

### DIFF
--- a/scripts/generators/typescript.js
+++ b/scripts/generators/typescript.js
@@ -107,6 +107,8 @@ for (let i = 0; i < t.TYPES.length; i++) {
 
   if (t.NODE_FIELDS[t.TYPES[i]]) {
     decl += `node is ${t.TYPES[i]};`;
+  } else if (t.FLIPPED_ALIAS_KEYS[t.TYPES[i]]) {
+    decl += `node is ${t.TYPES[i]};`;
   } else {
     decl += `boolean;`;
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | N/Y
| Documentation PR Link    | N/A
| Any Dependency Changes?  | N
| License                  | MIT

---

We weren't outputting aliased types in our `isXX` assertion methods so we would be losing type information (returning `boolean` instead).