### PR TITLE
New CLI feature: add envinfo to babel-cli via `babel --info`

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "convert-source-map": "^1.1.0",
+    "envinfo": "^5.12.1",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.0.0",
     "lodash": "^4.17.10",

--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -3,10 +3,16 @@
 import parseArgv from "./options";
 import dirCommand from "./dir";
 import fileCommand from "./file";
+import infoCommand from "./info";
 
 const opts = parseArgv(process.argv);
 
-const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
+const fn = opts.cliOptions.info
+  ? infoCommand
+  : opts.cliOptions.outDir
+    ? dirCommand
+    : fileCommand;
+
 fn(opts).catch(err => {
   console.error(err);
   process.exit(1);

--- a/packages/babel-cli/src/babel/info.js
+++ b/packages/babel-cli/src/babel/info.js
@@ -1,0 +1,18 @@
+import { run } from "envinfo";
+
+export default async function() {
+  console.log("\nEnvironment Info:");
+  return run(
+    {
+      System: ["OS", "CPU"],
+      Binaries: ["Node", "npm", "Yarn"],
+      Browsers: ["Chrome", "Edge", "Firefox", "Safari"],
+      npmPackages: "/**/{*babel*,@babel/*/}",
+      npmGlobalPackages: "*babel*",
+    },
+    {
+      duplicates: true,
+      showNotFound: true,
+    },
+  ).then(console.log);
+}

--- a/packages/babel-cli/src/babel/options.js
+++ b/packages/babel-cli/src/babel/options.js
@@ -148,6 +148,8 @@ commander.option(
   "Delete the out directory before compilation",
 );
 
+commander.option("--info", "Display environment debugging information");
+
 commander.version(pkg.version + " (@babel/core " + version + ")");
 commander.usage("[options] <files ...>");
 
@@ -201,6 +203,7 @@ export default function parseArgv(args: Array<string>) {
   }
 
   if (
+    !commander.info &&
     !commander.outDir &&
     filenames.length === 0 &&
     typeof commander.filename !== "string" &&
@@ -277,6 +280,7 @@ export default function parseArgv(args: Array<string>) {
       verbose: opts.verbose,
       deleteDirOnStart: opts.deleteDirOnStart,
       sourceMapTarget: opts.sourceMapTarget,
+      info: opts.info,
     },
   };
 }


### PR DESCRIPTION
This PR adds envinfo to babel-cli. https://github.com/babel/babel/issues/8227

From the issue: 

> 
> Babel gets an incredible number of issues, and managing and triaging them takes a lot of people and time, especially when issues are missing critical environment or setup info. 
> 
> I'd like to add envinfo to babel in some way to help facilitate developers to write better, more complete issues. envinfo can get all of your environment details quickly, all in one command.

Running `babel --info` will return this:

```
Environment Info:

  System:
    OS: macOS 10.14.1
    CPU: (8) x64 Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
  Binaries:
    Node: 8.12.0 - ~/.nvm/versions/node/v8.12.0/bin/node
    Yarn: 1.9.4 - ~/.yarn/bin/yarn
    npm: 6.4.1 - ~/.nvm/versions/node/v8.12.0/bin/npm
  Browsers:
    Chrome: 70.0.3538.77
    Firefox: Not Found
    Safari: 12.0.1
  npmPackages:
    @babel/cli: ^7.1.2 => 7.1.2 
    @babel/core: ^7.1.2 => 7.1.2 
    @babel/plugin-proposal-class-properties: ^7.1.0 => 7.1.0 
    @babel/plugin-proposal-export-namespace-from: ^7.0.0 => 7.0.0 
    @babel/plugin-proposal-numeric-separator: ^7.0.0 => 7.0.0 
    @babel/plugin-transform-modules-commonjs: ^7.1.0 => 7.1.0 
    @babel/plugin-transform-runtime: ^7.1.0 => 7.1.0 
    @babel/preset-env: ^7.1.0 => 7.1.0 
    @babel/preset-flow: ^7.0.0 => 7.0.0 
    @babel/register: ^7.0.0 => 7.0.0 
    @babel/runtime: ^7.1.2 => 7.1.2 
    babel-core: ^7.0.0-0 => 7.0.0-bridge.0 (6.26.0, 6.26.0, 6.26.0)
    babel-eslint: ^10.0.1 => 10.0.1 
    babel-jest: ^23.6.0 => 23.6.0 
    babel-loader: ^8.0.4 => 8.0.4 
    babel-plugin-transform-charcodes: ^0.1.0 => 0.1.0 
    eslint-config-babel: ^8.0.1 => 8.0.1 
    gulp-babel: ^8.0.0-beta.2 => 8.0.0-beta.2 
    rollup-plugin-babel: ^4.0.0-beta.0 => 4.0.0-beta.2 
```

Merging this PR will necessitate follow up PRs to update documentation and issue templates. 


