### PR TITLE
Fix babel helpers to not require `Symbol` to exist

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -864,10 +864,8 @@ helpers.iterableToArray = helper("7.0.0-beta.0")`
     if (
       Array.isArray(iter)
       || typeof iter === 'string'
-      || (typeof global.Symbol === 'function' && Symbol.iterator in Object(iter))
+      || (typeof Symbol === 'function' && Symbol.iterator in Object(iter))
       || (iter && 'length' in iter)
-      || (typeof global.Map !== 'undefined' && iter instanceof global.Map)
-      || (typeof global.Set !== 'undefined' && iter instanceof global.Set)
       || Object.prototype.toString.call(iter) === "[object Arguments]"
     ) return Array.from(iter);
   }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -859,14 +859,15 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 `;
 
 helpers.iterableToArray = helper("7.0.0-beta.0")`
+
   export default function _iterableToArray(iter) {
     if (
       Array.isArray(iter)
       || typeof iter === 'string'
-      || (typeof Symbol === 'function' && Symbol.iterator in Object(iter))
+      || (typeof global.Symbol === 'function' && Symbol.iterator in Object(iter))
       || (iter && 'length' in iter)
-      || Object.prototype.toString.call(iter) === "[object Map]"
-      || Object.prototype.toString.call(iter) === "[object Set]"
+      || (typeof global.Map !== 'undefined' && iter instanceof global.Map)
+      || (typeof global.Set !== 'undefined' && iter instanceof global.Set)
       || Object.prototype.toString.call(iter) === "[object Arguments]"
     ) return Array.from(iter);
   }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -861,8 +861,13 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
     if (
-      Symbol.iterator in Object(iter) ||
-      Object.prototype.toString.call(iter) === "[object Arguments]"
+      Array.isArray(iter)
+      || typeof iter === 'string'
+      || (typeof Symbol === 'function' && Symbol.iterator in Object(iter))
+      || (iter && 'length' in iter)
+      || (typeof Map !== 'undefined' && iter instanceof Map)
+      || (typeof Set !== 'undefined' && iter instanceof Set)
+      || Object.prototype.toString.call(iter) === "[object Arguments]"
     ) return Array.from(iter);
   }
 `;
@@ -1562,7 +1567,9 @@ helpers.decorate = helper("7.1.5")`
       value: "Descriptor",
       configurable: true,
     };
-    Object.defineProperty(obj, Symbol.toStringTag, desc);
+
+    if (typeof Symbol === 'function' && Symbol.toStringTag)
+      Object.defineProperty(obj, Symbol.toStringTag, desc);
 
     if (element.kind === "field") obj.initializer = element.initializer;
 
@@ -1675,7 +1682,9 @@ helpers.decorate = helper("7.1.5")`
     };
 
     var desc = { value: "Descriptor", configurable: true };
-    Object.defineProperty(obj, Symbol.toStringTag, desc);
+
+    if (typeof Symbol === 'function' && Symbol.toStringTag)
+      Object.defineProperty(obj, Symbol.toStringTag, desc);
 
     return obj;
   }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -946,7 +946,7 @@ helpers.toPrimitive = helper("7.1.5")`
     hint /*: "default" | "string" | "number" | void */
   ) {
     if (typeof input !== "object" || input === null) return input;
-    var prim = input[Symbol.toPrimitive];
+    var prim = typeof Symbol === 'function' ? input[Symbol.toPrimitive] : undefined;
     if (prim !== undefined) {
       var res = prim.call(input, hint || "default");
       if (typeof res !== "object") return res;

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -865,8 +865,8 @@ helpers.iterableToArray = helper("7.0.0-beta.0")`
       || typeof iter === 'string'
       || (typeof Symbol === 'function' && Symbol.iterator in Object(iter))
       || (iter && 'length' in iter)
