### PR TITLE
Create additional scope when redeclaring array variable in for..of loop

### DIFF
--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -44,6 +44,11 @@ export default declare((api, options) => {
           }
 
           const block = t.toBlock(body);
+
+          if (path.get("body").scope.hasOwnBinding(right.name)) {
+            block.body = [t.blockStatement(block.body)];
+          }
+
           block.body.unshift(assignment);
 
           path.replaceWith(
@@ -139,6 +144,10 @@ export default declare((api, options) => {
 
     t.inherits(loop, node);
     t.ensureBlock(loop);
+
+    if (path.get("body").scope.hasOwnBinding(right.name)) {
+      loop.body.body = [t.blockStatement(loop.body.body)];
+    }
 
     const iterationValue = t.memberExpression(
       t.cloneNode(right),

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/input.js
@@ -1,0 +1,3 @@
+for (let o of arr) {
+  const arr = o;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/output.js
@@ -1,0 +1,6 @@
+for (let _i = 0, _arr = arr; _i < _arr.length; _i++) {
+  let o = _arr[_i];
+  {
+    const arr = o;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/input.js
@@ -1,0 +1,5 @@
+function f(...t) {
+  for (let o of t) {
+    const t = o;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
@@ -1,0 +1,8 @@
+function f(...t) {
+  for (var _i = 0; _i < t.length; _i++) {
+    let o = t[_i];
+    {
+      const t = o;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8913  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When transforming a `for..of` loop that iterates through an array, redeclaring the array identifier within the loop would result in an ambiguity when assigning the iteration variable at the top of the transformed loop body, which could result in incorrect behavior.

This fix detects whether the array identifier is redeclared within the loop, and if so, wraps the original loop body in an additional block statement to prevent ambiguities when assigning the iteration variable.