### PR TITLE
[decorators] Correctly insert `_initialize(this)` after `super()`.

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer.js
+++ b/packages/babel-plugin-proposal-decorators/src/transformer.js
@@ -113,6 +113,10 @@ const bareSupersVisitor = {
   CallExpression(path, { initializeInstanceElements }) {
     if (path.get("callee").isSuper()) {
       path.insertAfter(t.cloneNode(initializeInstanceElements));
+
+      // Sometimes this path gets requeued (e.g. in (super(), foo)), and
+      // it leads to infinite recursion.
+      path.skip();
     }
   },
   Function(path) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initiailzer-after-super-bug-8808/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initiailzer-after-super-bug-8808/input.js
@@ -1,0 +1,6 @@
+@decorator(parameter)
+class Sub extends Super {
+  constructor() {
+    super().method();
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initiailzer-after-super-bug-8808/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initiailzer-after-super-bug-8808/output.js
@@ -1,0 +1,17 @@
+let Sub = babelHelpers.decorate([decorator(parameter)], function (_initialize, _Super) {
+  "use strict";
+
+  class Sub extends _Super {
+    constructor() {
+      var _temp;
+
+      (_temp = super(), _initialize(this), _temp).method();
+    }
+
+  }
+
+  return {
+    F: Sub,
+    d: []
+  };
+}, Super);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-bug-8931/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-bug-8931/input.js
@@ -1,0 +1,7 @@
+@dec
+class B extends A {
+  constructor() {
+    super();
+    [];
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-bug-8931/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-bug-8931/output.js
@@ -1,0 +1,19 @@
+let B = babelHelpers.decorate([dec], function (_initialize, _A) {
+  "use strict";
+
+  class B extends _A {
+    constructor() {
+      super();
+
+      _initialize(this);
+
+      [];
+    }
+
+  }
+
+  return {
+    F: B,
+    d: []
+  };
+}, A);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-expression/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-expression/input.js
@@ -1,0 +1,6 @@
+@dec
+class B extends A {
+  constructor() {
+    (0, super());
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-expression/output.js
@@ -1,0 +1,17 @@
+let B = babelHelpers.decorate([dec], function (_initialize, _A) {
+  "use strict";
+
+  class B extends _A {
+    constructor() {
+      var _temp;
+
+      0, (_temp = super(), _initialize(this), _temp);
+    }
+
+  }
+
+  return {
+    F: B,
+    d: []
+  };
+}, A);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-multiple/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-multiple/input.js
@@ -1,0 +1,14 @@
+@dec
+class B extends A {
+  constructor() {
+    const foo = () => { super(); };
+
+    if (a) { super(); }
+    else { foo(); }
+
+    while (0) { super(); }
+
+    super();
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-multiple/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-multiple/output.js
@@ -1,0 +1,37 @@
+let B = babelHelpers.decorate([dec], function (_initialize, _A) {
+  "use strict";
+
+  class B extends _A {
+    constructor() {
+      const foo = () => {
+        super();
+
+        _initialize(this);
+      };
+
+      if (a) {
+        super();
+
+        _initialize(this);
+      } else {
+        foo();
+      }
+
+      while (0) {
+        super();
+
+        _initialize(this);
+      }
+
+      super();
+
+      _initialize(this);
+    }
+
+  }
+
+  return {
+    F: B,
+    d: []
+  };
+}, A);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-statement/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-statement/input.js
@@ -1,0 +1,6 @@
+@dec
+class B extends A {
+  constructor() {
+    super();
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-statement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/initialize-after-super-statement/output.js
@@ -1,0 +1,17 @@
+let B = babelHelpers.decorate([dec], function (_initialize, _A) {
+  "use strict";
+
+  class B extends _A {
+    constructor() {
+      super();
+
+      _initialize(this);
+    }
+
+  }
+
+  return {
+    F: B,
+    d: []
+  };
+}, A);

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -235,7 +235,9 @@ describe("modification", function() {
         fnPath.insertAfter(t.identifier("x"));
 
         expect(bodyPath.get("body")).toHaveLength(2);
-        expect(bodyPath.get("body.1").node).toEqual(t.identifier("x"));
+        expect(bodyPath.get("body.1").node).toEqual(
+          t.expressionStatement(t.identifier("x")),
+        );
       });
 
       it("the ExportDefaultDeclaration, if a declaration is exported", function() {
@@ -246,7 +248,9 @@ describe("modification", function() {
         fnPath.insertAfter(t.identifier("x"));
 
         expect(bodyPath.get("body")).toHaveLength(2);
-        expect(bodyPath.get("body.1").node).toEqual(t.identifier("x"));
+        expect(bodyPath.get("body.1").node).toEqual(
+          t.expressionStatement(t.identifier("x")),
+        );
       });
 
       it("the exported expression", function() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8931, fixes #8808
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

> This commit fixes to problem:
> 1) After `super();` statements, `_initialize(this)` was inserted without
>   a trailing semicolon.
> 2) `(0, super())` causes an infinite recursion.

<!-- Describe your changes below in as much detail as possible -->
