### PR TITLE
Better support monorepos by allowing users to opt into automatically resolving 'root' with `rootMode: "upward"`.

### DIFF
--- a/packages/babel-cli/src/babel/options.js
+++ b/packages/babel-cli/src/babel/options.js
@@ -28,6 +28,11 @@ commander.option(
   "The name of the 'env' to use when loading configs and plugins. " +
     "Defaults to the value of BABEL_ENV, or else NODE_ENV, or else 'development'.",
 );
+commander.option(
+  "--root-mode [mode]",
+  "The project-root resolution mode. " +
+    "One of 'root' (the default), 'upward', or 'upward-optional'.",
+);
 
 // Basic file input configuration.
 commander.option("--source-type [script|module]", "");
@@ -220,6 +225,7 @@ export default function parseArgv(args: Array<string>) {
     babelOptions: {
       presets: opts.presets,
       plugins: opts.plugins,
+      rootMode: opts.rootMode,
       configFile: opts.configFile,
       envName: opts.envName,
       sourceType: opts.sourceType,

--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -24,6 +24,21 @@ const BABELRC_FILENAME = ".babelrc";
 const BABELRC_JS_FILENAME = ".babelrc.js";
 const BABELIGNORE_FILENAME = ".babelignore";
 
+export function findConfigUpwards(rootDir: string): string | null {
+  let dirname = rootDir;
+  while (true) {
+    if (fs.existsSync(path.join(dirname, BABEL_CONFIG_JS_FILENAME))) {
+      return dirname;
+    }
+
+    const nextDir = path.dirname(dirname);
+    if (dirname === nextDir) break;
+    dirname = nextDir;
+  }
+
+  return null;
+}
+
 export function findRelativeConfig(
   packageData: FilePackageData,
   envName: string,

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -11,6 +11,12 @@ import type { CallerMetadata } from "../validation/options";
 
 export type { ConfigFile, IgnoreFile, RelativeConfig, FilePackageData };
 
+export function findConfigUpwards(
+  rootDir: string, // eslint-disable-line no-unused-vars
+): string | null {
+  return null;
+}
+
 export function findPackageData(filepath: string): FilePackageData {
   return {
     filepath,

--- a/packages/babel-core/src/config/files/index.js
+++ b/packages/babel-core/src/config/files/index.js
@@ -10,6 +10,7 @@ import typeof * as indexType from "./index";
 export { findPackageData } from "./package";
 
 export {
+  findConfigUpwards,
   findRelativeConfig,
   findRootConfig,
   loadConfig,

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -15,6 +15,7 @@ import type {
   RootInputSourceMapOption,
   NestingPath,
   CallerMetadata,
+  RootMode,
 } from "./options";
 
 export type ValidatorSet = {
@@ -59,6 +60,20 @@ type AccessPath = $ReadOnly<{
   parent: GeneralPath,
 }>;
 type GeneralPath = OptionPath | AccessPath;
+
+export function assertRootMode(loc: OptionPath, value: mixed): RootMode | void {
+  if (
+    value !== undefined &&
+    value !== "root" &&
+    value !== "upward" &&
+    value !== "upward-optional"
+  ) {
+    throw new Error(
+      `${msg(loc)} must be a "root", "upward", "upward-optional" or undefined`,
+    );
+  }
+  return value;
+}
 
 export function assertSourceMaps(
   loc: OptionPath,

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -19,6 +19,7 @@ import {
   assertConfigFileSearch,
   assertBabelrcSearch,
   assertFunction,
+  assertRootMode,
   assertSourceMaps,
   assertCompact,
   assertSourceType,
@@ -30,6 +31,9 @@ import {
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
   root: (assertString: Validator<$PropertyType<ValidatedOptions, "root">>),
+  rootMode: (assertRootMode: Validator<
+    $PropertyType<ValidatedOptions, "rootMode">,
+  >),
   configFile: (assertConfigFileSearch: Validator<
     $PropertyType<ValidatedOptions, "configFile">,
   >),
@@ -176,6 +180,7 @@ export type ValidatedOptions = {
   babelrcRoots?: BabelrcSearch,
   configFile?: ConfigFileSearch,
   root?: string,
+  rootMode?: RootMode,
   code?: boolean,
   ast?: boolean,
   inputSourceMap?: RootInputSourceMapOption,
@@ -260,6 +265,7 @@ export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";
 export type RootInputSourceMapOption = {} | boolean;
+export type RootMode = "root" | "upward" | "upward-optional";
 
 export type OptionsSource =
   | "arguments"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | N
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This is an alternative to #8636 that is a bit simpler. It introduces a separate `rootMode: "root" | "upward" | "upward-optional"` option. From [the docs PR](https://github.com/babel/website/pull/1822):

* `"root"` - Passes the `"root"` value through as unchanged.
* `"upward"` - Walks upward from the `"root"` directory, looking
  for a directory containing a `babel.config.js`
  file, and throws an error if a `babel.config.js`
  is not found.
* `"upward-optional"` - Walk upward from the `"root"` directory,
  looking for a directory containing a `babel.config.js`
  file, and falls back to `"root"` if a `babel.config.js`
  is not found.

Otherwise, this is very similar to #8636 and has all of the same requirements of it being an opt-in feature.