### PR TITLE
Add useAutoDirectory option to transform-runtime plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ package-lock.json
 !/packages/babel-runtime/helpers/esm/toArray.js
 !/packages/babel-runtime/helpers/esm/iterableToArray.js
 !/packages/babel-runtime/helpers/esm/temporalRef.js
+/packages/babel-runtime/helpers/auto/*
+!/packages/babel-runtime/helpers/auto/toArray
+!/packages/babel-runtime/helpers/auto/iterableToArray
+!/packages/babel-runtime/helpers/auto/temporalRef
 
 /packages/babel-runtime-corejs2/helpers/*.js
 !/packages/babel-runtime-corejs2/helpers/toArray.js
@@ -33,6 +37,10 @@ package-lock.json
 !/packages/babel-runtime-corejs2/helpers/esm/toArray.js
 !/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
 !/packages/babel-runtime-corejs2/helpers/esm/temporalRef.js
+/packages/babel-runtime-corejs2/helpers/auto/*
+!/packages/babel-runtime-corejs2/helpers/auto/toArray
+!/packages/babel-runtime-corejs2/helpers/auto/iterableToArray
+!/packages/babel-runtime-corejs2/helpers/auto/temporalRef
 /packages/babel-runtime-corejs2/core-js/**/*.js
 !/packages/babel-runtime-corejs2/core-js/map.js
 

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -84,8 +84,6 @@ function writeAutoHelperFiles(runtimeName) {
       filename,
       JSON.stringify(
         {
-          name: `${runtimeName}/helpers/auto/${helperName}`,
-          private: true,
           main: `../../${helperName}.js`,
           module: `../../esm/${helperName}.js`,
         },

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -44,6 +44,7 @@ function writeCoreJS2(runtimeName) {
 function writeHelpers(runtimeName, { corejs } = {}) {
   writeHelperFiles(runtimeName, { corejs, esm: false });
   writeHelperFiles(runtimeName, { corejs, esm: true });
+  writeAutoHelperFiles(runtimeName);
 }
 
 function writeHelperFiles(runtimeName, { esm, corejs }) {
@@ -63,6 +64,34 @@ function writeHelperFiles(runtimeName, { esm, corejs }) {
         esm,
         corejs,
       })
+    );
+  }
+}
+
+function writeAutoHelperFiles(runtimeName) {
+  const pkgDirname = getRuntimeRoot(runtimeName);
+
+  for (const helperName of helpers.list) {
+    const filename = path.join(
+      pkgDirname,
+      "helpers",
+      "auto",
+      helperName,
+      "package.json"
+    );
+
+    outputFile(
+      filename,
+      JSON.stringify(
+        {
+          name: `${runtimeName}/helpers/auto/${helperName}`,
+          private: true,
+          main: `../../${helperName}.js`,
+          module: `../../esm/${helperName}.js`,
+        },
+        null,
+        2
+      ) + "\n"
     );
   }
 }

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -37,6 +37,7 @@ export default declare((api, options, dirname) => {
     helpers: useRuntimeHelpers = true,
     regenerator: useRuntimeRegenerator = true,
     useESModules = false,
+    useAutoDirectory = false,
     version: runtimeVersion = "7.0.0-beta.0",
     absoluteRuntime = false,
   } = options;
@@ -55,6 +56,14 @@ export default declare((api, options, dirname) => {
     throw new Error(
       "The 'useESModules' option must be undefined, or a boolean, or 'auto'.",
     );
+  }
+  if (useESModules && useAutoDirectory) {
+    throw new Error(
+      "'useESModules' & 'useAutoDirectory' options cannot be used at the same time.",
+    );
+  }
+  if (typeof useAutoDirectory !== "boolean") {
+    throw new Error("The 'useAutoDirectory' option must be a boolean.");
   }
   if (
     typeof absoluteRuntime !== "boolean" &&
@@ -156,8 +165,9 @@ export default declare((api, options, dirname) => {
           const blockHoist =
             isInteropHelper && !isModule(file.path) ? 4 : undefined;
 
-          const helpersDir =
-            esModules && file.path.node.sourceType === "module"
+          const helpersDir = useAutoDirectory
+            ? "helpers/auto"
+            : esModules && file.path.node.sourceType === "module"
               ? "helpers/esm"
               : "helpers";
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useAutoDirectory/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useAutoDirectory/input.mjs
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useAutoDirectory/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useAutoDirectory/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["transform-runtime", { "corejs": 2, "useAutoDirectory": true }],
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useAutoDirectory/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/corejs-useAutoDirectory/output.mjs
@@ -1,0 +1,18 @@
+import _classCallCheck from "@babel/runtime-corejs2/helpers/auto/classCallCheck";
+import _possibleConstructorReturn from "@babel/runtime-corejs2/helpers/auto/possibleConstructorReturn";
+import _getPrototypeOf from "@babel/runtime-corejs2/helpers/auto/getPrototypeOf";
+import _inherits from "@babel/runtime-corejs2/helpers/auto/inherits";
+
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useAutoDirectory/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useAutoDirectory/input.js
@@ -1,0 +1,1 @@
+class Foo extends Bar {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useAutoDirectory/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useAutoDirectory/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["transform-runtime", { "useAutoDirectory": true }],
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useAutoDirectory/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/use-options/useAutoDirectory/output.js
@@ -1,0 +1,23 @@
+var _classCallCheck = require("@babel/runtime/helpers/auto/classCallCheck");
+
+var _possibleConstructorReturn = require("@babel/runtime/helpers/auto/possibleConstructorReturn");
+
+var _getPrototypeOf = require("@babel/runtime/helpers/auto/getPrototypeOf");
+
+var _inherits = require("@babel/runtime/helpers/auto/inherits");
+
+let Foo =
+/*#__PURE__*/
+function (_Bar) {
+  "use strict";
+
+  _inherits(Foo, _Bar);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  return Foo;
+}(Bar);

--- a/packages/babel-runtime-corejs2/helpers/auto/iterableToArray/package.json
+++ b/packages/babel-runtime-corejs2/helpers/auto/iterableToArray/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@babel/runtime-corejs2/helpers/auto/iterableToArray",
+  "private": true,
+  "main": "../../iterableToArray.js",
+  "module": "../../esm/iterableToArray.js"
+}

--- a/packages/babel-runtime-corejs2/helpers/auto/iterableToArray/package.json
+++ b/packages/babel-runtime-corejs2/helpers/auto/iterableToArray/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@babel/runtime-corejs2/helpers/auto/iterableToArray",
-  "private": true,
   "main": "../../iterableToArray.js",
   "module": "../../esm/iterableToArray.js"
 }

--- a/packages/babel-runtime-corejs2/helpers/auto/temporalRef/package.json
+++ b/packages/babel-runtime-corejs2/helpers/auto/temporalRef/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@babel/runtime-corejs2/helpers/auto/temporalRef",
+  "private": true,
+  "main": "../../temporalRef.js",
+  "module": "../../esm/temporalRef.js"
+}

--- a/packages/babel-runtime-corejs2/helpers/auto/temporalRef/package.json
+++ b/packages/babel-runtime-corejs2/helpers/auto/temporalRef/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@babel/runtime-corejs2/helpers/auto/temporalRef",
-  "private": true,
   "main": "../../temporalRef.js",
   "module": "../../esm/temporalRef.js"
 }

--- a/packages/babel-runtime-corejs2/helpers/auto/toArray/package.json
+++ b/packages/babel-runtime-corejs2/helpers/auto/toArray/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@babel/runtime-corejs2/helpers/auto/toArray",
+  "private": true,
+  "main": "../../toArray.js",
+  "module": "../../esm/toArray.js"
+}

--- a/packages/babel-runtime-corejs2/helpers/auto/toArray/package.json
+++ b/packages/babel-runtime-corejs2/helpers/auto/toArray/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@babel/runtime-corejs2/helpers/auto/toArray",
-  "private": true,
   "main": "../../toArray.js",
   "module": "../../esm/toArray.js"
 }

