### PR TITLE
Improved build performance by optimizing makeMappingKey method.

### DIFF
--- a/packages/babel-core/src/transformation/file/merge-map.js
+++ b/packages/babel-core/src/transformation/file/merge-map.js
@@ -94,7 +94,7 @@ export default function mergeSourceMap(
 }
 
 function makeMappingKey(item: { line: number, columnStart: number }) {
-  return JSON.stringify([item.line, item.columnStart]);
+  return `${item.line}/${item.columnStart}`;
 }
 
 function eachOverlappingGeneratedOutputRange(


### PR DESCRIPTION
I improved performance of merge map algorithm. It improves babel build time in our application from ~65s to ~63s (-2s total time). JSON stringify seems really slow, I replaced it with string template.

Tested in NodeJS v10.10.0, babel 7.10.0

Before
![image](https://user-images.githubusercontent.com/2021355/45847842-0c2d1e80-bd35-11e8-9388-54507a3e1747.png)


After

![image](https://user-images.githubusercontent.com/2021355/45847865-2666fc80-bd35-11e8-9ef6-54042dd66b73.png)


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Tests pass
| Any Dependency Changes?  | No
| License                  | MIT