### PR TITLE
jsx: fix sequence expression at JSXAttributeValue

### DIFF
--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -327,8 +327,22 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         node.expression = this.jsxParseEmptyExpression();
       } else {
         node.expression = this.parseExpression();
+
+        if (
+          node.expression.type === "SequenceExpression" &&
+          ((node.expression.extra &&
+            node.expression.extra.parenthesized === false) ||
+            node.expression.extra === undefined)
+        ) {
+          this.raise(
+            this.state.start,
+            "Sequence of values at JSX must be parenthesized.",
+          );
+        }
       }
+
       this.expect(tt.braceR);
+
       return this.finishNode(node, "JSXExpressionContainer");
     }
 

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -330,9 +330,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
         if (
           node.expression.type === "SequenceExpression" &&
-          ((node.expression.extra &&
-            node.expression.extra.parenthesized === false) ||
-            node.expression.extra === undefined)
+          (!node.expression.extra ||
+            node.expression.extra.parenthesized !== true)
         ) {
           this.raise(
             this.state.start,

--- a/packages/babel-parser/src/plugins/jsx/index.js
+++ b/packages/babel-parser/src/plugins/jsx/index.js
@@ -326,20 +326,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (this.match(tt.braceR)) {
         node.expression = this.jsxParseEmptyExpression();
       } else {
-        node.expression = this.parseExpression();
-
-        if (
-          node.expression.type === "SequenceExpression" &&
-          (!node.expression.extra ||
-            node.expression.extra.parenthesized !== true)
-        ) {
-          this.raise(
-            this.state.start,
-            "Sequence of values at JSX must be parenthesized.",
-          );
-        }
+        node.expression = this.parseMaybeAssign();
       }
-
       this.expect(tt.braceR);
 
       return this.finishNode(node, "JSXExpressionContainer");

--- a/packages/babel-parser/test/fixtures/jsx/basic/sequence-expression/input.js
+++ b/packages/babel-parser/test/fixtures/jsx/basic/sequence-expression/input.js
@@ -1,0 +1,1 @@
+<div>{(console.log('foo'), JSON.stringify(props))}</div>

--- a/packages/babel-parser/test/fixtures/jsx/basic/sequence-expression/output.json
+++ b/packages/babel-parser/test/fixtures/jsx/basic/sequence-expression/output.json
@@ -1,0 +1,338 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 56,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 56
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 56,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 56
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 56,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 56
+          }
+        },
+        "expression": {
+          "type": "JSXElement",
+          "start": 0,
+          "end": 56,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 56
+            }
+          },
+          "openingElement": {
+            "type": "JSXOpeningElement",
+            "start": 0,
+            "end": 5,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "name": {
+              "type": "JSXIdentifier",
+              "start": 1,
+              "end": 4,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 4
+                }
+              },
+              "name": "div"
+            },
+            "attributes": [],
+            "selfClosing": false
+          },
+          "closingElement": {
+            "type": "JSXClosingElement",
+            "start": 50,
+            "end": 56,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 50
+              },
+              "end": {
+                "line": 1,
+                "column": 56
+              }
+            },
+            "name": {
+              "type": "JSXIdentifier",
+              "start": 52,
+              "end": 55,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 52
+                },
+                "end": {
+                  "line": 1,
+                  "column": 55
+                }
+              },
+              "name": "div"
+            }
+          },
+          "children": [
+            {
+              "type": "JSXExpressionContainer",
+              "start": 5,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 5
+                },
+                "end": {
+                  "line": 1,
+                  "column": 50
+                }
+              },
+              "expression": {
+                "type": "SequenceExpression",
+                "start": 7,
+                "end": 48,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 48
+                  }
+                },
+                "expressions": [
+                  {
+                    "type": "CallExpression",
+                    "start": 7,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 25
+                      }
+                    },
+                    "callee": {
+                      "type": "MemberExpression",
+                      "start": 7,
+                      "end": 18,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 18
+                        }
+                      },
+                      "object": {
+                        "type": "Identifier",
+                        "start": 7,
+                        "end": 14,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 7
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 14
+                          },
+                          "identifierName": "console"
+                        },
+                        "name": "console"
+                      },
+                      "property": {
+                        "type": "Identifier",
+                        "start": 15,
+                        "end": 18,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 15
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 18
+                          },
+                          "identifierName": "log"
+                        },
+                        "name": "log"
+                      },
+                      "computed": false
+                    },
+                    "arguments": [
+                      {
+                        "type": "StringLiteral",
+                        "start": 19,
+                        "end": 24,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 19
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 24
+                          }
+                        },
+                        "extra": {
+                          "rawValue": "foo",
+                          "raw": "'foo'"
+                        },
+                        "value": "foo"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CallExpression",
+                    "start": 27,
+                    "end": 48,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 27
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 48
+                      }
+                    },
+                    "callee": {
+                      "type": "MemberExpression",
+                      "start": 27,
+                      "end": 41,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 27
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 41
+                        }
+                      },
+                      "object": {
+                        "type": "Identifier",
+                        "start": 27,
+                        "end": 31,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 27
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 31
+                          },
+                          "identifierName": "JSON"
+                        },
+                        "name": "JSON"
+                      },
+                      "property": {
+                        "type": "Identifier",
+                        "start": 32,
+                        "end": 41,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 32
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 41
+                          },
+                          "identifierName": "stringify"
+                        },
+                        "name": "stringify"
+                      },
+                      "computed": false
+                    },
+                    "arguments": [
+                      {
+                        "type": "Identifier",
+                        "start": 42,
+                        "end": 47,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 42
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 47
+                          },
+                          "identifierName": "props"
+                        },
+                        "name": "props"
+                      }
+                    ]
+                  }
+                ],
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 6
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/jsx/errors/attribute-sequence-expression/input.js
+++ b/packages/babel-parser/test/fixtures/jsx/errors/attribute-sequence-expression/input.js
@@ -1,0 +1,1 @@
+<div key={console.log('foo'), JSON.stringify(props)} />

