### PR TITLE
Fix bug with parsing TS generic async arrow function

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -1299,11 +1299,17 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return undefined;
       }
 
+      const oldInAsync = this.state.inAsync;
+      const oldInGenerator = this.state.inGenerator;
+      this.state.inAsync = true;
+      this.state.inGenerator = false;
       res.id = null;
       res.generator = false;
       res.expression = true; // May be set again by parseFunctionBody.
       res.async = true;
       this.parseFunctionBody(res, true);
+      this.state.inAsync = oldInAsync;
+      this.state.inGenerator = oldInGenerator;
       return this.finishNode(res, "ArrowFunctionExpression");
     }
 

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/input.js
@@ -1,0 +1,1 @@
+async <T>() => await null;

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/output.json
@@ -1,0 +1,133 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 26,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 26
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 26,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 26
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 26
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 25,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 25
+            }
+          },
+          "typeParameters": {
+            "type": "TSTypeParameterDeclaration",
+            "start": 6,
+            "end": 9,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 9
+              }
+            },
+            "params": [
+              {
+                "type": "TSTypeParameter",
+                "start": 7,
+                "end": 8,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 8
+                  }
+                },
+                "name": "T"
+              }
+            ]
+          },
+          "params": [],
+          "id": null,
+          "generator": false,
+          "expression": true,
+          "async": true,
+          "body": {
+            "type": "AwaitExpression",
+            "start": 15,
+            "end": 25,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              }
+            },
+            "argument": {
+              "type": "NullLiteral",
+              "start": 21,
+              "end": 25,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 21
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9006 
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Y/Y
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
