### PR TITLE
Retain JSX pragma if defined as a comment

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -25,6 +25,8 @@ const PARSED_PARAMS = new WeakSet();
 export default declare((api, { jsxPragma = "React" }) => {
   api.assertVersion(7);
 
+  const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
+
   return {
     name: "transform-typescript",
     inherits: syntaxTypeScript,
@@ -37,6 +39,17 @@ export default declare((api, { jsxPragma = "React" }) => {
 
       Program(path, state: State) {
         state.programPath = path;
+
+        const { file } = state;
+
+        if (file.ast.comments) {
+          for (const comment of (file.ast.comments: Array<Object>)) {
+            const jsxMatches = JSX_ANNOTATION_REGEX.exec(comment.value);
+            if (jsxMatches) {
+              jsxPragma = jsxMatches[1];
+            }
+          }
+        }
 
         // remove type imports
         for (const stmt of path.get("body")) {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-no/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-no/input.mjs
@@ -1,0 +1,4 @@
+/* @jsx htm */
+// Don't elide htm if a JSX element appears somewhere.
+import { htm } from "fake-jsx-package";
+<div></div>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-no/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-no/options.json
@@ -1,0 +1,4 @@
+{
+    "plugins": [["transform-typescript", { "isTSX": true }]]
+}
+  

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-no/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-jsx-pragma-no/output.mjs
@@ -1,0 +1,4 @@
+/* @jsx htm */
+// Don't elide htm if a JSX element appears somewhere.
+import { htm } from "fake-jsx-package";
+<div></div>;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8958 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Bug Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

Currently, the TypeScript transform elides JSX pragma imports unless used explicitly. This PR modifies the transform to properly detect the JSX pragma declaration when defined as a comment, and appropriately retains imports if the import matches the pragma. The check was added by copying over the pragma detection from `babel-plugin-transform-react-jsx`.
