### PR TITLE
Fix warning when using prettier in code generators

### DIFF
--- a/packages/babel-types/scripts/generateTypeHelpers.js
+++ b/packages/babel-types/scripts/generateTypeHelpers.js
@@ -1,6 +1,7 @@
 "use strict";
 const fs = require("fs");
 const path = require("path");
+const chalk = require("chalk");
 const generateBuilders = require("./generators/generateBuilders");
 const generateValidators = require("./generators/generateValidators");
 const generateAsserts = require("./generators/generateAsserts");
@@ -26,6 +27,13 @@ function writeFile(content, location) {
 console.log("Generating @babel/types dynamic functions");
 
 writeFile(generateBuilders(), "builders/generated/index.js");
+console.log(`  ${chalk.green("✔")} Generated builders`);
+
 writeFile(generateValidators(), "validators/generated/index.js");
+console.log(`  ${chalk.green("✔")} Generated validators`);
+
 writeFile(generateAsserts(), "asserts/generated/index.js");
+console.log(`  ${chalk.green("✔")} Generated asserts`);
+
 writeFile(generateConstants(), "constants/generated/index.js");
+console.log(`  ${chalk.green("✔")} Generated constants`);

--- a/packages/babel-types/scripts/utils/formatCode.js
+++ b/packages/babel-types/scripts/utils/formatCode.js
@@ -4,6 +4,8 @@ const prettier = require("prettier");
 module.exports = function formatCode(code, filename) {
   filename = filename || __filename;
   const prettierConfig = prettier.resolveConfig.sync(filename);
+  prettierConfig.filepath = filename;
+  prettierConfig.parser = "babylon";
 
   return prettier.format(code, prettierConfig);
 };


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This fixes the warning `No parser and no filepath given, using 'babylon' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.` when generating the files for babel-types.

It also adds more output to see what it happening.

<img width="580" alt="screen shot 2018-11-27 at 2 42 32 pm" src="https://user-images.githubusercontent.com/231804/49116587-f49d7500-f252-11e8-80dc-fd18f7aa1934.png">

