### PR TITLE
Fix location for typescript type assertions in AST

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -896,6 +896,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     tsParseTypeAssertion(): N.TsTypeAssertion {
       const node: N.TsTypeAssertion = this.startNode();
+      this.next(); // <
       // Not actually necessary to set state.inType because we never reach here if JSX plugin is enabled,
       // but need `tsInType` to satisfy the assertion in `tsParseType`.
       node.typeAnnotation = this.tsInType(() => this.tsParseType());
@@ -2001,7 +2002,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     // Handle type assertions
     parseMaybeUnary(refShorthandDefaultPos?: ?Pos): N.Expression {
-      if (!this.hasPlugin("jsx") && this.eatRelational("<")) {
+      if (!this.hasPlugin("jsx") && this.isRelational("<")) {
         return this.tsParseTypeAssertion();
       } else {
         return super.parseMaybeUnary(refShorthandDefaultPos);

--- a/packages/babel-parser/test/fixtures/typescript/cast/need-parentheses/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/need-parentheses/output.json
@@ -59,12 +59,12 @@
           },
           "object": {
             "type": "TSTypeAssertion",
-            "start": 2,
+            "start": 1,
             "end": 6,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 2
+                "column": 1
               },
               "end": {
                 "line": 1,

--- a/packages/babel-parser/test/fixtures/typescript/cast/type-assertion-after-operator/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/type-assertion-after-operator/output.json
@@ -80,12 +80,12 @@
           "operator": "+",
           "right": {
             "type": "TSTypeAssertion",
-            "start": 5,
+            "start": 4,
             "end": 14,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 5
+                "column": 4
               },
               "end": {
                 "line": 1,

--- a/packages/babel-parser/test/fixtures/typescript/cast/type-assertion-and-assign/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/type-assertion-and-assign/output.json
@@ -60,12 +60,12 @@
           "operator": "+=",
           "left": {
             "type": "TSTypeAssertion",
-            "start": 2,
+            "start": 1,
             "end": 11,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 2
+                "column": 1
               },
               "end": {
                 "line": 1,

--- a/packages/babel-parser/test/fixtures/typescript/cast/type-assertion-before-operator/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/type-assertion-before-operator/output.json
@@ -59,12 +59,12 @@
           },
           "left": {
             "type": "TSTypeAssertion",
-            "start": 1,
+            "start": 0,
             "end": 10,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 1
+                "column": 0
               },
               "end": {
                 "line": 1,

--- a/packages/babel-parser/test/fixtures/typescript/cast/type-assertion/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/type-assertion/output.json
@@ -45,12 +45,12 @@
         },
         "expression": {
           "type": "TSTypeAssertion",
-          "start": 1,
+          "start": 0,
           "end": 10,
           "loc": {
             "start": {
               "line": 1,
-              "column": 1
+              "column": 0
             },
             "end": {
               "line": 1,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9282
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

The first character of a type assertion `<` was not included in the the range of the node `TSTypeAssertion `.
I guess this was just an oversight when adding typescript to babylon.

Can also be seen in astexplorer when hovering the `TSTypeAssertion` Node. https://astexplorer.net/#/gist/5fe1eaa61fe443bd75f9b1425bf11e34/89f5b9520e34c199838eb04db9bed0c755226899
