### PR TITLE
Unify reserved word checking and update error messages

### DIFF
--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -1,8 +1,6 @@
 // @flow
 
 import type { Options } from "../options";
-import { isES2015ReservedWord } from "../util/identifier";
-
 import type State from "../tokenizer/state";
 import type { PluginsMap } from "./index";
 
@@ -16,14 +14,6 @@ export default class BaseParser {
 
   // Initialized by Tokenizer
   state: State;
-
-  isReservedWord(word: string): boolean {
-    if (word === "await") {
-      return this.inModule;
-    } else {
-      return isES2015ReservedWord(word);
-    }
-  }
 
   hasPlugin(name: string): boolean {
     return this.plugins.has(name);

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -14,10 +14,7 @@ import type {
   SpreadElement,
 } from "../types";
 import type { Pos, Position } from "../util/location";
-import {
-  isStrictReservedWord,
-  isStrictBindReservedWord,
-} from "../util/identifier";
+import { isStrictBindReservedWord } from "../util/identifier";
 import { NodeUtils } from "./node";
 
 export default class LValParser extends NodeUtils {
@@ -336,12 +333,13 @@ export default class LValParser extends NodeUtils {
       case "Identifier":
         if (
           this.state.strict &&
-          (isStrictReservedWord(expr.name) ||
-            isStrictBindReservedWord(expr.name))
+          isStrictBindReservedWord(expr.name, this.inModule)
         ) {
           this.raise(
             expr.start,
-            expr.name + " is a reserved word in strict mode",
+            `${isBinding ? "Binding" : "Assigning to"} '${
+              expr.name
+            }' in strict mode`,
           );
         }
 

--- a/packages/babel-parser/src/util/identifier.js
+++ b/packages/babel-parser/src/util/identifier.js
@@ -4,27 +4,52 @@
 
 import * as charCodes from "charcodes";
 
-export const isES2015ReservedWord = (word: string): boolean => {
-  return word === "enum" || word === "await";
+const reservedWords = {
+  strict: [
+    "implements",
+    "interface",
+    "let",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "static",
+    "yield",
+  ],
+  strictBind: ["eval", "arguments"],
 };
 
-const reservedWordsStrict = new Set([
-  "implements",
-  "interface",
-  "let",
-  "package",
-  "private",
-  "protected",
-  "public",
-  "static",
-  "yield",
-]);
-export function isStrictReservedWord(word: string): boolean {
-  return reservedWordsStrict.has(word);
+const reservedWordsStrictSet = new Set(reservedWords.strict);
+const reservedWordsStrictBindSet = new Set(
+  reservedWords.strict.concat(reservedWords.strictBind),
+);
+
+/**
+ * Checks if word is a reserved word in non-strict mode
+ */
+export const isReservedWord = (word: string, inModule: boolean): boolean => {
+  return (inModule && word === "await") || word === "enum";
+};
+
+/**
+ * Checks if word is a reserved word in non-binding strict mode
+ *
+ * Includes non-strict reserved words
+ */
+export function isStrictReservedWord(word: string, inModule: boolean): boolean {
+  return isReservedWord(word, inModule) || reservedWordsStrictSet.has(word);
 }
 
-export function isStrictBindReservedWord(word: string): boolean {
-  return word === "eval" || word === "arguments";
+/**
+ * Checks if word is a reserved word in binding strict mode
+ *
+ * Includes non-strict reserved words and non-binding strict reserved words
+ */
+export function isStrictBindReservedWord(
+  word: string,
+  inModule: boolean,
+): boolean {
+  return isReservedWord(word, inModule) || reservedWordsStrictBindSet.has(word);
 }
 
 const keywords = new Set([

--- a/packages/babel-parser/test/expressions/is-expression-babel-parser/fail/8/options.json
+++ b/packages/babel-parser/test/expressions/is-expression-babel-parser/fail/8/options.json
@@ -1,4 +1,4 @@
 {
   "strictMode": true,
-  "throws": "public is a reserved word in strict mode (2:0)"
+  "throws": "Unexpected reserved word 'public' (2:0)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/468/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/468/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:36)"
+  "throws": "Binding 'eval' in strict mode (1:36)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/469/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/469/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:36)"
+  "throws": "Binding 'arguments' in strict mode (1:36)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/470/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/470/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:47)"
+  "throws": "Binding 'eval' in strict mode (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/471/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/471/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:47)"
+  "throws": "Binding 'arguments' in strict mode (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/472/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/472/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'eval' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/473/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/473/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'arguments' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/474/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/474/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'eval' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/475/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/475/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'eval' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/476/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/476/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'arguments' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/477/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/477/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'arguments' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/478/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/478/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'eval' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/479/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/479/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'eval' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/480/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/480/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'arguments' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/481/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/481/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'arguments' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/482/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/482/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:41)"
+  "throws": "Binding 'eval' in strict mode (1:41)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/483/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/483/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:41)"
+  "throws": "Binding 'arguments' in strict mode (1:41)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/484/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/484/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'eval' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/485/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/485/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'arguments' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/486/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/486/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:42)"
+  "throws": "Binding 'eval' in strict mode (1:42)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/487/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/487/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:42)"
+  "throws": "Binding 'arguments' in strict mode (1:42)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/488/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/488/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'eval' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/489/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/489/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'arguments' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/490/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/490/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:47)"
+  "throws": "Binding 'eval' in strict mode (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/491/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/491/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'package' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/492/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/492/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:48)"
+  "throws": "Binding 'eval' in strict mode (1:48)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/493/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/493/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:41)"
+  "throws": "Binding 'eval' in strict mode (1:41)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/494/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/494/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:49)"
+  "throws": "Binding 'eval' in strict mode (1:49)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/495/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/495/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/496/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/496/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'arguments' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/497/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/497/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:48)"
+  "throws": "Binding 'eval' in strict mode (1:48)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/498/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/498/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:48)"
+  "throws": "Binding 'arguments' in strict mode (1:48)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/504/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/504/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "implements is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'implements' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/505/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/505/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "interface is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'interface' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/506/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/506/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'package' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/507/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/507/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "private is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'private' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/508/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/508/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "protected is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'protected' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/509/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/509/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "public is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'public' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/510/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/510/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'static' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/511/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/511/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'static' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/512/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/512/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'static' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/513/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/513/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:23)"
+  "throws": "Unexpected reserved word 'static' (1:23)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/515/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/515/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:11)"
+  "throws": "Binding 'eval' in strict mode (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/516/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/516/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:11)"
+  "throws": "Binding 'package' in strict mode (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/520/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/520/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:12)"
+  "throws": "Binding 'eval' in strict mode (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/521/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/521/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:12)"
+  "throws": "Binding 'package' in strict mode (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/544/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/544/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "public is a reserved word in strict mode (2:8)"
+  "throws": "Unexpected reserved word 'public' (2:8)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/545/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/545/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "public is a reserved word in strict mode (1:8)"
+  "throws": "Unexpected reserved word 'public' (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/547/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/547/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (2:8)"
+  "throws": "Unexpected reserved word 'arguments' (2:8)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/548/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/548/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "arguments is a reserved word in strict mode (1:8)"
+  "throws": "Unexpected reserved word 'arguments' (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/binding-this/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/binding-this/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "this is a reserved word (1:6)"
+  "throws": "Unexpected keyword 'this' (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/let/let-as-identifier-strict-fail/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-as-identifier-strict-fail/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "let is a reserved word in strict mode (2:0)"
+  "throws": "Unexpected reserved word 'let' (2:0)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-flow/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-flow/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["flow"],
-  "throws": "default is a reserved word (1:9)"
+  "throws": "Unexpected keyword 'default' (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-typeof-flow/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-typeof-flow/options.json
@@ -1,4 +1,4 @@
 {
   "plugins": ["flow"],
-  "throws": "typeof is a reserved word (1:9)"
+  "throws": "Unexpected keyword 'typeof' (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-typeof/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-typeof/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "typeof is a reserved word (1:9)"
+  "throws": "Unexpected keyword 'typeof' (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "debugger is a reserved word (1:9)"
+  "throws": "Unexpected keyword 'debugger' (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/shorthand/1/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/shorthand/1/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "const is a reserved word (1:11)"
+  "throws": "Unexpected keyword 'const' (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/shorthand/2/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/shorthand/2/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "this is a reserved word (1:8)"
+  "throws": "Unexpected keyword 'this' (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/227/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/227/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:44)"
+  "throws": "Binding 'eval' in strict mode (1:44)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/233/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/233/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:20)"
+  "throws": "Assigning to 'eval' in strict mode (1:20)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/234/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/234/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:20)"
+  "throws": "Assigning to 'arguments' in strict mode (1:20)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/242/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/242/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Assigning to 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/243/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/243/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:14)"
+  "throws": "Binding 'eval' in strict mode (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/244/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/244/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:14)"
+  "throws": "Binding 'arguments' in strict mode (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/245/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/245/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/246/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/246/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'arguments' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/247/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/247/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/289/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/289/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:5)"
+  "throws": "Binding 'eval' in strict mode (1:5)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/296/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/296/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/297/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/297/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:1)"
+  "throws": "Binding 'eval' in strict mode (1:1)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/332/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/332/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:18)"
+  "throws": "Assigning to 'eval' in strict mode (1:18)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/333/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/333/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:16)"
+  "throws": "Unexpected reserved word 'eval' (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/334/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/334/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "eval is a reserved word in strict mode (1:4)"
+  "throws": "Assigning to 'eval' in strict mode (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/368/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/368/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "script",
-  "throws": "enum is a reserved word (1:0)"
+  "throws": "Unexpected reserved word 'enum' (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/369/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/369/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "enum is a reserved word (1:0)"
+  "throws": "Unexpected reserved word 'enum' (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/370/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/370/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "script",
-  "throws": "enum is a reserved word (1:6)"
+  "throws": "Unexpected reserved word 'enum' (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/371/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/371/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "enum is a reserved word (1:6)"
+  "throws": "Unexpected reserved word 'enum' (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/372/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/372/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "script",
-  "throws": "enum is a reserved word (1:8)"
+  "throws": "Unexpected reserved word 'enum' (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/373/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/373/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "enum is a reserved word (1:8)"
+  "throws": "Unexpected reserved word 'enum' (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/374/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/374/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "script",
-  "throws": "enum is a reserved word (1:15)"
+  "throws": "Unexpected reserved word 'enum' (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/375/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/375/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "enum is a reserved word (1:15)"
+  "throws": "Unexpected reserved word 'enum' (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/376/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/376/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "script",
-  "throws": "enum is a reserved word (1:9)"
+  "throws": "Unexpected reserved word 'enum' (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/377/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/377/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "enum is a reserved word (1:9)"
+  "throws": "Unexpected reserved word 'enum' (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/378/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/378/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "script",
-  "throws": "enum is a reserved word (1:6)"
+  "throws": "Unexpected reserved word 'enum' (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/379/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/379/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "enum is a reserved word (1:6)"
+  "throws": "Unexpected reserved word 'enum' (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/function-name-strict-body/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/function-name-strict-body/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'yield' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/function-name-strict/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/function-name-strict/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (2:9)"
+  "throws": "Unexpected reserved word 'yield' (2:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/in-class-heritage/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/in-class-heritage/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:16)"
+  "throws": "Unexpected reserved word 'yield' (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-strict/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-strict/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (2:16)"
+  "throws": "Unexpected reserved word 'yield' (2:16)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-strict-body/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-strict-body/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:12)"
+  "throws": "Binding 'yield' in strict mode (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-strict/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-strict/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (2:12)"
+  "throws": "Unexpected reserved word 'yield' (2:12)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/invalid-param-strict-mode/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/invalid-param-strict-mode/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:0)"
+  "throws": "Binding 'eval' in strict mode (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-export-default/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-export-default/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "yield is a reserved word in strict mode (1:25)"
+  "throws": "Unexpected reserved word 'yield' (1:25)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-strict-function-expression/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-strict-function-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:46)"
+  "throws": "Unexpected reserved word 'yield' (1:46)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-strict-function-parameter/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-strict-function-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:47)"
+  "throws": "Unexpected reserved word 'yield' (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-array-pattern/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-array-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:16)"
+  "throws": "Unexpected reserved word 'yield' (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-arrow-parameter-default/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-arrow-parameter-default/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:19)"
+  "throws": "Unexpected reserved word 'yield' (1:19)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-arrow-parameter-name/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-arrow-parameter-name/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:15)"
+  "throws": "Unexpected reserved word 'yield' (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-binding-element/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-binding-element/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:23)"
+  "throws": "Unexpected reserved word 'yield' (1:23)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-catch-parameter/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-catch-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:28)"
+  "throws": "Unexpected reserved word 'yield' (1:28)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-formal-parameter/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-formal-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:25)"
+  "throws": "Unexpected reserved word 'yield' (1:25)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-function-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-function-declaration/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'yield' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-function-expression/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-function-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'yield' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-identifier/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-identifier/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:29)"
+  "throws": "Unexpected reserved word 'yield' (1:29)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-lexical-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-lexical-declaration/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:18)"
+  "throws": "Unexpected reserved word 'yield' (1:18)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-rest-parameter/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-rest-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:28)"
+  "throws": "Unexpected reserved word 'yield' (1:28)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-variable-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-strict-variable-declaration/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:18)"
+  "throws": "Unexpected reserved word 'yield' (1:18)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0087/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0087/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Assigning to 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0088/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0088/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:14)"
+  "throws": "Binding 'eval' in strict mode (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0089/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0089/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:14)"
+  "throws": "Binding 'arguments' in strict mode (1:14)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0090/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0090/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0091/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0091/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'arguments' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0100/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0100/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0101/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0101/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:1)"
+  "throws": "Binding 'eval' in strict mode (1:1)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0185/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0185/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:36)"
+  "throws": "Binding 'eval' in strict mode (1:36)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0186/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0186/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:36)"
+  "throws": "Binding 'arguments' in strict mode (1:36)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0187/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0187/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:47)"
+  "throws": "Binding 'eval' in strict mode (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0188/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0188/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:47)"
+  "throws": "Binding 'arguments' in strict mode (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0189/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0189/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'eval' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0190/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0190/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'arguments' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0191/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0191/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'eval' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0192/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0192/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'eval' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0193/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0193/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'arguments' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0194/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0194/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:34)"
+  "throws": "Assigning to 'arguments' in strict mode (1:34)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0195/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0195/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'eval' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0196/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0196/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'eval' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0197/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0197/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'arguments' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0198/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0198/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:32)"
+  "throws": "Assigning to 'arguments' in strict mode (1:32)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0199/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0199/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:41)"
+  "throws": "Binding 'eval' in strict mode (1:41)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0200/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0200/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:41)"
+  "throws": "Binding 'arguments' in strict mode (1:41)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0201/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0201/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'eval' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0202/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0202/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'arguments' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0203/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0203/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:42)"
+  "throws": "Binding 'eval' in strict mode (1:42)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0204/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0204/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:42)"
+  "throws": "Binding 'arguments' in strict mode (1:42)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0205/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0205/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'eval' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0206/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0206/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'arguments' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0207/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0207/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:47)"
+  "throws": "Binding 'eval' in strict mode (1:47)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0208/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0208/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:10)"
+  "throws": "Binding 'package' in strict mode (1:10)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0209/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0209/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:48)"
+  "throws": "Binding 'eval' in strict mode (1:48)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0210/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0210/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:41)"
+  "throws": "Binding 'eval' in strict mode (1:41)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0211/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0211/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:49)"
+  "throws": "Binding 'eval' in strict mode (1:49)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0212/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0212/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'eval' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0213/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0213/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'arguments' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0214/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0214/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:48)"
+  "throws": "Binding 'eval' in strict mode (1:48)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0215/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0215/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:48)"
+  "throws": "Binding 'arguments' in strict mode (1:48)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0224/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0224/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "implements is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'implements' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0225/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0225/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "interface is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'interface' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0226/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0226/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'package' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0227/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0227/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "private is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'private' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0228/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0228/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "protected is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'protected' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0229/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0229/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "public is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'public' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0230/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0230/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'static' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0231/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0231/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'yield' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0232/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0232/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "let is a reserved word in strict mode (1:37)"
+  "throws": "Unexpected reserved word 'let' (1:37)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0233/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0233/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:15)"
+  "throws": "Binding 'static' in strict mode (1:15)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0234/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0234/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'static' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0235/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0235/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'eval' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0236/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0236/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "arguments is a reserved word in strict mode (1:9)"
+  "throws": "Binding 'arguments' in strict mode (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0239/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0239/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:23)"
+  "throws": "Unexpected reserved word 'static' (1:23)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0241/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0241/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:11)"
+  "throws": "Binding 'eval' in strict mode (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0242/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0242/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:11)"
+  "throws": "Binding 'package' in strict mode (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0246/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0246/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "eval is a reserved word in strict mode (1:12)"
+  "throws": "Binding 'eval' in strict mode (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0247/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0247/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "package is a reserved word in strict mode (1:12)"
+  "throws": "Binding 'package' in strict mode (1:12)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0277/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0277/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "enum is a reserved word (1:11)"
+  "throws": "Unexpected reserved word 'enum' (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0278/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0278/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "static is a reserved word in strict mode (1:17)"
+  "throws": "Unexpected reserved word 'static' (1:17)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-as/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-imports/invalid-import-type-as/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "debugger is a reserved word (1:17)"
+  "throws": "Unexpected keyword 'debugger' (1:17)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/reserved-word-class-name-failure/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-parameter-declaration/reserved-word-class-name-failure/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "delete is a reserved word (1:14)",
+  "throws": "Unexpected keyword 'delete' (1:14)",
   "plugins": ["flow", "jsx"]
 }

--- a/packages/babel-preset-typescript/test/fixtures/flow-compat/js-invalid/options.json
+++ b/packages/babel-preset-typescript/test/fixtures/flow-compat/js-invalid/options.json
@@ -1,4 +1,4 @@
 {
   "presets": [["flow", {}, "before"], "typescript", ["flow", {}, "after"]],
-  "throws": "enum is a reserved word (1:0)"
+  "throws": "Unexpected reserved word 'enum' (1:0)"
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | (y)
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

When checking for reserved words we currently do multiple checks: `isReservedWords`, `isReservedWordsStrict` and `isReservedWordsStrictBind`
This all is actually one check, but the list of reserved words changes depending on the context defined by `inModule`, `strict` and `isBinding`

So what this PR simply does is make it unnecessary to check all the different types of reserved words and instead only check against ONE list of reserved words for `non-strict`, `strict` or `strict-binding`. All this list contain their previous list:
```
non-strict: [..]
strict: non-strict + [...]
strict-binding: strict + [...]
```

For performance this is good because we do only one lookup against one list instead of multiple lookups. The non-strict "list" is not really a list because it contains the logic for `inModule`. I could have multiplied this out and created more lists (`non-strict, non-strict-in-module, strict, strict-in-module, strict-bind, strict-bin-in-module`) but decided not to.