### PR TITLE
@babel/types: added standard estree Property type

### DIFF
--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -687,6 +687,49 @@ defineType("ObjectProperty", {
   aliases: ["UserWhitespacable", "Property", "ObjectMember"],
 });
 
+defineType("Property", {
+  builder: ["key", "value", "computed", "shorthand", "decorators"],
+  fields: {
+    computed: {
+      validate: assertValueType("boolean"),
+      default: false,
+    },
+    key: {
+      validate: (function() {
+        const normal = assertNodeType(
+          "Identifier",
+          "StringLiteral",
+          "NumericLiteral",
+        );
+        const computed = assertNodeType("Expression");
+
+        return function(node, key, val) {
+          const validator = node.computed ? computed : normal;
+          validator(node, key, val);
+        };
+      })(),
+    },
+    value: {
+      // Value may be PatternLike if this is an AssignmentProperty
+      // https://github.com/babel/babylon/issues/434
+      validate: assertNodeType("Expression", "PatternLike"),
+    },
+    shorthand: {
+      validate: assertValueType("boolean"),
+      default: false,
+    },
+    decorators: {
+      validate: chain(
+        assertValueType("array"),
+        assertEach(assertNodeType("Decorator")),
+      ),
+      optional: true,
+    },
+  },
+  visitor: ["key", "value", "decorators"],
+  aliases: ["UserWhitespacable", "ObjectProperty", "ObjectMember"],
+});
+
 defineType("RestElement", {
   visitor: ["argument", "typeAnnotation"],
   builder: ["argument"],


### PR DESCRIPTION
Added standard `estree` [Property](https://github.com/estree/estree/blob/master/es2015.md#objectpattern) of `ObjectPattern`

Adds ability to use different parsers (like `acorn`, `espree`, `cherow` and all estree standard compatible) with @babel/traverse, not only @babel/parser

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8879, #9251  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->