### PR TITLE
don't throw classNameTDZError if referenced identifier is within a GenericTypeAnnotation or QualifiedTypeAnnotation

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type-challenge/input.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type-challenge/input.js
@@ -1,0 +1,7 @@
+const sym = Symbol();
+const sym1 = Symbol();
+
+class A {
+  [sym]: A.B;
+  [sym1]: Array<A>;
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type-challenge/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type-challenge/options.json
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "flow"
+  ],
+  "plugins": [
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type-challenge/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type-challenge/output.js
@@ -1,0 +1,13 @@
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+const sym = Symbol();
+const sym1 = Symbol();
+
+class A {
+  constructor() {
+    _defineProperty(this, sym, void 0);
+
+    _defineProperty(this, sym1, void 0);
+  }
+
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type/input.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type/input.js
@@ -1,0 +1,5 @@
+const sym = Symbol();
+
+class A {
+  [sym]: A;
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type/options.json
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type/options.json
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "flow"
+  ],
+  "plugins": [
+    "proposal-class-properties"
+  ]
+}

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/plugin-proposal-class-properties/recursive-class-property-type/output.js
@@ -1,0 +1,10 @@
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+const sym = Symbol();
+
+class A {
+  constructor() {
+    _defineProperty(this, sym, void 0);
+  }
+
+}

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -40,6 +40,9 @@ function skipAllButComputedKey(path) {
 }
 
 export const environmentVisitor = {
+  TypeAnnotation(path) {
+    path.skip();
+  },
   Function(path) {
     // Methods will be handled by the Method visit
     if (path.isMethod()) return;


### PR DESCRIPTION
It was easy to get the project setup to contribute and test this fix.  Thank you guys! :heart:

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fix #9189
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Obviously the code that was causing the bug is intended to throw an error if someone tries to reference a class before it's defined, like:
```js
class Foo {
  someField = Foo;
}
```
But there's no problem with referencing the class in a type annotation before it's defined, and this is often necessary for tree structures:
```js
class Foo {
  [someSymbol]: Foo;
}
```