### PR TITLE
 Allow extending untranspiled classes

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1155/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1155/options.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "transform-classes",
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "transform-block-scoping"
   ]
 }

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1155/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1155/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo(options) {
     babelHelpers.classCallCheck(this, Foo);
     var parentOptions = {};
@@ -11,7 +13,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
       this;
     };
 
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, parentOptions));
+    return _super.call(this, parentOptions);
   }
 
   return Foo;

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -502,10 +502,8 @@ helpers.setPrototypeOf = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.construct = helper("7.0.0-beta.0")`
-  import setPrototypeOf from "setPrototypeOf";
-
-  function isNativeReflectConstruct() {
+helpers.isNativeReflectConstruct = helper("7.9.0")`
+  export default function _isNativeReflectConstruct() {
     if (typeof Reflect === "undefined" || !Reflect.construct) return false;
 
     // core-js@3
@@ -529,6 +527,11 @@ helpers.construct = helper("7.0.0-beta.0")`
       return false;
     }
   }
+`;
+
+helpers.construct = helper("7.0.0-beta.0")`
+  import setPrototypeOf from "setPrototypeOf";
+  import isNativeReflectConstruct from "isNativeReflectConstruct";
 
   export default function _construct(Parent, args, Class) {
     if (isNativeReflectConstruct()) {
@@ -731,6 +734,26 @@ helpers.possibleConstructorReturn = helper("7.0.0-beta.0")`
     return assertThisInitialized(self);
   }
 `;
+
+helpers.createSuper = helper("7.9.0")`
+  import getPrototypeOf from "getPrototypeOf";
+  import isNativeReflectConstruct from "isNativeReflectConstruct";
+  import possibleConstructorReturn from "possibleConstructorReturn";
+
+  export default function _createSuper(Derived) {
+    return function () {
+      var Super = getPrototypeOf(Derived), result;
+      if (isNativeReflectConstruct()) {
+        // NOTE: This doesn't work if this.__proto__.constructor has been modified.
+        var NewTarget = getPrototypeOf(this).constructor;
+        result = Reflect.construct(Super, arguments, NewTarget);
+      } else {
+        result = Super.apply(this, arguments);
+      }
+      return possibleConstructorReturn(this, result);
+    }
+  }
+ `;
 
 helpers.superPropBase = helper("7.0.0-beta.0")`
   import getPrototypeOf from "getPrototypeOf";

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "proposal-class-properties",
     "transform-classes"
   ]

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
@@ -13,13 +13,15 @@ let Hello = function Hello() {
 let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
+  var _super = babelHelpers.createSuper(Outer);
+
   function Outer() {
     let _this2;
 
     var _this;
 
     babelHelpers.classCallCheck(this, Outer);
-    _this2 = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
+    _this2 = _this = _super.call(this);
 
     let Inner = function Inner() {
       babelHelpers.classCallCheck(this, Inner);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -17,13 +17,15 @@ let Hello = /*#__PURE__*/function () {
 let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
+  var _super = babelHelpers.createSuper(Outer);
+
   function Outer() {
     let _babelHelpers$get$cal;
 
     var _this;
 
     babelHelpers.classCallCheck(this, Outer);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
+    _this = _super.call(this);
     _babelHelpers$get$cal = babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
 
     let Inner = function Inner() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
@@ -3,19 +3,21 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
 
     if (condition) {
-      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this = _super.call(this);
       Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
         writable: true,
         value: "foo"
       });
     } else {
-      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this = _super.call(this);
       Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
         writable: true,
         value: "foo"

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
@@ -15,11 +15,13 @@ var Bar = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inherits(Bar, _Foo);
 
+  var _super = babelHelpers.createSuper(Bar);
+
   function Bar(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, Bar);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
+    _this = _super.call(this, ...args);
     Object.defineProperty(babelHelpers.assertThisInitialized(_this), _prop2, {
       writable: true,
       value: "bar"

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -3,11 +3,13 @@ var Child = /*#__PURE__*/function (_Parent) {
 
   babelHelpers.inherits(Child, _Parent);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 
     babelHelpers.classCallCheck(this, Child);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
+    _this = _super.call(this);
     Object.defineProperty(babelHelpers.assertThisInitialized(_this), _scopedFunctionWithThis, {
       writable: true,
       value: function value() {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/options.json
@@ -1,11 +1,6 @@
 {
   "plugins": [
-    [
-      "external-helpers",
-      {
-        "helperVersion": "7.0.2"
-      }
-    ],
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     ["proposal-class-properties", { "loose": true }],
     "transform-classes",
     "transform-block-scoping",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/private-in-derived/output.js
@@ -10,9 +10,11 @@ var Outer = function Outer() {
   var Test = /*#__PURE__*/function (_babelHelpers$classPr) {
     babelHelpers.inherits(Test, _babelHelpers$classPr);
 
+    var _super = babelHelpers.createSuper(Test);
+
     function Test() {
       babelHelpers.classCallCheck(this, Test);
-      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).apply(this, arguments));
+      return _super.apply(this, arguments);
     }
 
     return Test;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
+    foo((_temp = _this = _super.call(this), Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
       writable: true,
       value: "foo"
     }), _temp));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
     Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
       writable: true,
       value: "foo"

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -3,20 +3,22 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
 
     if (condition) {
-      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this = _super.call(this);
 
       _bar.set(babelHelpers.assertThisInitialized(_this), {
         writable: true,
         value: "foo"
       });
     } else {
-      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this = _super.call(this);
 
       _bar.set(babelHelpers.assertThisInitialized(_this), {
         writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -16,11 +16,13 @@ var Bar = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inherits(Bar, _Foo);
 
+  var _super = babelHelpers.createSuper(Bar);
+
   function Bar(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, Bar);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
+    _this = _super.call(this, ...args);
 
     _prop2.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
@@ -3,11 +3,13 @@ var Child = /*#__PURE__*/function (_Parent) {
 
   babelHelpers.inherits(Child, _Parent);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 
     babelHelpers.classCallCheck(this, Child);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
+    _this = _super.call(this);
 
     _scopedFunctionWithThis.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/options.json
@@ -1,11 +1,6 @@
 {
   "plugins": [
-    [
-      "external-helpers",
-      {
-        "helperVersion": "7.4.4"
-      }
-    ],
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "proposal-class-properties",
     "transform-classes",
     "transform-block-scoping",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/private-in-derived/output.js
@@ -11,9 +11,11 @@ var Outer = function Outer() {
   var Test = /*#__PURE__*/function (_babelHelpers$classPr) {
     babelHelpers.inherits(Test, _babelHelpers$classPr);
 
+    var _super = babelHelpers.createSuper(Test);
+
     function Test() {
       babelHelpers.classCallCheck(this, Test);
-      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).apply(this, arguments));
+      return _super.apply(this, arguments);
     }
 
     return Test;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -19,11 +19,13 @@ var B = /*#__PURE__*/function (_A) {
 
   babelHelpers.inherits(B, _A);
 
+  var _super = babelHelpers.createSuper(B);
+
   function B(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, B);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
+    _this = _super.call(this, ...args);
 
     _foo.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(babelHelpers.assertThisInitialized(_this), {
+    foo((_temp = _this = _super.call(this), _bar.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,
       value: "foo"
     }), _temp));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
 
     _bar.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/derived/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args));
+    _this = _super.call(this, ...args);
     _this.bar = "foo";
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     ["proposal-class-properties", { "loose": true }]
   ],
   "presets": ["env"]

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/foobar/output.js
@@ -3,11 +3,13 @@ var Child = /*#__PURE__*/function (_Parent) {
 
   babelHelpers.inherits(Child, _Parent);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 
     babelHelpers.classCallCheck(this, Child);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
+    _this = _super.call(this);
 
     _this.scopedFunctionWithThis = function () {
       _this.name = {};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     ["proposal-class-properties", { "loose": true }],
     "transform-classes",
     "transform-block-scoping",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/regression-T6719/output.js
@@ -6,9 +6,11 @@ function withContext(ComposedComponent) {
 
     babelHelpers.inherits(WithContext, _Component);
 
+    var _super = babelHelpers.createSuper(WithContext);
+
     function WithContext() {
       babelHelpers.classCallCheck(this, WithContext);
-      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(WithContext).apply(this, arguments));
+      return _super.apply(this, arguments);
     }
 
     return WithContext;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-super/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/static-super/output.js
@@ -11,9 +11,11 @@ var B = /*#__PURE__*/function (_A) {
 
   babelHelpers.inherits(B, _A);
 
+  var _super = babelHelpers.createSuper(B);
+
   function B() {
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return B;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -19,11 +19,13 @@ var B = /*#__PURE__*/function (_A) {
 
   babelHelpers.inherits(B, _A);
 
+  var _super = babelHelpers.createSuper(B);
+
   function B(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, B);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
+    _this = _super.call(this, ...args);
     _this.foo = babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-expression/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _this.bar = "foo", _temp));
+    foo((_temp = _this = _super.call(this), _this.bar = "foo", _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public-loose/super-statement/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
     _this.bar = "foo";
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
@@ -3,16 +3,18 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
 
     if (condition) {
-      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this = _super.call(this);
       babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     } else {
-      _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+      _this = _super.call(this);
       babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args));
+    _this = _super.call(this, ...args);
     babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
@@ -1,13 +1,19 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var Child = /*#__PURE__*/function (_Parent) {
   "use strict";
 
   babelHelpers.inherits(Child, _Parent);
 
+  var _super = _createSuper(Child);
+
   function Child() {
     var _this;
 
     babelHelpers.classCallCheck(this, Child);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
+    _this = _super.call(this);
     babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "scopedFunctionWithThis", function () {
       _this.name = {};
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "proposal-class-properties",
     "transform-classes",
     "transform-block-scoping",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/regression-T6719/output.js
@@ -6,9 +6,11 @@ function withContext(ComposedComponent) {
 
     babelHelpers.inherits(WithContext, _Component);
 
+    var _super = babelHelpers.createSuper(WithContext);
+
     function WithContext() {
       babelHelpers.classCallCheck(this, WithContext);
-      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(WithContext).apply(this, arguments));
+      return _super.apply(this, arguments);
     }
 
     return WithContext;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-super/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/static-super/output.js
@@ -11,9 +11,11 @@ var B = /*#__PURE__*/function (_A) {
 
   babelHelpers.inherits(B, _A);
 
+  var _super = babelHelpers.createSuper(B);
+
   function B() {
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return B;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -19,11 +19,13 @@ var B = /*#__PURE__*/function (_A) {
 
   babelHelpers.inherits(B, _A);
 
+  var _super = babelHelpers.createSuper(B);
+
   function B(...args) {
     var _this;
 
     babelHelpers.classCallCheck(this, B);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
+    _this = _super.call(this, ...args);
     babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), _temp));
+    foo((_temp = _this = _super.call(this), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
     babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     return _this;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -1,8 +1,12 @@
 function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -26,9 +30,9 @@ var Test = function Test() {
   var Other = /*#__PURE__*/function (_Test) {
     _inherits(Other, _Test);
 
-    function Other() {
-      var _getPrototypeOf2;
+    var _super = _createSuper(Other);
 
+    function Other() {
       var _this;
 
       _classCallCheck(this, Other);
@@ -37,7 +41,7 @@ var Test = function Test() {
         args[_key] = arguments[_key];
       }
 
-      _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args)));
+      _this = _super.call.apply(_super, [this].concat(args));
 
       _defineProperty(_assertThisInitialized(_this), "a", function () {
         return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     ["proposal-class-properties", { "loose": true }],
     "transform-classes",
     "transform-block-scoping",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/T6719/output.js
@@ -6,9 +6,11 @@ function withContext(ComposedComponent) {
 
     babelHelpers.inherits(WithContext, _Component);
 
+    var _super = babelHelpers.createSuper(WithContext);
+
     function WithContext() {
       babelHelpers.classCallCheck(this, WithContext);
-      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(WithContext).apply(this, arguments));
+      return _super.apply(this, arguments);
     }
 
     return WithContext;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
@@ -2,9 +2,13 @@ function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "functi
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -30,12 +34,14 @@ var A = /*#__PURE__*/function (_B) {
 
   _inherits(A, _B);
 
+  var _super = _createSuper(A);
+
   function A(timestamp) {
     var _this;
 
     _classCallCheck(this, A);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(A).call(this));
+    _this = _super.call(this);
     _this.timestamp = timestamp;
     _this.moment = moment(timestamp);
     return _this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/loose/output.js
@@ -1,10 +1,16 @@
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
 
-function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _construct(Parent, args, Class) { if (_isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
 
-function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
 
@@ -16,6 +22,8 @@ var List = /*#__PURE__*/function (_Array) {
   "use strict";
 
   _inheritsLoose(List, _Array);
+
+  var _super = _createSuper(List);
 
   function List() {
     return _Array.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/shadowed/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/shadowed/output.js
@@ -1,3 +1,7 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Array = function Array() {
   "use strict";
 
@@ -9,9 +13,11 @@ let List = /*#__PURE__*/function (_Array) {
 
   babelHelpers.inherits(List, _Array);
 
+  var _super = _createSuper(List);
+
   function List() {
     babelHelpers.classCallCheck(this, List);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(List).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return List;

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -1,5 +1,7 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
@@ -8,9 +10,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
 
-function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _construct(Parent, args, Class) { if (_isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
 
-function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
 
@@ -23,10 +25,12 @@ var List = /*#__PURE__*/function (_Array) {
 
   _inherits(List, _Array);
 
+  var _super = _createSuper(List);
+
   function List() {
     _classCallCheck(this, List);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(List).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return List;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-data-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = /*#__PURE__*/function () {
@@ -18,6 +28,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-getter-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -28,6 +38,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
@@ -1,11 +1,23 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -21,6 +31,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-data-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
@@ -8,6 +18,8 @@ Base.prototype.test = 1;
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-getter-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -24,6 +34,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-not-defined-on-parent/output.js
@@ -1,11 +1,23 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/get-semantics-setter-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -21,6 +31,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-assign/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-assign/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
@@ -24,6 +34,8 @@ const proper = {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-update/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/memoized-update/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
@@ -24,6 +34,8 @@ const proper = {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-data-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
@@ -12,6 +22,8 @@ Object.defineProperty(Base.prototype, 'test', {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-getter-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -26,6 +36,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -1,11 +1,23 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -4,6 +4,16 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
@@ -12,6 +22,8 @@ let called = false;
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -1,11 +1,23 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -4,6 +4,16 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 let Base = function Base() {};
@@ -12,6 +22,8 @@ let value = 2;
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/set-semantics-setter-defined-on-parent/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -23,6 +33,8 @@ let Base = /*#__PURE__*/function () {
 
 let Obj = /*#__PURE__*/function (_Base) {
   _inheritsLoose(Obj, _Base);
+
+  var _super = _createSuper(Obj);
 
   function Obj() {
     return _Base.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-data-defined-on-parent/output.js
@@ -1,12 +1,16 @@
 "use strict";
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -40,10 +44,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-getter-defined-on-parent/output.js
@@ -1,12 +1,16 @@
 "use strict";
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -43,10 +47,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
@@ -4,13 +4,17 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -27,10 +31,12 @@ let Base = function Base() {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/output.js
@@ -1,12 +1,16 @@
 "use strict";
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -38,10 +42,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
@@ -4,13 +4,17 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -29,10 +33,12 @@ Base.prototype.test = 1;
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
@@ -1,12 +1,16 @@
 "use strict";
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -39,10 +43,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
@@ -4,13 +4,17 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -27,10 +31,12 @@ let Base = function Base() {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
@@ -1,12 +1,16 @@
 "use strict";
 
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
-
-function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -38,10 +42,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-assign/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-assign/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -17,6 +13,14 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -51,10 +55,12 @@ const proper = {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-update/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-update/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -17,6 +13,14 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -51,10 +55,12 @@ const proper = {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -15,6 +11,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -37,10 +41,12 @@ Object.defineProperty(Base.prototype, 'test', {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
@@ -1,9 +1,5 @@
 "use strict";
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -11,6 +7,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -44,10 +48,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -15,6 +11,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -31,10 +35,12 @@ let Base = function Base() {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -15,6 +11,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -31,10 +35,12 @@ let Base = function Base() {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -15,6 +11,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -31,10 +35,12 @@ let Base = function Base() {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -4,10 +4,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -15,6 +11,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -33,10 +37,12 @@ let value = 2;
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
@@ -1,9 +1,5 @@
 "use strict";
 
-function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 
 function _set(target, property, value, receiver, isStrict) { var s = set(target, property, value, receiver || target); if (!s && isStrict) { throw new Error('failed to set property'); } return value; }
@@ -11,6 +7,14 @@ function _set(target, property, value, receiver, isStrict) { var s = set(target,
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -44,10 +48,12 @@ let Base = /*#__PURE__*/function () {
 let Obj = /*#__PURE__*/function (_Base) {
   _inherits(Obj, _Base);
 
+  var _super = _createSuper(Obj);
+
   function Obj() {
     _classCallCheck(this, Obj);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Obj).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   _createClass(Obj, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
@@ -1,4 +1,12 @@
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
@@ -10,6 +18,8 @@ let A = /*#__PURE__*/function (_B) {
   "use strict";
 
   _inheritsLoose(A, _B);
+
+  var _super = _createSuper(A);
 
   function A(track) {
     var _this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
@@ -3,6 +3,8 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inheritsLoose(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     var _Foo$prototype$test;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-properties/output.js
@@ -3,6 +3,8 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inheritsLoose(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
@@ -3,6 +3,8 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inheritsLoose(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inheritsLoose(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-falsey/output.js
@@ -3,6 +3,8 @@ var Child = /*#__PURE__*/function (_Base) {
 
   babelHelpers.inheritsLoose(Child, _Base);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-object/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-no-super-return-object/output.js
@@ -3,6 +3,8 @@ var Child = /*#__PURE__*/function (_Base) {
 
   babelHelpers.inheritsLoose(Child, _Base);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "transform-function-name",
     ["transform-classes", { "loose": true }],
     ["transform-spread", { "loose": true }],

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class-id-member-expression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class-id-member-expression/output.js
@@ -3,6 +3,8 @@ var BaseController = /*#__PURE__*/function (_Chaplin$Controller) {
 
   babelHelpers.inheritsLoose(BaseController, _Chaplin$Controller);
 
+  var _super = babelHelpers.createSuper(BaseController);
+
   function BaseController() {
     return _Chaplin$Controller.apply(this, arguments) || this;
   }
@@ -14,6 +16,8 @@ var BaseController2 = /*#__PURE__*/function (_Chaplin$Controller$A) {
   "use strict";
 
   babelHelpers.inheritsLoose(BaseController2, _Chaplin$Controller$A);
+
+  var _super2 = babelHelpers.createSuper(BaseController2);
 
   function BaseController2() {
     return _Chaplin$Controller$A.apply(this, arguments) || this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/super-class/output.js
@@ -3,6 +3,8 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inheritsLoose(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     return _Foo.apply(this, arguments) || this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2663/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2663/output.js
@@ -11,15 +11,21 @@ var _events = require("events");
 
 var _binarySerializer = babelHelpers.interopRequireDefault(require("./helpers/binary-serializer"));
 
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 // import ...
 var Connection = /*#__PURE__*/function (_EventEmitter) {
   babelHelpers.inherits(Connection, _EventEmitter);
+
+  var _super = _createSuper(Connection);
 
   function Connection(endpoint, joinKey, joinData, roomId) {
     var _this;
 
     babelHelpers.classCallCheck(this, Connection);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Connection).call(this));
+    _this = _super.call(this);
     _this.isConnected = false;
     _this.roomId = roomId; // ...
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2694/output.js
@@ -7,12 +7,18 @@ exports["default"] = void 0;
 
 var _BaseFoo2 = babelHelpers.interopRequireDefault(require("./BaseFoo"));
 
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var SubFoo = /*#__PURE__*/function (_BaseFoo) {
   babelHelpers.inherits(SubFoo, _BaseFoo);
 
+  var _super = _createSuper(SubFoo);
+
   function SubFoo() {
     babelHelpers.classCallCheck(this, SubFoo);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(SubFoo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   babelHelpers.createClass(SubFoo, null, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/2775/output.js
@@ -7,12 +7,18 @@ exports["default"] = void 0;
 
 var _react = babelHelpers.interopRequireDefault(require("react"));
 
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var RandomComponent = /*#__PURE__*/function (_Component) {
   babelHelpers.inherits(RandomComponent, _Component);
 
+  var _super = _createSuper(RandomComponent);
+
   function RandomComponent() {
     babelHelpers.classCallCheck(this, RandomComponent);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(RandomComponent).call(this));
+    return _super.call(this);
   }
 
   babelHelpers.createClass(RandomComponent, [{

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
@@ -5,6 +5,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var b = function b() {
   babelHelpers.classCallCheck(this, b);
 };
@@ -12,11 +16,13 @@ var b = function b() {
 var a1 = /*#__PURE__*/function (_b) {
   babelHelpers.inherits(a1, _b);
 
+  var _super = _createSuper(a1);
+
   function a1() {
     var _this;
 
     babelHelpers.classCallCheck(this, a1);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(a1).call(this));
+    _this = _super.call(this);
 
     _this.x = function () {
       return babelHelpers.assertThisInitialized(_this);
@@ -31,11 +37,13 @@ var a1 = /*#__PURE__*/function (_b) {
 var a2 = /*#__PURE__*/function (_b2) {
   babelHelpers.inherits(a2, _b2);
 
+  var _super2 = _createSuper(a2);
+
   function a2() {
     var _this2;
 
     babelHelpers.classCallCheck(this, a2);
-    _this2 = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(a2).call(this));
+    _this2 = _super2.call(this);
 
     _this2.x = function () {
       return babelHelpers.assertThisInitialized(_this2);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -1,3 +1,7 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var Point = /*#__PURE__*/function () {
   "use strict";
 
@@ -19,11 +23,13 @@ var ColorPoint = /*#__PURE__*/function (_Point) {
 
   babelHelpers.inherits(ColorPoint, _Point);
 
+  var _super = _createSuper(ColorPoint);
+
   function ColorPoint() {
     var _this;
 
     babelHelpers.classCallCheck(this, ColorPoint);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(ColorPoint).call(this));
+    _this = _super.call(this);
     _this.x = 2;
     babelHelpers.set(babelHelpers.getPrototypeOf(ColorPoint.prototype), "x", 3, babelHelpers.assertThisInitialized(_this), true);
     expect(_this.x).toBe(3); // A

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5817/output.js
@@ -1,13 +1,19 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var A = /*#__PURE__*/function (_B) {
   "use strict";
 
   babelHelpers.inherits(A, _B);
 
+  var _super = _createSuper(A);
+
   function A() {
     var _this;
 
     babelHelpers.classCallCheck(this, A);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(A).call(this));
+    _this = _super.call(this);
 
     _this.arrow1 = function (x) {
       return x;

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/exec.js
@@ -1,17 +1,26 @@
-// Pretend that `Reflect.construct` isn't supported.
-this.Reflect = undefined;
+const oldReflect = this.Reflect;
+const oldHTMLElement = this.HTMLElement;
 
-this.HTMLElement = function() {
-  // Here, `this.HTMLElement` is this function, not the original HTMLElement
-  // constructor. `this.constructor` should be this function too, but isn't.
-  constructor = this.constructor;
-};
+try {
+  // Pretend that `Reflect.construct` isn't supported.
+  this.Reflect = undefined;
 
-var constructor;
+  this.HTMLElement = function() {
+    // Here, `this.HTMLElement` is this function, not the original HTMLElement
+    // constructor. `this.constructor` should be this function too, but isn't.
+    constructor = this.constructor;
+  };
 
-class CustomElement extends HTMLElement {};
-new CustomElement();
+  var constructor;
 
-expect(constructor).toBe(CustomElement);
+  class CustomElement extends HTMLElement {};
+  new CustomElement();
+
+  expect(constructor).toBe(CustomElement);
+} finally {
+  // Restore original env
+  this.Reflect = oldReflect;
+  this.HTMLElement = oldHTMLElement;
+}
 
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/input.js
@@ -1,17 +1,26 @@
-// Pretend that `Reflect.construct` isn't supported.
-this.Reflect = undefined;
+const oldReflect = this.Reflect;
+const oldHTMLElement = this.HTMLElement;
 
-this.HTMLElement = function() {
-  // Here, `this.HTMLElement` is this function, not the original HTMLElement
-  // constructor. `this.constructor` should be this function too, but isn't.
-  constructor = this.constructor;
-};
+try {
+  // Pretend that `Reflect.construct` isn't supported.
+  this.Reflect = undefined;
 
-var constructor;
+  this.HTMLElement = function() {
+    // Here, `this.HTMLElement` is this function, not the original HTMLElement
+    // constructor. `this.constructor` should be this function too, but isn't.
+    constructor = this.constructor;
+  };
 
-class CustomElement extends HTMLElement {};
-new CustomElement();
+  var constructor;
 
-expect(constructor).toBe(CustomElement);
+  class CustomElement extends HTMLElement {};
+  new CustomElement();
+
+  expect(constructor).toBe(CustomElement);
+} finally {
+  // Restore original env
+  this.Reflect = oldReflect;
+  this.HTMLElement = oldHTMLElement;
+}
 
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/8499/output.js
@@ -1,27 +1,42 @@
-// Pretend that `Reflect.construct` isn't supported.
-this.Reflect = undefined;
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
 
-this.HTMLElement = function () {
-  // Here, `this.HTMLElement` is this function, not the original HTMLElement
-  // constructor. `this.constructor` should be this function too, but isn't.
-  constructor = this.constructor;
-};
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
-var constructor;
+var oldReflect = this.Reflect;
+var oldHTMLElement = this.HTMLElement;
 
-var CustomElement = /*#__PURE__*/function (_HTMLElement) {
-  "use strict";
+try {
+  // Pretend that `Reflect.construct` isn't supported.
+  this.Reflect = undefined;
 
-  babelHelpers.inherits(CustomElement, _HTMLElement);
+  this.HTMLElement = function () {
+    // Here, `this.HTMLElement` is this function, not the original HTMLElement
+    // constructor. `this.constructor` should be this function too, but isn't.
+    constructor = this.constructor;
+  };
 
-  function CustomElement() {
-    babelHelpers.classCallCheck(this, CustomElement);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(CustomElement).apply(this, arguments));
-  }
+  var constructor;
 
-  return CustomElement;
-}( /*#__PURE__*/babelHelpers.wrapNativeSuper(HTMLElement));
+  var CustomElement = /*#__PURE__*/function (_HTMLElement) {
+    "use strict";
 
-;
-new CustomElement();
-expect(constructor).toBe(CustomElement);
+    babelHelpers.inherits(CustomElement, _HTMLElement);
+
+    var _super = _createSuper(CustomElement);
+
+    function CustomElement() {
+      babelHelpers.classCallCheck(this, CustomElement);
+      return _super.apply(this, arguments);
+    }
+
+    return CustomElement;
+  }( /*#__PURE__*/babelHelpers.wrapNativeSuper(HTMLElement));
+
+  ;
+  new CustomElement();
+  expect(constructor).toBe(CustomElement);
+} finally {
+  // Restore original env
+  this.Reflect = oldReflect;
+  this.HTMLElement = oldHTMLElement;
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T2494/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T2494/output.js
@@ -1,12 +1,18 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var x = {
   Foo: /*#__PURE__*/function (_Foo) {
     "use strict";
 
     babelHelpers.inherits(_class, _Foo);
 
+    var _super = _createSuper(_class);
+
     function _class() {
       babelHelpers.classCallCheck(this, _class);
-      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(_class).apply(this, arguments));
+      return _super.apply(this, arguments);
     }
 
     return _class;

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T2997/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T2997/output.js
@@ -1,3 +1,7 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var A = function A() {
   "use strict";
 
@@ -9,11 +13,13 @@ var B = /*#__PURE__*/function (_A) {
 
   babelHelpers.inherits(B, _A);
 
+  var _super = _createSuper(B);
+
   function B() {
     var _this;
 
     babelHelpers.classCallCheck(this, B);
-    return babelHelpers.possibleConstructorReturn(_this, _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this)));
+    return babelHelpers.possibleConstructorReturn(_this, _this = _super.call(this));
   }
 
   return B;

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
@@ -1,8 +1,12 @@
 function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -23,12 +27,14 @@ var A = /*#__PURE__*/function (_B) {
 
   _inherits(A, _B);
 
+  var _super = _createSuper(A);
+
   function A(track) {
     var _this;
 
     _classCallCheck(this, A);
 
-    if (track !== undefined) _this = _possibleConstructorReturn(this, _getPrototypeOf(A).call(this, track));else _this = _possibleConstructorReturn(this, _getPrototypeOf(A).call(this));
+    if (track !== undefined) _this = _super.call(this, track);else _this = _super.call(this);
     return _possibleConstructorReturn(_this);
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -3,17 +3,19 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inherits(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
-    var _babelHelpers$getProt, _babelHelpers$get;
+    var _babelHelpers$get;
 
     var _this;
 
     babelHelpers.classCallCheck(this, Test);
     woops.super.test();
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).call(this));
+    _this = _super.call(this);
     babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).apply(this, arguments));
-    _this = babelHelpers.possibleConstructorReturn(this, (_babelHelpers$getProt = babelHelpers.getPrototypeOf(Test)).call.apply(_babelHelpers$getProt, [this, "test"].concat(Array.prototype.slice.call(arguments))));
+    _this = _super.apply(this, arguments);
+    _this = _super.call.apply(_super, [this, "test"].concat(Array.prototype.slice.call(arguments)));
     babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).apply(babelHelpers.assertThisInitialized(_this), arguments);
 
     (_babelHelpers$get = babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this))).call.apply(_babelHelpers$get, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
@@ -3,11 +3,13 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inherits(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     var _this;
 
     babelHelpers.classCallCheck(this, Test);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).call(this));
+    _this = _super.call(this);
     babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this));
     babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).whatever;
     return _this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
@@ -3,11 +3,13 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inherits(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     var _this;
 
     babelHelpers.classCallCheck(this, Test);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).call(this));
+    _this = _super.call(this);
     babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).whatever();
     babelHelpers.get(babelHelpers.getPrototypeOf(Test.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/constructor/output.js
@@ -10,11 +10,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
     _this.state = "test";
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/delay-arrow-function-for-bare-super-derived/output.js
@@ -3,13 +3,15 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, () => {
+    return _this = _super.call(this, () => {
       _this.test;
-    }));
+    });
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    if (eval("false")) _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    if (eval("false")) _this = _super.call(this);
     return babelHelpers.possibleConstructorReturn(_this);
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-3/output.js
@@ -3,12 +3,14 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var fn = () => _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    var fn = () => _this = _super.call(this);
 
     fn();
     return babelHelpers.possibleConstructorReturn(_this);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/output.js
@@ -3,12 +3,14 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var fn = () => _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    var fn = () => _this = _super.call(this);
 
     return babelHelpers.possibleConstructorReturn(_this);
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-falsey/output.js
@@ -3,6 +3,8 @@ var Child = /*#__PURE__*/function (_Base) {
 
   babelHelpers.inherits(Child, _Base);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-object/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-no-super-return-object/output.js
@@ -3,6 +3,8 @@ var Child = /*#__PURE__*/function (_Base) {
 
   babelHelpers.inherits(Child, _Base);
 
+  var _super = babelHelpers.createSuper(Child);
+
   function Child() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/export-super-class/output.mjs
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/export-super-class/output.mjs
@@ -1,9 +1,11 @@
 var _default = /*#__PURE__*/function (_A) {
   babelHelpers.inherits(_default, _A);
 
+  var _super = babelHelpers.createSuper(_default);
+
   function _default() {
     babelHelpers.classCallCheck(this, _default);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(_default).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return _default;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/extend-untranspiled-class/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/extend-untranspiled-class/exec.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var log = [];
+var SuperClass = require("module-which-exports-native-class");
+
+class SubClass extends SuperClass {
+  constructor() {
+    log.push(4);
+    super();
+  }
+  method() {
+    log.push(5);
+    super.method();
+  }
+  static method() {
+    log.push(6);
+    super.method();
+  }
+}
+
+new SubClass().method();
+SubClass.method();
+
+expect(log).toEqual([4, 1, 5, 2, 6, 3]);
+
+// Magic function to avoid transpiling class
+function require() {
+  return eval(`(
+    class SuperClass {
+      constructor() { log.push(1); }
+      method() { log.push(2); }
+      static method() { log.push(3); }
+    }
+  )`);
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-call-in-key/output.js
@@ -13,6 +13,8 @@ var Hello = function Hello() {
 var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
+  var _super = babelHelpers.createSuper(Outer);
+
   function Outer() {
     var _this2 = this;
 
@@ -26,7 +28,7 @@ var Outer = /*#__PURE__*/function (_Hello) {
       }
 
       babelHelpers.createClass(Inner, [{
-        key: _this = babelHelpers.possibleConstructorReturn(_this2, babelHelpers.getPrototypeOf(Outer).call(_this2)),
+        key: _this = _super.call(_this2),
         value: function value() {
           return 'hello';
         }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -17,11 +17,13 @@ var Hello = /*#__PURE__*/function () {
 var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
+  var _super = babelHelpers.createSuper(Outer);
+
   function Outer() {
     var _this;
 
     babelHelpers.classCallCheck(this, Outer);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
+    _this = _super.call(this);
 
     var Inner = /*#__PURE__*/function () {
       function Inner() {

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-call-in-key/output.js
@@ -13,12 +13,14 @@ var Hello = function Hello() {
 var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
+  var _super = babelHelpers.createSuper(Outer);
+
   function Outer() {
     var _this;
 
     babelHelpers.classCallCheck(this, Outer);
     var Inner = {
-      [_this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this))]() {
+      [_this = _super.call(this)]() {
         return 'hello';
       }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -17,11 +17,13 @@ var Hello = /*#__PURE__*/function () {
 var Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
 
+  var _super = babelHelpers.createSuper(Outer);
+
   function Outer() {
     var _this;
 
     babelHelpers.classCallCheck(this, Outer);
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Outer).call(this));
+    _this = _super.call(this);
     var Inner = {
       [babelHelpers.get(babelHelpers.getPrototypeOf(Outer.prototype), "toString", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))]() {
         return 'hello';

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "transform-function-name",
     "transform-classes",
     "transform-spread",

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-anonymous/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-anonymous/output.js
@@ -3,9 +3,11 @@ var TestEmpty = /*#__PURE__*/function (_ref) {
 
   babelHelpers.inherits(TestEmpty, _ref);
 
+  var _super = babelHelpers.createSuper(TestEmpty);
+
   function TestEmpty() {
     babelHelpers.classCallCheck(this, TestEmpty);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestEmpty).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return TestEmpty;
@@ -24,9 +26,11 @@ var TestConstructorOnly = /*#__PURE__*/function (_ref2) {
 
   babelHelpers.inherits(TestConstructorOnly, _ref2);
 
+  var _super2 = babelHelpers.createSuper(TestConstructorOnly);
+
   function TestConstructorOnly() {
     babelHelpers.classCallCheck(this, TestConstructorOnly);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestConstructorOnly).apply(this, arguments));
+    return _super2.apply(this, arguments);
   }
 
   return TestConstructorOnly;
@@ -45,9 +49,11 @@ var TestMethodOnly = /*#__PURE__*/function (_ref3) {
 
   babelHelpers.inherits(TestMethodOnly, _ref3);
 
+  var _super3 = babelHelpers.createSuper(TestMethodOnly);
+
   function TestMethodOnly() {
     babelHelpers.classCallCheck(this, TestMethodOnly);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestMethodOnly).apply(this, arguments));
+    return _super3.apply(this, arguments);
   }
 
   return TestMethodOnly;
@@ -70,9 +76,11 @@ var TestConstructorAndMethod = /*#__PURE__*/function (_ref4) {
 
   babelHelpers.inherits(TestConstructorAndMethod, _ref4);
 
+  var _super4 = babelHelpers.createSuper(TestConstructorAndMethod);
+
   function TestConstructorAndMethod() {
     babelHelpers.classCallCheck(this, TestConstructorAndMethod);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestConstructorAndMethod).apply(this, arguments));
+    return _super4.apply(this, arguments);
   }
 
   return TestConstructorAndMethod;
@@ -95,9 +103,11 @@ var TestMultipleMethods = /*#__PURE__*/function (_ref5) {
 
   babelHelpers.inherits(TestMultipleMethods, _ref5);
 
+  var _super5 = babelHelpers.createSuper(TestMultipleMethods);
+
   function TestMultipleMethods() {
     babelHelpers.classCallCheck(this, TestMultipleMethods);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(TestMultipleMethods).apply(this, arguments));
+    return _super5.apply(this, arguments);
   }
 
   return TestMultipleMethods;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-id-member-expression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class-id-member-expression/output.js
@@ -3,9 +3,11 @@ var BaseController = /*#__PURE__*/function (_Chaplin$Controller) {
 
   babelHelpers.inherits(BaseController, _Chaplin$Controller);
 
+  var _super = babelHelpers.createSuper(BaseController);
+
   function BaseController() {
     babelHelpers.classCallCheck(this, BaseController);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(BaseController).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return BaseController;
@@ -16,9 +18,11 @@ var BaseController2 = /*#__PURE__*/function (_Chaplin$Controller$A) {
 
   babelHelpers.inherits(BaseController2, _Chaplin$Controller$A);
 
+  var _super2 = babelHelpers.createSuper(BaseController2);
+
   function BaseController2() {
     babelHelpers.classCallCheck(this, BaseController2);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(BaseController2).apply(this, arguments));
+    return _super2.apply(this, arguments);
   }
 
   return BaseController2;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-class/output.js
@@ -3,9 +3,11 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   babelHelpers.inherits(Test, _Foo);
 
+  var _super = babelHelpers.createSuper(Test);
+
   function Test() {
     babelHelpers.classCallCheck(this, Test);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Test).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Test;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-correct-new-target/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-correct-new-target/exec.js
@@ -1,0 +1,14 @@
+"use strict";
+
+let NewTarget;
+
+class A {
+  constructor() { NewTarget = new.target; }
+}
+class B extends A {}
+
+new A();
+expect(NewTarget).toBe(A);
+
+new B();
+expect(NewTarget).toBe(B);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-proto-modifications/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-proto-modifications/exec.js
@@ -1,0 +1,15 @@
+var A_called = false;
+var X_called = false;
+
+class A { constructor() { A_called = true } }
+class X { constructor() { X_called = true } }
+class B extends A {}
+
+B.prototype.__proto__ = X.prototype;
+B.__proto__ = X;
+
+expect(new B() instanceof B).toBe(true);
+expect(new B() instanceof A).toBe(false);
+expect(new B() instanceof X).toBe(true);
+expect(A_called).toBe(false);
+expect(X_called).toBe(true);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -1,8 +1,12 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -19,12 +23,14 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   _inherits(Foo, _Bar);
 
+  var _super = _createSuper(Foo);
+
   function Foo() {
     var _this;
 
     _classCallCheck(this, Foo);
 
-    _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_assertThisInitialized(_this), _this = _possibleConstructorReturn(this, _getPrototypeOf(Foo).call(this)));
+    _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_assertThisInitialized(_this), _this = _super.call(this));
 
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -1,8 +1,12 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -19,6 +23,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   _inherits(Foo, _Bar);
 
+  var _super = _createSuper(Foo);
+
   function Foo() {
     var _this;
 
@@ -26,7 +32,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
     _get(_getPrototypeOf(Foo.prototype), "foo", _assertThisInitialized(_this)).call(_assertThisInitialized(_this));
 
-    return _this = _possibleConstructorReturn(this, _getPrototypeOf(Foo).call(this));
+    return _this = _super.call(this);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "transform-classes",
     "transform-block-scoping"
   ]

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
@@ -11,7 +13,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
     var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
 
     babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    return _this = _super.call(this);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "transform-classes",
     "transform-block-scoping"
   ]

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
@@ -10,7 +12,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
     var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
 
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
     t();
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.100.0" }],
     "transform-classes",
     "transform-block-scoping"
   ]

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
@@ -10,7 +12,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
     var t = () => babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
 
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    return _this = _super.call(this);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), (_this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this))).method, babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    babelHelpers.get(babelHelpers.getPrototypeOf(Foo.prototype), (_this = _super.call(this)).method, babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this;
   }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
@@ -3,11 +3,13 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, babelHelpers.assertThisInitialized(_this)));
+    return _this = _super.call(this, babelHelpers.assertThisInitialized(_this));
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
@@ -11,7 +13,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
     var fn = () => babelHelpers.assertThisInitialized(_this);
 
     fn();
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    return _this = _super.call(this);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
@@ -10,7 +12,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
     var fn = () => babelHelpers.assertThisInitialized(_this);
 
-    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    _this = _super.call(this);
     fn();
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
@@ -3,6 +3,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes/output.js
@@ -3,12 +3,14 @@ var Foo = /*#__PURE__*/function (_Bar) {
 
   babelHelpers.inherits(Foo, _Bar);
 
+  var _super = babelHelpers.createSuper(Foo);
+
   function Foo() {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
     _this.foo = "bar";
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
+    return _this = _super.call(this);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-3/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/modules-3/output.js
@@ -7,12 +7,18 @@ exports.default = void 0;
 
 var _store = require("./store");
 
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Login = /*#__PURE__*/function (_React$Component) {
   babelHelpers.inherits(Login, _React$Component);
 
+  var _super = _createSuper(Login);
+
   function Login() {
     babelHelpers.classCallCheck(this, Login);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Login).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   babelHelpers.createClass(Login, [{

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-nested-iife/output.js
@@ -1,3 +1,7 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 function broken(x) {
   if (true) {
     var Foo = /*#__PURE__*/function (_Bar) {
@@ -5,9 +9,11 @@ function broken(x) {
 
       babelHelpers.inherits(Foo, _Bar);
 
+      var _super = _createSuper(Foo);
+
       function Foo() {
         babelHelpers.classCallCheck(this, Foo);
-        return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).apply(this, arguments));
+        return _super.apply(this, arguments);
       }
 
       return Foo;

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -17,11 +17,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -32,9 +36,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 var App = /*#__PURE__*/function (_Component) {
   _inherits(App, _Component);
 
-  function App() {
-    var _getPrototypeOf2;
+  var _super = _createSuper(App);
 
+  function App() {
     var _this;
 
     _classCallCheck(this, App);
@@ -43,7 +47,7 @@ var App = /*#__PURE__*/function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args)));
+    _this = _super.call.apply(_super, [this].concat(args));
 
     _defineProperty(_assertThisInitialized(_this), "exportType", '');
 

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/optimisation.react.constant-elements/output.js
@@ -1,3 +1,7 @@
+function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 var _ref = /*#__PURE__*/<div className="navbar-header">
       <a className="navbar-brand" href="/">
         <img src="/img/logo/logo-96x36.png" />
@@ -9,9 +13,11 @@ let App = /*#__PURE__*/function (_React$Component) {
 
   babelHelpers.inherits(App, _React$Component);
 
+  var _super = _createSuper(App);
+
   function App() {
     babelHelpers.classCallCheck(this, App);
-    return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(App).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   babelHelpers.createClass(App, [{

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useES6Modules/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useES6Modules/output.mjs
@@ -1,15 +1,22 @@
+import _Reflect$construct from "@babel/runtime-corejs2/core-js/reflect/construct";
 import _classCallCheck from "@babel/runtime-corejs2/helpers/esm/classCallCheck";
 import _possibleConstructorReturn from "@babel/runtime-corejs2/helpers/esm/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime-corejs2/helpers/esm/getPrototypeOf";
 import _inherits from "@babel/runtime-corejs2/helpers/esm/inherits";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = _Reflect$construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !_Reflect$construct) return false; if (_Reflect$construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(_Reflect$construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
+
+  var _super = _createSuper(Foo);
 
   function Foo() {
     _classCallCheck(this, Foo);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs/output.mjs
@@ -1,15 +1,22 @@
+import _Reflect$construct from "@babel/runtime-corejs2/core-js/reflect/construct";
 import _classCallCheck from "@babel/runtime-corejs2/helpers/classCallCheck";
 import _possibleConstructorReturn from "@babel/runtime-corejs2/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime-corejs2/helpers/getPrototypeOf";
 import _inherits from "@babel/runtime-corejs2/helpers/inherits";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = _Reflect$construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !_Reflect$construct) return false; if (_Reflect$construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(_Reflect$construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
+
+  var _super = _createSuper(Foo);
 
   function Foo() {
     _classCallCheck(this, Foo);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs-auto/output.js
@@ -6,15 +6,21 @@ var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
 
 var _inherits = require("@babel/runtime/helpers/inherits");
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   _inherits(Foo, _Bar);
 
+  var _super = _createSuper(Foo);
+
   function Foo() {
     _classCallCheck(this, Foo);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-cjs/output.js
@@ -6,15 +6,21 @@ var _getPrototypeOf = require("@babel/runtime/helpers/getPrototypeOf");
 
 var _inherits = require("@babel/runtime/helpers/inherits");
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   _inherits(Foo, _Bar);
 
+  var _super = _createSuper(Foo);
+
   function Foo() {
     _classCallCheck(this, Foo);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs-auto/output.mjs
@@ -3,13 +3,19 @@ import _possibleConstructorReturn from "@babel/runtime/helpers/esm/possibleConst
 import _getPrototypeOf from "@babel/runtime/helpers/esm/getPrototypeOf";
 import _inherits from "@babel/runtime/helpers/esm/inherits";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
+
+  var _super = _createSuper(Foo);
 
   function Foo() {
     _classCallCheck(this, Foo);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useESModules-mjs/output.mjs
@@ -3,13 +3,19 @@ import _possibleConstructorReturn from "@babel/runtime/helpers/esm/possibleConst
 import _getPrototypeOf from "@babel/runtime/helpers/esm/getPrototypeOf";
 import _inherits from "@babel/runtime/helpers/esm/inherits";
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
 let Foo = /*#__PURE__*/function (_Bar) {
   _inherits(Foo, _Bar);
+
+  var _super = _createSuper(Foo);
 
   function Foo() {
     _classCallCheck(this, Foo);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+    return _super.apply(this, arguments);
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class-and-super/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class-and-super/output.js
@@ -1,8 +1,12 @@
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -15,12 +19,14 @@ let Employee = /*#__PURE__*/function (_Person) {
 
   _inherits(Employee, _Person);
 
+  var _super = _createSuper(Employee);
+
   function Employee(name) {
     var _this;
 
     _classCallCheck(this, Employee);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(Employee).call(this));
+    _this = _super.call(this);
     _this.name = name;
     return _this;
   }

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -4,6 +4,8 @@ function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "functi
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
@@ -12,9 +14,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
 
-function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _construct(Parent, args, Class) { if (_isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
 
-function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
 
@@ -25,10 +27,12 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.g
 var MyDate = /*#__PURE__*/function (_Date) {
   _inherits(MyDate, _Date);
 
+  var _super = _createSuper(MyDate);
+
   function MyDate(time) {
     _classCallCheck(this, MyDate);
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(MyDate).call(this, time));
+    return _super.call(this, time);
   }
 
   return MyDate;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7022
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes?[1]
| Minor: New Feature?      | y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Prev: #7081

This PR allows transpiled classes to extends untranspiled classes. This can happen, for example, when a dependency is transpiled using Babel and extends an user-provided class.
Example: https://github.com/Oblosys/react-lifecycle-visualizer/issues/4

The new helper only allows extending native classes when `Reflect.construct` is natively supported. Some envs (e.g. Node 4) have partial support for classes but don't provide `Reflect.construct`: in this case users need to ensure that every class (also in their dependencies) is transpiled, like it was before.

[1] If someone sets `.constructor` to something else, the new helper won't work. e.g.
```js
class A {}
class B extends A {}

B.prototype.constructor = A;

console.log(new B() instanceof A); // true
console.log(new B() instanceof B); // false, should be true
```
A workaround to avoid the breaking change could be to only use the `Reflect`-based version of the helper only if `Function.toString.call(SuperClass).slice(0, 5) === "class"`, but in those cases `this.constructor` still can't be modified.