### PR TITLE
TypeScript: reserve `unknown` as TSUnknownKeyword

### DIFF
--- a/packages/babel-generator/src/generators/typescript.js
+++ b/packages/babel-generator/src/generators/typescript.js
@@ -127,6 +127,9 @@ export function TSIndexSignature(node) {
 export function TSAnyKeyword() {
   this.word("any");
 }
+export function TSUnknownKeyword() {
+  this.word("unknown");
+}
 export function TSNumberKeyword() {
   this.word("number");
 }

--- a/packages/babel-generator/test/fixtures/typescript/types-keywords/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-keywords/input.js
@@ -1,4 +1,5 @@
 let a: any;
+let un: unknown;
 let b: boolean;
 let ne: never;
 let nul: null;

--- a/packages/babel-generator/test/fixtures/typescript/types-keywords/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-keywords/output.js
@@ -1,4 +1,5 @@
 let a: any;
+let un: unknown;
 let b: boolean;
 let ne: never;
 let nul: null;

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -57,6 +57,8 @@ function keywordTypeFromName(
       return "TSSymbolKeyword";
     case "undefined":
       return "TSUndefinedKeyword";
+    case "unknown":
+      return "TSUnknownKeyword";
     default:
       return undefined;
   }

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1119,6 +1119,7 @@ export type TsTypeBase = NodeBase;
 
 export type TsKeywordTypeType =
   | "TSAnyKeyword"
+  | "TSUnknownKeyword"
   | "TSNumberKeyword"
   | "TSObjectKeyword"
   | "TSBooleanKeyword"

--- a/packages/babel-parser/test/fixtures/typescript/types/keywords/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/keywords/input.js
@@ -1,4 +1,5 @@
 let a: any;
+let un: unknown;
 let b: boolean;
 let ne: never;
 let nul: null;

--- a/packages/babel-parser/test/fixtures/typescript/types/keywords/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/keywords/output.json
@@ -1,28 +1,28 @@
 {
   "type": "File",
   "start": 0,
-  "end": 152,
+  "end": 169,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 10,
+      "line": 11,
       "column": 12
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 152,
+    "end": 169,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 10,
+        "line": 11,
         "column": 12
       }
     },
