### PR TITLE
[flow] Explicit inexact objects with `...`

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -882,7 +882,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       this.expect(endDelim);
 
-      if (allowInexact || allowExact) {
+      /* The inexact flag should only be added on ObjectTypeAnnotations that
+       * are not the body of an interface, declare interface, or declare class.
+       * Since spreads are only allowed in objec types, checking that is
+       * sufficient here.
+       */
+      if (allowSpread) {
         nodeStart.inexact = inexact;
       }
 

--- a/packages/babel-parser/test/fixtures/flow/call-properties/1/output.json
+++ b/packages/babel-parser/test/fixtures/flow/call-properties/1/output.json
@@ -156,7 +156,8 @@
                   "properties": [],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/call-properties/2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/call-properties/2/output.json
@@ -156,7 +156,8 @@
                   "properties": [],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/call-properties/3/output.json
+++ b/packages/babel-parser/test/fixtures/flow/call-properties/3/output.json
@@ -308,7 +308,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/call-properties/4/output.json
+++ b/packages/babel-parser/test/fixtures/flow/call-properties/4/output.json
@@ -256,7 +256,8 @@
                   "properties": [],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/comment/02-type-include/output.json
+++ b/packages/babel-parser/test/fixtures/flow/comment/02-type-include/output.json
@@ -239,7 +239,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/comment/03-type-flow-include/output.json
+++ b/packages/babel-parser/test/fixtures/flow/comment/03-type-flow-include/output.json
@@ -239,7 +239,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/declare-module/10/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-module/10/output.json
@@ -146,7 +146,8 @@
             ],
             "indexers": [],
             "internalSlots": [],
-            "exact": false
+            "exact": false,
+            "inexact": false
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/flow/declare-module/6/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-module/6/output.json
@@ -192,7 +192,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             }

--- a/packages/babel-parser/test/fixtures/flow/declare-statements/14/output.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-statements/14/output.json
@@ -243,7 +243,8 @@
             }
           ],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/def-site-variance/1/output.json
+++ b/packages/babel-parser/test/fixtures/flow/def-site-variance/1/output.json
@@ -422,7 +422,8 @@
           "properties": [],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects1/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects1/input.js
