### PR TITLE
WIP: try to make flow enforce the signature of isType() 

### DIFF
--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -220,7 +220,7 @@ export function pushContext(context: traverse.TraversalContext) {
 export function setup(
   parentPath: traverse.NodePath,
   container: Array<traverse.NodePath>,
-  listKey: ?String,
+  listKey: ?string,
   key: number,
 ) {
   this.inList = !!listKey;

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -236,9 +236,6 @@ export function setKey(key: number) {
   this.key = key;
   this.node = this.container[this.key];
   this.type = this.node && this.node.type;
-  if (typeof this.type !== "string") {
-    throw new Error("NodePath.type is not string");
-  }
 }
 
 export function requeue(pathToQueue: traverse.NodePath = this) {

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -1,8 +1,9 @@
 // This file contains methods responsible for maintaining a TraversalContext.
+// @flow
 
 import traverse from "../index";
 
-export function call(key): boolean {
+export function call(key: number): boolean {
   const opts = this.opts;
 
   this.debug(key);
@@ -37,7 +38,9 @@ export function _call(fns?: Array<Function>): boolean {
       );
     }
     if (ret) {
-      throw new Error(`Unexpected return value from visitor method ${fn}`);
+      throw new Error(
+        `Unexpected return value from visitor method ${fn.toString()}`,
+      );
     }
 
     // node has been replaced, it will have been requeued
@@ -91,7 +94,7 @@ export function skip() {
   this.shouldSkip = true;
 }
 
-export function skipKey(key) {
+export function skipKey(key: Number) {
   this.skipKeys[key] = true;
 }
 
@@ -116,7 +119,7 @@ export function setScope() {
   if (this.scope) this.scope.init();
 }
 
-export function setContext(context) {
+export function setContext(context: traverse.TraversalContext) {
   this.shouldSkip = false;
   this.shouldStop = false;
   this.removed = false;
@@ -209,12 +212,17 @@ export function popContext() {
   }
 }
 
-export function pushContext(context) {
+export function pushContext(context: traverse.TraversalContext) {
   this.contexts.push(context);
   this.setContext(context);
 }
 
-export function setup(parentPath, container, listKey, key) {
+export function setup(
+  parentPath: traverse.NodePath,
+  container: Array<traverse.NodePath>,
+  listKey: ?String,
+  key: number,
+) {
   this.inList = !!listKey;
   this.listKey = listKey;
   this.parentKey = listKey || key;
@@ -224,13 +232,16 @@ export function setup(parentPath, container, listKey, key) {
   this.setKey(key);
 }
 
-export function setKey(key) {
+export function setKey(key: number) {
   this.key = key;
   this.node = this.container[this.key];
   this.type = this.node && this.node.type;
+  if (typeof this.type !== "string") {
+    throw new Error("NodePath.type is not string");
+  }
 }
 
-export function requeue(pathToQueue = this) {
+export function requeue(pathToQueue: traverse.NodePath = this) {
   if (pathToQueue.removed) return;
 
   // TODO(loganfsmyth): This should be switched back to queue in parent contexts

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -1,5 +1,7 @@
+// @flow
 import type { HubInterface } from "../hub";
 import type TraversalContext from "../context";
+// $FlowFixMe Not sure why flow can't find this.
 import * as virtualTypes from "./lib/virtual-types";
 import buildDebug from "debug";
 import traverse from "../index";
@@ -70,7 +72,21 @@ export default class NodePath {
   type: ?string;
   typeAnnotation: ?Object;
 
-  static get({ hub, parentPath, parent, container, listKey, key }): NodePath {
+  static get({
+    hub,
+    parentPath,
+    parent,
+    container,
+    listKey,
+    key,
+  }: {
+    hub: ?HubInterface,
+    parentPath: ?NodePath,
+    parent: NodePath,
+    container: Array<NodePath>,
+    listKey: string,
+    key: number,
+  }): NodePath {
     if (!hub && parentPath) {
       hub = parentPath.hub;
     }
@@ -86,7 +102,7 @@ export default class NodePath {
       pathCache.set(parent, paths);
     }
 
-    let path;
+    let path: ?NodePath;
 
     for (let i = 0; i < paths.length; i++) {
       const pathCheck = paths[i];
@@ -107,6 +123,7 @@ export default class NodePath {
   }
 
   getScope(scope: Scope) {
+    // $FlowFixMe I'm pretty sure this method can't exist.
     return this.isScope() ? new Scope(this) : scope;
   }
 
@@ -130,6 +147,7 @@ export default class NodePath {
 
   set(key: string, node: Object) {
     t.validate(this.node, key, node);
+    // $FlowFixMe not sure how to prove that this.node is not null here.
     this.node[key] = node;
   }
 
@@ -138,44 +156,143 @@ export default class NodePath {
     let path = this;
     do {
       let key = path.key;
+      // $FlowFixMe yeah yeah: in theory these can be null
       if (path.inList) key = `${path.listKey}[${key}]`;
       parts.unshift(key);
     } while ((path = path.parentPath));
     return parts.join(".");
   }
 
-  debug(message) {
+  debug(message: any) {
     if (!debug.enabled) return;
+    // $FlowFixMe yeah yeah: in theory these can be null
     debug(`${this.getPathLocation()} ${this.type}: ${message}`);
   }
 
   toString() {
     return generator(this.node).code;
   }
-}
 
-Object.assign(
-  NodePath.prototype,
-  NodePath_ancestry,
-  NodePath_inference,
-  NodePath_replacement,
-  NodePath_evaluation,
-  NodePath_conversion,
-  NodePath_introspection,
-  NodePath_context,
-  NodePath_removal,
-  NodePath_modification,
-  NodePath_family,
-  NodePath_comments,
-);
+  findParent = NodePath_ancestry.findParent;
+  find = NodePath_ancestry.find;
+  getFunctionParent = NodePath_ancestry.getFunctionParent;
+  getStatementParent = NodePath_ancestry.getStatementParent;
+  getEarliestCommonAncestorFrom =
+    NodePath_ancestry.getEarliestCommonAncestorFrom;
+  getDeepestCommonAncestorFrom = NodePath_ancestry.getDeepestCommonAncestorFrom;
+  getAncestry = NodePath_ancestry.getAncestry;
+  isAncestor = NodePath_ancestry.isAncestor;
+  isDescendant = NodePath_ancestry.isDescendant;
+  inType = NodePath_ancestry.inType;
+  getTypeAnnotation = NodePath_inference.getTypeAnnotation;
+  _getTypeAnnotation = NodePath_inference._getTypeAnnotation;
+  isBaseType = NodePath_inference.isBaseType;
+  couldBeBaseType = NodePath_inference.couldBeBaseType;
+  baseTypeStrictlyMatches = NodePath_inference.baseTypeStrictlyMatches;
+  isGenericType = NodePath_inference.isGenericType;
+
+  shareCommentsWithSiblings = NodePath_comments.shareCommentsWithSiblings;
+  addComment = NodePath_comments.addComment;
+  addComments = NodePath_comments.addComments;
+  call = NodePath_context.call;
+  _call = NodePath_context._call;
+  isBlacklisted = NodePath_context.isBlacklisted;
+  visit = NodePath_context.visit;
+  skip = NodePath_context.skip;
+  skipKey = NodePath_context.skipKey;
+  stop = NodePath_context.stop;
+  setScope = NodePath_context.setScope;
+  setContext = NodePath_context.setContext;
+  resync = NodePath_context.resync;
+  _resyncParent = NodePath_context._resyncParent;
+  _resyncKey = NodePath_context._resyncKey;
+  _resyncList = NodePath_context._resyncList;
+  _resyncRemoved = NodePath_context._resyncRemoved;
+  popContext = NodePath_context.popContext;
+  pushContext = NodePath_context.pushContext;
+  setup = NodePath_context.setup;
+  setKey = NodePath_context.setKey;
+  requeue = NodePath_context.requeue;
+  _getQueueContexts = NodePath_context._getQueueContexts;
+  toComputedKey = NodePath_conversion.toComputedKey;
+  ensureBlock = NodePath_conversion.ensureBlock;
+  arrowFunctionToShadowed = NodePath_conversion.arrowFunctionToShadowed;
+  unwrapFunctionEnvironment = NodePath_conversion.unwrapFunctionEnvironment;
+  arrowFunctionToExpression = NodePath_conversion.arrowFunctionToExpression;
+  evaluateTruthy = NodePath_evaluation.evaluateTruthy;
+  evaluate = NodePath_evaluation.evaluate;
+  getOpposite = NodePath_family.getOpposite;
+  getCompletionRecords = NodePath_family.getCompletionRecords;
+  getSibling = NodePath_family.getSibling;
+  getPrevSibling = NodePath_family.getPrevSibling;
+  getNextSibling = NodePath_family.getNextSibling;
+  getAllNextSiblings = NodePath_family.getAllNextSiblings;
+  getAllPrevSiblings = NodePath_family.getAllPrevSiblings;
+  get = NodePath_family.get;
+  _getKey = NodePath_family._getKey;
+  _getPattern = NodePath_family._getPattern;
+  getBindingIdentifiers = NodePath_family.getBindingIdentifiers;
+  getOuterBindingIdentifiers = NodePath_family.getOuterBindingIdentifiers;
+  getBindingIdentifierPaths = NodePath_family.getBindingIdentifierPaths;
+  getOuterBindingIdentifierPaths =
+    NodePath_family.getOuterBindingIdentifierPaths;
+  matchesPattern = NodePath_introspection.matchesPattern;
+  has = NodePath_introspection.has;
+  isStatic = NodePath_introspection.isStatic;
+  isnt = NodePath_introspection.isnt;
+  equals = NodePath_introspection.equals;
+  isNodeType = NodePath_introspection.isNodeType;
+  canHaveVariableDeclarationOrExpression =
+    NodePath_introspection.canHaveVariableDeclarationOrExpression;
+  canSwapBetweenExpressionAndStatement =
+    NodePath_introspection.canSwapBetweenExpressionAndStatement;
+  isCompletionRecord = NodePath_introspection.isCompletionRecord;
+  isStatementOrBlock = NodePath_introspection.isStatementOrBlock;
+  referencesImport = NodePath_introspection.referencesImport;
+  getSource = NodePath_introspection.getSource;
+  willIMaybeExecuteBefore = NodePath_introspection.willIMaybeExecuteBefore;
+  _guessExecutionStatusRelativeTo =
+    NodePath_introspection._guessExecutionStatusRelativeTo;
+  _guessExecutionStatusRelativeToDifferentFunctions =
+    NodePath_introspection._guessExecutionStatusRelativeToDifferentFunctions;
+  resolve = NodePath_introspection.resolve;
+  _resolve = NodePath_introspection._resolve;
+  isConstantExpression = NodePath_introspection.isConstantExpression;
+  isInStrictMode = NodePath_introspection.isInStrictMode;
+  insertBefore = NodePath_modification.insertBefore;
+  _containerInsert = NodePath_modification._containerInsert;
+  _containerInsertBefore = NodePath_modification._containerInsertBefore;
+  _containerInsertAfter = NodePath_modification._containerInsertAfter;
+  insertAfter = NodePath_modification.insertAfter;
+  updateSiblingKeys = NodePath_modification.updateSiblingKeys;
+  _verifyNodeList = NodePath_modification._verifyNodeList;
+  unshiftContainer = NodePath_modification.unshiftContainer;
+  pushContainer = NodePath_modification.pushContainer;
+  hoist = NodePath_modification.hoist;
+  remove = NodePath_removal.remove;
+  _removeFromScope = NodePath_removal._removeFromScope;
+  _callRemovalHooks = NodePath_removal._callRemovalHooks;
+  _remove = NodePath_removal._remove;
+  _markRemoved = NodePath_removal._markRemoved;
+  _assertUnremoved = NodePath_removal._assertUnremoved;
+  replaceWithMultiple = NodePath_replacement.replaceWithMultiple;
+  replaceWithSourceString = NodePath_replacement.replaceWithSourceString;
+  replaceWith = NodePath_replacement.replaceWith;
+  _replaceWith = NodePath_replacement._replaceWith;
+  replaceExpressionWithStatements =
+    NodePath_replacement.replaceExpressionWithStatements;
+  replaceInline = NodePath_replacement.replaceInline;
+}
 
 for (const type of (t.TYPES: Array<string>)) {
   const typeKey = `is${type}`;
   const fn = t[typeKey];
+  // $FlowFixMe somehow generate these?
   NodePath.prototype[typeKey] = function(opts) {
     return fn(this.node, opts);
   };
 
+  // $FlowFixMe somehow generate these?
   NodePath.prototype[`assert${type}`] = function(opts) {
     if (!fn(this.node, opts)) {
       throw new TypeError(`Expected node path of type ${type}`);
@@ -189,6 +306,7 @@ for (const type in virtualTypes) {
 
   const virtualType = virtualTypes[type];
 
+  // $FlowFixMe somehow generate these?
   NodePath.prototype[`is${type}`] = function(opts) {
     return virtualType.checkPath(this, opts);
   };

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -285,6 +285,805 @@ export default class NodePath {
   replaceExpressionWithStatements =
     NodePath_replacement.replaceExpressionWithStatements;
   replaceInline = NodePath_replacement.replaceInline;
+  isArrayExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isAssignmentExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isBinaryExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isInterpreterDirective = function(opts?: Object): boolean {
+    return false;
+  };
+  isDirective = function(opts?: Object): boolean {
+    return false;
+  };
+  isDirectiveLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isBlockStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isBreakStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isCallExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isCatchClause = function(opts?: Object): boolean {
+    return false;
+  };
+  isConditionalExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isContinueStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isDebuggerStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isDoWhileStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isEmptyStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isExpressionStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isFile = function(opts?: Object): boolean {
+    return false;
+  };
+  isForInStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isForStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isFunctionDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isFunctionExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isIdentifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isIfStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isLabeledStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isStringLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isNumericLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isNullLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isBooleanLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isRegExpLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isLogicalExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isMemberExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isNewExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isProgram = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectMethod = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isRestElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isReturnStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isSequenceExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isSwitchCase = function(opts?: Object): boolean {
+    return false;
+  };
+  isSwitchStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isThisExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isThrowStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isTryStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isUnaryExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isUpdateExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isVariableDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isVariableDeclarator = function(opts?: Object): boolean {
+    return false;
+  };
+  isWhileStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isWithStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isAssignmentPattern = function(opts?: Object): boolean {
+    return false;
+  };
+  isArrayPattern = function(opts?: Object): boolean {
+    return false;
+  };
+  isArrowFunctionExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassBody = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportAllDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportDefaultDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportNamedDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isForOfStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isImportDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isImportDefaultSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isImportNamespaceSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isImportSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isMetaProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassMethod = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectPattern = function(opts?: Object): boolean {
+    return false;
+  };
+  isSpreadElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isSuper = function(opts?: Object): boolean {
+    return false;
+  };
+  isTaggedTemplateExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isTemplateElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isTemplateLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isYieldExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isAnyTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isArrayTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isBooleanTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isBooleanLiteralTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isNullLiteralTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassImplements = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareClass = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareFunction = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareInterface = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareModule = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareModuleExports = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareTypeAlias = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareOpaqueType = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareVariable = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareExportDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclareExportAllDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclaredPredicate = function(opts?: Object): boolean {
+    return false;
+  };
+  isExistsTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isFunctionTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isFunctionTypeParam = function(opts?: Object): boolean {
+    return false;
+  };
+  isGenericTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isInferredPredicate = function(opts?: Object): boolean {
+    return false;
+  };
+  isInterfaceExtends = function(opts?: Object): boolean {
+    return false;
+  };
+  isInterfaceDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isInterfaceTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isIntersectionTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isMixedTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isEmptyTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isNullableTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isNumberLiteralTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isNumberTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectTypeInternalSlot = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectTypeCallProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectTypeIndexer = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectTypeProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectTypeSpreadProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isOpaqueType = function(opts?: Object): boolean {
+    return false;
+  };
+  isQualifiedTypeIdentifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isStringLiteralTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isStringTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isThisTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isTupleTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeofTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeAlias = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeCastExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeParameter = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeParameterDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTypeParameterInstantiation = function(opts?: Object): boolean {
+    return false;
+  };
+  isUnionTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isVariance = function(opts?: Object): boolean {
+    return false;
+  };
+  isVoidTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXAttribute = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXClosingElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXEmptyExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXExpressionContainer = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXSpreadChild = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXIdentifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXMemberExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXNamespacedName = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXOpeningElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXSpreadAttribute = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXText = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXFragment = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXOpeningFragment = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSXClosingFragment = function(opts?: Object): boolean {
+    return false;
+  };
+  isNoop = function(opts?: Object): boolean {
+    return false;
+  };
+  isParenthesizedExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isAwaitExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isBindExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isOptionalMemberExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isPipelineTopicExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isPipelineBareFunction = function(opts?: Object): boolean {
+    return false;
+  };
+  isPipelinePrimaryTopicReference = function(opts?: Object): boolean {
+    return false;
+  };
+  isOptionalCallExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassPrivateProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isClassPrivateMethod = function(opts?: Object): boolean {
+    return false;
+  };
+  isImport = function(opts?: Object): boolean {
+    return false;
+  };
+  isDecorator = function(opts?: Object): boolean {
+    return false;
+  };
+  isDoExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportDefaultSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportNamespaceSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isPrivateName = function(opts?: Object): boolean {
+    return false;
+  };
+  isBigIntLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSParameterProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSDeclareFunction = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSDeclareMethod = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSQualifiedName = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSCallSignatureDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSConstructSignatureDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSPropertySignature = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSMethodSignature = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSIndexSignature = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSAnyKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSUnknownKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSNumberKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSObjectKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSBooleanKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSStringKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSSymbolKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSVoidKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSUndefinedKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSNullKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSNeverKeyword = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSThisType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSFunctionType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSConstructorType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeReference = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypePredicate = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeQuery = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSArrayType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTupleType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSOptionalType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSRestType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSUnionType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSIntersectionType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSConditionalType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSInferType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSParenthesizedType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeOperator = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSIndexedAccessType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSMappedType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSLiteralType = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSExpressionWithTypeArguments = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSInterfaceDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSInterfaceBody = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeAliasDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSAsExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeAssertion = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSEnumDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSEnumMember = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSModuleDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSModuleBlock = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSImportEqualsDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSExternalModuleReference = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSNonNullExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSExportAssignment = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSNamespaceExportDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeParameterInstantiation = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeParameterDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeParameter = function(opts?: Object): boolean {
+    return false;
+  };
+
+  isExpression = function(opts?: Object): boolean {
+    return false;
+  };
+  isBinary = function(opts?: Object): boolean {
+    return false;
+  };
+  isScopable = function(opts?: Object): boolean {
+    return false;
+  };
+  isBlockParent = function(opts?: Object): boolean {
+    return false;
+  };
+  isBlock = function(opts?: Object): boolean {
+    return false;
+  };
+  isStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isTerminatorless = function(opts?: Object): boolean {
+    return false;
+  };
+  isCompletionStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isConditional = function(opts?: Object): boolean {
+    return false;
+  };
+  isLoop = function(opts?: Object): boolean {
+    return false;
+  };
+  isWhile = function(opts?: Object): boolean {
+    return false;
+  };
+  isExpressionWrapper = function(opts?: Object): boolean {
+    return false;
+  };
+  isFor = function(opts?: Object): boolean {
+    return false;
+  };
+  isForXStatement = function(opts?: Object): boolean {
+    return false;
+  };
+  isFunction = function(opts?: Object): boolean {
+    return false;
+  };
+  isFunctionParent = function(opts?: Object): boolean {
+    return false;
+  };
+  isPureish = function(opts?: Object): boolean {
+    return false;
+  };
+  isDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isPatternLike = function(opts?: Object): boolean {
+    return false;
+  };
+  isLVal = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSEntityName = function(opts?: Object): boolean {
+    return false;
+  };
+  isLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isImmutable = function(opts?: Object): boolean {
+    return false;
+  };
+  isUserWhitespacable = function(opts?: Object): boolean {
+    return false;
+  };
+  isMethod = function(opts?: Object): boolean {
+    return false;
+  };
+  isObjectMember = function(opts?: Object): boolean {
+    return false;
+  };
+  isProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isUnaryLike = function(opts?: Object): boolean {
+    return false;
+  };
+  isPattern = function(opts?: Object): boolean {
+    return false;
+  };
+  isClass = function(opts?: Object): boolean {
+    return false;
+  };
+  isModuleDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isExportDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isModuleSpecifier = function(opts?: Object): boolean {
+    return false;
+  };
+  isFlow = function(opts?: Object): boolean {
+    return false;
+  };
+  isFlowType = function(opts?: Object): boolean {
+    return false;
+  };
+  isFlowBaseAnnotation = function(opts?: Object): boolean {
+    return false;
+  };
+  isFlowDeclaration = function(opts?: Object): boolean {
+    return false;
+  };
+  isFlowPredicate = function(opts?: Object): boolean {
+    return false;
+  };
+  isJSX = function(opts?: Object): boolean {
+    return false;
+  };
+  isPrivate = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSTypeElement = function(opts?: Object): boolean {
+    return false;
+  };
+  isTSType = function(opts?: Object): boolean {
+    return false;
+  };
+  isNumberLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isRegexLiteral = function(opts?: Object): boolean {
+    return false;
+  };
+  isRestProperty = function(opts?: Object): boolean {
+    return false;
+  };
+  isSpreadProperty = function(opts?: Object): boolean {
+    return false;
+  };
 }
 
 for (const type of (t.TYPES: Array<string>)) {

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -37,6 +37,7 @@ export default class NodePath {
     this.state = null;
     this.opts = null;
     this.skipKeys = null;
+    // $FlowFixMe we immediately call path.setup() so this is fine for now.
     this.parentPath = null;
     this.context = null;
     this.container = null;
@@ -60,7 +61,7 @@ export default class NodePath {
   state: any;
   opts: ?Object;
   skipKeys: ?Object;
-  parentPath: ?NodePath;
+  parentPath: NodePath;
   context: TraversalContext;
   container: ?Object | Array<Object>;
   listKey: ?string;
@@ -80,7 +81,7 @@ export default class NodePath {
     listKey,
     key,
   }: {
-    hub: ?HubInterface,
+    hub?: HubInterface,
     parentPath: ?NodePath,
     parent: NodePath,
     container: Array<NodePath>,
@@ -113,6 +114,8 @@ export default class NodePath {
     }
 
     if (!path) {
+      // TODO: make a constructor that does the setup, so that
+      // path.parentPath is never set to null.
       path = new NodePath(hub, parent);
       paths.push(path);
     }

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -147,6 +147,8 @@ export function isCompletionRecord(allowInsideFunction: ?boolean): boolean {
 export function isStatementOrBlock(): boolean {
   if (
     this.parentPath.isLabeledStatement() ||
+    // this.container could be an array but isBlockStatement() only
+    // understands Object. $FlowFixMe
     t.isBlockStatement(this.container)
   ) {
     return false;
@@ -280,8 +282,11 @@ export function _guessExecutionStatusRelativeTo(target: NodePath) {
 }
 
 export function _guessExecutionStatusRelativeToDifferentFunctions(
+  // FIXME: I don't know whether targetFuncParent is actually a NodePath.
+  // I suspect it isn't, because it has a .path property.
   targetFuncParent: NodePath,
 ) {
+  // $FlowFixMe NodePath doesn't have a .path. It's probably not a NodePath.
   const targetFuncPath = targetFuncParent.path;
   if (!targetFuncPath.isFunctionDeclaration()) return;
 

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -68,6 +68,7 @@ export function equals(key: string, value: string): boolean {
  */
 
 export function isNodeType(type: string): boolean {
+  // $FlowFixMe WOO! this is the error that we were hoping to get
   return t.isType(this.type, type);
 }
 

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -147,8 +147,6 @@ export function isCompletionRecord(allowInsideFunction: ?boolean): boolean {
 export function isStatementOrBlock(): boolean {
   if (
     this.parentPath.isLabeledStatement() ||
-    // this.container could be an array but isBlockStatement() only
-    // understands Object. $FlowFixMe
     t.isBlockStatement(this.container)
   ) {
     return false;

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -1,5 +1,5 @@
 // This file contains methods responsible for introspecting the current path for certain values.
-
+// @flow
 import type NodePath from "./index";
 import includes from "lodash/includes";
 import * as t from "@babel/types";
@@ -23,7 +23,7 @@ export function matchesPattern(
  * if the array has any items, otherwise we just check if it's falsy.
  */
 
-export function has(key): boolean {
+export function has(key: string): boolean {
   const val = this.node && this.node[key];
   if (val && Array.isArray(val)) {
     return !!val.length;
@@ -36,7 +36,7 @@ export function has(key): boolean {
  * Description
  */
 
-export function isStatic() {
+export function isStatic(): boolean {
   return this.scope.isStatic(this.node);
 }
 
@@ -50,7 +50,7 @@ export const is = has;
  * Opposite of `has`.
  */
 
-export function isnt(key): boolean {
+export function isnt(key: string): boolean {
   return !this.has(key);
 }
 
@@ -58,7 +58,7 @@ export function isnt(key): boolean {
  * Check whether the path node `key` strict equals `value`.
  */
 
-export function equals(key, value): boolean {
+export function equals(key: string, value: string): boolean {
   return this.node[key] === value;
 }
 
@@ -95,7 +95,9 @@ export function canHaveVariableDeclarationOrExpression() {
  * is the same as containing a block statement.
  */
 
-export function canSwapBetweenExpressionAndStatement(replacement) {
+export function canSwapBetweenExpressionAndStatement(
+  replacement: NodePath,
+): boolean {
   if (this.key !== "body" || !this.parentPath.isArrowFunctionExpression()) {
     return false;
   }
@@ -113,7 +115,7 @@ export function canSwapBetweenExpressionAndStatement(replacement) {
  * Check whether the current path references a completion record
  */
 
-export function isCompletionRecord(allowInsideFunction?) {
+export function isCompletionRecord(allowInsideFunction: ?boolean): boolean {
   let path = this;
   let first = true;
 
@@ -142,7 +144,7 @@ export function isCompletionRecord(allowInsideFunction?) {
  * so we can explode it if necessary.
  */
 
-export function isStatementOrBlock() {
+export function isStatementOrBlock(): boolean {
   if (
     this.parentPath.isLabeledStatement() ||
     t.isBlockStatement(this.container)
@@ -157,7 +159,7 @@ export function isStatementOrBlock() {
  * Check if the currently assigned path references the `importName` of `moduleSource`.
  */
 
-export function referencesImport(moduleSource, importName) {
+export function referencesImport(moduleSource: NodePath, importName: string) {
   if (!this.isReferencedIdentifier()) return false;
 
   const binding = this.scope.getBinding(this.node.name);
@@ -202,7 +204,7 @@ export function getSource() {
   return "";
 }
 
-export function willIMaybeExecuteBefore(target) {
+export function willIMaybeExecuteBefore(target: NodePath) {
   return this._guessExecutionStatusRelativeTo(target) !== "after";
 }
 
@@ -213,7 +215,7 @@ export function willIMaybeExecuteBefore(target) {
  * before or after the input `target` element.
  */
 
-export function _guessExecutionStatusRelativeTo(target) {
+export function _guessExecutionStatusRelativeTo(target: NodePath) {
   // check if the two paths are in different functions, we can't track execution of these
   const targetFuncParent =
     target.scope.getFunctionParent() || target.scope.getProgramParent();
@@ -255,6 +257,7 @@ export function _guessExecutionStatusRelativeTo(target) {
   }
 
   // get the relationship paths that associate these nodes to their common ancestor
+  // $FlowFixMe if commonPath is set then targetIndex must also be set.
   const targetRelationship = targetPaths[targetIndex - 1];
   const selfRelationship = selfPaths[selfIndex - 1];
   if (!targetRelationship || !selfRelationship) {
@@ -277,7 +280,7 @@ export function _guessExecutionStatusRelativeTo(target) {
 }
 
 export function _guessExecutionStatusRelativeToDifferentFunctions(
-  targetFuncParent,
+  targetFuncParent: NodePath,
 ) {
   const targetFuncPath = targetFuncParent.path;
   if (!targetFuncPath.isFunctionDeclaration()) return;
@@ -324,14 +327,20 @@ export function _guessExecutionStatusRelativeToDifferentFunctions(
 }
 
 /**
- * Resolve a "pointer" `NodePath` to it's absolute path.
+ * Resolve a "pointer" `NodePath` to its absolute path.
  */
 
-export function resolve(dangerous, resolved) {
+export function resolve(
+  dangerous: ?Array<NodePath>,
+  resolved: ?Array<NodePath>,
+): NodePath {
   return this._resolve(dangerous, resolved) || this;
 }
 
-export function _resolve(dangerous?, resolved?): ?NodePath {
+export function _resolve(
+  dangerous: ?Array<NodePath>,
+  resolved: ?Array<NodePath>,
+): ?NodePath {
   // detect infinite recursion
   // todo: possibly have a max length on this just to be safe
   if (resolved && resolved.indexOf(this) >= 0) return;
@@ -377,7 +386,7 @@ export function _resolve(dangerous?, resolved?): ?NodePath {
 
     if (target.isObjectExpression()) {
       const props = target.get("properties");
-      for (const prop of (props: Array)) {
+      for (const prop of (props: Array<any>)) {
         if (!prop.isProperty()) continue;
 
         const key = prop.get("key");

--- a/packages/babel-traverse/src/path/introspection.js
+++ b/packages/babel-traverse/src/path/introspection.js
@@ -68,7 +68,6 @@ export function equals(key: string, value: string): boolean {
  */
 
 export function isNodeType(type: string): boolean {
-  // $FlowFixMe WOO! this is the error that we were hoping to get
   return t.isType(this.type, type);
 }
 

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -1,15 +1,18 @@
 // This file contains methods that modify the path/node in some ways.
+// @flow
 
 import { path as pathCache } from "../cache";
+// $FlowFixMe Not sure why flow can't find this.
 import PathHoister from "./lib/hoister";
 import NodePath from "./index";
+import type { Scope } from "../scope";
 import * as t from "@babel/types";
 
 /**
  * Insert the provided nodes before the current one.
  */
 
-export function insertBefore(nodes) {
+export function insertBefore(nodes: Array<NodePath>): Array<NodePath> {
   this._assertUnremoved();
 
   nodes = this._verifyNodeList(nodes);
@@ -50,7 +53,10 @@ export function insertBefore(nodes) {
   }
 }
 
-export function _containerInsert(from, nodes) {
+export function _containerInsert(
+  from: number,
+  nodes: Array<NodePath>,
+): Array<NodePath> {
   this.updateSiblingKeys(from, nodes.length);
 
   const paths = [];
@@ -80,11 +86,13 @@ export function _containerInsert(from, nodes) {
   return paths;
 }
 
-export function _containerInsertBefore(nodes) {
+export function _containerInsertBefore(
+  nodes: Array<NodePath>,
+): Array<NodePath> {
   return this._containerInsert(this.key, nodes);
 }
 
-export function _containerInsertAfter(nodes) {
+export function _containerInsertAfter(nodes: Array<NodePath>): Array<NodePath> {
   return this._containerInsert(this.key + 1, nodes);
 }
 
@@ -93,7 +101,7 @@ export function _containerInsertAfter(nodes) {
  * expression, ensure that the completion record is correct by pushing the current node.
  */
 
-export function insertAfter(nodes) {
+export function insertAfter(nodes: Array<NodePath>): Array<NodePath> {
   this._assertUnremoved();
 
   nodes = this._verifyNodeList(nodes);
@@ -159,7 +167,10 @@ export function insertAfter(nodes) {
  * Update all sibling node paths after `fromIndex` by `incrementBy`.
  */
 
-export function updateSiblingKeys(fromIndex, incrementBy) {
+export function updateSiblingKeys(
+  fromIndex: number,
+  incrementBy: number,
+): ?Array<NodePath> {
   if (!this.parent) return;
 
   const paths = pathCache.get(this.parent);
@@ -171,7 +182,7 @@ export function updateSiblingKeys(fromIndex, incrementBy) {
   }
 }
 
-export function _verifyNodeList(nodes) {
+export function _verifyNodeList(nodes: Array<NodePath>): Array<NodePath> {
   if (!nodes) {
     return [];
   }
@@ -205,7 +216,10 @@ export function _verifyNodeList(nodes) {
   return nodes;
 }
 
-export function unshiftContainer(listKey, nodes) {
+export function unshiftContainer(
+  listKey: string,
+  nodes: Array<NodePath>,
+): Array<NodePath> {
   this._assertUnremoved();
 
   nodes = this._verifyNodeList(nodes);
@@ -223,7 +237,10 @@ export function unshiftContainer(listKey, nodes) {
   return path.insertBefore(nodes);
 }
 
-export function pushContainer(listKey, nodes) {
+export function pushContainer(
+  listKey: string,
+  nodes: Array<NodePath>,
+): Array<NodePath> {
   this._assertUnremoved();
 
   nodes = this._verifyNodeList(nodes);
@@ -248,7 +265,7 @@ export function pushContainer(listKey, nodes) {
  * referencing it.
  */
 
-export function hoist(scope = this.scope) {
+export function hoist(scope: Scope = this.scope): NodePath {
   const hoister = new PathHoister(this, scope);
   return hoister.run();
 }

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -27,7 +27,8 @@ export function insertBefore(nodes: Array<NodePath>): Array<NodePath> {
   ) {
     return parentPath.insertBefore(nodes);
   } else if (
-    (this.isNodeType("Expression") &&
+    (this.type &&
+      this.isNodeType("Expression") &&
       this.listKey !== "params" &&
       this.listKey !== "arguments") ||
     (parentPath.isForStatement() && this.key === "init")
@@ -125,7 +126,7 @@ export function insertAfter(nodes: Array<NodePath>): Array<NodePath> {
       }),
     );
   } else if (
-    (this.isNodeType("Expression") && !this.isJSXElement()) ||
+    (this.type && this.isNodeType("Expression") && !this.isJSXElement()) ||
     (parentPath.isForStatement() && this.key === "init")
   ) {
     if (this.node) {

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -61,8 +61,6 @@ export function _containerInsert(
 
   const paths = [];
 
-  // Is there any way to discriminate between NodePath objects that
-  // have Array containers and those that have Object containers? $FlowFixMe
   this.container.splice(from, 0, ...nodes);
   for (let i = 0; i < nodes.length; i++) {
     const to = from + i;

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -37,9 +37,10 @@ export function insertBefore(nodes: Array<NodePath>): Array<NodePath> {
   } else if (Array.isArray(this.container)) {
     return this._containerInsertBefore(nodes);
   } else if (this.isStatementOrBlock()) {
+    const node = this.node;
     const shouldInsertCurrentNode =
       this.node &&
-      (!this.isExpressionStatement() || this.node.expression != null);
+      (this.node.expression != null || !this.isExpressionStatement());
 
     this.replaceWith(
       t.blockStatement(shouldInsertCurrentNode ? [this.node] : []),
@@ -61,6 +62,8 @@ export function _containerInsert(
 
   const paths = [];
 
+  // Is there any way to discriminate between NodePath objects that
+  // have Array containers and those that have Object containers? $FlowFixMe
   this.container.splice(from, 0, ...nodes);
   for (let i = 0; i < nodes.length; i++) {
     const to = from + i;
@@ -149,7 +152,7 @@ export function insertAfter(nodes: Array<NodePath>): Array<NodePath> {
   } else if (this.isStatementOrBlock()) {
     const shouldInsertCurrentNode =
       this.node &&
-      (!this.isExpressionStatement() || this.node.expression != null);
+      (this.node.expression != null || !this.isExpressionStatement());
 
     this.replaceWith(
       t.blockStatement(shouldInsertCurrentNode ? [this.node] : []),
@@ -182,12 +185,14 @@ export function updateSiblingKeys(
   }
 }
 
-export function _verifyNodeList(nodes: Array<NodePath>): Array<NodePath> {
+export function _verifyNodeList(
+  nodes: Array<NodePath> | NodePath,
+): Array<NodePath> {
   if (!nodes) {
     return [];
   }
 
-  if (nodes.constructor !== Array) {
+  if (!Array.isArray(nodes)) {
     nodes = [nodes];
   }
 

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -27,8 +27,7 @@ export function insertBefore(nodes: Array<NodePath>): Array<NodePath> {
   ) {
     return parentPath.insertBefore(nodes);
   } else if (
-    (this.type &&
-      this.isNodeType("Expression") &&
+    (this.isNodeType("Expression") &&
       this.listKey !== "params" &&
       this.listKey !== "arguments") ||
     (parentPath.isForStatement() && this.key === "init")
@@ -126,7 +125,7 @@ export function insertAfter(nodes: Array<NodePath>): Array<NodePath> {
       }),
     );
   } else if (
-    (this.type && this.isNodeType("Expression") && !this.isJSXElement()) ||
+    (this.isNodeType("Expression") && !this.isJSXElement()) ||
     (parentPath.isForStatement() && this.key === "init")
   ) {
     if (this.node) {

--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -37,7 +37,6 @@ export function insertBefore(nodes: Array<NodePath>): Array<NodePath> {
   } else if (Array.isArray(this.container)) {
     return this._containerInsertBefore(nodes);
   } else if (this.isStatementOrBlock()) {
-    const node = this.node;
     const shouldInsertCurrentNode =
       this.node &&
       (this.node.expression != null || !this.isExpressionStatement());

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -192,17 +192,14 @@ export function _replaceWith(node: NodePath) {
   }
 
   if (this.inList) {
-    // $FlowFixMe how do we prove that this.key is not null?
     t.validate(this.parent, this.key, [node]);
   } else {
-    // $FlowFixMe how do we prove that this.key is not null?
     t.validate(this.parent, this.key, node);
   }
 
   // $FlowFixMe coercing undefined to string for debugging is fine
   this.debug(`Replace with ${node && node.type}`);
 
-  // $FlowFixMe is this.container an object or an array?
   this.node = this.container[this.key] = node;
 }
 

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -140,7 +140,11 @@ export function replaceWith(replacement) {
 
   let nodePath = "";
 
-  if (this.isNodeType("Statement") && t.isExpression(replacement)) {
+  if (
+    this.type &&
+    this.isNodeType("Statement") &&
+    t.isExpression(replacement)
+  ) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
       !this.canSwapBetweenExpressionAndStatement(replacement) &&
@@ -152,7 +156,11 @@ export function replaceWith(replacement) {
     }
   }
 
-  if (this.isNodeType("Expression") && t.isStatement(replacement)) {
+  if (
+    this.type &&
+    this.isNodeType("Expression") &&
+    t.isStatement(replacement)
+  ) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
       !this.canSwapBetweenExpressionAndStatement(replacement)

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -44,18 +44,19 @@ const hoistVariablesVisitor = {
  */
 
 export function replaceWithMultiple(nodes: Array<NodePath>) {
-  this.resync();
+  const _this: NodePath = this;
+  _this.resync();
 
-  nodes = this._verifyNodeList(nodes);
-  t.inheritLeadingComments(nodes[0], this.node);
-  t.inheritTrailingComments(nodes[nodes.length - 1], this.node);
-  this.node = this.container[this.key] = null;
-  const paths = this.insertAfter(nodes);
+  nodes = _this._verifyNodeList(nodes);
+  t.inheritLeadingComments(nodes[0], _this.node);
+  t.inheritTrailingComments(nodes[nodes.length - 1], _this.node);
+  _this.node = _this.container[_this.key] = null;
+  const paths = _this.insertAfter(nodes);
 
-  if (this.node) {
-    this.requeue();
+  if (_this.node) {
+    _this.requeue();
   } else {
-    this.remove();
+    _this.remove();
   }
   return paths;
 }

--- a/packages/babel-traverse/src/path/replacement.js
+++ b/packages/babel-traverse/src/path/replacement.js
@@ -140,11 +140,7 @@ export function replaceWith(replacement: NodePath) {
 
   let nodePath = "";
 
-  if (
-    this.type &&
-    this.isNodeType("Statement") &&
-    t.isExpression(replacement)
-  ) {
+  if (this.isNodeType("Statement") && t.isExpression(replacement)) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
       !this.canSwapBetweenExpressionAndStatement(replacement) &&
@@ -156,11 +152,7 @@ export function replaceWith(replacement: NodePath) {
     }
   }
 
-  if (
-    this.type &&
-    this.isNodeType("Expression") &&
-    t.isStatement(replacement)
-  ) {
+  if (this.isNodeType("Expression") && t.isStatement(replacement)) {
     if (
       !this.canHaveVariableDeclarationOrExpression() &&
       !this.canSwapBetweenExpressionAndStatement(replacement)

--- a/packages/babel-types/src/comments/inheritLeadingComments.js
+++ b/packages/babel-types/src/comments/inheritLeadingComments.js
@@ -2,8 +2,8 @@
 import inherit from "../utils/inherit";
 
 export default function inheritLeadingComments(
-  child: Object,
-  parent: Object,
+  child: ?Object,
+  parent: ?Object,
 ): void {
   inherit("leadingComments", child, parent);
 }

--- a/packages/babel-types/src/comments/inheritTrailingComments.js
+++ b/packages/babel-types/src/comments/inheritTrailingComments.js
@@ -2,8 +2,8 @@
 import inherit from "../utils/inherit";
 
 export default function inheritTrailingComments(
-  child: Object,
-  parent: Object,
+  child: ?Object,
+  parent: ?Object,
 ): void {
   inherit("trailingComments", child, parent);
 }

--- a/packages/babel-types/src/utils/inherit.js
+++ b/packages/babel-types/src/utils/inherit.js
@@ -3,8 +3,8 @@ import uniq from "lodash/uniq";
 
 export default function inherit(
   key: string,
-  child: Object,
-  parent: Object,
+  child: ?Object,
+  parent: ?Object,
 ): void {
   if (child && parent) {
     child[key] = uniq([].concat(child[key], parent[key]).filter(Boolean));

--- a/packages/babel-types/src/validators/isType.js
+++ b/packages/babel-types/src/validators/isType.js
@@ -5,9 +5,6 @@ import { FLIPPED_ALIAS_KEYS, ALIAS_KEYS } from "../definitions";
  * Test if a `nodeType` is a `targetType` or if `targetType` is an alias of `nodeType`.
  */
 export default function isType(nodeType: string, targetType: string): boolean {
-  if (typeof nodeType !== "string" || typeof targetType !== "string") {
-    throw new Error("nodeType and targetType must be strings");
-  }
   if (nodeType === targetType) return true;
 
   // This is a fast-path. If the test above failed, but an alias key is found, then the

--- a/packages/babel-types/src/validators/isType.js
+++ b/packages/babel-types/src/validators/isType.js
@@ -5,6 +5,9 @@ import { FLIPPED_ALIAS_KEYS, ALIAS_KEYS } from "../definitions";
  * Test if a `nodeType` is a `targetType` or if `targetType` is an alias of `nodeType`.
  */
 export default function isType(nodeType: string, targetType: string): boolean {
+  if (typeof nodeType !== "string" || typeof targetType !== "string") {
+    throw new Error("nodeType and targetType must be strings");
+  }
   if (nodeType === targetType) return true;
 
   // This is a fast-path. If the test above failed, but an alias key is found, then the

--- a/packages/babel-types/src/validators/isType.js
+++ b/packages/babel-types/src/validators/isType.js
@@ -4,7 +4,7 @@ import { FLIPPED_ALIAS_KEYS, ALIAS_KEYS } from "../definitions";
 /**
  * Test if a `nodeType` is a `targetType` or if `targetType` is an alias of `nodeType`.
  */
-export default function isType(nodeType: string, targetType: string): boolean {
+export default function isType(nodeType: ?string, targetType: string): boolean {
   if (nodeType === targetType) return true;
 
   // This is a fast-path. If the test above failed, but an alias key is found, then the

--- a/packages/babel-types/src/validators/validate.js
+++ b/packages/babel-types/src/validators/validate.js
@@ -1,7 +1,7 @@
 // @flow
 import { NODE_FIELDS } from "../definitions";
 
-export default function validate(node?: Object, key: string, val: any): void {
+export default function validate(node: ?Object, key: string, val: any): void {
   if (!node) return;
 
   const fields = NODE_FIELDS[node.type];

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -136,5 +136,8 @@ describe("validators", function() {
     it("returns false if nodeType and targetType are unrelated", function() {
       expect(t.isType("ArrayExpression", "ClassBody")).toBe(false);
     });
+    it("returns false if nodeType is undefined", function() {
+      expect(t.isType(undefined, "Expression")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
The signature of isType() is `isType(nodeType: string, targetType: string): boolean` but if I assert that nodeType and targetType are both strings (as in this patch) I get a bunch of test failures:


    Test Suites: 86 failed, 47 passed, 133 total
    Tests:       155 failed, 54 skipped, 6600 passed, 6809 total
    Snapshots:   7 passed, 7 total
    Time:        47.333s, estimated 76s

In my other branch (re-writing bits of babel in rust) it's easier for me if I rely on nodeType and targetType both being strings, but in a bunch of tests they end up being undefined (the type property is not set on a bunch of nodes).

The question is: should I write a patch which fixes the above tests, or should I change the documentation/signature/tests for isType() to make it explicit that it needs to survive its arguments being undefined?

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Not sure. Needs discussion.
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
