### PR TITLE
Fix bug while running tests when a top directory contains escaped RegExp characters

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -196,7 +196,7 @@ function run(task) {
   if (!execCode || actualCode) {
     result = babel.transform(actualCode, getOpts(actual));
     const expectedCode = result.code.replace(
-      escapeRegExp(path.resolve(__dirname, "../../../")),
+      new RegExp(escapeRegExp(path.resolve(__dirname, "../../../"))),
       "<CWD>",
     );
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When one of the parent directories of your babel working directory contains a special RexExp char (ex. a dot) some tests fail. For example with those tests `TEST_ONLY=babel-plugin-transform-runtime make test`

The problem comes from the missing usage of `new RexExp()` after `escapeRegExp` the working path.

I've also checked if this could happen in other places in the code but I only found and correct this minor bug. #