@@ -1,0 +1,4 @@
+//@flow
+declare class A {
+  ...;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects1/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects1/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (3:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects2/input.js
@@ -1,0 +1,5 @@
+//@flow
+declare class B {
+  foo: number;
+  ...;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects2/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects2/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (4:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects3/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects3/input.js
@@ -1,0 +1,5 @@
+//@flow
+declare class C {
+  ...;
+  foo: number;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects3/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects3/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (3:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects4/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects4/input.js
@@ -1,0 +1,6 @@
+//@flow
+declare class D {
+  foo: number;
+  ...;
+  bar: number;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects4/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects4/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (4:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects5/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects5/input.js
@@ -1,0 +1,5 @@
+//@flow
+interface F {
+  foo: number;
+  ...;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects5/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects5/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (4:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects6/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects6/input.js
@@ -1,0 +1,5 @@
+//@flow
+interface G {
+  ...;
+  foo: number;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects6/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects6/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (3:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects7/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects7/input.js
@@ -1,0 +1,6 @@
+//@flow
+interface H {
+  foo: number;
+  ...;
+  bar: number;
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects7/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_disallowed_in_non_objects7/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Spread operator cannot appear in class or interface definitions (4:2)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_forbidden_in_exact/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_forbidden_in_exact/input.js
@@ -1,0 +1,2 @@
+//@flow
+type T = {| foo: number, ... |}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_forbidden_in_exact/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_forbidden_in_exact/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Explicit inexact syntax cannot appear inside an explicit exact object type (2:29)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_must_appear_last/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_must_appear_last/input.js
@@ -1,0 +1,2 @@
+//@flow
+type T = {..., foo: number};

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_must_appear_last/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_must_appear_last/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Explicit inexact syntax must appear at the end of an inexact object (2:15)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object/input.js
@@ -1,0 +1,4 @@
+//@flow
+type T = {...};
+type U = {x: number, ...};
+type V = {x: number, ...V, ...U};

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object/output.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object/output.json
@@ -1,0 +1,437 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 84,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 33
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 84,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 33
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 8,
+        "end": 23,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 15
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 13,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 17,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 9
+            },
+            "end": {
+              "line": 2,
+              "column": 14
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": true
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": "@flow",
+            "start": 0,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "TypeAlias",
+        "start": 24,
+        "end": 50,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 26
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 29,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 5
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            },
+            "identifierName": "U"
+          },
+          "name": "U"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 33,
+          "end": 49,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 25
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 34,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 10
+                },
+                "end": {
+                  "line": 3,
+                  "column": 19
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 34,
+                "end": 35,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 37,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                }
+              },
+              "variance": null,
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": true
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 51,
+        "end": 84,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 33
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 56,
+          "end": 57,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 5
+            },
+            "end": {
+              "line": 4,
+              "column": 6
+            },
+            "identifierName": "V"
+          },
+          "name": "V"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 60,
+          "end": 83,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 9
+            },
+            "end": {
+              "line": 4,
+              "column": 32
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 61,
+              "end": 70,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 10
+                },
+                "end": {
+                  "line": 4,
+                  "column": 19
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 61,
+                "end": 62,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 11
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 64,
+                "end": 70,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 19
+                  }
+                }
+              },
+              "variance": null,
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeSpreadProperty",
+              "start": 72,
+              "end": 76,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 21
+                },
+                "end": {
+                  "line": 4,
+                  "column": 25
+                }
+              },
+              "argument": {
+                "type": "GenericTypeAnnotation",
+                "start": 75,
+                "end": 76,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 25
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 75,
+                  "end": 76,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 25
+                    },
+                    "identifierName": "V"
+                  },
+                  "name": "V"
+                }
+              }
+            },
+            {
+              "type": "ObjectTypeSpreadProperty",
+              "start": 78,
+              "end": 82,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 27
+                },
+                "end": {
+                  "line": 4,
+                  "column": 31
+                }
+              },
+              "argument": {
+                "type": "GenericTypeAnnotation",
+                "start": 81,
+                "end": 82,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 31
+                  }
+                },
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start": 81,
+                  "end": 82,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 31
+                    },
+                    "identifierName": "U"
+                  },
+                  "name": "U"
+                }
+              }
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": false
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": "@flow",
+      "start": 0,
+      "end": 7,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid1/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid1/input.js
@@ -1,0 +1,2 @@
+//@flow
+type T = {x: number, ..., y: number};

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid1/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid1/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Explicit inexact syntax must appear at the end of an inexact object (2:26)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid2/input.js
@@ -1,0 +1,2 @@
+//@flow
+type U = {x: number, ..., ...};

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid2/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid2/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Explicit inexact syntax must appear at the end of an inexact object (2:26)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid3/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid3/input.js
@@ -1,0 +1,2 @@
+//@flow
+type V = {x: number, ..., ...X};

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid3/options.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_object_invalid3/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["jsx", "flow"],
+  "throws": "Explicit inexact syntax must appear at the end of an inexact object (2:26)"
+}

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_trailing_comma/input.js
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_trailing_comma/input.js
@@ -1,0 +1,11 @@
+//@flow
+type T = { ..., };
+type U = { ...; };
+type V = {
+  x: number,
+  ...,
+};
+type W = {
+  x: number;
+  ...;
+};

--- a/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_trailing_comma/output.json
+++ b/packages/babel-parser/test/fixtures/flow/explicit-inexact-object/explicit_inexact_trailing_comma/output.json
@@ -1,0 +1,395 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 113,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 113,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 8,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 18
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 13,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 17,
+          "end": 25,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 9
+            },
+            "end": {
+              "line": 2,
+              "column": 17
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": true
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": "@flow",
+            "start": 0,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "TypeAlias",
+        "start": 27,
+        "end": 45,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 18
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 32,
+          "end": 33,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 5
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            },
+            "identifierName": "U"
+          },
+          "name": "U"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 36,
+          "end": 44,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 17
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": true
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 46,
+        "end": 79,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 2
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 51,
+          "end": 52,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 5
+            },
+            "end": {
+              "line": 4,
+              "column": 6
+            },
+            "identifierName": "V"
+          },
+          "name": "V"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 55,
+          "end": 78,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 9
+            },
+            "end": {
+              "line": 7,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 59,
+              "end": 68,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 11
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 59,
+                "end": 60,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 62,
+                "end": 68,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 11
+                  }
+                }
+              },
+              "variance": null,
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": true
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 80,
+        "end": 113,
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 0
+          },
+          "end": {
+            "line": 11,
+            "column": 2
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 85,
+          "end": 86,
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 5
+            },
+            "end": {
+              "line": 8,
+              "column": 6
+            },
+            "identifierName": "W"
+          },
+          "name": "W"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 89,
+          "end": 112,
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 9
+            },
+            "end": {
+              "line": 11,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 93,
+              "end": 102,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 11
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 93,
+                "end": 94,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 3
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "proto": false,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 96,
+                "end": 102,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 11
+                  }
+                }
+              },
+              "variance": null,
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false,
+          "inexact": true
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": "@flow",
+      "start": 0,
+      "end": 7,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/internal-slot/object-method/output.json
+++ b/packages/babel-parser/test/fixtures/flow/internal-slot/object-method/output.json
@@ -166,7 +166,8 @@
               }
             }
           ],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/internal-slot/object-optional/output.json
