### PR TITLE
flow type update: babel-types.isType(?string, string): boolean

### DIFF
--- a/packages/babel-types/src/validators/isType.js
+++ b/packages/babel-types/src/validators/isType.js
@@ -4,7 +4,7 @@ import { FLIPPED_ALIAS_KEYS, ALIAS_KEYS } from "../definitions";
 /**
  * Test if a `nodeType` is a `targetType` or if `targetType` is an alias of `nodeType`.
  */
-export default function isType(nodeType: string, targetType: string): boolean {
+export default function isType(nodeType: ?string, targetType: string): boolean {
   if (nodeType === targetType) return true;
 
   // This is a fast-path. If the test above failed, but an alias key is found, then the

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -136,5 +136,8 @@ describe("validators", function() {
     it("returns false if nodeType and targetType are unrelated", function() {
       expect(t.isType("ArrayExpression", "ClassBody")).toBe(false);
     });
+    it("returns false if nodeType is undefined", function() {
+      expect(t.isType(undefined, "Expression")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
NodePath.type is a ?string so we need to accept undefined here too.

I didn't see that @nicolo-ribaudo edited his comment on https://github.com/babel/babel/pull/9262 so I went down a massive rabbit-hole trying to get flow to check things properly. This is a micro-pr that fixes the original isType() discrepancy that I spotted.

If you want me to cherry-pick anything from the other PR, I'd be happy to.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | bug in our type annotations
| Major: Breaking Change?  | no: isType()'s signature is now more permissive than before, and its return type has not changed.
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
