### PR TITLE
Use jsonc to parse babelrc comments in markdown files

### DIFF
--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/README.md
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/README.md
@@ -36,7 +36,7 @@ npm install --save-dev @babel/plugin-codemod-object-assign-to-object-spread
 
 **.babelrc**
 
-```json
+```jsonc
 {
   "plugins": ["@babel/plugin-codemod-object-assign-to-object-spread"]
 }

--- a/codemods/babel-plugin-codemod-optional-catch-binding/README.md
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/README.md
@@ -34,7 +34,7 @@ npm install --save-dev @babel/plugin-codemod-optional-catch-binding
 
 **.babelrc**
 
-```json
+```jsonc
 {
   "plugins": ["@babel/plugin-codemod-optional-catch-binding"]
 }

--- a/packages/babel-preset-stage-0/README.md
+++ b/packages/babel-preset-stage-0/README.md
@@ -8,7 +8,7 @@ For a more automatic migration, we have updated [babel-upgrade](https://github.c
 
 If you want the same configuration as before:
 
-```json
+```jsonc
 {
   "plugins": [
     // Stage 0

--- a/packages/babel-preset-stage-1/README.md
+++ b/packages/babel-preset-stage-1/README.md
@@ -8,7 +8,7 @@ For a more automatic migration, we have updated [babel-upgrade](https://github.c
 
 If you want the same configuration as before:
 
-```json
+```jsonc
 {
   "plugins": [
     // Stage 1

--- a/packages/babel-preset-stage-2/README.md
+++ b/packages/babel-preset-stage-2/README.md
@@ -8,7 +8,7 @@ For a more automatic migration, we have updated [babel-upgrade](https://github.c
 
 If you want the same configuration as before:
 
-```json
+```jsonc
 {
   "plugins": [
     // Stage 2


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Properly parses comments in `.babelrc` examples in markdown files
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Since `.babelrc` can be of `json` type with comments, markdown examples of `.babelrc` should use `jsonc` to parse comments without error marks.