### PR TITLE
@babel/types: getBindingIdentifiers: add Property to support estree s…

### DIFF
--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.js
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.js
@@ -111,6 +111,7 @@ getBindingIdentifiers.keys = {
   UpdateExpression: ["argument"],
 
   ObjectProperty: ["value"],
+  Property: ["value"],
 
   AssignmentPattern: ["left"],
   ArrayPattern: ["elements"],


### PR DESCRIPTION
…tandard

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fixes ability to identify variables when `estree` plugin used.
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Add ability to use `@babel/traverse` using `estree` plugin, also fixes https://github.com/cherow/cherow/issues/273:

```js
const babel = require('@babel/parser');
const traverse = require('@babel/traverse').default;

const source = `
    const t = ({a}) => a
`;

const babelAST = babel.parse(source, {
    plugins: [
       'estree', // with estree plugin @babel/traverse doesn't define variables
    ]
});

traverse(babelAST, {
    Identifier(path) {
        console.log('babel:', path.scope.hasBinding('a'));
        //outputs
        false
    }
});
```