### PR TITLE
[Types] fix generated TS/Flow comment types

### DIFF
--- a/scripts/generators/flow.js
+++ b/scripts/generators/flow.js
@@ -15,12 +15,12 @@ declare class ${NODE_PREFIX}Comment {
   loc: ${NODE_PREFIX}SourceLocation;
 }
 
-declare class ${NODE_PREFIX}BlockComment extends ${NODE_PREFIX}Comment {
-  type: "BlockComment";
+declare class ${NODE_PREFIX}CommentBlock extends ${NODE_PREFIX}Comment {
+  type: "CommentBlock";
 }
 
-declare class ${NODE_PREFIX}LineComment extends ${NODE_PREFIX}Comment {
-  type: "LineComment";
+declare class ${NODE_PREFIX}CommentLine extends ${NODE_PREFIX}Comment {
+  type: "CommentLine";
 }
 
 declare class ${NODE_PREFIX}SourceLocation {

--- a/scripts/generators/typescript.js
+++ b/scripts/generators/typescript.js
@@ -11,18 +11,18 @@ interface BaseComment {
   start: number;
   end: number;
   loc: SourceLocation;
-  type: "BlockComment" | "LineComment";
+  type: "CommentBlock" | "CommentLine";
 }
 
-export interface BlockComment extends BaseComment {
-  type: "BlockComment";
+export interface CommentBlock extends BaseComment {
+  type: "CommentBlock";
 }
 
-export interface LineComment extends BaseComment {
-  type: "LineComment";
+export interface CommentLine extends BaseComment {
+  type: "CommentLine";
 }
 
-export type Comment = BlockComment | LineComment;
+export type Comment = CommentBlock | CommentLine;
 
 export interface SourceLocation {
   start: {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8969 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No need
| Documentation PR Link    | None <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As described in #8969, the generated TS/Flow types for comments are not aligned with the ones used by  `@babel/parser`. This change makes them same as the real types used in code.
Specifically:
`BlockComment` => `CommentBlock`
`LineComment` => `CommentLine`