### PR TITLE
Rename primitive types to reserved types

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -10,7 +10,7 @@ import { types as tc } from "../tokenizer/context";
 import * as charCodes from "charcodes";
 import { isIteratorStart } from "../util/identifier";
 
-const primitiveTypes = [
+const reservedTypes = [
   "any",
   "bool",
   "boolean",
@@ -504,8 +504,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     checkReservedType(word: string, startLoc: number) {
-      if (primitiveTypes.indexOf(word) > -1) {
-        this.raise(startLoc, `Cannot overwrite primitive type ${word}`);
+      if (reservedTypes.indexOf(word) > -1) {
+        this.raise(startLoc, `Cannot overwrite reserved type ${word}`);
       }
     }
 

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/id-reserved-type-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/id-reserved-type-invalid/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:10)"
+  "throws": "Cannot overwrite reserved type string (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/implements-reserved-type-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/implements-reserved-type-invalid/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:21)"
+  "throws": "Cannot overwrite reserved type string (1:21)"
 }

--- a/packages/babel-parser/test/fixtures/flow/opaque-type-alias/reserved-type-invalid/options.json
+++ b/packages/babel-parser/test/fixtures/flow/opaque-type-alias/reserved-type-invalid/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:12)"
+  "throws": "Cannot overwrite reserved type string (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/131/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/131/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type number (1:5)"
+  "throws": "Cannot overwrite reserved type number (1:5)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/132/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/132/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type number (1:9)"
+  "throws": "Cannot overwrite reserved type number (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/133/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/133/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:11)"
+  "throws": "Cannot overwrite reserved type string (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/134/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/134/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type bool (1:13)"
+  "throws": "Cannot overwrite reserved type bool (1:13)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-2/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-2/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:14)"
+  "throws": "Cannot overwrite reserved type string (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-3/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-3/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:14)"
+  "throws": "Cannot overwrite reserved type string (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-4/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-4/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:19)"
+  "throws": "Cannot overwrite reserved type string (1:19)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-shorthand-3/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-shorthand-3/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:16)"
+  "throws": "Cannot overwrite reserved type string (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-shorthand-4/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-shorthand-4/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:14)"
+  "throws": "Cannot overwrite reserved type string (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Cannot overwrite primitive type string (1:12)"
+  "throws": "Cannot overwrite reserved type string (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_name/options.json
+++ b/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_name/options.json
@@ -4,5 +4,5 @@
     "jsx",
     "flow"
   ],
-  "throws": "Cannot overwrite primitive type _ (2:5)"
+  "throws": "Cannot overwrite reserved type _ (2:5)"
 }

--- a/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_param_name/options.json
+++ b/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_param_name/options.json
@@ -4,5 +4,5 @@
     "jsx",
     "flow"
   ],
-  "throws": "Cannot overwrite primitive type _ (2:13)"
+  "throws": "Cannot overwrite reserved type _ (2:13)"
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Not all of the types on the list are primitive anymore. Also flow calls it reserved type.
