### PR TITLE
Deleting compiled files when source files are deleted, renamed or moved, when using --watch

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -89,12 +89,18 @@ export default async function({ cliOptions, babelOptions }) {
     const dest = getDest(relative, base);
     util.deleteFile(dest);
     // Delete the source map if they're enabled
+    let sourceMapMessage = "";
     if (
       util.isCompilableExtension(relative, cliOptions.extensions) &&
       babelOptions.sourceMaps &&
       babelOptions.sourceMaps !== "inline"
     ) {
       util.deleteFile(dest + ".map");
+      sourceMapMessage = " and " + dest + ".map";
+    }
+
+    if (cliOptions.verbose) {
+      console.log(dest + sourceMapMessage + " deleted by Babel.");
     }
   }
 

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -105,7 +105,6 @@ export function deleteFile(path) {
   if (fs.existsSync(path)) {
     fs.unlink(path, err => {
       if (err) throw err;
-      console.log(path + " was deleted");
     });
   }
 }

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -101,6 +101,17 @@ export function deleteDir(path) {
   }
 }
 
+export function deleteFile(path) {
+  if (fs.existsSync(path)) {
+    //fs.unlinkSync(path);
+
+    fs.unlink(path, err => {
+      if (err) throw err;
+      console.log(path + " was deleted");
+    });
+  }
+}
+
 process.on("uncaughtException", function(err) {
   console.error(err);
   process.exit(1);

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -103,8 +103,6 @@ export function deleteDir(path) {
 
 export function deleteFile(path) {
   if (fs.existsSync(path)) {
-    //fs.unlinkSync(path);
-
     fs.unlink(path, err => {
       if (err) throw err;
       console.log(path + " was deleted");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5636
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

When using the --watch flag on the Babel CLI, it currently only watches for files being added or changed.  We have run into issues when files have that have been deleted still have their compiled versions available.  This PR ensures that when a file is unlinked it's compiled version (and the .map if available) is also deleted.

For more information on why this is an issue for us (and potentially others), it's worth adding some context:

We're creating a quite a lot of packages within a monorepo (using Lerna and Yarn workspaces).  These packages are consumed by sample clients, which are also in the monorepo.  To do work we first run a scoped lerna exec command that runs Babel watch on all of the packages, creating the code that's then consumed in the sample clients.  We then work on functionality, previewing using one of the sample clients.  Most of the work is done in the packages, and during any refactoring it's easy to get in the state where the client code is still consuming the 'deleted' compiled code, where a file has been renamed or moved.  This issue only reveals itself when performing a fresh compilation.  At the moment we're restarting the babel --watch with the --delete-dir-on-start flag, so this cleans things up, but it's something each developer has to remember to do, and can be complicated when pulling in others code.  I've been working with this fork and it's working nicely for our use case.

In the issue #5636 (https://github.com/babel/babel/issues/5636#issuecomment-294332495) it was mentioned that if this functionality was implemented it'd be the default behaviour so I have made this the case in this fork.  I know the issue was closed but this piece of the functionality is missing and would be very useful for us, and I'm assuming others (mentioned in https://github.com/runvnc/babel-changed/issues/3).  

I'm hoping this helps, and happy for any feedback.  Great work on Babel (and Lerna), we're really making great use of it!

 


