### PR TITLE
preset-env: Edge support for arrow param destructuring

### DIFF
--- a/packages/babel-preset-env/data/plugin-features.js
+++ b/packages/babel-preset-env/data/plugin-features.js
@@ -57,7 +57,11 @@ const es = {
     features: "spread syntax for iterable objects",
   },
   "transform-parameters": {
-    features: ["default function parameters", "rest parameters"],
+    features: [
+      "default function parameters",
+      "rest parameters",
+      "destructuring, parameters / defaults, arrow function",
+    ],
   },
   "transform-destructuring": {
     features: [

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -149,7 +149,6 @@
   },
   "transform-parameters": {
     "chrome": "49",
-    "edge": "14",
     "firefox": "53",
     "safari": "10",
     "node": "6",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8349
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No tests added (only data changed), all tests passed locally
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Added the as-yet-Edge-unsupported arrow function parameter destructuring as a feature supported by `transform-parameters`, per [compat-table](http://kangax.github.io/compat-table/es6/#test-destructuring,_parameters_defaults,_arrow_function).