### PR TITLE
Fix parsing typescript function types with destructuring

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -314,13 +314,19 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsParseBindingListForSignature(): $ReadOnlyArray<
-      N.Identifier | N.RestElement,
+      N.Identifier | N.RestElement | N.ObjectPattern,
     > {
       return this.parseBindingList(tt.parenR).map(pattern => {
-        if (pattern.type !== "Identifier" && pattern.type !== "RestElement") {
+        if (
+          pattern.type !== "Identifier" &&
+          pattern.type !== "RestElement" &&
+          pattern.type !== "ObjectPattern"
+        ) {
           throw this.unexpected(
             pattern.start,
-            "Name in a signature must be an Identifier.",
+            `Name in a signature must be an Identifier or ObjectPattern, instead got ${
+              pattern.type
+            }`,
           );
         }
         return pattern;
@@ -747,6 +753,22 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.next();
         return true;
       }
+
+      if (this.match(tt.braceL)) {
+        const braceStack = [tt.braceL];
+        this.next();
+
+        while (braceStack.length > 0) {
+          if (this.match(tt.braceL)) {
+            braceStack.push(tt.braceL);
+          } else if (this.match(tt.braceR)) {
+            braceStack.pop();
+          }
+          this.next();
+        }
+        return true;
+      }
+
       return false;
     }
 

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -755,14 +755,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
 
       if (this.match(tt.braceL)) {
-        const braceStack = [tt.braceL];
+        let braceStackCounter = 1;
         this.next();
 
-        while (braceStack.length > 0) {
+        while (braceStackCounter > 0) {
           if (this.match(tt.braceL)) {
-            braceStack.push(tt.braceL);
+            ++braceStackCounter;
           } else if (this.match(tt.braceR)) {
-            braceStack.pop();
+            --braceStackCounter;
           }
           this.next();
         }

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1037,7 +1037,7 @@ export type TsSignatureDeclaration =
 
 export type TsSignatureDeclarationOrIndexSignatureBase = NodeBase & {
   // Not using TypeScript's "ParameterDeclaration" here, since it's inconsistent with regular functions.
-  parameters: $ReadOnlyArray<Identifier | RestElement>,
+  parameters: $ReadOnlyArray<Identifier | RestElement | ObjectPattern>,
   typeAnnotation: ?TsTypeAnnotation,
 };
 

--- a/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/input.js
@@ -1,0 +1,1 @@
+type MyType = ({ theme }: any) => any

--- a/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/output.json
@@ -1,0 +1,216 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 37,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 37
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 37,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 37
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start": 0,
+        "end": 37,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 37
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            },
+            "identifierName": "MyType"
+          },
+          "name": "MyType"
+        },
+        "typeAnnotation": {
+          "type": "TSFunctionType",
+          "start": 14,
+          "end": 37,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 37
+            }
+          },
+          "parameters": [
+            {
+              "type": "ObjectPattern",
+              "start": 15,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 15
+                },
+                "end": {
+                  "line": 1,
+                  "column": 29
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 17,
+                  "end": 22,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    }
+                  },
+                  "method": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 17,
+                    "end": 22,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      },
+                      "identifierName": "theme"
+                    },
+                    "name": "theme"
+                  },
+                  "computed": false,
+                  "shorthand": true,
+                  "value": {
+                    "type": "Identifier",
+                    "start": 17,
+                    "end": 22,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      },
+                      "identifierName": "theme"
+                    },
+                    "name": "theme"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 24,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 29
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSAnyKeyword",
+                  "start": 26,
+                  "end": 29,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 26
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 29
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "typeAnnotation": {
+            "type": "TSTypeAnnotation",
+            "start": 31,
+            "end": 37,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 31
+              },
+              "end": {
+                "line": 1,
+                "column": 37
+              }
+            },
+            "typeAnnotation": {
+              "type": "TSAnyKeyword",
+              "start": 34,
+              "end": 37,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 34
+                },
+                "end": {
+                  "line": 1,
+                  "column": 37
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8745, fixes #8099 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Allows parsing of destructured params in function type declarations.
