### PR TITLE
Adding ability to use jest's --watch feature.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,11 @@ $ TEST_DEBUG=true make test
 
 You can combine `TEST_DEBUG` with `TEST_GREP` or `TEST_ONLY` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by editing [test/mocha.opts](https://github.com/babel/babel/blob/master/test/mocha.opts).
 
+To use jest's watch feature, you can set the `TEST_WATCH` variable:
+```sh
+$ TEST_WATCH=true make test
+```
+
 To overwrite any test fixtures when fixing a bug or anything, add the env variable `OVERWRITE=true`
 
 ```sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,4 +23,8 @@ if [ -n "$TEST_ONLY" ]; then
   jestArgs+=("(packages|codemods)/.*$TEST_ONLY.*/test")
 fi
 
+if [ -n "$TEST_WATCH" ]; then
+  jestArgs+=("--watch")
+fi
+
 $node node_modules/jest/bin/jest.js "${jestArgs[@]}"


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |  No issue for this
| Patch: Bug Fix?          | N/A (dev change, only)
| Major: Breaking Change?  | N/A (dev change, only)
| Minor: New Feature?      | N/A (dev change, only)
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

Jest's watch feature is nice because then you can use jest's built-in filename and test name regex searchers and switch between tests without having to wait on it when restarted. It also allows you to run only the failed tests, which is nice.
