### PR TITLE
Fix perf issue in typescript parser plugin

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -1368,10 +1368,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return this.finishNode(nonNullExpression, "TSNonNullExpression");
       }
 
-      // There are number of things we are going to "maybe" parse, like type arguments on
-      // tagged template expressions. If any of them fail, walk it back and continue.
-      const result = this.tsTryParseAndCatch(() => {
-        if (this.isRelational("<")) {
+      if (this.isRelational("<")) {
+        // tsTryParseAndCatch is expensive, so avoid if not necessary.
+        // There are number of things we are going to "maybe" parse, like type arguments on
+        // tagged template expressions. If any of them fail, walk it back and continue.
+        const result = this.tsTryParseAndCatch(() => {
           if (!noCalls && this.atPossibleAsync(base)) {
             // Almost certainly this is a generic async function `async <T>() => ...
             // But it might be a call with a type argument `async<T>();`
@@ -1409,12 +1410,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
               );
             }
           }
-        }
 
-        this.unexpected();
-      });
+          this.unexpected();
+        });
 
-      if (result) return result;
+        if (result) return result;
+      }
 
       return super.parseSubscript(base, startPos, startLoc, noCalls, state);
     }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8779 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/A
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

This commit fixes a perf regression introduced by 8ee24fd. Throwing an
exception in `tsTryParseAndCatch` is expensive. We can avoid it in the
common case by moving the conditional outside of the callback passed
to `tsTryParseAndCatch`.
