### PR TITLE
Use babel-check-duplicated-nodes

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.1.0",
     "@babel/helper-fixtures": "^7.0.0",
     "@babel/polyfill": "^7.0.0",
+    "babel-check-duplicated-nodes": "^1.0.0",
     "jest": "^22.4.2",
     "jest-diff": "^22.4.0",
     "lodash": "^4.17.10",


### PR DESCRIPTION
The code that I removed in this PR was extracted by @Andarist so that it can aldo be used by regenerator. `babel-check-duplicated-nodes` contains exactly the same code.