### PR TITLE
Simplify rest parameter output

### DIFF
--- a/packages/babel-plugin-transform-parameters/src/rest.js
+++ b/packages/babel-plugin-transform-parameters/src/rest.js
@@ -1,11 +1,10 @@
 import { template, types as t } from "@babel/core";
 
 const buildRest = template(`
-  for (var LEN = ARGUMENTS.length,
-           ARRAY = new Array(ARRAY_LEN),
-           KEY = START;
-       KEY < LEN;
-       KEY++) {
+  for (var KEY = ARGUMENTS.length,
+           ARRAY = [];
+       KEY-- > START;
+       ) {
     ARRAY[ARRAY_KEY] = ARGUMENTS[KEY];
   }
 `);


### PR DESCRIPTION
This was one of the main things we got stuck with when trying to [move Microbundle from Buble to Babel](developit/microbundle#263).

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No (yet!)
| Documentation PR Link    | (not yet)
| Any Dependency Changes?  | no
| License                  | MIT

Input:

```js
function a(b, c, ...d) {
  return d;
}
```

Output (current):

```js
function a(b, c) {
  for (var e = arguments.length, d = new Array(e), t = 2; t < e; t++)
    d[t - 2] = arguments[t];
  return d;
}
```

Output (this PR):

```js
function a(b, c) {
  for (var e = arguments.length, d = []; e-- > 2; )
    d[e - 2] = arguments[e];
  return d;
}
```