### PR TITLE
Update flow tests and fix underscore being a reserved type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS = -j1
-FLOW_COMMIT = bea8b83f50f597454941d2a7ecef6e93a881e576
+FLOW_COMMIT = e192e1a4793dd8e43415fbfe8046d832cb513c8b
 TEST262_COMMIT = 06c2f019019cf7850923de4d56828e6dfd9212b8
 
 # Fix color output until TravisCI fixes https://github.com/travis-ci/travis-ci/issues/7967
@@ -82,7 +82,7 @@ test-ci-coverage:
 bootstrap-flow:
 	rm -rf ./build/flow
 	mkdir -p ./build
-	git clone --branch=master --single-branch --shallow-since=2017-01-01 https://github.com/facebook/flow.git ./build/flow
+	git clone --branch=master --single-branch --shallow-since=2018-11-01 https://github.com/facebook/flow.git ./build/flow
 	cd build/flow && git checkout $(FLOW_COMMIT)
 
 test-flow:

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -23,6 +23,9 @@ const primitiveTypes = [
   "true",
   "typeof",
   "void",
+  "interface",
+  "extends",
+  "_",
 ];
 
 function isEsModuleType(bodyElement: N.Node): boolean {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | sort of, if _ was used as type name
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Additionally to #8883 this adds `_` as reserved type name.

This also updates the flow test suite.