### PR TITLE
Remove direct options to @babel/plugin-class-features

### DIFF
--- a/packages/babel-plugin-class-features/src/index.js
+++ b/packages/babel-plugin-class-features/src/index.js
@@ -27,60 +27,15 @@ export { enableFeature, FEATURES, setLoose };
 const version = pkg.version.split(".").reduce((v, x) => v * 1e5 + +x, 0);
 const versionKey = "@babel/plugin-class-features/version";
 
-const getFeatureOptions = (options, name) => {
-  const value = options[name];
-
-  if (value === undefined || value === false) return { enabled: false };
-  if (value === true) return { enabled: true, loose: false };
-
-  if (typeof value === "object") {
-    if (
-      typeof value.loose !== "undefined" &&
-      typeof value.loose !== "boolean"
-    ) {
-      throw new Error(`.${name}.loose must be a boolean or undefined.`);
-    }
-
-    return { enabled: true, loose: !!value.loose };
-  }
-
-  throw new Error(
-    `.${name} must be a boolean, an object with a 'loose'` +
-      ` property or undefined.`,
-  );
-};
-
-export default declare((api, options) => {
+export default declare(api => {
   api.assertVersion(7);
-
-  const fields = getFeatureOptions(options, "fields");
-  const privateMethods = getFeatureOptions(options, "privateMethods");
-  const decorators = getFeatureOptions(options, "decorators");
 
   return {
     name: "class-features",
 
-    manipulateOptions(opts, parserOpts) {
-      if (fields) {
-        parserOpts.plugins.push("classProperties", "classPrivateProperties");
-      }
-    },
-
     pre() {
       if (!this.file.get(versionKey) || this.file.get(versionKey) < version) {
         this.file.set(versionKey, version);
-      }
-
-      if (fields.enabled) {
-        enableFeature(this.file, FEATURES.fields, fields.loose);
-      }
-      if (privateMethods.enabled) {
-        throw new Error("Private methods are not supported yet");
-        enableFeature(this.file, FEATURES.privateMethods);
-      }
-      if (decorators.enabled) {
-        throw new Error("Decorators are not supported yet");
-        enableFeature(this.file, FEATURES.decorators);
       }
     },
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | :warning: We should merge this before the next release
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR removes the ability of using the class-features plugin like this:

```json
{
  "plugins": [
    ["@babel/plugin-class-features", { "decorators": true }]
  ]
}
```

Since it could cause problems because it behaves differently from how other plugins behave (see https://github.com/babel/babel/pull/8130#discussion_r231804956).
With this PR only the old packages (`@babel/plugin-proposal-class-properties`, etc) can be used to configure `@babel/plugin-class-features`.