### PR TITLE
Copy "optional" property when cloning Identifier node

### DIFF
--- a/packages/babel-types/src/clone/cloneNode.js
+++ b/packages/babel-types/src/clone/cloneNode.js
@@ -38,12 +38,14 @@ export default function cloneNode<T: Object>(node: T, deep: boolean = true): T {
   if (type === "Identifier") {
     newNode.name = node.name;
 
+    if (has(node, "optional") && typeof node.optional === "boolean") {
+      newNode.optional = node.optional;
+    }
+
     if (has(node, "typeAnnotation")) {
       newNode.typeAnnotation = deep
         ? cloneIfNodeOrArray(node.typeAnnotation, true)
         : node.typeAnnotation;
-
-      newNode.optional = node.optional;
     }
   } else if (!has(NODE_FIELDS, type)) {
     throw new Error(`Unknown node type: "${type}"`);

--- a/packages/babel-types/src/clone/cloneNode.js
+++ b/packages/babel-types/src/clone/cloneNode.js
@@ -42,6 +42,8 @@ export default function cloneNode<T: Object>(node: T, deep: boolean = true): T {
       newNode.typeAnnotation = deep
         ? cloneIfNodeOrArray(node.typeAnnotation, true)
         : node.typeAnnotation;
+
+      newNode.optional = node.optional;
     }
   } else if (!has(NODE_FIELDS, type)) {
     throw new Error(`Unknown node type: "${type}"`);


### PR DESCRIPTION
Fixes #9331

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9331
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | None added, should pass
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Copying value of `optional` property of "Identifier" nodes when cloning AST nodes means that clone will be more similar to original node and optional parameters will continue to be optional. Very important when used through babel-template. 
See #9331 to find out how not copying it caused problems
