### PR TITLE
Inherit properties in function from method in loose mode

### DIFF
--- a/packages/babel-plugin-transform-classes/src/transformClass.js
+++ b/packages/babel-plugin-transform-classes/src/transformClass.js
@@ -494,7 +494,8 @@ export default function transformClass(
         node.generator,
         node.async,
       );
-      func.returnType = node.returnType;
+      t.inherits(func, node);
+
       const key = t.toComputedKey(node, node.key);
       if (t.isStringLiteral(key)) {
         func = nameFunction({


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | There was a test for this and keeps passing
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

This modifies the class transform to inherit the properties from methods to the function that's generated in loose mode.

There was a test to ensure the return type was copied to the new function, but the `loc` of the node was lost because it was copied manually instead of using `inherits`.

This is tested in `packages/babel-plugin-transform-classes/test/fixtures/loose/method-return-type-annotation` and the test keeps passing.

Perhaps I should add a test for the location, but so far all tests for the package only check input/output, not the node state.