--- a/packages/babel-runtime/helpers/auto/iterableToArray/package.json
+++ b/packages/babel-runtime/helpers/auto/iterableToArray/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@babel/runtime/helpers/auto/iterableToArray",
+  "private": true,
+  "main": "../../iterableToArray.js",
+  "module": "../../esm/iterableToArray.js"
+}

--- a/packages/babel-runtime/helpers/auto/iterableToArray/package.json
+++ b/packages/babel-runtime/helpers/auto/iterableToArray/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@babel/runtime/helpers/auto/iterableToArray",
-  "private": true,
   "main": "../../iterableToArray.js",
   "module": "../../esm/iterableToArray.js"
 }

--- a/packages/babel-runtime/helpers/auto/temporalRef/package.json
+++ b/packages/babel-runtime/helpers/auto/temporalRef/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@babel/runtime/helpers/auto/temporalRef",
-  "private": true,
   "main": "../../temporalRef.js",
   "module": "../../esm/temporalRef.js"
 }

--- a/packages/babel-runtime/helpers/auto/temporalRef/package.json
+++ b/packages/babel-runtime/helpers/auto/temporalRef/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@babel/runtime/helpers/auto/temporalRef",
+  "private": true,
+  "main": "../../temporalRef.js",
+  "module": "../../esm/temporalRef.js"
+}

