### PR TITLE
Fix browser files to have the same API as the nodejs ones

### DIFF
--- a/packages/babel-core/src/transform-file-browser.js
+++ b/packages/babel-core/src/transform-file-browser.js
@@ -1,14 +1,29 @@
 // @flow
-import type { FileResult } from "./transformation";
 
-export default function transformFile(
-  filename: string,
-  opts?: Object = {},
-  callback: (?Error, FileResult | null) => void,
+// duplicated from transform-file so we do not have to import anything here
+type TransformFile = {
+  (filename: string, callback: Function): void,
+  (filename: string, opts: ?Object, callback: Function): void,
+};
+
+export const transformFile: TransformFile = (function transformFile(
+  filename,
+  opts,
+  callback,
 ) {
   if (typeof opts === "function") {
     callback = opts;
   }
 
   callback(new Error("Transforming files is not supported in browsers"), null);
+}: Function);
+
+export function transformFileSync() {
+  throw new Error("Transforming files is not supported in browsers");
+}
+
+export function transformFileAsync() {
+  return Promise.reject(
+    new Error("Transforming files is not supported in browsers"),
+  );
 }

--- a/packages/babel-core/src/transform-file-sync-browser.js
+++ b/packages/babel-core/src/transform-file-sync-browser.js
@@ -1,5 +1,0 @@
-// @flow
-
-export default function transformFileSync() {
-  throw new Error("Transforming files is not supported in browsers");
-}

--- a/packages/babel-core/src/transform-file.js
+++ b/packages/babel-core/src/transform-file.js
@@ -9,6 +9,14 @@ import {
   type FileResultCallback,
 } from "./transformation";
 
+import typeof * as transformFileBrowserType from "./transform-file-browser";
+import typeof * as transformFileType from "./transform-file";
+
+// Kind of gross, but essentially asserting that the exports of this module are the same as the
+// exports of transform-file-browser, since this file may be replaced at bundle time with
+// transform-file-browser.
+((({}: any): $Exact<transformFileBrowserType>): $Exact<transformFileType>);
+
 type TransformFile = {
   (filename: string, callback: FileResultCallback): void,
   (filename: string, opts: ?InputOptions, callback: FileResultCallback): void,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |n
| Minor: New Feature?      |n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

It seems this was missed when the new apis were added.

I also added the flow workaround to make sure this does not happen in future.
