### PR TITLE
@babel/parser(ts): Add parsing of type import

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -225,7 +225,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.expect(tt._import);
       this.expect(tt.parenL);
       if (!this.match(tt.string)) {
-        throw this.unexpected();
+        throw this.unexpected(
+          null,
+          "Argument in a type import must be an string literal",
+        );
       }
       node.argument = this.parseLiteral(this.state.value, "StringLiteral");
       this.expect(tt.parenR);

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -227,7 +227,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (!this.match(tt.string)) {
         throw this.unexpected(
           null,
-          "Argument in a type import must be an string literal",
+          "Argument in a type import must be a string literal",
         );
       }
       node.argument = this.parseLiteral(this.state.value, "StringLiteral");

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -221,7 +221,25 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     tsParseEntityName(allowReservedWords: boolean): N.TsEntityName {
-      let entity: N.TsEntityName = this.parseIdentifier();
+      let entity: N.TsEntityName;
+      // TODO: package this into its own tsParse function
+      if (this.state.type === tt._import) {
+        entity = this.startNode();
+        this.next();
+        if (!this.match(tt.parenL)) {
+          this.unexpected(null, tt.parenL);
+        }
+        this.eat(tt.parenL);
+        const args = this.parseCallExpressionArguments(tt.parenR, false, {
+          start: -1,
+        });
+        // TODO: assert args is length 1
+        entity.argument = args[0];
+        // TODO: make a TS-specific node type
+        entity = this.finishNode(entity, "Import");
+      } else {
+        entity = this.parseIdentifier();
+      }
       while (this.eat(tt.dot)) {
         const node: N.TsQualifiedName = this.startNodeAtNode(entity);
         node.left = entity;
@@ -645,6 +663,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         }
         case tt._typeof:
           return this.tsParseTypeQuery();
+        case tt._import:
+          // TODO: should this really be the same as parsing the RHS of typeof?
+          // XXX: TSQualifiedName is not allowed to be a return type of this function but import() references
+          // are allowed to have dots to access exported members
+          return this.tsParseEntityName(true);
         case tt.braceL:
           return this.tsLookAhead(this.tsIsStartOfMappedType.bind(this))
             ? this.tsParseMappedType()

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -234,7 +234,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         this.eat(tt.dot);
         node.qualifier = this.tsParseEntityName(allowReservedWords);
       }
-      if (!this.hasPrecedingLineBreak() && this.isRelational("<")) {
+      if (this.isRelational("<")) {
         node.typeParameters = this.tsParseTypeArguments();
       }
       return this.finishNode(node, "TSImportType");

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -220,7 +220,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return result;
     }
 
