### PR TITLE
Added type-level mapping between aliases and nodes that have that alias.

### DIFF
--- a/scripts/generators/typescript.js
+++ b/scripts/generators/typescript.js
@@ -160,6 +160,13 @@ for (const type in t.FLIPPED_ALIAS_KEYS) {
     .map(type => `${type}`)
     .join(" | ")};\n`;
 }
+code += "\n";
+
+code += "export interface Aliases {\n";
+for (const type in t.FLIPPED_ALIAS_KEYS) {
+  code += `  ${type}: ${type};\n`;
+}
+code += "}\n\n";
 
 code += lines.join("\n") + "\n";
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9092 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | :+1: 
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

## Problem

The [TypeScript types for `Visitor` in `@babel/traverse`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/46aea293fad10e638e6885b9f1f0d2938a711e16/types/babel__traverse/index.d.ts#L142) do not allow node aliases as properties. These cannot be added with the current contents of the auto-generated TypeScript definitions for `@babel/types`.

## Solution

If `@babel/types` had a type-level mapping between aliases and the node types that have those aliases, e.g:

```typescript
export interface Aliases {
  Function: Function;
  Expression: Expression;
  LVal: LVal;
  // ...etc
}
```

Then the `Visitor` type in the TypeScript definitions can be intersected with the following type:

```typescript
{ [K in keyof Aliases]?: VisitNode<S, Aliases[K]> }
```

This would then allow using aliases as `Visitor` properties when using TypeScript.

This PR adds such an `Aliases` type.

## Concerns

* There are no tests for this, because it seems like the infrastructure for testing `d.ts` files is not set up. If tests are required then I can set this infrastructure up.
* This does not add equivalent functionality to the flow types. I believe that if the same thing was added, then it could be used in the same way as the TypeScript types by using `$ObjMap`. Can somebody confirm what the situation with flow definitions for `@babel/traverse` are and whether this would be a useful addition to the flow types?