### PR TITLE
babel-parser: typescript: add missing bigint keyword

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -45,6 +45,8 @@ function keywordTypeFromName(
       return "TSAnyKeyword";
     case "boolean":
       return "TSBooleanKeyword";
+    case "bigint":
+      return "TSBigIntKeyword";
     case "never":
       return "TSNeverKeyword";
     case "number":

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1157,6 +1157,7 @@ export type TsKeywordTypeType =
   | "TSNumberKeyword"
   | "TSObjectKeyword"
   | "TSBooleanKeyword"
+  | "TSBigIntKeyword"
   | "TSStringKeyword"
   | "TSSymbolKeyword"
   | "TSVoidKeyword"

--- a/packages/babel-parser/test/fixtures/typescript/types/keywords/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/keywords/input.js
@@ -9,3 +9,4 @@ let st: string;
 let sy: symbol;
 let u: undefined;
 let v: void;
+let n: bigint;

--- a/packages/babel-parser/test/fixtures/typescript/types/keywords/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/keywords/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 169,
+  "end": 184,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 11,
-      "column": 12
+      "line": 12,
+      "column": 14
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 169,
+    "end": 184,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 11,
-        "column": 12
+        "line": 12,
+        "column": 14
       }
     },
     "sourceType": "module",
@@ -910,6 +910,87 @@
                     "end": {
                       "line": 11,
                       "column": 11
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 170,
+        "end": 184,
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 0
+          },
+          "end": {
+            "line": 12,
+            "column": 14
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 174,
+            "end": 183,
+            "loc": {
+              "start": {
+                "line": 12,
+                "column": 4
+              },
+              "end": {
+                "line": 12,
+                "column": 13
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 174,
+              "end": 183,
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 4
+                },
+                "end": {
+                  "line": 12,
+                  "column": 13
+                },
+                "identifierName": "n"
+              },
+              "name": "n",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 175,
+                "end": 183,
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 13
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSBigIntKeyword",
+                  "start": 177,
+                  "end": 183,
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 13
                     }
                   }
                 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 👎 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 👎 
| Minor: New Feature?      | 👎 
| Tests Added + Pass?      | 👍 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 👎 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR adds new `bigint` keyword added in Typescript 3.2.

reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#bigint