### PR TITLE
Update helpers version from 7.0.1 to 7.0.2

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1054,7 +1054,7 @@ helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
   }
 `;
 
-helpers.classStaticPrivateFieldSpecGet = helper("7.0.1")`
+helpers.classStaticPrivateFieldSpecGet = helper("7.0.2")`
   export default function _classStaticPrivateFieldSpecGet(receiver, classConstructor, descriptor) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
@@ -1063,7 +1063,7 @@ helpers.classStaticPrivateFieldSpecGet = helper("7.0.1")`
   }
 `;
 
-helpers.classStaticPrivateFieldSpecSet = helper("7.0.1")`
+helpers.classStaticPrivateFieldSpecSet = helper("7.0.2")`
   export default function _classStaticPrivateFieldSpecSet(receiver, classConstructor, descriptor, value) {
     if (receiver !== classConstructor) {
       throw new TypeError("Private static access of wrong provenance");
@@ -1079,7 +1079,7 @@ helpers.classStaticPrivateFieldSpecSet = helper("7.0.1")`
   }
 `;
 
-helpers.decorate = helper("7.0.1")`
+helpers.decorate = helper("7.0.2")`
   import toArray from "toArray";
 
   // These comments are stripped by @babel/template

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/native-classes/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/native-classes/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/non-block-arrow-func/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/reevaluated/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-export/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-export/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-infer-name/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-infer-name/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-inherited/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-inherited/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-undefined/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static-undefined/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/static/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     ["proposal-class-properties", { "loose": true }],

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/instance/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/native-classes/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/native-classes/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/non-block-arrow-func/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/non-block-arrow-func/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/reevaluated/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T2983/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T2983/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T6719/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T6719/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/regression-T7364/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-export/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-export/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-infer-name/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-infer-name/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-inherited/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-inherited/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-undefined/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static-undefined/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/static/options.json
@@ -3,7 +3,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "proposal-class-properties",

--- a/packages/babel-plugin-proposal-decorators/src/transformer.js
+++ b/packages/babel-plugin-proposal-decorators/src/transformer.js
@@ -207,7 +207,7 @@ function addDecorateHelper(file) {
     if (err.code === "BABEL_HELPER_UNKNOWN") {
       err.message +=
         "\n  '@babel/plugin-transform-decorators' in non-legacy mode" +
-        " requires '@babel/core' version ^7.0.1 and you appear to be using" +
+        " requires '@babel/core' version ^7.0.2 and you appear to be using" +
         " an older version.";
     }
     throw err;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/element-descriptors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/element-descriptors/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/finishers/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/finishers/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/ordering/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/class-decorators-yield-await/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/class-decorators-yield-await/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ],
     "syntax-async-generators"

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.1"
+        "helperVersion": "7.0.2"
       }
     ]
   ]

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/math/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/math/options.json
@@ -4,7 +4,7 @@
       "transform-runtime",
       {
         "corejs": 2,
-        "version": "^7.0.1"
+        "version": "^7.0.2"
       }
     ],
     "transform-regenerator"


### PR DESCRIPTION
Since we released 7.0.1 branching from 7.0.0, all the new helpers will be released in the first version *after* 7.0.1.