### PR TITLE
Add test sources to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 package.json
 packages/babel-preset-env/data
+packages/*/test/fixtures/**/input.*
+packages/*/test/fixtures/**/exec.*
+packages/*/test/fixtures/**/output.*


### PR DESCRIPTION
I use VSCode's "Prettier on save" but it also formats test files.