### PR TITLE
Skip minifying standalone in non-publish runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ prepublish-build:
 	rm -rf packages/babel-runtime/helpers
 	rm -rf packages/babel-runtime-corejs2/helpers
 	rm -rf packages/babel-runtime-corejs2/core-js
-	BABEL_ENV=production make build-dist
+	BABEL_ENV=production IS_PUBLISH=true make build-dist
 	make clone-license
 
 prepublish:

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "rollup-stream": "^1.24.1",
     "test262-stream": "^1.2.0",
     "through2": "^2.0.0",
-    "uglify-js": "^2.4.16",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "webpack": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9357,7 +9357,7 @@ uglify-js@3.3.x, uglify-js@^3.0.5:
     commander "~2.14.1"
     source-map "~0.6.1"
 
-uglify-js@^2.4.16, uglify-js@^2.6, uglify-js@^2.8.29:
+uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This only minifies the standalone packages when publishing. We already skipped it on CI, because it is not necessary for the tests. Now it is also skipped in dev unless it is called from publish. I think unless one is working on the standalone packages it is not really necessary to always minify.

Also added a message that states if it is skipped or not.
<img width="542" alt="screen shot 2018-11-27 at 3 58 50 pm" src="https://user-images.githubusercontent.com/231804/49119505-6bd80680-f25d-11e8-869a-20da834ee795.png">
<img width="661" alt="screen shot 2018-11-27 at 4 02 22 pm" src="https://user-images.githubusercontent.com/231804/49119616-da1cc900-f25d-11e8-95b5-063fdb5b240e.png">


Also remove unused dependency on uglify js. gulp-uglify uses its own version.