@@ -113,7 +113,7 @@
       {
         "type": "VariableDeclaration",
         "start": 12,
-        "end": 27,
+        "end": 28,
         "loc": {
           "start": {
             "line": 2,
@@ -121,308 +121,65 @@
           },
           "end": {
             "line": 2,
-            "column": 15
-          }
-        },
-        "declarations": [
-          {
-            "type": "VariableDeclarator",
-            "start": 16,
-            "end": 26,
-            "loc": {
-              "start": {
-                "line": 2,
-                "column": 4
-              },
-              "end": {
-                "line": 2,
-                "column": 14
-              }
-            },
-            "id": {
-              "type": "Identifier",
-              "start": 16,
-              "end": 26,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 4
-                },
-                "end": {
-                  "line": 2,
-                  "column": 14
-                },
-                "identifierName": "b"
-              },
-              "name": "b",
-              "typeAnnotation": {
-                "type": "TSTypeAnnotation",
-                "start": 17,
-                "end": 26,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 5
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 14
-                  }
-                },
-                "typeAnnotation": {
-                  "type": "TSBooleanKeyword",
-                  "start": 19,
-                  "end": 26,
-                  "loc": {
-                    "start": {
-                      "line": 2,
-                      "column": 7
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 14
-                    }
-                  }
-                }
-              }
-            },
-            "init": null
-          }
-        ],
-        "kind": "let"
-      },
-      {
-        "type": "VariableDeclaration",
-        "start": 28,
-        "end": 42,
-        "loc": {
-          "start": {
-            "line": 3,
-            "column": 0
-          },
-          "end": {
-            "line": 3,
-            "column": 14
-          }
-        },
-        "declarations": [
-          {
-            "type": "VariableDeclarator",
-            "start": 32,
-            "end": 41,
-            "loc": {
-              "start": {
-                "line": 3,
-                "column": 4
-              },
-              "end": {
-                "line": 3,
-                "column": 13
-              }
-            },
-            "id": {
-              "type": "Identifier",
-              "start": 32,
-              "end": 41,
-              "loc": {
-                "start": {
-                  "line": 3,
-                  "column": 4
-                },
-                "end": {
-                  "line": 3,
-                  "column": 13
-                },
-                "identifierName": "ne"
-              },
-              "name": "ne",
-              "typeAnnotation": {
-                "type": "TSTypeAnnotation",
-                "start": 34,
-                "end": 41,
-                "loc": {
-                  "start": {
-                    "line": 3,
-                    "column": 6
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13
-                  }
-                },
-                "typeAnnotation": {
-                  "type": "TSNeverKeyword",
-                  "start": 36,
-                  "end": 41,
-                  "loc": {
-                    "start": {
-                      "line": 3,
-                      "column": 8
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13
-                    }
-                  }
-                }
-              }
-            },
-            "init": null
-          }
-        ],
-        "kind": "let"
-      },
-      {
-        "type": "VariableDeclaration",
-        "start": 43,
-        "end": 57,
-        "loc": {
-          "start": {
-            "line": 4,
-            "column": 0
-          },
-          "end": {
-            "line": 4,
-            "column": 14
-          }
-        },
-        "declarations": [
-          {
-            "type": "VariableDeclarator",
-            "start": 47,
-            "end": 56,
-            "loc": {
-              "start": {
-                "line": 4,
-                "column": 4
-              },
-              "end": {
-                "line": 4,
-                "column": 13
-              }
-            },
-            "id": {
-              "type": "Identifier",
-              "start": 47,
-              "end": 56,
-              "loc": {
-                "start": {
-                  "line": 4,
-                  "column": 4
-                },
-                "end": {
-                  "line": 4,
-                  "column": 13
-                },
-                "identifierName": "nul"
-              },
-              "name": "nul",
-              "typeAnnotation": {
-                "type": "TSTypeAnnotation",
-                "start": 50,
-                "end": 56,
-                "loc": {
-                  "start": {
-                    "line": 4,
-                    "column": 7
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 13
-                  }
-                },
-                "typeAnnotation": {
-                  "type": "TSNullKeyword",
-                  "start": 52,
-                  "end": 56,
-                  "loc": {
-                    "start": {
-                      "line": 4,
-                      "column": 9
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 13
-                    }
-                  }
-                }
-              }
-            },
-            "init": null
-          }
-        ],
-        "kind": "let"
-      },
-      {
-        "type": "VariableDeclaration",
-        "start": 58,
-        "end": 74,
-        "loc": {
-          "start": {
-            "line": 5,
-            "column": 0
-          },
-          "end": {
-            "line": 5,
             "column": 16
           }
         },
         "declarations": [
           {
             "type": "VariableDeclarator",
-            "start": 62,
-            "end": 73,
+            "start": 16,
+            "end": 27,
             "loc": {
               "start": {
-                "line": 5,
+                "line": 2,
                 "column": 4
               },
               "end": {
-                "line": 5,
+                "line": 2,
                 "column": 15
               }
             },
             "id": {
               "type": "Identifier",
-              "start": 62,
-              "end": 73,
+              "start": 16,
+              "end": 27,
               "loc": {
                 "start": {
-                  "line": 5,
+                  "line": 2,
                   "column": 4
                 },
                 "end": {
-                  "line": 5,
+                  "line": 2,
                   "column": 15
                 },
-                "identifierName": "num"
+                "identifierName": "un"
               },
-              "name": "num",
+              "name": "un",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start": 65,
-                "end": 73,
+                "start": 18,
+                "end": 27,
                 "loc": {
                   "start": {
-                    "line": 5,
-                    "column": 7
+                    "line": 2,
+                    "column": 6
                   },
                   "end": {
-                    "line": 5,
+                    "line": 2,
                     "column": 15
                   }
                 },
                 "typeAnnotation": {
-                  "type": "TSNumberKeyword",
-                  "start": 67,
-                  "end": 73,
+                  "type": "TSUnknownKeyword",
+                  "start": 20,
+                  "end": 27,
                   "loc": {
                     "start": {
-                      "line": 5,
-                      "column": 9
+                      "line": 2,
+                      "column": 8
                     },
                     "end": {
-                      "line": 5,
+                      "line": 2,
                       "column": 15
                     }
                   }
@@ -436,74 +193,155 @@
       },
       {
         "type": "VariableDeclaration",
-        "start": 75,
-        "end": 89,
+        "start": 29,
+        "end": 44,
         "loc": {
           "start": {
-            "line": 6,
+            "line": 3,
             "column": 0
           },
           "end": {
-            "line": 6,
+            "line": 3,
+            "column": 15
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 33,
+            "end": 43,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 4
+              },
+              "end": {
+                "line": 3,
+                "column": 14
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 33,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 4
+                },
+                "end": {
+                  "line": 3,
+                  "column": 14
+                },
+                "identifierName": "b"
+              },
+              "name": "b",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 34,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 14
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSBooleanKeyword",
+                  "start": 36,
+                  "end": 43,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 14
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 45,
+        "end": 59,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
             "column": 14
           }
         },
         "declarations": [
           {
             "type": "VariableDeclarator",
-            "start": 79,
-            "end": 88,
+            "start": 49,
+            "end": 58,
             "loc": {
               "start": {
-                "line": 6,
+                "line": 4,
                 "column": 4
               },
               "end": {
-                "line": 6,
+                "line": 4,
                 "column": 13
               }
             },
             "id": {
               "type": "Identifier",
-              "start": 79,
-              "end": 88,
+              "start": 49,
+              "end": 58,
               "loc": {
                 "start": {
-                  "line": 6,
+                  "line": 4,
                   "column": 4
                 },
                 "end": {
-                  "line": 6,
+                  "line": 4,
                   "column": 13
                 },
-                "identifierName": "o"
+                "identifierName": "ne"
               },
-              "name": "o",
+              "name": "ne",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start": 80,
-                "end": 88,
+                "start": 51,
+                "end": 58,
                 "loc": {
                   "start": {
-                    "line": 6,
-                    "column": 5
+                    "line": 4,
+                    "column": 6
                   },
                   "end": {
-                    "line": 6,
+                    "line": 4,
                     "column": 13
                   }
                 },
                 "typeAnnotation": {
-                  "type": "TSObjectKeyword",
-                  "start": 82,
-                  "end": 88,
+                  "type": "TSNeverKeyword",
+                  "start": 53,
+                  "end": 58,
                   "loc": {
                     "start": {
-                      "line": 6,
-                      "column": 7
+                      "line": 4,
+                      "column": 8
                     },
                     "end": {
-                      "line": 6,
+                      "line": 4,
                       "column": 13
                     }
                   }
@@ -517,8 +355,170 @@
       },
       {
         "type": "VariableDeclaration",
-        "start": 90,
-        "end": 105,
+        "start": 60,
+        "end": 74,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 14
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 64,
+            "end": 73,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 4
+              },
+              "end": {
+                "line": 5,
+                "column": 13
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 64,
+              "end": 73,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 4
+                },
+                "end": {
+                  "line": 5,
+                  "column": 13
+                },
+                "identifierName": "nul"
+              },
+              "name": "nul",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 67,
+                "end": 73,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 13
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSNullKeyword",
+                  "start": 69,
+                  "end": 73,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 13
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 75,
+        "end": 91,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 16
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 79,
+            "end": 90,
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 4
+              },
+              "end": {
+                "line": 6,
+                "column": 15
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 79,
+              "end": 90,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 4
+                },
+                "end": {
+                  "line": 6,
+                  "column": 15
+                },
+                "identifierName": "num"
+              },
+              "name": "num",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 82,
+                "end": 90,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 15
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSNumberKeyword",
+                  "start": 84,
+                  "end": 90,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 15
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 92,
+        "end": 106,
         "loc": {
           "start": {
             "line": 7,
@@ -526,14 +526,14 @@
           },
           "end": {
             "line": 7,
-            "column": 15
+            "column": 14
           }
         },
         "declarations": [
           {
             "type": "VariableDeclarator",
-            "start": 94,
-            "end": 104,
+            "start": 96,
+            "end": 105,
             "loc": {
               "start": {
                 "line": 7,
@@ -541,13 +541,13 @@
               },
               "end": {
                 "line": 7,
-                "column": 14
+                "column": 13
               }
             },
             "id": {
               "type": "Identifier",
-              "start": 94,
-              "end": 104,
+              "start": 96,
+              "end": 105,
               "loc": {
                 "start": {
                   "line": 7,
@@ -555,6 +555,87 @@
                 },
                 "end": {
                   "line": 7,
+                  "column": 13
+                },
+                "identifierName": "o"
+              },
+              "name": "o",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 97,
+                "end": 105,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 13
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSObjectKeyword",
+                  "start": 99,
+                  "end": 105,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 13
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 107,
+        "end": 122,
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 0
+          },
+          "end": {
+            "line": 8,
+            "column": 15
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 111,
+            "end": 121,
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 4
+              },
+              "end": {
+                "line": 8,
+                "column": 14
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 111,
+              "end": 121,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 4
+                },
+                "end": {
+                  "line": 8,
                   "column": 14
                 },
                 "identifierName": "st"
@@ -562,29 +643,29 @@
               "name": "st",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start": 96,
-                "end": 104,
+                "start": 113,
+                "end": 121,
                 "loc": {
                   "start": {
-                    "line": 7,
+                    "line": 8,
                     "column": 6
                   },
                   "end": {
-                    "line": 7,
+                    "line": 8,
                     "column": 14
                   }
                 },
                 "typeAnnotation": {
                   "type": "TSStringKeyword",
-                  "start": 98,
-                  "end": 104,
+                  "start": 115,
+                  "end": 121,
                   "loc": {
                     "start": {
-                      "line": 7,
+                      "line": 8,
                       "column": 8
                     },
                     "end": {
-                      "line": 7,
+                      "line": 8,
                       "column": 14
                     }
                   }
@@ -598,44 +679,44 @@
       },
       {
         "type": "VariableDeclaration",
-        "start": 106,
-        "end": 121,
+        "start": 123,
+        "end": 138,
         "loc": {
           "start": {
-            "line": 8,
+            "line": 9,
             "column": 0
           },
           "end": {
-            "line": 8,
+            "line": 9,
             "column": 15
           }
         },
         "declarations": [
           {
             "type": "VariableDeclarator",
-            "start": 110,
-            "end": 120,
+            "start": 127,
+            "end": 137,
             "loc": {
               "start": {
-                "line": 8,
+                "line": 9,
                 "column": 4
               },
               "end": {
-                "line": 8,
+                "line": 9,
                 "column": 14
               }
             },
             "id": {
               "type": "Identifier",
-              "start": 110,
-              "end": 120,
+              "start": 127,
+              "end": 137,
               "loc": {
                 "start": {
-                  "line": 8,
+                  "line": 9,
                   "column": 4
                 },
                 "end": {
-                  "line": 8,
+                  "line": 9,
                   "column": 14
                 },
                 "identifierName": "sy"
@@ -643,29 +724,29 @@
               "name": "sy",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start": 112,
-                "end": 120,
+                "start": 129,
+                "end": 137,
                 "loc": {
                   "start": {
-                    "line": 8,
+                    "line": 9,
                     "column": 6
                   },
                   "end": {
-                    "line": 8,
+                    "line": 9,
                     "column": 14
                   }
                 },
                 "typeAnnotation": {
                   "type": "TSSymbolKeyword",
-                  "start": 114,
-                  "end": 120,
+                  "start": 131,
+                  "end": 137,
                   "loc": {
                     "start": {
-                      "line": 8,
+                      "line": 9,
                       "column": 8
                     },
                     "end": {
-                      "line": 8,
+                      "line": 9,
                       "column": 14
                     }
                   }
@@ -679,44 +760,44 @@
       },
       {
         "type": "VariableDeclaration",
-        "start": 122,
-        "end": 139,
+        "start": 139,
+        "end": 156,
         "loc": {
           "start": {
-            "line": 9,
+            "line": 10,
             "column": 0
           },
           "end": {
-            "line": 9,
+            "line": 10,
             "column": 17
           }
         },
         "declarations": [
           {
             "type": "VariableDeclarator",
-            "start": 126,
-            "end": 138,
+            "start": 143,
+            "end": 155,
             "loc": {
               "start": {
-                "line": 9,
+                "line": 10,
                 "column": 4
               },
               "end": {
-                "line": 9,
+                "line": 10,
                 "column": 16
               }
             },
             "id": {
               "type": "Identifier",
-              "start": 126,
-              "end": 138,
+              "start": 143,
+              "end": 155,
               "loc": {
                 "start": {
-                  "line": 9,
+                  "line": 10,
                   "column": 4
                 },
                 "end": {
-                  "line": 9,
+                  "line": 10,
                   "column": 16
                 },
                 "identifierName": "u"
@@ -724,29 +805,29 @@
               "name": "u",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start": 127,
-                "end": 138,
+                "start": 144,
+                "end": 155,
                 "loc": {
                   "start": {
-                    "line": 9,
+                    "line": 10,
                     "column": 5
                   },
                   "end": {
-                    "line": 9,
+                    "line": 10,
                     "column": 16
                   }
                 },
                 "typeAnnotation": {
                   "type": "TSUndefinedKeyword",
-                  "start": 129,
-                  "end": 138,
+                  "start": 146,
+                  "end": 155,
                   "loc": {
                     "start": {
-                      "line": 9,
+                      "line": 10,
                       "column": 7
                     },
                     "end": {
-                      "line": 9,
+                      "line": 10,
                       "column": 16
                     }
                   }
@@ -760,44 +841,44 @@
       },
       {
         "type": "VariableDeclaration",
-        "start": 140,
-        "end": 152,
+        "start": 157,
+        "end": 169,
         "loc": {
           "start": {
-            "line": 10,
+            "line": 11,
             "column": 0
           },
           "end": {
-            "line": 10,
+            "line": 11,
             "column": 12
           }
         },
         "declarations": [
           {
             "type": "VariableDeclarator",
-            "start": 144,
-            "end": 151,
+            "start": 161,
+            "end": 168,
             "loc": {
               "start": {
-                "line": 10,
+                "line": 11,
                 "column": 4
               },
               "end": {
-                "line": 10,
+                "line": 11,
                 "column": 11
               }
             },
             "id": {
               "type": "Identifier",
-              "start": 144,
-              "end": 151,
+              "start": 161,
+              "end": 168,
               "loc": {
                 "start": {
-                  "line": 10,
+                  "line": 11,
                   "column": 4
                 },
                 "end": {
-                  "line": 10,
+                  "line": 11,
                   "column": 11
                 },
                 "identifierName": "v"
@@ -805,29 +886,29 @@
               "name": "v",
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
-                "start": 145,
-                "end": 151,
+                "start": 162,
+                "end": 168,
                 "loc": {
                   "start": {
-                    "line": 10,
+                    "line": 11,
                     "column": 5
                   },
                   "end": {
-                    "line": 10,
+                    "line": 11,
                     "column": 11
                   }
                 },
                 "typeAnnotation": {
                   "type": "TSVoidKeyword",
-                  "start": 147,
-                  "end": 151,
+                  "start": 164,
+                  "end": 168,
                   "loc": {
                     "start": {
-                      "line": 10,
+                      "line": 11,
                       "column": 7
                     },
                     "end": {
-                      "line": 10,
+                      "line": 11,
                       "column": 11
                     }
                   }

--- a/packages/babel-types/src/asserts/generated/index.js
+++ b/packages/babel-types/src/asserts/generated/index.js
@@ -762,6 +762,9 @@ export function assertTSIndexSignature(node: Object, opts?: Object = {}): void {
 export function assertTSAnyKeyword(node: Object, opts?: Object = {}): void {
   assert("TSAnyKeyword", node, opts);
 }
+export function assertTSUnknownKeyword(node: Object, opts?: Object = {}): void {
+  assert("TSUnknownKeyword", node, opts);
+}
 export function assertTSNumberKeyword(node: Object, opts?: Object = {}): void {
   assert("TSNumberKeyword", node, opts);
 }

--- a/packages/babel-types/src/builders/generated/index.js
+++ b/packages/babel-types/src/builders/generated/index.js
@@ -698,6 +698,11 @@ export function TSAnyKeyword(...args: Array<any>): Object {
 }
 export { TSAnyKeyword as tsAnyKeyword };
 export { TSAnyKeyword as tSAnyKeyword };
+export function TSUnknownKeyword(...args: Array<any>): Object {
+  return builder("TSUnknownKeyword", ...args);
+}
+export { TSUnknownKeyword as tsUnknownKeyword };
+export { TSUnknownKeyword as tSUnknownKeyword };
 export function TSNumberKeyword(...args: Array<any>): Object {
   return builder("TSNumberKeyword", ...args);
 }

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -128,6 +128,7 @@ defineType("TSIndexSignature", {
 
 const tsKeywordTypes = [
   "TSAnyKeyword",
+  "TSUnknownKeyword",
   "TSNumberKeyword",
   "TSObjectKeyword",
   "TSBooleanKeyword",

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -2406,6 +2406,20 @@ export function isTSAnyKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
+export function isTSUnknownKeyword(node: Object, opts?: Object): boolean {
+  if (!node) return false;
+
+  const nodeType = node.type;
+  if (nodeType === "TSUnknownKeyword") {
+    if (typeof opts === "undefined") {
+      return true;
+    } else {
+      return shallowEqual(node, opts);
+    }
+  }
+
+  return false;
+}
 export function isTSNumberKeyword(node: Object, opts?: Object): boolean {
   if (!node) return false;
 
@@ -4116,6 +4130,7 @@ export function isTSType(node: Object, opts?: Object): boolean {
   if (
     nodeType === "TSType" ||
     "TSAnyKeyword" === nodeType ||
+    "TSUnknownKeyword" === nodeType ||
     "TSNumberKeyword" === nodeType ||
     "TSObjectKeyword" === nodeType ||
     "TSBooleanKeyword" === nodeType ||


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | None
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`unknown` is reserved as a keyword since TypeScript 3.0, so I add it. The AST node name is `TSUnknownKeyword`.