### PR TITLE
Typescript: Validate tuple type element positions

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -513,14 +513,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       //   If there's a rest element, it must be at the end of the tuple
       let seenOptionalElement = false;
       node.elementTypes.forEach((elementNode, i) => {
-        if (
-          elementNode.type === "TSRestType" &&
-          i !== node.elementTypes.length - 1
-        ) {
-          this.raise(
-            elementNode.start,
-            "A rest element must be last in a tuple type.",
-          );
+        if (elementNode.type === "TSRestType") {
+          if (i !== node.elementTypes.length - 1) {
+            this.raise(
+              elementNode.start,
+              "A rest element must be last in a tuple type.",
+            );
+          }
         } else if (elementNode.type === "TSOptionalType") {
           seenOptionalElement = true;
         } else if (seenOptionalElement) {

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/input.js
@@ -1,0 +1,1 @@
+let x: [string?, number]

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "typescript"
+  ],
+  "throws": "A required element cannot follow an optional element. (1:17)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-after-optional/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-after-optional/input.js
@@ -1,0 +1,1 @@
+function foo(...args: [number, string?, ...number[]]) {}

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-after-optional/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-after-optional/output.json
@@ -1,0 +1,242 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 56,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 56
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 56,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 56
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 56,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 56
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "RestElement",
+            "start": 13,
+            "end": 52,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 52
+              }
+            },
+            "argument": {
+              "type": "Identifier",
+              "start": 16,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                },
+                "identifierName": "args"
+              },
+              "name": "args"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 20,
+              "end": 52,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 20
+                },
+                "end": {
+                  "line": 1,
+                  "column": 52
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSTupleType",
+                "start": 22,
+                "end": 52,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 52
+                  }
+                },
+                "elementTypes": [
+                  {
+                    "type": "TSNumberKeyword",
+                    "start": 23,
+                    "end": 29,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 29
+                      }
+                    }
+                  },
+                  {
+                    "type": "TSOptionalType",
+                    "start": 31,
+                    "end": 38,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 31
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 38
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "TSStringKeyword",
+                      "start": 31,
+                      "end": 37,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 31
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 37
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "TSRestType",
+                    "start": 40,
+                    "end": 51,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 40
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 51
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "TSArrayType",
+                      "start": 43,
+                      "end": 51,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 43
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 51
+                        }
+                      },
+                      "elementType": {
+                        "type": "TSNumberKeyword",
+                        "start": 43,
+                        "end": 49,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 43
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 49
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "body": {
+          "type": "BlockStatement",
+          "start": 54,
+          "end": 56,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 54
+            },
+            "end": {
+              "line": 1,
+              "column": 56
+            }
+          },
+          "body": [],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/input.js
@@ -1,0 +1,1 @@
+let x: [...number[], string]

--- a/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/tuple-rest-invalid/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "typescript"
+  ],
+  "throws": "A rest element must be last in a tuple type. (1:8)"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Adds additional validation to the parser functionality added by #8720 and #8805.  Per [this comment](https://github.com/babel/babel/pull/8805#issuecomment-427252654), adds a validation step to the parser which raises syntax errors if a rest param is not at the end of a tuple, or if a mandatory param follows an optional parameter.  So the following snippets are correctly considered syntax errors:

```ts
const x: [number?, number]; // can't have mandatory member after optional member
const x: [...number[], string]; // rest element must be the last element of the tuple
```