### PR TITLE
Fix es6.string.iterator mapping in babel-preset-env

### DIFF
--- a/packages/babel-preset-env/data/built-in-features.js
+++ b/packages/babel-preset-env/data/built-in-features.js
@@ -277,7 +277,7 @@ const es = {
   "es6.string.from-code-point": "String static methods / String.fromCodePoint",
   "es6.string.includes": "String.prototype methods / String.prototype.includes",
   "es6.string.italics": "String.prototype HTML methods",
-  "es6.string.iterator": "String properties and methods / Property access on strings",
+  "es6.string.iterator": "String.prototype methods / String.prototype[Symbol.iterator]",
   "es6.string.link": "String.prototype HTML methods",
   // "String.prototype methods / String.prototype.normalize" not implemented
   "es7.string.pad-start": "String padding / String.prototype.padStart",

--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -1183,16 +1183,14 @@
     "electron": "1.1"
   },
   "es6.string.iterator": {
-    "chrome": "5",
-    "opera": "10.10",
+    "chrome": "38",
     "edge": "12",
-    "firefox": "2",
-    "safari": "3.1",
-    "node": "0.10",
-    "ie": "8",
-    "android": "4.0",
-    "ios": "6",
-    "electron": "1.1"
+    "firefox": "36",
+    "safari": "9",
+    "node": "0.12",
+    "ios": "9",
+    "opera": "25",
+    "electron": "0.2"
   },
   "es6.string.link": {
     "chrome": "5",

--- a/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/android/stdout.txt
@@ -129,6 +129,7 @@ Using polyfills with `entry` option:
   es6.string.ends-with { "android":"4" }
   es6.string.from-code-point { "android":"4" }
   es6.string.includes { "android":"4" }
+  es6.string.iterator { "android":"4" }
   es7.string.pad-start { "android":"4" }
   es7.string.pad-end { "android":"4" }
   es6.string.raw { "android":"4" }

--- a/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/builtins/stdout.txt
@@ -140,6 +140,7 @@ Using polyfills with `entry` option:
   es6.string.from-code-point { "ie":"10" }
   es6.string.includes { "ie":"10" }
   es6.string.italics { "ie":"10" }
+  es6.string.iterator { "ie":"10" }
   es6.string.link { "ie":"10" }
   es7.string.pad-start { "chrome":"54", "ie":"10", "node":"6" }
   es7.string.pad-end { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/electron/stdout.txt
@@ -100,7 +100,6 @@ Using polyfills with `entry` option:
   es6.string.fontcolor { "electron":"0.36" }
   es6.string.fontsize { "electron":"0.36" }
   es6.string.italics { "electron":"0.36" }
-  es6.string.iterator { "electron":"0.36" }
   es6.string.link { "electron":"0.36" }
   es7.string.pad-start { "electron":"0.36" }
   es7.string.pad-end { "electron":"0.36" }

--- a/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -144,6 +144,7 @@ Using polyfills with `entry` option:
   es6.string.from-code-point { "ie":"10", "safari":"7" }
   es6.string.includes { "ie":"10", "safari":"7" }
   es6.string.italics { "ie":"10" }
+  es6.string.iterator { "ie":"10", "safari":"7" }
   es6.string.link { "ie":"10" }
   es7.string.pad-start { "chrome":"54", "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   es7.string.pad-end { "chrome":"54", "edge":"13", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage/stdout.txt
@@ -43,6 +43,7 @@ Using polyfills with `usage` option:
 [<CWD>/src/in.js] Added following polyfills:
   es6.promise { "ie":"11" }
   es6.map { "firefox":"50", "ie":"11" }
+  es6.string.iterator { "ie":"11" }
   es6.array.iterator { "ie":"11" }
   web.dom.iterable { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-decimals/stdout.txt
@@ -167,7 +167,7 @@ Using polyfills with `entry` option:
   es6.string.from-code-point { "ie":"10" }
   es6.string.includes { "ie":"10" }
   es6.string.italics { "electron":"0.36", "ie":"10" }
-  es6.string.iterator { "electron":"0.36" }
+  es6.string.iterator { "ie":"10" }
   es6.string.link { "electron":"0.36", "ie":"10" }
   es7.string.pad-start { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   es7.string.pad-end { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/versions-strings/stdout.txt
@@ -140,6 +140,7 @@ Using polyfills with `entry` option:
   es6.string.from-code-point { "ie":"10" }
   es6.string.includes { "ie":"10" }
   es6.string.italics { "ie":"10" }
+  es6.string.iterator { "ie":"10" }
   es6.string.link { "ie":"10" }
   es7.string.pad-start { "chrome":"54", "ie":"10", "node":"6.10" }
   es7.string.pad-end { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-all/output.mjs
@@ -1,5 +1,6 @@
 import "core-js/modules/web.dom.iterable";
 import "core-js/modules/es6.array.iterator";
+import "core-js/modules/es6.string.iterator";
 import "core-js/modules/es6.promise";
 var p = Promise.resolve(0);
 Promise.all([p]).then(function (outcome) {

--- a/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options-add-used-built-ins/promise-race/output.mjs
@@ -1,5 +1,6 @@
 import "core-js/modules/web.dom.iterable";
 import "core-js/modules/es6.array.iterator";
+import "core-js/modules/es6.string.iterator";
 import "core-js/modules/es6.promise";
 var p = Promise.resolve(0);
 Promise.race([p]).then(function (outcome) {

--- a/packages/babel-preset-env/test/fixtures/preset-options/ie-11-built-ins/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/ie-11-built-ins/output.mjs
@@ -94,6 +94,7 @@ import "core-js/modules/es6.string.fontsize";
 import "core-js/modules/es6.string.from-code-point";
 import "core-js/modules/es6.string.includes";
 import "core-js/modules/es6.string.italics";
+import "core-js/modules/es6.string.iterator";
 import "core-js/modules/es6.string.link";
 import "core-js/modules/es7.string.pad-start";
 import "core-js/modules/es7.string.pad-end";

--- a/packages/babel-preset-env/test/fixtures/preset-options/use-builtins-ie-9/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/use-builtins-ie-9/output.mjs
@@ -96,6 +96,7 @@ import "core-js/modules/es6.string.fontsize";
 import "core-js/modules/es6.string.from-code-point";
 import "core-js/modules/es6.string.includes";
 import "core-js/modules/es6.string.italics";
+import "core-js/modules/es6.string.iterator";
 import "core-js/modules/es6.string.link";
 import "core-js/modules/es7.string.pad-start";
 import "core-js/modules/es7.string.pad-end";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8691 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
