### PR TITLE
Update v8flags to version 3.x in v6

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -29,7 +29,7 @@
     "path-is-absolute": "^1.0.1",
     "slash": "^1.0.0",
     "source-map": "^0.5.7",
-    "v8flags": "^2.1.1"
+    "v8flags": "^3.1.1"
   },
   "optionalDependencies": {
     "chokidar": "^1.6.1"


### PR DESCRIPTION

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    | 
| Any Dependency Changes?  | 👍
| License                  | MIT

Backported from #5975 to v6. This enables bable-cli@6 to run on Node 10.
