### PR TITLE
Fix Flow error with new versionRange test.

### DIFF
--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -156,7 +156,7 @@ export default class File {
    * helper exists, but was not available for the full given range, it will be
    * considered unavailable.
    */
-  availableHelper(name: string, versionRange: ?string) {
+  availableHelper(name: string, versionRange: ?string): boolean {
     let minVersion;
     try {
       minVersion = helpers.minVersion(name);
@@ -165,6 +165,8 @@ export default class File {
 
       return false;
     }
+
+    if (typeof versionRange !== "string") return true;
 
     // semver.intersects() has some surprising behavior with comparing ranges
     // with preprelease versions. We add '^' to ensure that we are always
@@ -186,9 +188,8 @@ export default class File {
     if (semver.valid(versionRange)) versionRange = `^${versionRange}`;
 
     return (
-      typeof versionRange !== "string" ||
-      (!semver.intersects(`<${minVersion}`, versionRange) &&
-        !semver.intersects(`>=8.0.0`, versionRange))
+      !semver.intersects(`<${minVersion}`, versionRange) &&
+      !semver.intersects(`>=8.0.0`, versionRange)
     );
   }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This isn't an actual issue because `semver.valid` thankfully just considers non-string values invalid, but it does cause Flow errors, since our type definitions expected `valid` to get a string, and sticking to that definition is probably best.