+++ b/packages/babel-parser/test/fixtures/flow/internal-slot/object-optional/output.json
@@ -148,7 +148,8 @@
               }
             }
           ],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/internal-slot/object/output.json
+++ b/packages/babel-parser/test/fixtures/flow/internal-slot/object/output.json
@@ -147,7 +147,8 @@
               }
             }
           ],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/iterator/12/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/12/output.json
@@ -168,7 +168,8 @@
             ],
             "indexers": [],
             "internalSlots": [],
-            "exact": false
+            "exact": false,
+            "inexact": false
           }
         },
         "body": {

--- a/packages/babel-parser/test/fixtures/flow/iterator/13/output.json
+++ b/packages/babel-parser/test/fixtures/flow/iterator/13/output.json
@@ -168,7 +168,8 @@
             ],
             "indexers": [],
             "internalSlots": [],
-            "exact": false
+            "exact": false,
+            "inexact": false
           }
         },
         "body": {

--- a/packages/babel-parser/test/fixtures/flow/object-types/complex-param-types/output.json
+++ b/packages/babel-parser/test/fixtures/flow/object-types/complex-param-types/output.json
@@ -233,7 +233,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-alias/4/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-alias/4/output.json
@@ -153,7 +153,8 @@
               ],
               "indexers": [],
               "internalSlots": [],
-              "exact": false
+              "exact": false,
+              "inexact": false
             },
             {
               "type": "ObjectTypeAnnotation",
@@ -232,7 +233,8 @@
               ],
               "indexers": [],
               "internalSlots": [],
-              "exact": false
+              "exact": false,
+              "inexact": false
             }
           ]
         }
@@ -626,7 +628,8 @@
                     ],
                     "indexers": [],
                     "internalSlots": [],
-                    "exact": false
+                    "exact": false,
+                    "inexact": false
                   },
                   {
                     "type": "ObjectTypeAnnotation",
@@ -705,7 +708,8 @@
                     ],
                     "indexers": [],
                     "internalSlots": [],
-                    "exact": false
+                    "exact": false,
+                    "inexact": false
                   }
                 ]
               },
@@ -715,7 +719,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {
@@ -893,7 +898,8 @@
                     ],
                     "indexers": [],
                     "internalSlots": [],
-                    "exact": false
+                    "exact": false,
+                    "inexact": false
                   },
                   {
                     "type": "ObjectTypeAnnotation",
@@ -972,7 +978,8 @@
                     ],
                     "indexers": [],
                     "internalSlots": [],
-                    "exact": false
+                    "exact": false,
+                    "inexact": false
                   }
                 ]
               },
@@ -982,7 +989,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/108/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/108/output.json
@@ -213,7 +213,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": true
+                  "exact": true,
+                  "inexact": false
                 }
               }
             },
@@ -532,7 +533,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": true
+                  "exact": true,
+                  "inexact": false
                 }
               }
             },
@@ -744,7 +746,8 @@
                   "properties": [],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": true
+                  "exact": true,
+                  "inexact": false
                 }
               }
             },
@@ -1003,7 +1006,8 @@
                         ],
                         "indexers": [],
                         "internalSlots": [],
-                        "exact": true
+                        "exact": true,
+                        "inexact": false
                       },
                       "variance": null,
                       "optional": false
@@ -1064,7 +1068,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },
@@ -1537,7 +1542,8 @@
                         ],
                         "indexers": [],
                         "internalSlots": [],
-                        "exact": false
+                        "exact": false,
+                        "inexact": false
                       },
                       "variance": null,
                       "optional": false
@@ -1598,7 +1604,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": true
+                  "exact": true,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/110/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/110/output.json
@@ -166,7 +166,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/111/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/111/output.json
@@ -166,7 +166,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/114/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/114/output.json
@@ -195,7 +195,8 @@
             }
           ],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/115/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/115/output.json
@@ -195,7 +195,8 @@
             }
           ],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/127/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/127/output.json
@@ -128,7 +128,8 @@
             }
           ],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/128/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/128/output.json
@@ -160,7 +160,8 @@
             }
           ],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/135/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/135/output.json
@@ -110,7 +110,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/136/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/136/output.json
@@ -130,7 +130,8 @@
                 "properties": [],
                 "indexers": [],
                 "internalSlots": [],
-                "exact": false
+                "exact": false,
+                "inexact": false
               },
               "variance": null,
               "optional": false
@@ -167,13 +168,15 @@
                 "properties": [],
                 "indexers": [],
                 "internalSlots": [],
-                "exact": false
+                "exact": false,
+                "inexact": false
               }
             }
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/138/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/138/output.json
@@ -276,7 +276,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/16/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/16/output.json
@@ -96,7 +96,8 @@
             "properties": [],
             "indexers": [],
             "internalSlots": [],
