### PR TITLE
Fix label handling in `scope`, to avoid causing collisions

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -238,7 +238,7 @@ export default class Scope {
       .replace(/[0-9]+$/g, "");
 
     let uid;
-    let i = 0;
+    let i = 1;
     do {
       uid = this._generateUid(name, i);
       i++;

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -107,11 +107,6 @@ const collectorVisitor = {
     },
   },
 
-  LabeledStatement(path) {
-    path.scope.getProgramParent().addGlobal(path.node);
-    path.scope.getBlockParent().registerDeclaration(path);
-  },
-
   AssignmentExpression(path, state) {
     state.assignments.push(path);
   },
@@ -148,6 +143,43 @@ const collectorVisitor = {
       }
     }
   },
+
+  LabeledStatement: {
+    enter(path, state) {
+      state.allLabels.push(path);
+      state.activeLabels.push(path);
+    },
+
+    exit(path, state) {
+      state.activeLabels.pop();
+    },
+  },
+
+  Scopable: {
+    /*
+     * state.activeLabels: All labels that are ancestors of the
+     *   current node.
+     *
+     * state.allLabels: All labels seen in traversal so far.
+     *
+     * state.labelIndexStack: A stack of indexes into allLabels,
+     *   so that `l === labelIndexStack[i]` means that the i'th
+     *   active scope started after the first l labels were seen.
+     *
+     * This logic is a little over-inclusive: it doesn't take advantage
+     * of the fact that scopes inside a function don't need to worry about
+     * labels outside, and vice versa.
+     */
+    enter(path, state) {
+      state.labelIndexStack.push(state.allLabels.length);
+    },
+
+    exit(path, state) {
+      const start = state.labelIndexStack.pop();
+      path.scope.registerInnerLabels(state.allLabels.slice(start));
+      path.scope.registerOuterLabels(state.activeLabels);
+    },
+  },
 };
 
 let uid = 0;
@@ -173,7 +205,8 @@ export default class Scope {
     this.block = node;
     this.path = path;
 
-    this.labels = new Map();
+    this.innerLabels = new Map();
+    this.outerLabels = new Map();
   }
 
   /**
@@ -455,17 +488,23 @@ export default class Scope {
   }
 
   getLabel(name: string) {
-    return this.labels.get(name);
+    return this.outerLabels.get(name) || this.innerLabels.get(name);
   }
 
-  registerLabel(path: NodePath) {
-    this.labels.set(path.node.label.name, path);
+  registerInnerLabels(paths: Array<NodePath>) {
+    for (const path of paths) {
+      this.innerLabels.set(path.node.label.name, path);
+    }
+  }
+
+  registerOuterLabels(paths: Array<NodePath>) {
+    for (const path of paths) {
+      this.outerLabels.set(path.node.label.name, path);
+    }
   }
 
   registerDeclaration(path: NodePath) {
-    if (path.isLabeledStatement()) {
-      this.registerLabel(path);
-    } else if (path.isFunctionDeclaration()) {
+    if (path.isFunctionDeclaration()) {
       this.registerBinding("hoisted", path.get("id"), path);
     } else if (path.isVariableDeclaration()) {
       const declarations = path.get("declarations");
@@ -738,11 +777,16 @@ export default class Scope {
       references: [],
       constantViolations: [],
       assignments: [],
+      activeLabels: [],
+      allLabels: [],
+      labelIndexStack: [],
     };
 
     this.crawling = true;
     path.traverse(collectorVisitor, state);
     this.crawling = false;
+
+    this.registerInnerLabels(state.allLabels);
 
     // register assignments
     for (const path of state.assignments) {

--- a/packages/babel-traverse/test/fixtures/labels/collisions/exec.js
+++ b/packages/babel-traverse/test/fixtures/labels/collisions/exec.js
@@ -1,0 +1,20 @@
+
+const log = [];
+
+(function () {
+  // _label:   // TODO: known failure
+  do {
+    { log.push(0); }
+    _label2: if (1) {
+      { { log.push(1); } }
+      { break _label2; }
+      log.push(2);
+    }
+    log.push(3);
+    continue; // _label;  // goes with known-failing bit above
+    log.push(4);
+  } while (0);
+  log.push(5);
+})();
+
+expect(log.join("")).toBe("0135");

--- a/packages/babel-traverse/test/fixtures/labels/collisions/exec.js
+++ b/packages/babel-traverse/test/fixtures/labels/collisions/exec.js
@@ -2,7 +2,7 @@
 const log = [];
 
 (function () {
-  // _label:   // TODO: known failure
+  _label:
   do {
     { log.push(0); }
     _label2: if (1) {
@@ -11,7 +11,7 @@ const log = [];
       log.push(2);
     }
     log.push(3);
-    continue; // _label;  // goes with known-failing bit above
+    continue _label;
     log.push(4);
   } while (0);
   log.push(5);

--- a/packages/babel-traverse/test/fixtures/labels/collisions/options.json
+++ b/packages/babel-traverse/test/fixtures/labels/collisions/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/labels/collisions/plugin.js
+++ b/packages/babel-traverse/test/fixtures/labels/collisions/plugin.js
@@ -4,20 +4,12 @@ module.exports = function(babel) {
     visitor: {
       Statement: {
         exit(path) {
-          /* The aggressive version.  But even the mild version doesn't work...
-
           if (path.parentPath.isFunction()) {
             // or TryStatement or CatchClause
             return;
           }
 
           if (path.isVariableDeclaration()) {
-            return;
-          }
-          */
-
-          // A mild version.
-          if (!path.isIfStatement()) {
             return;
           }
 

