### PR TITLE
Treat break inside block inside loop

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -289,7 +289,7 @@ const loopVisitor = {
   },
 
   "BreakStatement|ContinueStatement|ReturnStatement"(path, state) {
-    const { node, parent, scope } = path;
+    const { node, scope } = path;
     if (node[this.LOOP_IGNORE]) return;
 
     let replace;
@@ -309,7 +309,7 @@ const loopVisitor = {
         if (state.ignoreLabeless) return;
 
         // break statements mean something different in this context
-        if (t.isBreakStatement(node) && t.isSwitchCase(parent)) return;
+        if (t.isBreakStatement(node) && state.inSwitchCase) return;
       }
 
       state.hasBreakContinue = true;

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/switch-labeled-break.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/exec/switch-labeled-break.js
@@ -1,0 +1,14 @@
+// it shouldn't break on a case-break statement
+var i;
+the_loop: for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 3: {
+      break the_loop;
+    }
+  }
+
+  const z = 3; // to force the plugin to convert to loop function call
+  () => z;
+}
+
+expect(i).toBe(3);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/block-inside-switch-inside-loop/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/block-inside-switch-inside-loop/exec.js
@@ -1,0 +1,51 @@
+// it shouldn't break on a case-break statement
+var i;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 1: {
+      break;
+    }
+  }
+
+  const z = 3; // to force the plugin to convert to loop function call
+  () => z;
+}
+
+expect(i).toBe(10);
+
+// it should continue on continue statements within switch
+var j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0: {
+      continue;
+    }
+  }
+  j++;
+
+  const z = 3;
+  () => z;
+}
+
+expect(j).toBe(9);
+
+// it should work with loops nested within switch
+j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0: {
+      for (var k = 0; k < 10; k++) {
+        const z = 3;
+        () => z;
+        j++;
+        break;
+      }
+      break;
+    }
+  }
+
+  const z = 3;
+  () => z;
+}
+
+expect(j).toBe(1);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/block-inside-switch-inside-loop/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/block-inside-switch-inside-loop/input.js
@@ -1,0 +1,48 @@
+// it shouldn't break on a case-break statement
+var i;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 1:
+      break;
+  }
+
+  const z = 3; // to force the plugin to convert to loop function call
+  () => z;
+}
+
+expect(i).toBe(10);
+
+// it should continue on continue statements within switch
+var j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      continue;
+  }
+  j++;
+
+  const z = 3;
+  () => z;
+}
+
+expect(j).toBe(9);
+
+// it should work with loops nested within switch
+j = 0;
+for (i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      for (var k = 0; k < 10; k++) {
+        const z = 3;
+        () => z;
+        j++;
+        break;
+      }
+      break;
+  }
+
+  const z = 3;
+  () => z;
+}
+
+expect(j).toBe(1);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/block-inside-switch-inside-loop/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/block-inside-switch-inside-loop/output.js
@@ -1,0 +1,85 @@
+// it shouldn't break on a case-break statement
+var i;
+
+var _loop = function () {
+  switch (i) {
+    case 1:
+      break;
+  }
+
+  var z = 3; // to force the plugin to convert to loop function call
+
+  (function () {
+    return z;
+  });
+};
+
+for (i = 0; i < 10; i++) {
+  _loop();
+}
+
+expect(i).toBe(10); // it should continue on continue statements within switch
+
+var j = 0;
+
+var _loop2 = function () {
+  switch (i) {
+    case 0:
+      return "continue";
+  }
+
+  j++;
+  var z = 3;
+
+  (function () {
+    return z;
+  });
+};
+
+for (i = 0; i < 10; i++) {
+  var _ret = _loop2();
+
+  if (_ret === "continue") continue;
+}
+
+expect(j).toBe(9); // it should work with loops nested within switch
+
+j = 0;
+
+var _loop3 = function () {
+  switch (i) {
+    case 0:
+      var _loop4 = function () {
+        var z = 3;
+
+        (function () {
+          return z;
+        });
+
+        j++;
+        return "break";
+      };
+
+      for (k = 0; k < 10; k++) {
+        var _ret2 = _loop4();
+
+        if (_ret2 === "break") break;
+      }
+
+      break;
+  }
+
+  var z = 3;
+
+  (function () {
+    return z;
+  });
+};
+
+for (i = 0; i < 10; i++) {
+  var k;
+
+  _loop3();
+}
+
+expect(j).toBe(1);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8709 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | ❌
| Minor: New Feature?      | ❌
| Tests Added + Pass?      | Yes
| Documentation PR Link    | -- <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | ❌
| License                  | MIT

Fixes scope for break inside switch statement. The problem was caused by only checking the immediate parent instead of whole ancestor chain.