-    tsParseImportType(allowReservedWords: boolean): N.TsImportType {
+    tsParseImportType(): N.TsImportType {
       const node: N.TsImportType = this.startNode();
       this.expect(tt._import);
       this.expect(tt.parenL);
@@ -230,9 +230,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node.argument = this.parseLiteral(this.state.value, "StringLiteral");
       this.expect(tt.parenR);
 
-      if (this.match(tt.dot)) {
-        this.eat(tt.dot);
-        node.qualifier = this.tsParseEntityName(allowReservedWords);
+      if (this.eat(tt.dot)) {
+        node.qualifier = this.tsParseEntityName(/* allowReservedWords */ true);
       }
       if (this.isRelational("<")) {
         node.typeParameters = this.tsParseTypeArguments();
@@ -278,7 +277,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const node: N.TsTypeQuery = this.startNode();
       this.expect(tt._typeof);
       if (this.match(tt._import)) {
-        node.exprName = this.tsParseImportType(/* allowReservedWords */ true);
+        node.exprName = this.tsParseImportType();
       } else {
         node.exprName = this.tsParseEntityName(/* allowReservedWords */ true);
       }
@@ -670,7 +669,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         case tt._typeof:
           return this.tsParseTypeQuery();
         case tt._import:
-          return this.tsParseImportType(true);
+          return this.tsParseImportType();
         case tt.braceL:
           return this.tsLookAhead(this.tsIsStartOfMappedType.bind(this))
             ? this.tsParseMappedType()

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1286,6 +1286,13 @@ export type TsLiteralType = TsTypeBase & {
   literal: NumericLiteral | StringLiteral | BooleanLiteral,
 };
 
+export type TsImportType = TsTypeBase & {
+  type: "TsImportType",
+  argument: StringLiteral,
+  qualifier?: TsEntityName,
+  typeParameter?: TsTypeParameter,
+};
+
 // ================
 // TypeScript declarations
 // ================

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1146,6 +1146,7 @@ export type TsType =
   | TsIndexedAccessType
   | TsMappedType
   | TsLiteralType
+  | TsImportType
   // TODO: This probably shouldn't be included here.
   | TsTypePredicate;
 
@@ -1201,7 +1202,7 @@ export type TsTypePredicate = TsTypeBase & {
 // `typeof` operator
 export type TsTypeQuery = TsTypeBase & {
   type: "TSTypeQuery",
-  exprName: TsEntityName,
+  exprName: TsEntityName | TsImportType,
 };
 
 export type TsTypeLiteral = TsTypeBase & {
@@ -1290,7 +1291,7 @@ export type TsImportType = TsTypeBase & {
   type: "TsImportType",
   argument: StringLiteral,
   qualifier?: TsEntityName,
-  typeParameter?: TsTypeParameter,
+  typeParameters?: TsTypeParameterInstantiation,
 };
 
 // ================

--- a/packages/babel-parser/test/fixtures/typescript/types/import/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/input.js
@@ -1,2 +1,3 @@
 let x: typeof import('./x');
 let Y: import('./y').Y;
+let z: import("/z").foo.bar<string>;

--- a/packages/babel-parser/test/fixtures/typescript/types/import/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/input.js
@@ -1,0 +1,2 @@
+let x: typeof import('./x');
+let Y: import('./y').Y;

--- a/packages/babel-parser/test/fixtures/typescript/types/import/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/options.json
@@ -1,4 +1,0 @@
-{
-  "sourceType": "module",
-  "plugins": ["typescript", "dynamicImport"]
-}

--- a/packages/babel-parser/test/fixtures/typescript/types/import/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["typescript", "dynamicImport"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/import/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/output.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 52,
+  "end": 89,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 2,
-      "column": 23
+      "line": 3,
+      "column": 36
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 52,
+    "end": 89,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 2,
-        "column": 23
+        "line": 3,
+        "column": 36
       }
     },
     "sourceType": "module",
@@ -103,7 +103,7 @@
                     }
                   },
                   "exprName": {
-                    "type": "Import",
+                    "type": "TSImportType",
                     "start": 14,
                     "end": 27,
                     "loc": {
@@ -205,7 +205,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "TSQualifiedName",
+                  "type": "TSImportType",
                   "start": 36,
                   "end": 51,
                   "loc": {
@@ -218,42 +218,27 @@
                       "column": 22
                     }
                   },
-                  "left": {
-                    "type": "Import",
-                    "start": 36,
-                    "end": 49,
+                  "argument": {
+                    "type": "StringLiteral",
+                    "start": 43,
+                    "end": 48,
                     "loc": {
                       "start": {
                         "line": 2,
-                        "column": 7
+                        "column": 14
                       },
                       "end": {
                         "line": 2,
-                        "column": 20
+                        "column": 19
                       }
                     },
-                    "argument": {
-                      "type": "StringLiteral",
-                      "start": 43,
-                      "end": 48,
-                      "loc": {
-                        "start": {
-                          "line": 2,
-                          "column": 14
-                        },
-                        "end": {
-                          "line": 2,
-                          "column": 19
-                        }
-                      },
-                      "extra": {
-                        "rawValue": "./y",
-                        "raw": "'./y'"
-                      },
-                      "value": "./y"
-                    }
+                    "extra": {
+                      "rawValue": "./y",
+                      "raw": "'./y'"
+                    },
+                    "value": "./y"
                   },
-                  "right": {
+                  "qualifier": {
                     "type": "Identifier",
                     "start": 50,
                     "end": 51,
@@ -269,6 +254,188 @@
                       "identifierName": "Y"
                     },
                     "name": "Y"
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 53,
+        "end": 89,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 36
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 57,
+            "end": 88,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 4
+              },
+              "end": {
+                "line": 3,
+                "column": 35
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 57,
+              "end": 88,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 4
+                },
+                "end": {
+                  "line": 3,
+                  "column": 35
+                },
+                "identifierName": "z"
+              },
+              "name": "z",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 58,
+                "end": 88,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 35
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSImportType",
+                  "start": 60,
+                  "end": 88,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 35
+                    }
+                  },
+                  "argument": {
+                    "type": "StringLiteral",
+                    "start": 67,
+                    "end": 71,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 18
+                      }
+                    },
+                    "extra": {
+                      "rawValue": "/z",
+                      "raw": "\"/z\""
+                    },
+                    "value": "/z"
+                  },
+                  "qualifier": {
+                    "type": "TSQualifiedName",
+                    "start": 73,
+                    "end": 80,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 27
+                      }
+                    },
+                    "left": {
+                      "type": "Identifier",
+                      "start": 73,
+                      "end": 76,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 20
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 23
+                        },
+                        "identifierName": "foo"
+                      },
+                      "name": "foo"
+                    },
+                    "right": {
+                      "type": "Identifier",
+                      "start": 77,
+                      "end": 80,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 24
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 27
+                        },
+                        "identifierName": "bar"
+                      },
+                      "name": "bar"
+                    }
+                  },
+                  "typeParameters": {
+                    "type": "TSTypeParameterInstantiation",
+                    "start": 80,
+                    "end": 88,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 27
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 35
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "TSStringKeyword",
+                        "start": 81,
+                        "end": 87,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 28
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 34
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/packages/babel-parser/test/fixtures/typescript/types/import/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/import/output.json
@@ -1,0 +1,284 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 52,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 23
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 52,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 23
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 28
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 5,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 27
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSTypeQuery",
+                  "start": 7,
+                  "end": 27,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 27
+                    }
+                  },
+                  "exprName": {
+                    "type": "Import",
+                    "start": 14,
+                    "end": 27,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 27
+                      }
+                    },
+                    "argument": {
+                      "type": "StringLiteral",
+                      "start": 21,
+                      "end": 26,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 21
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 26
+                        }
+                      },
+                      "extra": {
+                        "rawValue": "./x",
+                        "raw": "'./x'"
+                      },
+                      "value": "./x"
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 29,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 23
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 33,
+            "end": 51,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 22
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 33,
+              "end": 51,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 22
+                },
+                "identifierName": "Y"
+              },
+              "name": "Y",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 34,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 22
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSQualifiedName",
+                  "start": 36,
+                  "end": 51,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 22
+                    }
+                  },
+                  "left": {
+                    "type": "Import",
+                    "start": 36,
+                    "end": 49,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 20
+                      }
+                    },
+                    "argument": {
+                      "type": "StringLiteral",
+                      "start": 43,
+                      "end": 48,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 14
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 19
+                        }
+                      },
+                      "extra": {
+                        "rawValue": "./y",
+                        "raw": "'./y'"
+                      },
+                      "value": "./y"
+                    }
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 50,
+                    "end": 51,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 22
+                      },
+                      "identifierName": "Y"
+                    },
+                    "name": "Y"
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #7749
| Patch: Bug Fix?          | 👎 
| Major: Breaking Change?  | 👎 
| Minor: New Feature?      | 👍 
| Tests Added + Pass?      | 👍
| Documentation PR Link    | 👎 
| Any Dependency Changes?  | 👎 
| License                  | MIT

This PR is continuation of work done in #8798 by @Kovensky few months ago.
This PR adds new node `TSImportType`.

Comparing to how TS parses this there is one difference
```ts
typeof import("./a")
```
in typescript is represented by `ImportType[typeof=true]`
this implementation will parse it into: `TSTypeQuery[exprName='TSImportType']`

i can easily change that if you think it will be better.