--- a/packages/babel-traverse/test/fixtures/labels/collisions/plugin.js
+++ b/packages/babel-traverse/test/fixtures/labels/collisions/plugin.js
@@ -1,0 +1,31 @@
+module.exports = function(babel) {
+  const t = babel.types;
+  return {
+    visitor: {
+      Statement: {
+        exit(path) {
+          /* The aggressive version.  But even the mild version doesn't work...
+
+          if (path.parentPath.isFunction()) {
+            // or TryStatement or CatchClause
+            return;
+          }
+
+          if (path.isVariableDeclaration()) {
+            return;
+          }
+          */
+
+          // A mild version.
+          if (!path.isIfStatement()) {
+            return;
+          }
+
+          const label = path.scope.generateUidIdentifier("label");
+          path.replaceWith(t.labeledStatement(label, path.node));
+          path.skip();
+        }
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -13,6 +13,20 @@ function getPath(code, options) {
   return path;
 }
 
+function getPathHere(code, options) {
+  const ast = parse(code, options);
+  let result;
+  traverse(ast, {
+    Identifier: function(path) {
+      if (path.node.name === "HERE") {
+        result = path;
+        path.stop();
+      }
+    },
+  });
+  return result;
+}
+
 function getIdentifierPath(code) {
   const ast = parse(code);
   let nodePath;
@@ -217,23 +231,18 @@ describe("scope", function() {
     });
 
     test("generateUid collision check with labels", function() {
-      expect(
-        getPath(
-          `
-      _foo: { }
-    `,
-        ).scope.generateUid("foo"),
-      ).toBe("_foo2");
+      const gen = (id, path) => path.scope.generateUid(id);
 
+      expect(gen("foo", getPath("_foo: { }"))).toBe("_foo2");
       expect(
-        getPath(
-          `
-      _foo: { }
-      _foo1: { }
-      _foo2: { }
-    `,
-        ).scope.generateUid("foo"),
+        gen("foo", getPath("_foo: { } _foo1: { } _foo2: { }")), //
       ).toBe("_foo3");
+      /* Known failures.
+      expect(gen("foo", getPath("do { _foo: { } } while (0)"))).toBe("_foo2");
+      expect(
+        gen("foo", getPathHere("_foo: do { HERE } while (0)")), //
+      ).toBe("_foo2");
+      */
     });
 
     it("reference paths", function() {

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -214,7 +214,7 @@ describe("scope", function() {
       ).toBeTruthy();
     });
 
-    test("label", function() {
+    test("getLabel", function() {
       expect(getPath("foo: { }").scope.getBinding("foo")).toBeUndefined();
       expect(getPath("foo: { }").scope.getLabel("foo").type).toBe(
         "LabeledStatement",
@@ -237,12 +237,10 @@ describe("scope", function() {
       expect(
         gen("foo", getPath("_foo: { } _foo1: { } _foo2: { }")), //
       ).toBe("_foo3");
-      /* Known failures.
       expect(gen("foo", getPath("do { _foo: { } } while (0)"))).toBe("_foo2");
       expect(
         gen("foo", getPathHere("_foo: do { HERE } while (0)")), //
       ).toBe("_foo2");
-      */
     });
 
     it("reference paths", function() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes!
| Major: Breaking Change?  | nope
| Minor: New Feature?      | nope
| Tests Added + Pass?      | :heavy_check_mark: 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | nope
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Labels work quite differently from identifier bindings in how they collide.  Because we track them on scopes in a very similar way to identifier bindings, this means that a transform which innocently tries to insert a label using `scope.generateUid`, like this:

    const label = path.scope.generateUidIdentifier("label");
    path.replaceWith(t.labeledStatement(label, path.node));

is subject to a bug where it can generate invalid code.

Specifically, it's actually perfectly fine to have several labels as siblings:

    function f() {
      loop: do { continue loop; } while (0);
      loop: while (1) { break loop; };
      loop: if (1) { break loop; /* :-P */ }
    }
  
but on the other hand, it's *not* permitted to have one as an ancestor of another:
  
    function f() {
      loop: do {
        loop: while (1) { // Error!
          break loop;     // After all -- what should this mean?
        }
        console.log("would this run?");
      } while (0);
    }

This commit adds several test cases to demonstrate the issue -- an end-to-end test featuring a transform, and a couple of unit tests -- and then changes the algorithm a Scope uses for tracking labels to one that more closely reflects the language semantics, fixing the issue.
