### PR TITLE
Allow keywords to be used in type annotations

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -1384,6 +1384,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         default:
           if (this.state.type.keyword === "typeof") {
             return this.flowParseTypeofType();
+          } else if (this.state.type.keyword) {
+            const label = this.state.type.label;
+            this.next();
+            return super.createIdentifier(node, label);
           }
       }
 

--- a/packages/babel-parser/test/fixtures/flow/declare-export/invalid-export-default-var/options.json
+++ b/packages/babel-parser/test/fixtures/flow/declare-export/invalid-export-default-var/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:23)"
+  "throws": "Unexpected token, expected \";\" (1:27)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/function-is-valid-type/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/function-is-valid-type/input.js
@@ -1,0 +1,1 @@
+function foo(a:function) {}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/function-is-valid-type/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/function-is-valid-type/output.json
@@ -1,0 +1,137 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 27
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 27,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 27
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "Identifier",
+            "start": 13,
+            "end": 23,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 23
+              },
+              "identifierName": "a"
+            },
+            "name": "a",
+            "typeAnnotation": {
+              "type": "TypeAnnotation",
+              "start": 14,
+              "end": 23,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 14
+                },
+                "end": {
+                  "line": 1,
+                  "column": 23
+                }
+              },
+              "typeAnnotation": {
+                "type": "Identifier",
+                "start": 15,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 23
+                  },
+                  "identifierName": "function"
+                },
+                "name": "function"
+              }
+            }
+          }
+        ],
+        "body": {
+          "type": "BlockStatement",
+          "start": 25,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 25
+            },
+            "end": {
+              "line": 1,
+              "column": 27
+            }
+          },
+          "body": [],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/scripts/tests/flow/flow_tests_whitelist.txt
+++ b/scripts/tests/flow/flow_tests_whitelist.txt
@@ -26,7 +26,6 @@ decorators/migrated_0003.js
 decorators/migrated_0007.js
 private_class_properties/multiple.js
 private_class_properties/super.js
-types/annotations/migrated_0001.js
 types/annotations/void_is_reserved_param.js
 types/member/reserved_words.js
 types/parameter_defaults/migrated_0032.js
@@ -37,4 +36,3 @@ numbers/underscored_float_whole.js
 numbers/underscored_hex.js
 numbers/underscored_number.js
 numbers/underscored_oct.js
-types/annotations_in_comments/migrated_0001.js


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

This allows keywords to be used as type annotations like

```js
function foo(a:function, b: switch) {}
```

Flow does also not error in this cases.