--- a/packages/babel-runtime/helpers/auto/toArray/package.json
+++ b/packages/babel-runtime/helpers/auto/toArray/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "@babel/runtime/helpers/auto/toArray",
-  "private": true,
   "main": "../../toArray.js",
   "module": "../../esm/toArray.js"
 }

--- a/packages/babel-runtime/helpers/auto/toArray/package.json
+++ b/packages/babel-runtime/helpers/auto/toArray/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@babel/runtime/helpers/auto/toArray",
+  "private": true,
+  "main": "../../toArray.js",
+  "module": "../../esm/toArray.js"
+}


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | TODO
| Any Dependency Changes?  |
| License                  | MIT

**Why?** 
When building libraries it's annoying to setup different options for `@babel/plugin-transform-runtime` for ESM and CJS builds.

With this the configuration can be unified with the newly introduced option and i.e. when bundling with rollup we could shorten this:
```js
const config = [
  {
    input: 'src/index.js',
    output: { file: 'dist/library.js', output: 'cjs' },
    plugins: [
      babel({
        runtimeHelpers: true,
        plugins: [
          '@babel/transform-runtime'
        ]
      }),  
    ]
  },
  {
    input: 'src/index.js',
    output: { file: 'dist/library.esm.js', output: 'esm' },
    plugins: [
      babel({
        runtimeHelpers: true,
        plugins: [
          [
            '@babel/transform-runtime',
            { useESModules: true }
          ]
        ]
      }),  
    ]
  }
]
```
to this
```js
const config =   {
  input: 'src/index.js',
  output: [
    { file: 'dist/library.js', output: 'cjs' },
    { file: 'dist/library.esm.js', output: 'esm' }
  ],
  plugins: [
    babel({
      runtimeHelpers: true,
      plugins: [
        [
          '@babel/transform-runtime',
          { useAutoDirectory: true }
        ]
      ]
    }),  
  ]
}
```

This technique of creating extra package.json files is not well-known but it's part of the node resolution algorithm - https://nodejs.org/api/modules.html#modules_all_together & resolution algorithms of webpack, rollup and other tools support this. This has an advantage of allowing tools to pick up appropriate files thanks to being able to specify both main & module entries for a single request path.

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 
Unfortunately helpers written in CJS format have different shape from the helpers written in ESM. With ESM things are exported as default, with CJS they are assigned directly to `module.exports`.

As we know those things are not really compatible and I have 2 ideas how we could fix this (the issue to be fixed is that package.json in auto directory should point to modules with the same shape, regardless of the format):
- introduce extra files 😭 that would reexport current CJS helpers as `module.exports.default = require('../createClass')` and point to those proxy files from auto package.json files
- as helpers are mostly functions we can assign to them `.default` property that would self-reference to them, I'm not sure if this is completely safe though, could it cause problems with live bindings such as in `extends` helper?