### PR TITLE
Fix typescript import elision

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -40,7 +40,7 @@ export default declare((api, { jsxPragma = "React" }) => {
             // Note: this will allow both `import { } from "m"` and `import "m";`.
             // In TypeScript, the former would be elided.
             if (stmt.node.specifiers.length === 0) {
-              return;
+              continue;
             }
 
             let allElided = true;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elision/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elision/input.mjs
@@ -1,3 +1,4 @@
+import "lib";
 import A, { B, Used } from "lib";
 import Used2, { C } from "lib";
 import * as D from "lib";

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elision/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elision/output.mjs
@@ -1,3 +1,4 @@
+import "lib";
 import { Used } from "lib";
 import Used2 from "lib";
 import * as Used3 from "lib";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A (No open issue that I've found) <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes an issue where babel-plugin-transform-typescript is not properly eliding its imports: if there is any unnamed import (e.g. `import 'foo'`), then it bailed out and does not properly elide the other imports in the file.

So, while this would correctly compile:

```ts
import { Foo } from "foo";

const foos = [] as Foo[];
```

to 

```js
const foos = [];
```

If an unnamed import was added, the `Foo` import would no longer be elided.  So:

```ts
import "something";
import { Foo } from "foo";

const foos = [] as Foo[];
```

would compile to

```js
import "something";
import { Foo } from "foo";

const foos = [];
```