### PR TITLE
Disallow usage of invalid keyword after export abstract statement in Typescript

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -1265,7 +1265,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           if (next || this.match(tt._class)) {
             const cls: N.ClassDeclaration = node;
             cls.abstract = true;
-            if (next) this.next();
+            if (next) {
+              this.next();
+              if (!this.match(tt._class)) {
+                this.unexpected(null, tt._class);
+              }
+            }
             return this.parseClass(
               cls,
               /* isStatement */ true,

--- a/packages/babel-parser/test/fixtures/typescript/interface/export-abstract-interface/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/interface/export-abstract-interface/input.js
@@ -1,0 +1,3 @@
+export abstract interface I {
+
+}

--- a/packages/babel-parser/test/fixtures/typescript/interface/export-abstract-interface/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/interface/export-abstract-interface/options.json
@@ -1,7 +1,3 @@
 {
-  "sourceType": "module",
-  "plugins": [
-    "typescript"
-  ],
   "throws": "Unexpected token, expected \"class\" (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/typescript/interface/export-abstract-interface/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/interface/export-abstract-interface/options.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "typescript"
+  ],
+  "throws": "Unexpected token, expected \"class\" (1:16)"
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9304
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | 👎 
| Minor: New Feature?      | 👎 
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  | 👎 
| License                  | MIT

This PR makes parser error on unexpected keywords used after `export abstract` and disallow usage of unknown keywords as "classes":

example of fixed cases:
```ts
export abstract interface X {}
```
```ts
export abstract putHereWhathever X {}
```

-----------

`this.parseClass` does not check if its actually class, it's just doing `this.next()` on first token
it can be also solved by moving this check there