### PR TITLE
Better support monorepos by allowing users to opt into autoconfiguring "root"

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -49,7 +49,7 @@ export type PresetInstance = {
 export type ConfigContext = {
   filename: string | void,
   cwd: string,
-  root: string,
+  root: string | false,
   envName: string,
   caller: CallerMetadata | void,
 };
@@ -150,7 +150,7 @@ export function buildRootChain(
       context.envName,
       context.caller,
     );
-  } else if (opts.configFile !== false) {
+  } else if (opts.configFile !== false && context.root !== false) {
     configFile = findRootConfig(context.root, context.envName, context.caller);
   }
 
@@ -237,6 +237,8 @@ function babelrcLoadEnabled(
   // Fast path to avoid having to match patterns if the babelrc is just
   // loading in the standard root directory.
   if (babelrcRoots === undefined) {
+    if (absoluteRoot === false) return false;
+
     return pkgData.directories.indexOf(absoluteRoot) !== -1;
   }
 
@@ -248,7 +250,11 @@ function babelrcLoadEnabled(
 
   // Fast path to avoid having to match patterns if the babelrc is just
   // loading in the standard root directory.
-  if (babelrcPatterns.length === 1 && babelrcPatterns[0] === absoluteRoot) {
+  if (
+    absoluteRoot !== false &&
+    babelrcPatterns.length === 1 &&
+    babelrcPatterns[0] === absoluteRoot
+  ) {
     return pkgData.directories.indexOf(absoluteRoot) !== -1;
   }
 
@@ -661,9 +667,9 @@ function matchesPatterns(
 }
 
 function matchPattern(
-  pattern,
-  dirname,
-  pathToTest,
+  pattern: string | RegExp | Function,
+  dirname: string,
+  pathToTest: string | void,
   context: ConfigContext,
 ): boolean {
   if (typeof pattern === "function") {

--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -24,6 +24,24 @@ const BABELRC_FILENAME = ".babelrc";
 const BABELRC_JS_FILENAME = ".babelrc.js";
 const BABELIGNORE_FILENAME = ".babelignore";
 
+export function findConfigRoot(cwd: string): string {
+  let dirname = cwd;
+  while (true) {
+    if (fs.existsSync(path.join(dirname, BABEL_CONFIG_JS_FILENAME))) {
+      return dirname;
+    }
+
+    const nextDir = path.dirname(dirname);
+    if (dirname === nextDir) break;
+    dirname = nextDir;
+  }
+
+  throw new Error(
+    `Babel was run with root:true but a root babel.config.js could not ` +
+      `be found when searching from "${dirname}"`,
+  );
+}
+
 export function findRelativeConfig(
   packageData: FilePackageData,
   envName: string,

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -11,6 +11,14 @@ import type { CallerMetadata } from "../validation/options";
 
 export type { ConfigFile, IgnoreFile, RelativeConfig, FilePackageData };
 
+export function findConfigRoot(
+  cwd: string, // eslint-disable-line no-unused-vars
+): string {
+  throw new Error(
+    `Cannot search for filesystem config root when running in a browser`,
+  );
+}
+
 export function findPackageData(filepath: string): FilePackageData {
   return {
     filepath,

--- a/packages/babel-core/src/config/files/index.js
+++ b/packages/babel-core/src/config/files/index.js
@@ -10,6 +10,7 @@ import typeof * as indexType from "./index";
 export { findPackageData } from "./package";
 
 export {
+  findConfigRoot,
   findRelativeConfig,
   findRootConfig,
   loadConfig,

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -30,7 +30,8 @@ export default function loadPrivatePartialConfig(
 
   const { envName = getEnv(), cwd = ".", root: rootDir = ".", caller } = args;
   const absoluteCwd = path.resolve(cwd);
-  const absoluteRootDir = path.resolve(absoluteCwd, rootDir);
+  const absoluteRootDir =
+    rootDir === false ? false : path.resolve(absoluteCwd, rootDir);
 
   const context: ConfigContext = {
     filename:

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -8,7 +8,7 @@ import { buildRootChain, type ConfigContext } from "./config-chain";
 import { getEnv } from "./helpers/environment";
 import { validate, type ValidatedOptions } from "./validation/options";
 
-import type { ConfigFile, IgnoreFile } from "./files";
+import { findConfigRoot, type ConfigFile, type IgnoreFile } from "./files";
 
 export default function loadPrivatePartialConfig(
   inputOpts: mixed,
@@ -31,7 +31,11 @@ export default function loadPrivatePartialConfig(
   const { envName = getEnv(), cwd = ".", root: rootDir = ".", caller } = args;
   const absoluteCwd = path.resolve(cwd);
   const absoluteRootDir =
-    rootDir === false ? false : path.resolve(absoluteCwd, rootDir);
+    typeof rootDir === "boolean"
+      ? rootDir
+        ? findConfigRoot(absoluteCwd)
+        : false
+      : path.resolve(absoluteCwd, rootDir);
 
   const context: ConfigContext = {
     filename:

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -79,7 +79,11 @@ export function assertSourceMaps(
 }
 
 export function assertRoot(loc: OptionPath, value: mixed): ProjectRoot | void {
-  if (value !== undefined && value !== false && typeof value !== "string") {
+  if (
+    value !== undefined &&
+    typeof value !== "boolean" &&
+    typeof value !== "string"
+  ) {
     throw new Error(`${msg(loc)} must be a string, false, or undefined`);
   }
   return value;

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -15,6 +15,7 @@ import type {
   RootInputSourceMapOption,
   NestingPath,
   CallerMetadata,
+  ProjectRoot,
 } from "./options";
 
 export type ValidatorSet = {
@@ -73,6 +74,13 @@ export function assertSourceMaps(
     throw new Error(
       `${msg(loc)} must be a boolean, "inline", "both", or undefined`,
     );
+  }
+  return value;
+}
+
+export function assertRoot(loc: OptionPath, value: mixed): ProjectRoot | void {
+  if (value !== undefined && value !== false && typeof value !== "string") {
+    throw new Error(`${msg(loc)} must be a string, false, or undefined`);
   }
   return value;
 }

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -22,6 +22,7 @@ import {
   assertSourceMaps,
   assertCompact,
   assertSourceType,
+  assertRoot,
   type ValidatorSet,
   type Validator,
   type OptionPath,
@@ -29,7 +30,7 @@ import {
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
-  root: (assertString: Validator<$PropertyType<ValidatedOptions, "root">>),
+  root: (assertRoot: Validator<$PropertyType<ValidatedOptions, "root">>),
   configFile: (assertConfigFileSearch: Validator<
     $PropertyType<ValidatedOptions, "configFile">,
   >),
@@ -175,7 +176,7 @@ export type ValidatedOptions = {
   babelrc?: boolean,
   babelrcRoots?: BabelrcSearch,
   configFile?: ConfigFileSearch,
-  root?: string,
+  root?: ProjectRoot,
   code?: boolean,
   ast?: boolean,
   inputSourceMap?: RootInputSourceMapOption,
@@ -260,6 +261,7 @@ export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";
 export type RootInputSourceMapOption = {} | boolean;
+export type ProjectRoot = string | false;
 
 export type OptionsSource =
   | "arguments"

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -261,7 +261,7 @@ export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";
 export type RootInputSourceMapOption = {} | boolean;
-export type ProjectRoot = string | false;
+export type ProjectRoot = string | boolean;
 
 export type OptionsSource =
   | "arguments"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  | N
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Definitely curious for feedback on this one. 

### The Problem

In Babel 7, we've limited the expected scope of config files a lot, which has caused some migration pains for users. Because the scope of `.babelrc` files is now limited to a single package, users are trying to transition to use `babel.config.js` files. The issue is that, by default, Babel expects that file to be in the working directory of the build, and that is commonly not the case for monorepo users.

### Current Requirements

Currently, the workaround is that users have to manually pass the name, e.g.
```
// from ./packages/some-packages/
babel --config-file ../../babel.config.js src -d lib
```
which is painful, and similar steps would need to be taken for anything that runs in a per-package way. This means that monorepos that have repo-wide builds, like Babel's monorepo, work fine, but monorepos with per-package logic end up requiring lots of manual configuration. This is particularly painful for packages that are commonly used without any options (like `@babel/register`), or provide no way to easily pass options (like `babel-jest`).

### This PR

This PR proposes to allow `--root true` or `root: true` (where before `root` was only a string, and defaulted to `cwd`), which would walk up the directory structure looking for a `babel.config.js` file, and set `root` to that directory, and would throw an error if no root was found.

What this would allow is for users to opt into more intelligent 'root' handling. Specifically, they would have to opt in because this option then _requires_ the presence of a `babel.config.js` in your repo.

For cases like `@babel/register` and `babel-jest`, we could consider exposing extra entrypoints to handle this in an automated way, for example `@babel/register/auto-root` could be exposed as an entry point for users who want to use it in the context of a monorepo. And `babel-jest` can expose a `babel-jest/auto-root` that does `module.exports = require(".").createTransformer({ root: true });`, so users would opt into monorepo-global configs by using these special entry points.

### Questions

One of the benefits of dropping the unbounded-searching behavior we had for `.babelrc` files in Babel 6 is that it meant that it was easy to accidentally pick up a configuration that you didn't mean to apply. `babel.config.js` files are specifically loaded from a single location to avoid issues like this. This PR requires an opt-in and throws loudly when a `babel.config.js` isn't found to try to avoid any concerns about this kind off thing. If we opted into searching as the default, it's also not at all clear what should happen when the file isn't found. Do we use the working directory as `root`? That would mean that the addition of a `babel.config.js` into the monorepo root would change the `root` value and potentially change what `.babelrc` files are considered valid, since `root` is the default value for `babelrcRoots`. To me that seems like it would be a pretty bad experience for users. Changing defaults now would also likely be a breaking change.

What do folks think about using alternative module entry points for this? It still requires monorepo users to do additional steps, but at least it's something that we could clearly document and recommend. It's also infinitely better than expecting people to do all of this themselves in any monorepo project that they need to migrate.

What do you think about overloading `root` here? I think `root: false` at least makes sense as "there is no root, so don't load config files", but `root: true` meaning to automatically search for the root isn't necessarily super discoverable. I also considered `monorepo: true` or something, but I wasn't convinced that it was any more clear, and it meant that the behavior of `root` then depends tangentially on another flag that users may or may not expect.