-      || (typeof Map !== 'undefined' && iter instanceof Map)
-      || (typeof Set !== 'undefined' && iter instanceof Set)
+      || Object.prototype.toString.call(iter) === "[object Map]"
+      || Object.prototype.toString.call(iter) === "[object Set]"
       || Object.prototype.toString.call(iter) === "[object Arguments]"
     ) return Array.from(iter);
   }

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -213,6 +213,12 @@ export default declare((api, options, dirname) => {
         if (!has(definitions.builtins, node.name)) return;
         if (scope.getBindingIdentifier(node.name)) return;
 
+        // If we are checking Symbol using the typeof check,
+        // don't pull in the corejs builtin for Symbol
+        if (parent.type === "UnaryExpression" && parent.name === "typeof") {
+          return;
+        }
+
         // Symbol() -> _core.Symbol(); new Promise -> new _core.Promise
         path.replaceWith(
           this.addDefaultImport(

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,9 +1,7 @@
 import _Array$from from "../../core-js/array/from";
-import _Set from "../../core-js/set";
-import _Map from "../../core-js/map";
 import _isIterable from "../../core-js/is-iterable";
 import _Symbol from "../../core-js/symbol";
 import _Array$isArray from "../../core-js/array/is-array";
 export default function _iterableToArray(iter) {
-  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || typeof _Map !== 'undefined' && iter instanceof _Map || typeof _Set !== 'undefined' && iter instanceof _Set || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,7 +1,6 @@
 import _Array$from from "../../core-js/array/from";
 import _isIterable from "../../core-js/is-iterable";
-import _Symbol from "../../core-js/symbol";
 import _Array$isArray from "../../core-js/array/is-array";
 export default function _iterableToArray(iter) {
-  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_Array$isArray(iter) || typeof iter === 'string' || typeof global.Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || typeof global.Map !== 'undefined' && iter instanceof global.Map || typeof global.Set !== 'undefined' && iter instanceof global.Set || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,5 +1,9 @@
 import _Array$from from "../../core-js/array/from";
+import _Set from "../../core-js/set";
+import _Map from "../../core-js/map";
 import _isIterable from "../../core-js/is-iterable";
+import _Symbol from "../../core-js/symbol";
+import _Array$isArray from "../../core-js/array/is-array";
 export default function _iterableToArray(iter) {
-  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || typeof _Map !== 'undefined' && iter instanceof _Map || typeof _Set !== 'undefined' && iter instanceof _Set || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -1,9 +1,17 @@
 var _Array$from = require("../core-js/array/from");
 
+var _Set = require("../core-js/set");
+
+var _Map = require("../core-js/map");
+
 var _isIterable = require("../core-js/is-iterable");
 
+var _Symbol = require("../core-js/symbol");
+
+var _Array$isArray = require("../core-js/array/is-array");
+
 function _iterableToArray(iter) {
-  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || typeof _Map !== 'undefined' && iter instanceof _Map || typeof _Set !== 'undefined' && iter instanceof _Set || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -2,12 +2,10 @@ var _Array$from = require("../core-js/array/from");
 
 var _isIterable = require("../core-js/is-iterable");
 
-var _Symbol = require("../core-js/symbol");
-
 var _Array$isArray = require("../core-js/array/is-array");
 
 function _iterableToArray(iter) {
-  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_Array$isArray(iter) || typeof iter === 'string' || typeof global.Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || typeof global.Map !== 'undefined' && iter instanceof global.Map || typeof global.Set !== 'undefined' && iter instanceof global.Set || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -1,9 +1,5 @@
 var _Array$from = require("../core-js/array/from");
 
-var _Set = require("../core-js/set");
-
-var _Map = require("../core-js/map");
-
 var _isIterable = require("../core-js/is-iterable");
 
 var _Symbol = require("../core-js/symbol");
@@ -11,7 +7,7 @@ var _Symbol = require("../core-js/symbol");
 var _Array$isArray = require("../core-js/array/is-array");
 
 function _iterableToArray(iter) {
-  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || typeof _Map !== 'undefined' && iter instanceof _Map || typeof _Set !== 'undefined' && iter instanceof _Set || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_Array$isArray(iter) || typeof iter === 'string' || typeof _Symbol === 'function' && _isIterable(Object(iter)) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || typeof Map !== 'undefined' && iter instanceof Map || typeof Set !== 'undefined' && iter instanceof Set || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Array.isArray(iter) || typeof iter === 'string' || typeof global.Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || typeof global.Map !== 'undefined' && iter instanceof global.Map || typeof global.Set !== 'undefined' && iter instanceof global.Set || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || typeof Map !== 'undefined' && iter instanceof Map || typeof Set !== 'undefined' && iter instanceof Set || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,5 @@
 function _iterableToArray(iter) {
-  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Array.isArray(iter) || typeof iter === 'string' || typeof global.Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || typeof global.Map !== 'undefined' && iter instanceof global.Map || typeof global.Set !== 'undefined' && iter instanceof global.Set || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,5 @@
 function _iterableToArray(iter) {
-  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || typeof Map !== 'undefined' && iter instanceof Map || typeof Set !== 'undefined' && iter instanceof Set || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,5 @@
 function _iterableToArray(iter) {
-  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || typeof Map !== 'undefined' && iter instanceof Map || typeof Set !== 'undefined' && iter instanceof Set || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Array.isArray(iter) || typeof iter === 'string' || typeof Symbol === 'function' && Symbol.iterator in Object(iter) || iter && 'length' in iter || Object.prototype.toString.call(iter) === "[object Map]" || Object.prototype.toString.call(iter) === "[object Set]" || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
 }
 
 module.exports = _iterableToArray;


### PR DESCRIPTION
Fixes #7597

Ensure that `Symbol` exists and is a function before using it.

In the `_iterableToArray` helper, we update the condition to check for objects that act as arrays such as, objects with the `length` property, Maps, and Sets. This change is being made because we ran into an issue with the usage of `Symbol` breaking on ie11 because it is not supported.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #7597 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | ✅
| Major: Breaking Change?  | ❌
| Minor: New Feature?      | ❌
| Tests Added + Pass?      | ✅
| Documentation PR Link    | N/A <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | ❌
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

cc. @ljharb @loganfsmyth 