### PR TITLE
Add option to resolve imports in the UMD transform plugin

### DIFF
--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -1,5 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { basename, extname } from "path";
+import { basename, extname, dirname, join, normalize } from "path";
 import {
   isModule,
   rewriteModuleStatementsAndPrepareHeader,
@@ -42,6 +42,7 @@ export default declare((api, options) => {
     strict,
     strictMode,
     noInterop,
+    resolveImports,
   } = options;
 
   /**
@@ -96,7 +97,13 @@ export default declare((api, options) => {
   /**
    * Build the member expression that reads from a global for a given source.
    */
-  function buildBrowserArg(browserGlobals, exactGlobals, source) {
+  function buildBrowserArg(
+    browserGlobals,
+    exactGlobals,
+    resolveImports,
+    source,
+    modulePath,
+  ) {
     let memberExpression;
     if (exactGlobals) {
       const globalRef = browserGlobals[source];
@@ -107,12 +114,16 @@ export default declare((api, options) => {
             (accum, curr) => t.memberExpression(accum, t.identifier(curr)),
             t.identifier("global"),
           );
+      } else if (resolveImports) {
+        memberExpression = resolveImport(t, source, modulePath);
       } else {
         memberExpression = t.memberExpression(
           t.identifier("global"),
           t.identifier(t.toIdentifier(source)),
         );
       }
+    } else if (resolveImports) {
+      memberExpression = resolveImport(t, source, modulePath);
     } else {
       const requireName = basename(source, extname(source));
       const globalName = browserGlobals[requireName] || requireName;
@@ -133,7 +144,13 @@ export default declare((api, options) => {
           const browserGlobals = globals || {};
 
           let moduleName = this.getModuleName();
-          if (moduleName) moduleName = t.stringLiteral(moduleName);
+          let modulePath = moduleName;
+
+          if (moduleName) {
+            moduleName = t.stringLiteral(moduleName);
+          } else {
+            modulePath = this.file.opts.filenameRelative;
+          }
 
           const { meta, headers } = rewriteModuleStatementsAndPrepareHeader(
             path,
@@ -168,7 +185,13 @@ export default declare((api, options) => {
               ]),
             );
             browserArgs.push(
-              buildBrowserArg(browserGlobals, exactGlobals, source),
+              buildBrowserArg(
+                browserGlobals,
+                exactGlobals,
+                resolveImports,
+                source,
+                modulePath,
+              ),
             );
             importNames.push(t.identifier(metadata.name));
 
@@ -229,3 +252,23 @@ export default declare((api, options) => {
     },
   };
 });
+
+function resolveImport(t, dependency, modulePath) {
+  if (modulePath.includes("/")) {
+    modulePath = dirname(modulePath);
+  }
+
+  const [root, ...path] = modulePath.split("/");
+  let resolved;
+
+  if (dependency.startsWith("./") || dependency.startsWith("../")) {
+    resolved = root + join(`/${path.join("/")}`, dependency);
+  } else {
+    resolved = normalize(dependency);
+  }
+
+  return t.memberExpression(
+    t.identifier("global"),
+    t.identifier(t.toIdentifier(resolved)),
+  );
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-exact-globals-true/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-exact-globals-true/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-exact-globals-true/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-exact-globals-true/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true,
+        "exactGlobals": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-exact-globals-true/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-exact-globals-true/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.looseResolveImportsWithExactGlobalsTrueDownTheRabbitHoleWeGo, global.looseResolveImportsWithExactGlobalsTrueFizzbuzz, global.looseBar);
+    global.input = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-id/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-id/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-id/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true
+      }
+    ]
+  ],
+  "moduleId": "MyLib"
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-id/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-id/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("MyLib", ["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.MyLibDownTheRabbitHoleWeGo, global.MyLibFizzbuzz, global.MyLibBar);
+    global.MyLib = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-name/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-name/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-name/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-name/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true
+      }
+    ]
+  ],
+  "moduleIds": true
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports-with-module-name/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("loose/resolve-imports-with-module-name/input", ["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.looseResolveImportsWithModuleNameDownTheRabbitHoleWeGo, global.looseResolveImportsWithModuleNameFizzbuzz, global.looseBar);
+    global.looseResolveImportsWithModuleNameInput = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/resolve-imports/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.looseResolveImportsDownTheRabbitHoleWeGo, global.looseResolveImportsFizzbuzz, global.looseBar);
+    global.input = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true,
+        "exactGlobals": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-exact-globals-true/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.umdResolveImportsWithExactGlobalsTrueDownTheRabbitHoleWeGo, global.umdResolveImportsWithExactGlobalsTrueFizzbuzz, global.umdBar);
+    global.input = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true
+      }
+    ]
+  ],
+  "moduleId": "MyLib"
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-id/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("MyLib", ["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.MyLibDownTheRabbitHoleWeGo, global.MyLibFizzbuzz, global.MyLibBar);
+    global.MyLib = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true
+      }
+    ]
+  ],
+  "moduleIds": true
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports-with-module-name/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define("umd/resolve-imports-with-module-name/input", ["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.umdResolveImportsWithModuleNameDownTheRabbitHoleWeGo, global.umdResolveImportsWithModuleNameFizzbuzz, global.umdBar);
+    global.umdResolveImportsWithModuleNameInput = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports/input.mjs
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports/input.mjs
@@ -1,0 +1,4 @@
+import foo from 'non/relative'
+import alice from './down/the-rabbit-hole/we/go'
+import { fizzbuzz } from './baz/../fizzbuzz'
+import { default as bar } from '../../../bar'

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports/options.json
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-modules-umd",
+      {
+        "resolveImports": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/resolve-imports/output.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["non/relative", "./down/the-rabbit-hole/we/go", "./baz/../fizzbuzz", "../../../bar"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("non/relative"), require("./down/the-rabbit-hole/we/go"), require("./baz/../fizzbuzz"), require("../../../bar"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.nonRelative, global.umdResolveImportsDownTheRabbitHoleWeGo, global.umdResolveImportsFizzbuzz, global.umdBar);
+    global.input = mod.exports;
+  }
+})(this, function (_relative, _go, _fizzbuzz, _bar) {
+  "use strict";
+
+  _relative = babelHelpers.interopRequireDefault(_relative);
+  _go = babelHelpers.interopRequireDefault(_go);
+  _bar = babelHelpers.interopRequireDefault(_bar);
+});


### PR DESCRIPTION
#4381 describes this issue in rather extensive detail. What this PR does is add the resolveImports option to the UMD transform plugin, which resolves the aforementioned issue. It should also take care of relative imports, by resolving them relative to the current module if moduleIds or moduleId is set, or relative to the file importing the dependencies.

This PR was originally opened as #4766, but since it was never reviewed and merge it fell behind and needed some significant work to get up to date with recent babel changes. Rebasing wasn't really an option, so I rewrote the patch manually instead.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #4381 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->