### PR TITLE
Differentiate object spread and non-spread properties

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -391,7 +391,7 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
     for (var i = 1; i < arguments.length; i++) {
       var argument = arguments[i];
       if (argument.isSpread) {
-        var source = (arguments[i] != null) ? arguments[i] : {};
+        var source = (argument.argument != null) ? argument.argument : {};
         var ownKeys = Object.keys(source);
         if (typeof Object.getOwnPropertySymbols === 'function') {
           ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
@@ -402,7 +402,7 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
           defineProperty(target, key, source[key]);
         });
       } else {
-        Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument));
+        Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.argument));
       }
     }
     return target;

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -389,16 +389,21 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
 
   export default function _objectSpread(target) {
     for (var i = 1; i < arguments.length; i++) {
-      var source = (arguments[i] != null) ? arguments[i] : {};
-      var ownKeys = Object.keys(source);
-      if (typeof Object.getOwnPropertySymbols === 'function') {
-        ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
-          return Object.getOwnPropertyDescriptor(source, sym).enumerable;
-        }));
+      var argument = arguments[i];
+      if (argument.isSpread) {
+        var source = (arguments[i] != null) ? arguments[i] : {};
+        var ownKeys = Object.keys(source);
+        if (typeof Object.getOwnPropertySymbols === 'function') {
+          ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
+            return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+          }));
+        }
+        ownKeys.forEach(function(key) {
+          defineProperty(target, key, source[key]);
+        });
+      } else {
+        Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument));
       }
-      ownKeys.forEach(function(key) {
-        defineProperty(target, key, source[key]);
-      });
     }
     return target;
   }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -387,20 +387,25 @@ helpers.extends = helper("7.0.0-beta.0")`
 helpers.objectSpread = helper("7.0.0-beta.0")`
   import defineProperty from "defineProperty";
 
+  function _objectSpreadStep(target, object) {
+    var source = (object != null) ? object : {};
+    var ownKeys = Object.keys(source);
+    if (typeof Object.getOwnPropertySymbols === 'function') {
+      ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
+        return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+      }));
+    }
+    ownKeys.forEach(function(key) {
+      defineProperty(target, key, source[key]);
+    });
+  }
+
   export default function _objectSpread(target) {
-    for (var i = 1; i < arguments.length; i++) {
+    _objectSpreadStep(target, arguments[1]);
+    for (var i = 2; i < arguments.length; i++) {
       var argument = arguments[i];
       if (argument.isSpread) {
-        var source = (argument.object != null) ? argument.object : {};
-        var ownKeys = Object.keys(source);
-        if (typeof Object.getOwnPropertySymbols === 'function') {
-          ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
-            return Object.getOwnPropertyDescriptor(source, sym).enumerable;
-          }));
-        }
-        ownKeys.forEach(function(key) {
-          defineProperty(target, key, source[key]);
-        });
+        _objectSpreadStep(target, argument.object);
       } else {
         Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object));
       }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -387,27 +387,21 @@ helpers.extends = helper("7.0.0-beta.0")`
 helpers.objectSpread = helper("7.0.0-beta.0")`
   import defineProperty from "defineProperty";
 
