### PR TITLE
Normalize presets before merging config with others.

### DIFF
--- a/packages/babel-core/src/config/config-chain.js
+++ b/packages/babel-core/src/config/config-chain.js
@@ -67,7 +67,7 @@ export function buildPresetChain(
   return {
     plugins: dedupDescriptors(chain.plugins),
     presets: dedupDescriptors(chain.presets),
-    options: chain.options,
+    options: chain.options.map(o => normalizeOptions(o)),
   };
 }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9031
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Because we weren't normalizing this, roundtripping a config through `loadOptions` would re-add the plugins/preset inside `env` and `overrides` blocks, causing unexpected plugin duplication.