### PR TITLE
Add @babel/parser support for typescript type import()

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -219,7 +219,25 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsParseEntityName(allowReservedWords: boolean): N.TsEntityName {
-      let entity: N.TsEntityName = this.parseIdentifier();
+      let entity: N.TsEntityName;
+      // TODO: package this into its own tsParse function
+      if (this.state.type === tt._import) {
+        entity = this.startNode();
+        this.next();
+        if (!this.match(tt.parenL)) {
+          this.unexpected(null, tt.parenL);
+        }
+        this.eat(tt.parenL);
+        const args = this.parseCallExpressionArguments(tt.parenR, false, {
+          start: -1,
+        });
+        // TODO: assert args is length 1
+        entity.argument = args[0];
+        // TODO: make a TS-specific node type
+        entity = this.finishNode(entity, "Import");
+      } else {
+        entity = this.parseIdentifier();
+      }
       while (this.eat(tt.dot)) {
         const node: N.TsQualifiedName = this.startNodeAtNode(entity);
         node.left = entity;
@@ -595,6 +613,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         }
         case tt._typeof:
           return this.tsParseTypeQuery();
+        case tt._import:
+          // TODO: should this really be the same as parsing the RHS of typeof?
+          // XXX: TSQualifiedName is not allowed to be a return type of this function but import() references
+          // are allowed to have dots to access exported members
+          return this.tsParseEntityName(true);
         case tt.braceL:
           return this.tsLookAhead(this.tsIsStartOfMappedType.bind(this))
             ? this.tsParseMappedType()

--- a/packages/babel-parser/test/fixtures/typescript/types/import/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/input.js
@@ -1,0 +1,2 @@
+let x: typeof import('./x');
+let Y: import('./y').Y;

--- a/packages/babel-parser/test/fixtures/typescript/types/import/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/options.json
@@ -1,4 +1,0 @@
-{
-  "sourceType": "module",
-  "plugins": ["typescript", "dynamicImport"]
-}

--- a/packages/babel-parser/test/fixtures/typescript/types/import/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["typescript", "dynamicImport"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/import/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/output.json
@@ -1,0 +1,284 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 52,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 23
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 52,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 23
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 28
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 5,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 27
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSTypeQuery",
+                  "start": 7,
+                  "end": 27,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 27
+                    }
+                  },
+                  "exprName": {
+                    "type": "Import",
+                    "start": 14,
+                    "end": 27,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 27
+                      }
+                    },
+                    "argument": {
+                      "type": "StringLiteral",
+                      "start": 21,
+                      "end": 26,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 21
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 26
+                        }
+                      },
+                      "extra": {
+                        "rawValue": "./x",
+                        "raw": "'./x'"
+                      },
+                      "value": "./x"
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 29,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 23
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 33,
+            "end": 51,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 22
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 33,
+              "end": 51,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 22
+                },
+                "identifierName": "Y"
+              },
+              "name": "Y",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 34,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 22
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSQualifiedName",
+                  "start": 36,
+                  "end": 51,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 22
+                    }
+                  },
+                  "left": {
+                    "type": "Import",
+                    "start": 36,
+                    "end": 49,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 20
+                      }
+                    },
+                    "argument": {
+                      "type": "StringLiteral",
+                      "start": 43,
+                      "end": 48,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 14
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 19
+                        }
+                      },
+                      "extra": {
+                        "rawValue": "./y",
+                        "raw": "'./y'"
+                      },
+                      "value": "./y"
+                    }
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 50,
+                    "end": 51,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 22
+                      },
+                      "identifierName": "Y"
+                    },
+                    "name": "Y"
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #7749
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This was my first time touching the parser at all so I'm kinda lost as to what to do; but through hacks and ~~`printf`~~ `console.log` debugging I got something that works, even if it's producing invalid AST nodes.

There are various TODOs and a possible problem that I noted in comments in the code.

One of the things I think is important is that this `import()` be its own node type (`TSImport`?) instead of the `CallExpression(Import, AssignmentExpression)` it normally would be if parsed with the `dynamicImport` parser. This also needs to work even when the `dynamicImport` plugin is not enabled, as it does not actually represent a dynamic import, just copies its syntax.

This definitely needs more work, I just want to know what the next steps are 😊