### PR TITLE
Fix message when plugin of a wrong type is passed

### DIFF
--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -132,7 +132,7 @@ function resolveStandardizedName(
     } catch (e2) {}
 
     if (resolvedOppositeType) {
-      e.message += `\n- Did you accidentally pass a ${type} as a ${oppositeType}?`;
+      e.message += `\n- Did you accidentally pass a ${oppositeType} as a ${type}?`;
     }
 
     throw e;

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -400,7 +400,7 @@ describe("addon resolution", function() {
         presets: ["testplugin"],
       });
     }).toThrow(
-      /Cannot find module 'babel-preset-testplugin'.*\n- Did you accidentally pass a preset as a plugin\?/,
+      /Cannot find module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/,
     );
   });
 
@@ -414,7 +414,7 @@ describe("addon resolution", function() {
         plugins: ["testpreset"],
       });
     }).toThrow(
-      /Cannot find module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a plugin as a preset\?/,
+      /Cannot find module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/,
     );
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Display a correct message when a plugin is passed to "presets" and when a preset is passed to "plugins".