### PR TITLE
fix single-arg async arrows when retainLines=true

### DIFF
--- a/packages/babel-generator/src/generators/methods.js
+++ b/packages/babel-generator/src/generators/methods.js
@@ -111,7 +111,23 @@ export function ArrowFunctionExpression(node: Object) {
     t.isIdentifier(firstParam) &&
     !hasTypes(node, firstParam)
   ) {
-    this.print(firstParam, node);
+    if (
+      this.format.retainLines &&
+      node.loc.start.line < node.body.loc.start.line
+    ) {
+      this.token("(");
+      if (firstParam.loc.start.line > node.loc.start.line) {
+        this.indent();
+        this.print(firstParam, node);
+        this.dedent();
+        this._catchUp("start", node.body.loc);
+      } else {
+        this.print(firstParam, node);
+      }
+      this.token(")");
+    } else {
+      this.print(firstParam, node);
+    }
   } else {
     this._params(node);
   }

--- a/packages/babel-generator/test/fixtures/edgecase/single-arg-async-arrow-with-retainlines/input.js
+++ b/packages/babel-generator/test/fixtures/edgecase/single-arg-async-arrow-with-retainlines/input.js
@@ -1,0 +1,11 @@
+var fn = async (
+    arg
+) => {}
+
+async (x)
+=> {}
+
+async x => {}
+
+async (x
+) => {};

--- a/packages/babel-generator/test/fixtures/edgecase/single-arg-async-arrow-with-retainlines/options.json
+++ b/packages/babel-generator/test/fixtures/edgecase/single-arg-async-arrow-with-retainlines/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}

--- a/packages/babel-generator/test/fixtures/edgecase/single-arg-async-arrow-with-retainlines/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/single-arg-async-arrow-with-retainlines/output.js
@@ -1,0 +1,11 @@
+var fn = async (
+  arg
+) => {};
+
+async (x) =>
+{};
+
+async x => {};
+
+async (x) =>
+{};


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7275
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | ?
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I came across babel/babel#7275 trying to work around facebook/create-react-app#5319 @roblourens pointed me here.

re: @loganfsmyth 

> 
> ```javascript
> var fn = async (
>   arg
> ) => {}
> ```
> 
> with retainLines: true becomes
> 
> ```javascript
> var fn = async 
>   arg => {}
> ```
> which is a syntax error since async and arg need to be on the same line when there aren't parens.
> 
> We need to detect that retainLines is enabled, and that the identifier will insert new lines, and if so, wrap parens around the argument.
> 

So that's what I did but there's only one new test. This could probably use a few more test cases but I don't know what they would be, I just want the upstream issues (facebook/create-react-app#5319, facebook/jest#5326, Microsoft/vscode#60468, Microsoft/vscode#60187) to be resolved so I can go on my merry way and this seemed to be the root blocker. If someone could point me to a few more cases that this should handle I will gladly add them. 