### PR TITLE
release v6.26.4 with the added LICENSE files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,20 @@ test-ci-coverage:
 clone-license:
 	./scripts/clone-license.sh
 
+publish-with-licenses:
+	make clone-license
+	find packages -name LICENSE | xargs git add -f
+	git commit -m 'chore: commit LICENSE files temporarilly'
+	node ./scripts/lerna.js publish --only-explicit-updates
+	git reset HEAD^ # TMP
+
 publish:
 	node scripts/verify-lerna-version.js
 	git pull --rebase
 	rm -rf packages/*/lib
 	BABEL_ENV=production make build-dist
 	make test
-	make clone-license
-	# not using lerna independent mode atm, so only update packages that have changed since we use ^
-	node ./scripts/lerna.js publish --only-explicit-updates
+	make publish-with-licenses
 	make clean
 
 bootstrap:

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0-beta.38",
-  "version": "6.26.3",
+  "version": "6.26.4",
   "changelog": {
     "repo": "babel/babel",
     "labels": {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Concludes the work on #8524 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This should help concluding the work done in https://github.com/babel/babel/pull/8524 and make a 6.x release with the added LICESENSE files.

It adds a temporary commit with all the LICENSE files, runs lerna publish and then discards the commit afterwards. This is only necessary to do once the Makefile changes can be discarded after making the release as there is no need to add the temporary commit later on anymore.
