### PR TITLE
Add node 11 to CI and remove node 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     working_directory: ~/babel
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:11
     steps:
       - checkout
       - restore-cache: *restore-yarn-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 git:
-  depth: 10
+  depth: 5
 sudo: false
 language: node_js
 cache:
   yarn: true
-  directories:
-    - node_modules
 node_js:
   # We test the latest version on circleci
-  - '9'
+  - '10'
   - '8'
   - '6'
 
@@ -20,7 +18,9 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
 
-install: yarn --ignore-engines
+install:
+  # the `make test-ci` script runs this command already
+  - if [ "$JOB" != "test" ]; then yarn install; fi
 
 before_script:
   - 'if [ "$JOB" = "babel-parser-flow-tests" ]; then make bootstrap-flow; fi'


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8871
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Enable node 11 on circleCI.
Remove node 9 on travis and instead use node 10.
Do not cache node_modules as extracting the cache takes significant amount of time, but not sure about that, lets see what happens to build times.
Do not run `yarn install` twice when running tests.

This also incorporates some changes from #8871.