### PR TITLE
Remove unused variable

### DIFF
--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -363,14 +363,14 @@ export default class Printer {
     }
     if (needsParens) this.token("(");
 
-    this._printLeadingComments(node, parent);
+    this._printLeadingComments(node);
 
     const loc = t.isProgram(node) || t.isFile(node) ? null : node.loc;
     this.withSource("start", loc, () => {
       this[node.type](node, parent);
     });
 
-    this._printTrailingComments(node, parent);
+    this._printTrailingComments(node);
 
     if (needsParens) this.token(")");
 
@@ -472,12 +472,12 @@ export default class Printer {
     this.print(node, parent);
   }
 
-  _printTrailingComments(node, parent) {
-    this._printComments(this._getComments(false, node, parent));
+  _printTrailingComments(node) {
+    this._printComments(this._getComments(false, node));
   }
 
-  _printLeadingComments(node, parent) {
-    this._printComments(this._getComments(true, node, parent));
+  _printLeadingComments(node) {
+    this._printComments(this._getComments(true, node));
   }
 
   printInnerComments(node, indent = true) {


### PR DESCRIPTION
When I was reading the code, I see `parent` is not used in `_getComments` function.
so it make me confused why we delivery the `parent` in those functions.

If I'm wrong, please correct me.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
