### PR TITLE
Ensure we always use repository versions of babel dependencies in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,9 @@
       "/test/tmp/",
       "/test/__data__/",
       "<rootDir>/build/"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^@babel/([a-zA-Z0-9_-]+)$": "<rootDir>/packages/babel-$1/"
+    }
   }
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

This increases the codecoverage around 3% from 80% to 83% in my local testing and ensures we always test with code from our repository and not installed versions in node_modules.
