### PR TITLE
Pass `rootMode` from `@babel/node`.

### DIFF
--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -64,7 +64,7 @@ program.version(pkg.version);
 program.usage("[options] [ -e script | script.js ] [arguments]");
 program.parse(process.argv);
 
-register({
+const babelOptions = {
   caller: {
     name: "@babel/node",
   },
@@ -81,7 +81,15 @@ register({
   // leave them undefined so that @babel/core can handle the
   // default-assignment logic on its own.
   babelrc: program.babelrc === true ? undefined : program.babelrc,
-});
+};
+
+for (const key of Object.keys(babelOptions)) {
+  if (babelOptions[key] === undefined) {
+    delete babelOptions[key];
+  }
+}
+
+register(babelOptions);
 
 const replPlugin = ({ types: t }) => ({
   visitor: {

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -52,6 +52,11 @@ program.option(
   "The name of the 'env' to use when loading configs and plugins. " +
     "Defaults to the value of BABEL_ENV, or else NODE_ENV, or else 'development'.",
 );
+commander.option(
+  "--root-mode [mode]",
+  "The project-root resolution mode. " +
+    "One of 'root' (the default), 'upward', or 'upward-optional'.",
+);
 program.option("-w, --plugins [string]", "", collect);
 program.option("-b, --presets [string]", "", collect);
 
@@ -70,6 +75,7 @@ register({
   presets: program.presets,
   configFile: program.configFile,
   envName: program.envName,
+  rootMode: program.rootMode,
 
   // Commander will default the "--no-" arguments to true, but we want to
   // leave them undefined so that @babel/core can handle the


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8968 (although it's already closed).
| Patch: Bug Fix?          | No.
| Major: Breaking Change?  | No.
| Minor: New Feature?      | Yes.
| Tests Added + Pass?      | No.
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
#8660 added support for `rootMode` for `@babel/core` and `@babel/cli`, but it can't be touched from `@babel/node`.  This pretty much copypastes what `@babel/cli` got.