### PR TITLE
Export @babel/parser#tokTypes in @babel/core

### DIFF
--- a/packages/babel-core/src/config/helpers/config-api.js
+++ b/packages/babel-core/src/config/helpers/config-api.js
@@ -55,6 +55,7 @@ export default function makeAPI(
     async: () => false,
     caller,
     assertVersion,
+    tokTypes: undefined,
   };
 }
 

--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -10,7 +10,8 @@ export { version } from "../package.json";
 export { getEnv } from "./config/helpers/environment";
 
 export * as types from "@babel/types";
-export * as parser from "@babel/parser";
+export { tokTypes } from "@babel/parser";
+
 export { default as traverse } from "@babel/traverse";
 export { default as template } from "@babel/template";
 

--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -10,6 +10,7 @@ export { version } from "../package.json";
 export { getEnv } from "./config/helpers/environment";
 
 export * as types from "@babel/types";
+export * as parser from "@babel/parser";
 export { default as traverse } from "@babel/traverse";
 export { default as template } from "@babel/template";
 

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -154,6 +154,14 @@ describe("api", function() {
     );
   });
 
+  it("exposes the parser", function() {
+    expect(babel.parser).toBeDefined();
+  });
+
+  it("exposes types", function() {
+    expect(babel.types).toBeDefined();
+  });
+
   it("transformFile", function(done) {
     const options = {
       babelrc: false,

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -154,12 +154,12 @@ describe("api", function() {
     );
   });
 
-  it("exposes the parser", function() {
-    expect(babel.parser).toBeDefined();
-  });
-
   it("exposes types", function() {
     expect(babel.types).toBeDefined();
+  });
+
+  it("exposes the parser's token types", function() {
+    expect(babel.tokTypes).toBeDefined();
   });
 
   it("transformFile", function(done) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Refs https://github.com/babel/babel-eslint/pull/711/files#r231363345
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This exposes `@babel/parser` in `@babel/core`, as proposed [here](https://github.com/babel/babel-eslint/pull/711/files#r231363345). Figured it would be best to just make a PR that we could discuss on :) I wasn't sure if testing deeper than this would be worth it or not, given it would have to change any time `@babel/parser`'s API changes, but happy to update as the team sees fit. Thanks!