### PR TITLE
Add tests for babel-types.isType()

### DIFF
--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -122,4 +122,19 @@ describe("validators", function() {
       expect(t.isReferenced(node, parent)).toBe(true);
     });
   });
+
+  describe("isType", function() {
+    it("returns true if nodeType equals targetType", function() {
+      expect(t.isType("Identifier", "Identifier")).toBe(true);
+    });
+    it("returns false if targetType is a primary node type", function() {
+      expect(t.isType("Expression", "ArrayExpression")).toBe(false);
+    });
+    it("returns true if targetType is an alias of nodeType", function() {
+      expect(t.isType("ArrayExpression", "Expression")).toBe(true);
+    });
+    it("returns false if nodeType and targetType are unrelated", function() {
+      expect(t.isType("ArrayExpression", "ClassBody")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In another branch, I'm trying to replace hot code with rust implementations. That project hasn't gotten anywhere useful yet, but I have been writing unit tests as I go, so I thought I'd better contribute them upstream.

I'm pretty sure that this doesn't actually improve coverage, because things are already covered in other test files (I get failures in `babel-types/test/asserts.js`, `babel-types/test/converters.js` and a few other places if I break any branch of the isType() implementation).

If this kind of test is useful to you, then I'll keep sending tests your way as I make them. If you prefer to test the layer above, then I won't be offended by you closing this PR.