-  function _objectSpreadStep(target, object) {
-    var source = (object != null) ? object : {};
-    var ownKeys = Object.keys(source);
-    if (typeof Object.getOwnPropertySymbols === 'function') {
-      ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
-        return Object.getOwnPropertyDescriptor(source, sym).enumerable;
-      }));
-    }
-    ownKeys.forEach(function(key) {
-      defineProperty(target, key, source[key]);
-    });
-  }
-
   export default function _objectSpread(target) {
-    _objectSpreadStep(target, arguments[1]);
-    for (var i = 2; i < arguments.length; i++) {
-      var argument = arguments[i];
-      if (argument.isSpread) {
-        _objectSpreadStep(target, argument.object);
+    for (var i = 1; i < arguments.length; i++) {
+      if (i % 2) {
+        var source = (arguments[i] != null) ? arguments[i] : {};
+        var ownKeys = Object.keys(source);
+        if (typeof Object.getOwnPropertySymbols === 'function') {
+          ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
+            return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+          }));
+        }
+        ownKeys.forEach(function(key) {
+          defineProperty(target, key, source[key]);
+        });
       } else {
-        Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object));
+        Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i]));
       }
     }
     return target;

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -391,7 +391,7 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
     for (var i = 1; i < arguments.length; i++) {
       var argument = arguments[i];
       if (argument.isSpread) {
-        var source = (argument.argument != null) ? argument.argument : {};
+        var source = (argument.object != null) ? argument.object : {};
         var ownKeys = Object.keys(source);
         if (typeof Object.getOwnPropertySymbols === 'function') {
           ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
@@ -402,7 +402,7 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
           defineProperty(target, key, source[key]);
         });
       } else {
-        Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.argument));
+        Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object));
       }
     }
     return target;

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -459,7 +459,7 @@ export default declare((api, opts) => {
               ),
             ])
           );
