### PR TITLE
@babel/parser(ts): include leading character into range of generic ArrowFunctionExpression

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -2001,10 +2001,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       // Correct TypeScript code should have at least 1 type parameter, but don't crash on bad code.
       if (typeParameters && typeParameters.params.length !== 0) {
-        this.resetStartLocationFromNode(
-          arrowExpression,
-          typeParameters.params[0],
-        );
+        this.resetStartLocationFromNode(arrowExpression, typeParameters);
       }
       arrowExpression.typeParameters = typeParameters;
       return arrowExpression;

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/output.json
@@ -45,12 +45,12 @@
         },
         "expression": {
           "type": "ArrowFunctionExpression",
-          "start": 62,
+          "start": 61,
           "end": 78,
           "loc": {
             "start": {
               "line": 2,
-              "column": 1
+              "column": 0
             },
             "end": {
               "line": 2,

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/generic/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/generic/output.json
@@ -45,12 +45,12 @@
         },
         "expression": {
           "type": "ArrowFunctionExpression",
-          "start": 1,
+          "start": 0,
           "end": 17,
           "loc": {
             "start": {
               "line": 1,
-              "column": 1
+              "column": 0
             },
             "end": {
               "line": 1,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9285
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 👎 
| Minor: New Feature?      | 👎 
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 👎
| License                  | MIT

This PR fix starting location of ArrowFunctionExpression when used in in typescript with type generic.

input code:
```ts
<X>(b: X): X => b;
```

range before:
```ts
X>(b: X): X => b
```

range after:
```ts
<X>(b: X): X => b
```