### PR TITLE
Bump `@babel/preset-typescript` to 7.2.0

### DIFF
--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/preset-typescript",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Babel preset for TypeScript.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
   "license": "MIT",
@@ -14,13 +14,13 @@
   ],
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-transform-typescript": "^7.1.0"
+    "@babel/plugin-transform-typescript": "^7.2.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.2.0",
     "@babel/helper-plugin-test-runner": "^7.0.0"
   }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | Yes
| License                  | MIT

Bumps the `@babel/preset-typescript` to **7.2.0**
=> Upgraded `@babel/plugin-transform-typescript` dependency to **^7.2.0**
=> Upgraded `@babel/core` devDependency to **^7.2.0**

I'm not sure how to test this version bump locally, so I let the CI pipeline decide.
EDIT : Tests passed

I'm submitting this PR as the preset doesn't seem to be kept up to date. (Maybe there is a reason ?)