### PR TITLE
Update debug dependency

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -41,7 +41,7 @@
     "@babel/traverse": "^7.1.5",
     "@babel/types": "^7.1.5",
     "convert-source-map": "^1.1.0",
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "json5": "^0.5.0",
     "lodash": "^4.17.10",
     "resolve": "^1.3.2",

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -17,7 +17,7 @@
     "@babel/helper-split-export-declaration": "^7.0.0",
     "@babel/parser": "^7.1.5",
     "@babel/types": "^7.1.5",
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "globals": "^11.1.0",
     "lodash": "^4.17.10"
   },


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | 👍
| License                  | MIT

Update debug from ^3.1.0 to ^4.1.0. The breaking change is that debug dropped support for node 4.
https://github.com/visionmedia/debug/releases/tag/4.0.0
