### PR TITLE
Fix "TypeError: comments is not iterable"

### DIFF
--- a/packages/babel-plugin-transform-flow-strip-types/src/index.js
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.js
@@ -25,15 +25,19 @@ export default declare(api => {
         skipStrip = false;
         let directiveFound = false;
 
-        for (const comment of (comments: Array<Object>)) {
-          if (comment.value.indexOf(FLOW_DIRECTIVE) >= 0) {
-            directiveFound = true;
+        if (comments) {
+          for (const comment of (comments: Array<Object>)) {
+            if (comment.value.indexOf(FLOW_DIRECTIVE) >= 0) {
+              directiveFound = true;
 
-            // remove flow directive
-            comment.value = comment.value.replace(FLOW_DIRECTIVE, "");
+              // remove flow directive
+              comment.value = comment.value.replace(FLOW_DIRECTIVE, "");
 
-            // remove the comment completely if it only consists of whitespace and/or stars
-            if (!comment.value.replace(/\*/g, "").trim()) comment.ignore = true;
+              // remove the comment completely if it only consists of whitespace and/or stars
+              if (!comment.value.replace(/\*/g, "").trim()) {
+                comment.ignore = true;
+              }
+            }
           }
         }
 

--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -51,16 +51,18 @@ export default declare((api, options) => {
       let pragmaSet = !!options.pragma;
       let pragmaFragSet = !!options.pragmaFrag;
 
-      for (const comment of (file.ast.comments: Array<Object>)) {
-        const jsxMatches = JSX_ANNOTATION_REGEX.exec(comment.value);
-        if (jsxMatches) {
-          pragma = jsxMatches[1];
-          pragmaSet = true;
-        }
-        const jsxFragMatches = JSX_FRAG_ANNOTATION_REGEX.exec(comment.value);
-        if (jsxFragMatches) {
-          pragmaFrag = jsxFragMatches[1];
-          pragmaFragSet = true;
+      if (file.ast.comments) {
+        for (const comment of (file.ast.comments: Array<Object>)) {
+          const jsxMatches = JSX_ANNOTATION_REGEX.exec(comment.value);
+          if (jsxMatches) {
+            pragma = jsxMatches[1];
+            pragmaSet = true;
+          }
+          const jsxFragMatches = JSX_FRAG_ANNOTATION_REGEX.exec(comment.value);
+          if (jsxFragMatches) {
+            pragmaFrag = jsxFragMatches[1];
+            pragmaFragSet = true;
+          }
         }
       }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8700 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

In some cases, `comments` is `null` and `for (const comment of comments)` throws a TypeError. I have simply wrapped `for`s with a check.