### PR TITLE
Use toPropertyKey in the "decorate" helper, delegate to @@toPrimitive and set correct methods namee

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-4855/options.json
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-4855/options.json
@@ -1,5 +1,8 @@
 {
   "compact": false,
   "presets": ["env"],
-  "plugins": ["external-helpers", "proposal-object-rest-spread"]
+  "plugins": [
+    ["external-helpers", { "helperVersion": "7.1.5" }],
+    "proposal-object-rest-spread"
+  ]
 }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1236,6 +1236,8 @@ helpers.decorate = helper("7.1.5")`
   function _createElementDescriptor(
     def /*: ElementDefinition */,
   ) /*: ElementDescriptor */ {
+    var key = toPropertyKey(def.key);
+
     var descriptor /*: PropertyDescriptor */;
     if (def.kind === "method") {
       descriptor = {
@@ -1244,6 +1246,10 @@ helpers.decorate = helper("7.1.5")`
         configurable: true,
         enumerable: false,
       };
+      Object.defineProperty(def.value, "name", {
+        value: typeof key === "symbol" ? "" : key,
+        configurable: true,
+      });
     } else if (def.kind === "get") {
       descriptor = { get: def.value, configurable: true, enumerable: false };
     } else if (def.kind === "set") {
@@ -1254,7 +1260,7 @@ helpers.decorate = helper("7.1.5")`
 
     var element /*: ElementDescriptor */ = {
       kind: def.kind === "field" ? "field" : "method",
-      key: def.key,
+      key: key,
       placement: def.static
         ? "static"
         : def.kind === "field"

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.2"
+        "helperVersion": "7.1.5"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/element-descriptors/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/element-descriptors/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.2"
+        "helperVersion": "7.1.5"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/finishers/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/finishers/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.2"
+        "helperVersion": "7.1.5"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name/exec.js
@@ -1,0 +1,8 @@
+function decorator() {}
+
+@decorator
+class Foo {
+  method() {}
+}
+
+expect(Foo.prototype.method.name).toBe("method");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/misc/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/misc/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    ["proposal-decorators", { "decoratorsBeforeExport": false }],
+    "proposal-class-properties",
+    [
+      "external-helpers",
+      {
+        "helperVersion": "7.1.5"
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/misc/to-primitive/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/misc/to-primitive/exec.js
@@ -1,0 +1,16 @@
+let calls = 0;
+const baz = {
+  [Symbol.toPrimitive]() {
+    calls++;
+    return "baz";
+  }
+}
+
+function dec() {}
+
+@dec
+class A {
+  [baz]() {}
+}
+
+expect(calls).toBe(1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/ordering/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/ordering/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.2"
+        "helperVersion": "7.1.5"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/async-generator-method/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/async-generator-method/options.json
@@ -3,6 +3,6 @@
     ["proposal-decorators", { "decoratorsBeforeExport": false }],
     "proposal-class-properties",
     "syntax-async-generators",
-    ["external-helpers", { "helperVersion": "7.0.2" }]
+    ["external-helpers", { "helperVersion": "7.1.5" }]
   ]
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/class-decorators-yield-await/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/class-decorators-yield-await/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.2"
+        "helperVersion": "7.1.5"
       }
     ],
     "syntax-async-generators"

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/options.json
@@ -5,7 +5,7 @@
     [
       "external-helpers",
       {
-        "helperVersion": "7.0.2"
+        "helperVersion": "7.1.5"
       }
     ]
   ]

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/options.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/options.json
@@ -2,6 +2,6 @@
   "plugins": [
     "syntax-async-generators",
     "proposal-object-rest-spread",
-    "external-helpers"
+    ["external-helpers", { "helperVersion": "7.1.5" }]
   ]
 }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-builtins/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.1.5" }],
     ["transform-destructuring", { "useBuiltIns": true }],
     "transform-spread",
     "transform-parameters",

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/options.json
@@ -1,6 +1,7 @@
 {
   "plugins": [
     ["transform-destructuring", { "loose": true }],
-    "proposal-object-rest-spread"
+    "proposal-object-rest-spread",
+    ["external-helpers", { "helperVersion": "7.1.5" }]
   ]
 }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/es7-object-rest-loose/output.js
@@ -1,29 +1,20 @@
-function _toPropertyKey(key) { if (typeof key === "symbol") { return key; } else { return String(key); } }
-
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-
 var z = {};
-
 var _z = z,
-    x = _extends({}, _z);
-
+    x = babelHelpers.extends({}, _z);
 var _z2 = z,
     x = _z2.x,
-    y = _objectWithoutPropertiesLoose(_z2, ["x"]);
-
+    y = babelHelpers.objectWithoutPropertiesLoose(_z2, ["x"]);
 var _z3 = z,
     x = _z3[x],
-    y = _objectWithoutPropertiesLoose(_z3, [x].map(_toPropertyKey));
+    y = babelHelpers.objectWithoutPropertiesLoose(_z3, [x].map(babelHelpers.toPropertyKey));
 
 (function (_ref) {
   let x = _ref.x,
-      y = _objectWithoutPropertiesLoose(_ref, ["x"]);
+      y = babelHelpers.objectWithoutPropertiesLoose(_ref, ["x"]);
 });
 
 var _o = o;
 x = _o.x;
 y = _o.y;
-z = _objectWithoutPropertiesLoose(_o, ["x", "y"]);
+z = babelHelpers.objectWithoutPropertiesLoose(_o, ["x", "y"]);
 _o;

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "external-helpers",
+    ["external-helpers", { "helperVersion": "7.1.5" }],
     "transform-destructuring",
     "transform-spread",
     "transform-parameters",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8740, fixes #8746
| Patch: Bug Fix?          | :+1: 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR probably also fixes some bugs with object rest and `@@toPrimitive`.

cc @miyaokamarina Thank you for the detailed investigation in the issue! I used `toPropertyKey` instead of `toPrimitive` because I merged steps 5 and 7 of the `ToElementDescriptor` operation (step 6 is not supported yet).