--- a/packages/babel-parser/test/fixtures/jsx/errors/attribute-sequence-expression/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/attribute-sequence-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Sequence of values at JSX must be parenthesized. (1:51)"
+  "throws": "Unexpected token, expected \"}\" (1:28)"
 }

--- a/packages/babel-parser/test/fixtures/jsx/errors/attribute-sequence-expression/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/attribute-sequence-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Sequence of values at JSX must be parenthesized. (1:51)"
+}

--- a/packages/babel-parser/test/fixtures/jsx/errors/sequence-expression/input.js
+++ b/packages/babel-parser/test/fixtures/jsx/errors/sequence-expression/input.js
@@ -1,0 +1,1 @@
+<div>{console.log('foo'), JSON.stringify(props)}</div>

--- a/packages/babel-parser/test/fixtures/jsx/errors/sequence-expression/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/sequence-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Sequence of values at JSX must be parenthesized. (1:47)"
+}

--- a/packages/babel-parser/test/fixtures/jsx/errors/sequence-expression/options.json
+++ b/packages/babel-parser/test/fixtures/jsx/errors/sequence-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Sequence of values at JSX must be parenthesized. (1:47)"
+  "throws": "Unexpected token, expected \"}\" (1:24)"
 }


### PR DESCRIPTION
Following https://github.com/babel/babel/issues/8604, we should not allow codes like these
```js
<div key={console.log('foo'), JSON.stringify(props)} />
<div>{console.log('foo'), JSON.stringify(props)}</div>
```

But we should allow codes like
```js
<div key={(console.log('foo'), JSON.stringify(props))} />
<div>{(console.log('foo'), JSON.stringify(props))}</div>
```

This PR fixes it, raising an exception with this message: `Sequence of values at JSX must be parenthesized.`
But, since we currently allow the wrong code, this fix is a breaking change.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8604
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT