### PR TITLE
[smart pipes] Parser yield bugfix 

### DIFF
--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -13,7 +13,12 @@
 // expressions and divisions. It is set on all token types that can
 // be followed by an expression (thus, a slash after them would be a
 // regular expression).
-//
+
+// The `startsExpr` property is used to determine whether an expression
+// may be the “argument” subexpression of a `yield` expression or
+// `yield` statement. It is set on all token types that may be at the
+// start of a subexpression.
+
 // `isLoop` marks a keyword as starting a loop, which is important
 // to know when parsing a label, in order to allow or disallow
 // continue jumps to that label.
@@ -104,7 +109,7 @@ export const types: { [name: string]: TokenType } = {
   backQuote: new TokenType("`", { startsExpr }),
   dollarBraceL: new TokenType("${", { beforeExpr, startsExpr }),
   at: new TokenType("@"),
-  hash: new TokenType("#"),
+  hash: new TokenType("#", { startsExpr }),
 
   // Special hashbang token.
   interpreterDirective: new TokenType("#!..."),

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-async-await/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-async-await/input.js
@@ -1,0 +1,3 @@
+async function f () {
+  return x |> await #;
+}

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-async-await/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-async-await/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["pipelineOperator", { "proposal": "smart" }]]
+}

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-async-await/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-async-await/output.json
@@ -1,0 +1,181 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 46,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 46,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 46,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "f"
+          },
+          "name": "f"
+        },
+        "generator": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 20,
+          "end": 46,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 20
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ReturnStatement",
+              "start": 24,
+              "end": 44,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 22
+                }
+              },
+              "argument": {
+                "type": "BinaryExpression",
+                "start": 31,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 21
+                  }
+                },
+                "left": {
+                  "type": "Identifier",
+                  "start": 31,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "PipelineTopicExpression",
+                  "start": 36,
+                  "end": 43,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 21
+                    }
+                  },
+                  "expression": {
+                    "type": "AwaitExpression",
+                    "start": 36,
+                    "end": 43,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 21
+                      }
+                    },
+                    "argument": {
+                      "type": "PipelinePrimaryTopicReference",
+                      "start": 42,
+                      "end": 43,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 20
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 21
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-generator-yield/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-generator-yield/input.js
@@ -1,0 +1,3 @@
+function * f () {
+  return x |> (yield #);
+}

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-generator-yield/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-generator-yield/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["pipelineOperator", { "proposal": "smart" }]]
+}

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-generator-yield/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-generator-yield/output.json
@@ -1,0 +1,186 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 44,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 44,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 44,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 11,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 11
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            },
+            "identifierName": "f"
+          },
+          "name": "f"
+        },
+        "generator": true,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 16,
+          "end": 44,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ReturnStatement",
+              "start": 20,
+              "end": 42,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 24
+                }
+              },
+              "argument": {
+                "type": "BinaryExpression",
+                "start": 27,
+                "end": 41,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 23
+                  }
+                },
+                "left": {
+                  "type": "Identifier",
+                  "start": 27,
+                  "end": 28,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "operator": "|>",
+                "right": {
+                  "type": "PipelineTopicExpression",
+                  "start": 32,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 23
+                    }
+                  },
+                  "expression": {
+                    "type": "YieldExpression",
+                    "start": 33,
+                    "end": 40,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 22
+                      }
+                    },
+                    "delegate": false,
+                    "argument": {
+                      "type": "PipelinePrimaryTopicReference",
+                      "start": 39,
+                      "end": 40,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 21
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 22
+                        }
+                      }
+                    },
+                    "extra": {
+                      "parenthesized": true,
+                      "parenStart": 32
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9178
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | None
| Any Dependency Changes?  | No
| License                  | MIT

Fixes #9178 by adding startsExpr to the hash/number-sign token. Also adds test fixutres for `yield` and `await`. CC @thiagoarrais, @mAAdhaTTah.