### PR TITLE
[decorators] Set method names at compile time instead of at runtime

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1246,10 +1246,6 @@ helpers.decorate = helper("7.1.5")`
         configurable: true,
         enumerable: false,
       };
-      Object.defineProperty(def.value, "name", {
-        value: typeof key === "symbol" ? "" : key,
-        configurable: true,
-      });
     } else if (def.kind === "get") {
       descriptor = { get: def.value, configurable: true, enumerable: false };
     } else if (def.kind === "set") {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/computed-keys-same-ast/output.js
@@ -13,19 +13,15 @@ let Foo = babelHelpers.decorate([_ => desc = _], function (_initialize) {
     d: [{
       kind: "method",
       key: getKey(),
-
-      value() {
+      value: function () {
         return 1;
       }
-
     }, {
       kind: "method",
       key: getKey(),
-
-      value() {
+      value: function () {
         return 2;
       }
-
     }]
   };
 });

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/duplicated-keys/computed-keys-same-value/output.js
@@ -13,19 +13,15 @@ let Foo = babelHelpers.decorate([_ => desc = _], function (_initialize) {
     d: [{
       kind: "method",
       key: getKeyI(),
-
-      value() {
+      value: function () {
         return 1;
       }
-
     }, {
       kind: "method",
       key: getKeyJ(),
-
-      value() {
+      value: function () {
         return 2;
       }
-
     }]
   };
 });

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name-not-shadow/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name-not-shadow/exec.js
@@ -1,0 +1,13 @@
+function decorator() {}
+
+var method = 1;
+
+@decorator
+class Foo {
+  method() {
+    return method;
+  }
+}
+
+expect(new Foo().method()).toBe(1);
+expect(Foo.prototype.method.name).toBe("method");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name-not-shadow/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name-not-shadow/input.js
@@ -1,0 +1,8 @@
+var method = 1;
+
+@decorator
+class Foo {
+  method() {
+    return method;
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name-not-shadow/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/misc/method-name-not-shadow/output.js
@@ -1,3 +1,4 @@
+var _method = 1;
 let Foo = babelHelpers.decorate([decorator], function (_initialize) {
   "use strict";
 
@@ -12,16 +13,10 @@ let Foo = babelHelpers.decorate([decorator], function (_initialize) {
     F: Foo,
     d: [{
       kind: "method",
-      key: "f1",
-      value: async function f1() {}
-    }, {
-      kind: "method",
-      key: "f2",
-      value: function* f2() {}
-    }, {
-      kind: "method",
-      key: "f3",
-      value: async function* f3() {}
+      key: "method",
+      value: function method() {
+        return _method;
+      }
     }]
   };
 });

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/arguments/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/arguments/output.js
@@ -14,9 +14,7 @@ let A = babelHelpers.decorate([dec(a, b, ...c)], function (_initialize) {
       kind: "method",
       decorators: [dec(a, b, ...c)],
       key: "method",
-
-      value() {}
-
+      value: function method() {}
     }]
   };
 });

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/strict-directive/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/transformation/strict-directive/output.js
@@ -14,9 +14,7 @@
       d: [{
         kind: "method",
         key: "method",
-
-        value() {}
-
+        value: function method() {}
       }]
     };
   });
@@ -38,9 +36,7 @@
       d: [{
         kind: "method",
         key: "method",
-
-        value() {}
-
+        value: function method() {}
       }]
     };
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9234
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

> In gh-8743 I used `Object.defineProperty` in the decorators helper
to set the correct methods name: it was needed because methods were
renamed to `value`. Apparently some browsers set `Function#name` as
non-configurable: gh-9234, so it throws.
>
> This commit removes that fix from the helper and changes the
transform so that it gives the correct name at compile time. It
doesn't work with computed keys, but it should be ok because we
already don't handle method names in classes and object methods.

<details>
<summary>Output for methods, classes and decorated classes</summary>

#### Objects:
In:
```js
var key = "k";
var obj = {
  fn() {},
  [key]() {}
}
```
Out:
```js
var key = "k";

var obj = _defineProperty({
  fn: function fn() {}
}, key, function () {});
```
Test:
```js
obj.fn.name; // "fn"
obj.k.name; // ""
```

#### Classes:
In:
```js
var key = "k";
class Cl {
  fn() {}
  [key]() {}
}
```
Out:
```js
var key = "k";

var Cl =
/*#__PURE__*/
function () {
  function Cl() {
    _classCallCheck(this, Cl);
  }

  _createClass(Cl, [{
    key: "fn",
    value: function fn() {}
  }, {
    key: key,
    value: function () {}
  }]);

  return Cl;
}();
```
Test:
```js
new Cl().fn.name; // "fn"
new Cl().k.name; // "value"
```

#### Decorated classes:
In:
```js
var key = "k";

@(_ => _)
class DecCl {
  fn() {}
  [key]() {}
}
```
Out:
```js
var key = "k";

let DecCl = _decorate([_ => _], function (_initialize) {
  class DecCl {
    constructor() {
      _initialize(this);
    }

  }

  return {
    F: DecCl,
    d: [{
      kind: "method",
      key: "fn",
      value: function fn() {}
    }, {
      kind: "method",
      key: key,
      value: function () {}
    }]
  };
});
```
Test:
```js
new Cl().fn.name; // "fn"
new Cl().k.name; // "value"
```