### PR TITLE
Test Windows on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ git:
   depth: 5
 sudo: false
 language: node_js
+os:
+  - linux
+  - windows
 cache:
   yarn: true
 node_js:


### PR DESCRIPTION
This is an alternative to #8201.

I haven't tested this yet but I expect the same failures as there :)

Also, if it passes this will need some tweaks so that:

* [x] we only run `test-ci` on Windows and not everything
* [x] maybe skip Node.js 9
* [ ] caching does not work on Windows currently
