### PR TITLE
class private methods and properties: should not allow spaces between # and identifier

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -923,7 +923,19 @@ export default class ExpressionParser extends LValParser {
     if (isPrivate) {
       this.expectOnePlugin(["classPrivateProperties", "classPrivateMethods"]);
       const node = this.startNode();
+      const columnHashEnd = this.state.end;
       this.next();
+      const columnIdentifierStart = this.state.start;
+
+      const spacesBetweenHashAndIdentifier =
+        columnIdentifierStart - columnHashEnd;
+      if (spacesBetweenHashAndIdentifier != 0) {
+        this.raise(
+          columnIdentifierStart,
+          "Unexpected space between # and identifier",
+        );
+      }
+
       node.id = this.parseIdentifier(true);
       return this.finishNode(node, "PrivateName");
     } else {

--- a/packages/babel-parser/test/fixtures/experimental/class-private-methods/failure-spaces/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-methods/failure-spaces/input.js
@@ -1,0 +1,5 @@
+class Spaces {
+  #  wrongSpaces() {
+    return fail();
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-methods/failure-spaces/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-methods/failure-spaces/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "Unexpected space between # and identifier (2:5)",
+  "plugins": ["classPrivateMethods"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/failure-spaces/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/failure-spaces/input.js
@@ -1,0 +1,3 @@
+class Spaces {
+  #  wrongSpaces;
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/failure-spaces/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/failure-spaces/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "Unexpected space between # and identifier (2:5)",
+  "plugins": ["classPrivateMethods"]
+}


### PR DESCRIPTION
Following https://github.com/babel/proposals/issues/12#issuecomment-399756043, we should not allow spaces between `#` and identifier.
But, since we currently allow it, this fix is a breaking change.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8225
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT