### PR TITLE
types: allow jsxEmptyExpression inside jsxExpressionContainer

### DIFF
--- a/packages/babel-types/src/definitions/jsx.js
+++ b/packages/babel-types/src/definitions/jsx.js
@@ -73,7 +73,7 @@ defineType("JSXExpressionContainer", {
   aliases: ["JSX", "Immutable"],
   fields: {
     expression: {
-      validate: assertNodeType("Expression"),
+      validate: assertNodeType("Expression", "JSXEmptyExpression"),
     },
   },
 });


### PR DESCRIPTION
This fixes #8549.

This now allows to create a JSXEmptyExpression inside a JSXExpressionContainer, which allows you to construct block comments inside JSX:

```js
<div>{ /* I'm a comment */ }</div>
```

The JSXElement child can be created using:

```js
const expr = types.jsxEmptyExpression();
types.addComment(expr, "leading", " I'm a comment ");
types.jsxExpressionContainer(emptyExpression);
```

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8549 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | -
| Minor: New Feature?      | -
| Tests Added + Pass?      | Nothing added
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | -
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