-          objects[0] = objects[0].properties[1];
+          objects[0] = objects[0].properties[1].value;
           path.replaceWith(t.callExpression(helper, objects));
         }
       },

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -429,7 +429,7 @@ export default declare((api, opts) => {
             push();
             args.push(t.objectExpression([
               t.objectProperty(t.identifier("isSpread"), t.booleanLiteral(true)),
-              t.objectProperty(t.identifier("argument"), props.argument)
+              t.objectProperty(t.identifier("argument"), prop.argument)
             ]));
           } else {
             props.push(prop);

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -457,6 +457,7 @@ export default declare((api, opts) => {
             ]),
           );
           objects[0] = objects[0].properties[1].value;
+          objects[1] = objects[1].properties[1].value;
           path.replaceWith(t.callExpression(helper, objects));
         }
       },

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -421,7 +421,10 @@ export default declare((api, opts) => {
         }
 
         if (t.isSpreadElement(path.node.properties[0])) {
-          args.push(t.objectExpression([]));
+          args.push(t.objectExpression([
+            t.objectProperty(t.identifier("isSpread"), t.booleanLiteral(false)),
+            t.objectProperty(t.identifier("argument"), t.objectExpression([]))
+          ]));
         }
 
         for (const prop of (path.node.properties: Array)) {

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -423,7 +423,7 @@ export default declare((api, opts) => {
         if (t.isSpreadElement(path.node.properties[0])) {
           args.push({
             isSpread: false,
-            object: [],
+            object: t.objectExpression([]),
           });
         }
 

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -453,11 +453,8 @@ export default declare((api, opts) => {
                 t.identifier("isSpread"),
                 t.booleanLiteral(arg.isSpread),
               ),
-              t.objectProperty(
-                t.identifier("object"),
-                arg.object,
-              ),
-            ])
+              t.objectProperty(t.identifier("object"), arg.object),
+            ]),
           );
           objects[0] = objects[0].properties[1].value;
           path.replaceWith(t.callExpression(helper, objects));

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -414,7 +414,7 @@ export default declare((api, opts) => {
         function push() {
           if (!props.length) return;
           args.push(t.objectExpression([
-            t.objectProperty(t.identifier("isSpread"), false),
+            t.objectProperty(t.identifier("isSpread"), t.booleanLiteral(false)),
             t.objectProperty(t.identifier("argument"), t.objectExpression(props))
           ]));
           props = [];
@@ -428,7 +428,7 @@ export default declare((api, opts) => {
           if (t.isSpreadElement(prop)) {
             push();
             args.push(t.objectExpression([
-              t.objectProperty(t.identifier("isSpread"), true),
+              t.objectProperty(t.identifier("isSpread"), t.booleanLiteral(true)),
               t.objectProperty(t.identifier("argument"), props.argument)
             ]));
           } else {

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/assignment/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/assignment/output.js
@@ -1,11 +1,17 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 z = _objectSpread({
   x
-}, y);
+}, {
+  isSpread: true,
+  object: y
+});
 z = {
   x,
-  w: _objectSpread({}, y)
+  w: _objectSpread({}, {
+    isSpread: true,
+    object: y
+  })
 };

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/assignment/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/assignment/output.js
@@ -1,17 +1,13 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
+
+function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 z = _objectSpread({
   x
-}, {
-  isSpread: true,
-  object: y
-});
+}, y);
 z = {
   x,
-  w: _objectSpread({}, {
-    isSpread: true,
-    object: y
-  })
+  w: _objectSpread({}, y)
 };

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/assignment/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/assignment/output.js
@@ -1,6 +1,4 @@
-function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
-
-function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/exec.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/exec.js
@@ -1,0 +1,8 @@
+var log = [];
+
+var a = {
+  ...{ get foo() { log.push(1); } },
+  get bar() { log.push(2); }
+};
+
+expect(log).toEqual([1]);

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/input.js
@@ -4,6 +4,6 @@
 
 ({ ...{ foo: 'bar' } });
 
-({ ...{ get foo () { return 'foo' } } });
+({ ...{ foo: 'bar' }, ...{ bar: 'baz' } });
 
-({ ...{ foo: 'bar' }, get foo () { return 'foo' } });
+({ ...{ get foo () { return 'foo' } } });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/input.js
@@ -5,3 +5,5 @@
 ({ ...{ foo: 'bar' } });
 
 ({ ...{ get foo () { return 'foo' } } });
+
+({ ...{ foo: 'bar' }, get foo () { return 'foo' } });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
@@ -33,3 +33,15 @@ _objectSpread({}, {
   }
 
 });
+
+_objectSpread({}, {
+  foo: 'bar'
+}, {
+  isSpread: false,
+  object: {
+    get foo() {
+      return 'foo';
+    }
+
+  }
+});

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
@@ -1,24 +1,13 @@
-function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
-
-function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 _objectSpread({
   x
 }, y, {
-  isSpread: false,
-  object: {
-    a
-  }
-}, {
-  isSpread: true,
-  object: b
-}, {
-  isSpread: false,
-  object: {
-    c
-  }
+  a
+}, b, {
+  c
 });
 
 _objectSpread({}, Object.prototype);
@@ -28,20 +17,14 @@ _objectSpread({}, {
 });
 
 _objectSpread({}, {
+  foo: 'bar'
+}, {}, {
+  bar: 'baz'
+});
+
+_objectSpread({}, {
   get foo() {
     return 'foo';
   }
 
-});
-
-_objectSpread({}, {
-  foo: 'bar'
-}, {
-  isSpread: false,
-  object: {
-    get foo() {
-      return 'foo';
-    }
-
-  }
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
@@ -1,24 +1,45 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 _objectSpread({
   x
-}, y, {
-  a
-}, b, {
-  c
-});
-
-_objectSpread({}, Object.prototype);
-
-_objectSpread({}, {
-  foo: 'bar'
-});
-
-_objectSpread({}, {
-  get foo() {
-    return 'foo';
+}, {
+  isSpread: true,
+  object: y
+}, {
+  isSpread: false,
+  object: {
+    a
   }
+}, {
+  isSpread: true,
+  object: b
+}, {
+  isSpread: false,
+  object: {
+    c
+  }
+});
 
+_objectSpread({}, {
+  isSpread: true,
+  object: Object.prototype
+});
+
+_objectSpread({}, {
+  isSpread: true,
+  object: {
+    foo: 'bar'
+  }
+});
+
+_objectSpread({}, {
+  isSpread: true,
+  object: {
+    get foo() {
+      return 'foo';
+    }
+
+  }
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/expression/output.js
@@ -1,13 +1,12 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
+
+function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 _objectSpread({
   x
-}, {
-  isSpread: true,
-  object: y
-}, {
+}, y, {
   isSpread: false,
   object: {
     a
@@ -22,24 +21,15 @@ _objectSpread({
   }
 });
 
+_objectSpread({}, Object.prototype);
+
 _objectSpread({}, {
-  isSpread: true,
-  object: Object.prototype
+  foo: 'bar'
 });
 
 _objectSpread({}, {
-  isSpread: true,
-  object: {
-    foo: 'bar'
+  get foo() {
+    return 'foo';
   }
-});
 
-_objectSpread({}, {
-  isSpread: true,
-  object: {
-    get foo() {
-      return 'foo';
-    }
-
-  }
 });

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/variable-declaration/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/variable-declaration/output.js
@@ -1,6 +1,4 @@
-function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
-
-function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/variable-declaration/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/variable-declaration/output.js
@@ -1,5 +1,8 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var z = _objectSpread({}, x);
+var z = _objectSpread({}, {
+  isSpread: true,
+  object: x
+});

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/variable-declaration/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/variable-declaration/output.js
@@ -1,8 +1,7 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
+
+function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var z = _objectSpread({}, {
-  isSpread: true,
-  object: x
-});
+var z = _objectSpread({}, x);

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
@@ -1,6 +1,4 @@
-function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
-
-function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
@@ -1,4 +1,6 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
+
+function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -35,10 +37,7 @@ var _x$y$a$b = {
 var n = _objectSpread({
   x: x,
   y: y
-}, {
-  isSpread: true,
-  object: z
-});
+}, z);
 
 function agf() {
   return _agf.apply(this, arguments);

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-entry/output.js
@@ -1,4 +1,4 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -35,7 +35,10 @@ var _x$y$a$b = {
 var n = _objectSpread({
   x: x,
   y: y
-}, z);
+}, {
+  isSpread: true,
+  object: z
+});
 
 function agf() {
   return _agf.apply(this, arguments);

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
@@ -1,5 +1,9 @@
 "use strict";
 
+require("core-js/modules/es7.object.get-own-property-descriptors");
+
+require("core-js/modules/es6.object.define-properties");
+
 require("core-js/modules/es6.array.for-each");
 
 require("core-js/modules/es6.array.filter");
@@ -22,7 +26,7 @@ require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.promise");
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -59,7 +63,10 @@ var _x$y$a$b = {
 var n = _objectSpread({
   x: x,
   y: y
-}, z);
+}, {
+  isSpread: true,
+  object: z
+});
 
 function agf() {
   return _agf.apply(this, arguments);

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
@@ -26,7 +26,9 @@ require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.promise");
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
+
+function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -63,10 +65,7 @@ var _x$y$a$b = {
 var n = _objectSpread({
   x: x,
   y: y
-}, {
-  isSpread: true,
-  object: z
-});
+}, z);
 
 function agf() {
   return _agf.apply(this, arguments);

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals-use-builtins-usage/output.js
@@ -26,9 +26,7 @@ require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.promise");
 
-function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
-
-function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
@@ -1,6 +1,4 @@
-function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
-
-function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
@@ -1,4 +1,6 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
+function _objectSpreadStep(target, object) { var source = object != null ? object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); }
+
+function _objectSpread(target) { _objectSpreadStep(target, arguments[1]); for (var i = 2; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { _objectSpreadStep(target, argument.object); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -35,10 +37,7 @@ var _x$y$a$b = {
 var n = _objectSpread({
   x: x,
   y: y
-}, {
-  isSpread: true,
-  object: z
-});
+}, z);
 
 function agf() {
   return _agf.apply(this, arguments);

--- a/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/shippedProposals/output.js
@@ -1,4 +1,4 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var argument = arguments[i]; if (argument.isSpread) { var source = argument.object != null ? argument.object : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(argument.object)); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -35,7 +35,10 @@ var _x$y$a$b = {
 var n = _objectSpread({
   x: x,
   y: y
-}, z);
+}, {
+  isSpread: true,
+  object: z
+});
 
 function agf() {
   return _agf.apply(this, arguments);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9322 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

~~This adds `isSpread: true/false` to differentiate arguments for `_objectSpread()`, so that non-spread properties including getter/setter can be safely transferred.~~

This modifies `_objectSpread()` so that only the even arguments would be considered as spreads.