### PR TITLE
Update find-cache-dir to v2

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "core-js": "^2.5.7",
-    "find-cache-dir": "^1.0.0",
+    "find-cache-dir": "^2.0.0",
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | yes
| License                  | MIT

Dropped support for node <6
https://github.com/avajs/find-cache-dir/commits/master
