### PR TITLE
Bump flow to 0.80 and fix sourceType error

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-config-babel": "^7.0.2",
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-prettier": "^2.6.2",
-    "flow-bin": "^0.79.0",
+    "flow-bin": "^0.80.0",
     "graceful-fs": "^4.1.11",
     "gulp": "^4.0.0",
     "gulp-babel": "^8.0.0-beta.2",

--- a/packages/babel-parser/src/options.js
+++ b/packages/babel-parser/src/options.js
@@ -5,8 +5,10 @@ import type { PluginList } from "./plugin-utils";
 // A second optional argument can be given to further configure
 // the parser process. These options are recognized:
 
+export type SourceType = "script" | "module" | "unambiguous";
+
 export type Options = {
-  sourceType: "script" | "module" | "unambiguous",
+  sourceType: SourceType,
   sourceFilename?: string,
   startLine: number,
   allowAwaitOutsideFunction: boolean,

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1,5 +1,6 @@
 // @flow
 
+import type { SourceType } from "./options";
 import type { Token } from "./tokenizer";
 import type { SourceLocation } from "./util/location";
 
@@ -135,7 +136,7 @@ export type File = NodeBase & {
 
 export type Program = NodeBase & {
   type: "Program",
-  sourceType: "script" | "module",
+  sourceType: SourceType,
   body: Array<Statement | ModuleDeclaration>, // TODO: $ReadOnlyArray
   directives: $ReadOnlyArray<Directive>, // TODO: Not in spec
   interpreter: InterpreterDirective | null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,9 +3516,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.79.0:
-  version "0.79.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.79.0.tgz#a7029f2832d45e5b78f7e77a74fee898722fb6ef"
+flow-bin@^0.80.0:
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
 
 flush-write-stream@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Fixed an issue from https://github.com/babel/babel/pull/8610, that missed one reference. (Ugh, need to resume looking into why flow reports diff on CI than local...)