### PR TITLE
Revert "Revert babel-helper-builder-react-jsx change from #4988"

### DIFF
--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -19,6 +19,13 @@ You can turn on the 'throwIfNamespace' flag to bypass this warning.`,
       );
     }
   };
+
+  visitor.JSXSpreadChild = function(path) {
+    throw path.buildCodeFrameError(
+      "Spread children are not supported in React.",
+    );
+  };
+
   visitor.JSXElement = {
     exit(path, file) {
       const callExpr = buildElementCall(path, file);

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/input.js
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/input.js
@@ -1,0 +1,1 @@
+<div>{...children}</div>;

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/should-disallow-spread-children/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Spread children are not supported in React."
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5492, Fixes #8456
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

This readds the throw for `JSXSpreadChild` in the react transform.

It was initially added in #4988 but later reverted (#5015) because there were breaking cases when people used the latest version of the react transform but an older versions of babel-types (which did not yet know the new node `JSXSpreadChild`).

We now do not have this problem anymore as a) we released a major and b) renamed the project after the node was added.

I thought about adding a flag similar to the namespace flag, but atm if someone would use the react-transform with the SpreacChildren it would throw anyway with:

```
TypeError: Property arguments[2] of CallExpression expected node to
 be of a type ["Expression","SpreadElement","JSXNamespacedName"] but in
stead got "JSXSpreadChild"
``` 


