### PR TITLE
Move `fs-readdir-recursive` and `output-file-sync` to `devDependencies` for `@babel/node`.

### DIFF
--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -22,9 +22,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/register": "^7.0.0",
     "commander": "^2.8.1",
-    "fs-readdir-recursive": "^1.0.0",
     "lodash": "^4.17.10",
-    "output-file-sync": "^2.0.0",
     "v8flags": "^3.1.1"
   },
   "peerDependencies": {
@@ -32,7 +30,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/helper-fixtures": "^7.0.0"
+    "@babel/helper-fixtures": "^7.0.0",
+    "fs-readdir-recursive": "^1.0.0",
+    "output-file-sync": "^2.0.0"
   },
   "bin": {
     "babel-node": "./bin/babel-node.js"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | No.
| Major: Breaking Change?  | No.
| Minor: New Feature?      | No.
| Tests Added + Pass?      | No.
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`fs-readdir-recursive` and `output-file-sync` are only used in the tests for `@babel/node`.