-            "exact": false
+            "exact": false,
+            "inexact": false
           }
         },
         "body": {

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/32/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/32/output.json
@@ -160,7 +160,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/33/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/33/output.json
@@ -160,7 +160,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/34/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/34/output.json
@@ -225,7 +225,8 @@
                     }
                   ],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/35/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/35/output.json
@@ -174,7 +174,8 @@
                     ],
                     "indexers": [],
                     "internalSlots": [],
-                    "exact": false
+                    "exact": false,
+                    "inexact": false
                   }
                 }
               }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/36/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/36/output.json
@@ -213,7 +213,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/37/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/37/output.json
@@ -211,7 +211,8 @@
                         ],
                         "indexers": [],
                         "internalSlots": [],
-                        "exact": false
+                        "exact": false,
+                        "inexact": false
                       },
                       "variance": null,
                       "optional": false
@@ -219,7 +220,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/38/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/38/output.json
@@ -225,7 +225,8 @@
                           ],
                           "indexers": [],
                           "internalSlots": [],
-                          "exact": false
+                          "exact": false,
+                          "inexact": false
                         }
                       },
                       "variance": null,
@@ -234,7 +235,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/39/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/39/output.json
@@ -213,7 +213,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/40/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/40/output.json
@@ -213,7 +213,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/41/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/41/output.json
@@ -235,7 +235,8 @@
                     }
                   ],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/42/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/42/output.json
@@ -322,7 +322,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/43/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/43/output.json
@@ -295,7 +295,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/60/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/60/output.json
@@ -215,7 +215,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/61/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/61/output.json
@@ -215,7 +215,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/63/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/63/output.json
@@ -220,7 +220,8 @@
                 ],
                 "indexers": [],
                 "internalSlots": [],
-                "exact": false
+                "exact": false,
+                "inexact": false
               }
             }
           }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/98/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/98/output.json
@@ -266,7 +266,8 @@
                   ],
                   "indexers": [],
                   "internalSlots": [],
-                  "exact": false
+                  "exact": false,
+                  "inexact": false
                 }
               }
             },

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/object-type-method/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/object-type-method/output.json
@@ -151,7 +151,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {
@@ -309,7 +310,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {
@@ -433,7 +435,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {
@@ -590,7 +593,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {
@@ -693,7 +697,8 @@
           "properties": [],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {
@@ -896,7 +901,8 @@
           "properties": [],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       },
       {

--- a/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/output.json
@@ -492,7 +492,8 @@
           ],
           "indexers": [],
           "internalSlots": [],
-          "exact": false
+          "exact": false,
+          "inexact": false
         }
       }
     ],

--- a/packages/babel-parser/test/fixtures/flow/typecasts/2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/typecasts/2/output.json
@@ -323,7 +323,8 @@
               ],
               "indexers": [],
               "internalSlots": [],
-              "exact": false
+              "exact": false,
+              "inexact": false
             }
           },
           "extra": {

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -277,6 +277,7 @@ defineType("ObjectTypeAnnotation", {
       validate: assertValueType("boolean"),
       default: false,
     },
+    inexact: validateOptional(assertValueType("boolean")),
   },
 });
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -277,6 +277,9 @@ defineType("ObjectTypeAnnotation", {
       validate: assertValueType("boolean"),
       default: false,
     },
+    // If the inexact flag is present then this is an object type, and not a
+    // declare class, declare interface, or interface. If it is true, the
+    // object uses ... to express that it is inexact.
     inexact: validateOptional(assertValueType("boolean")),
   },
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In https://github.com/facebook/flow/commit/1ac913040f38309480934ccb6717a3ffc65094a8, flow started parsing `{foo: number, ...}` as an inexact object. This is part of a larger effort to move to [parsing object types as exact by default](https://medium.com/flow-type/on-the-roadmap-exact-objects-by-default-16b72933c5cf). 

`...` can only appear at the end of the props list, and it cannot appear inside `{||}`. Additionally, it can only appear inside object types, and not interfaces, declare classes, or declare interfaces. `...` also supports trailing commas.

For any object type, but not in declare class, declare interface, or interface, the `ObjectTypeAnnotation` representing it now has an `inexact` property. This property is true if and only if `...` was used to indicate the inexactness. To minimize confusion, it is best to read `exact` as `explicitly exact` (containing curlybars) and `inexact` as `explicitly inexact` (containing `...`). This mimics the behavior in Flow's estree output https://github.com/facebook/flow/commit/231256cfe5afc3c7576f05ac9929859dfa813a35. In a few releases, we will get rid of the exact flag entirely, which will be a breaking change to other tools.

Tests had to be re-recorded to include the `inexact` flag. I separated the re-recording of old tests into a separate commit for reviewing ease.

Let me know if there is anything else I need to update in this change.
