### PR TITLE
Simplify await and yield tracking in params

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -596,9 +596,11 @@ export default class ExpressionParser extends LValParser {
       return this.finishNode(node, "MemberExpression");
     } else if (!noCalls && this.match(tt.parenL)) {
       const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
-      const oldYOAIPAP = this.state.yieldOrAwaitInPossibleArrowParameters;
+      const oldYieldPos = this.state.yieldPos;
+      const oldAwaitPos = this.state.awaitPos;
       this.state.maybeInArrowParameters = true;
-      this.state.yieldOrAwaitInPossibleArrowParameters = null;
+      this.state.yieldPos = 0;
+      this.state.awaitPos = 0;
 
       const possibleAsync = this.atPossibleAsync(base);
       this.next();
@@ -629,14 +631,16 @@ export default class ExpressionParser extends LValParser {
           this.startNodeAt(startPos, startLoc),
           node,
         );
-        this.state.yieldOrAwaitInPossibleArrowParameters = oldYOAIPAP;
+        this.checkYieldAwaitInDefaultParams();
+        this.state.yieldPos = oldYieldPos;
+        this.state.awaitPos = oldAwaitPos;
       } else {
         this.toReferencedListDeep(node.arguments);
 
         // We keep the old value if it isn't null, for cases like
         //   (x = async(yield)) => {}
-        this.state.yieldOrAwaitInPossibleArrowParameters =
-          this.state.yieldOrAwaitInPossibleArrowParameters || oldYOAIPAP;
+        this.state.yieldPos = oldYieldPos || this.state.yieldPos;
+        this.state.awaitPos = oldAwaitPos || this.state.awaitPos;
       }
 
       this.state.maybeInArrowParameters = oldMaybeInArrowParameters;
@@ -872,25 +876,19 @@ export default class ExpressionParser extends LValParser {
           this.match(tt.name) &&
           !this.canInsertSemicolon()
         ) {
-          const oldYOAIPAP = this.state.yieldOrAwaitInPossibleArrowParameters;
           const oldInAsync = this.state.inAsync;
-          this.state.yieldOrAwaitInPossibleArrowParameters = null;
           this.state.inAsync = true;
           const params = [this.parseIdentifier()];
           this.expect(tt.arrow);
           // let foo = async bar => {};
           this.parseArrowExpression(node, params, true);
-          this.state.yieldOrAwaitInPossibleArrowParameters = oldYOAIPAP;
           this.state.inAsync = oldInAsync;
           return node;
         }
 
         if (canBeArrow && this.match(tt.arrow) && !this.canInsertSemicolon()) {
           this.next();
-          const oldYOAIPAP = this.state.yieldOrAwaitInPossibleArrowParameters;
-          this.state.yieldOrAwaitInPossibleArrowParameters = null;
-          this.parseArrowExpression(node, [id]);
-          this.state.yieldOrAwaitInPossibleArrowParameters = oldYOAIPAP;
+          this.parseArrowExpression(node, [id], false);
           return node;
         }
 
@@ -1171,9 +1169,11 @@ export default class ExpressionParser extends LValParser {
     this.expect(tt.parenL);
 
     const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
-    const oldYOAIPAP = this.state.yieldOrAwaitInPossibleArrowParameters;
+    const oldYieldPos = this.state.yieldPos;
+    const oldAwaitPos = this.state.awaitPos;
     this.state.maybeInArrowParameters = true;
-    this.state.yieldOrAwaitInPossibleArrowParameters = null;
+    this.state.yieldPos = 0;
+    this.state.awaitPos = 0;
 
     const innerStartPos = this.state.start;
     const innerStartLoc = this.state.startLoc;
@@ -1234,21 +1234,23 @@ export default class ExpressionParser extends LValParser {
       this.shouldParseArrow() &&
       (arrowNode = this.parseArrow(arrowNode))
     ) {
+      this.checkYieldAwaitInDefaultParams();
+      this.state.yieldPos = oldYieldPos;
+      this.state.awaitPos = oldAwaitPos;
       for (const param of exprList) {
         if (param.extra && param.extra.parenthesized) {
           this.unexpected(param.extra.parenStart);
         }
       }
 
-      this.parseArrowExpression(arrowNode, exprList);
-      this.state.yieldOrAwaitInPossibleArrowParameters = oldYOAIPAP;
+      this.parseArrowExpression(arrowNode, exprList, false);
       return arrowNode;
     }
 
     // We keep the old value if it isn't null, for cases like
     //   (x = (yield)) => {}
-    this.state.yieldOrAwaitInPossibleArrowParameters =
-      this.state.yieldOrAwaitInPossibleArrowParameters || oldYOAIPAP;
+    this.state.yieldPos = oldYieldPos || this.state.yieldPos;
+    this.state.awaitPos = oldAwaitPos || this.state.awaitPos;
 
     if (!exprList.length) {
       this.unexpected(this.state.lastTokStart);
@@ -1716,21 +1718,28 @@ export default class ExpressionParser extends LValParser {
     const oldInMethod = this.state.inMethod;
     const oldInAsync = this.state.inAsync;
     const oldInGenerator = this.state.inGenerator;
+    const oldYieldPos = this.state.yieldPos;
+    const oldAwaitPos = this.state.awaitPos;
     this.state.inFunction = true;
     this.state.inMethod = node.kind || true;
     this.state.inAsync = isAsync;
     this.state.inGenerator = isGenerator;
+    this.state.yieldPos = 0;
+    this.state.awaitPos = 0;
 
     this.initFunction(node, isAsync);
     node.generator = !!isGenerator;
     const allowModifiers = isConstructor; // For TypeScript parameter properties
     this.parseFunctionParams((node: any), allowModifiers);
+    this.checkYieldAwaitInDefaultParams();
     this.parseFunctionBodyAndFinish(node, type);
 
     this.state.inFunction = oldInFunc;
     this.state.inMethod = oldInMethod;
     this.state.inAsync = oldInAsync;
     this.state.inGenerator = oldInGenerator;
+    this.state.yieldPos = oldYieldPos;
+    this.state.awaitPos = oldAwaitPos;
 
     return node;
   }
@@ -1740,44 +1749,33 @@ export default class ExpressionParser extends LValParser {
   // assignable list.
   parseArrowExpression(
     node: N.ArrowFunctionExpression,
-    params?: ?(N.Expression[]),
-    isAsync?: boolean = false,
+    params: ?(N.Expression[]),
+    isAsync: boolean,
   ): N.ArrowFunctionExpression {
-    // if we got there, it's no more "yield in possible arrow parameters";
-    // it's just "yield in arrow parameters"
-    const yOAIPAP = this.state.yieldOrAwaitInPossibleArrowParameters;
-    if (yOAIPAP) {
-      if (yOAIPAP.type === "YieldExpression") {
-        this.raise(
-          yOAIPAP.start,
-          "yield is not allowed in the parameters of an arrow function" +
-            " inside a generator",
-        );
-      } else {
-        this.raise(
-          yOAIPAP.start,
-          "await is not allowed in the parameters of an arrow function" +
-            " inside an async function",
-        );
-      }
-    }
+    this.initFunction(node, isAsync);
 
     const oldInFunc = this.state.inFunction;
-    this.state.inFunction = true;
-    this.initFunction(node, isAsync);
-    if (params) this.setArrowFunctionParameters(node, params);
-
     const oldInAsync = this.state.inAsync;
     const oldInGenerator = this.state.inGenerator;
     const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
+    const oldYieldPos = this.state.yieldPos;
+    const oldAwaitPos = this.state.awaitPos;
+    this.state.inFunction = true;
     this.state.inAsync = isAsync;
     this.state.inGenerator = false;
     this.state.maybeInArrowParameters = false;
+    this.state.yieldPos = 0;
+    this.state.awaitPos = 0;
+
+    if (params) this.setArrowFunctionParameters(node, params);
     this.parseFunctionBody(node, true);
+
     this.state.inAsync = oldInAsync;
     this.state.inGenerator = oldInGenerator;
     this.state.inFunction = oldInFunc;
     this.state.maybeInArrowParameters = oldMaybeInArrowParameters;
+    this.state.yieldPos = oldYieldPos;
+    this.state.awaitPos = oldAwaitPos;
 
     return this.finishNode(node, "ArrowFunctionExpression");
   }
@@ -2031,16 +2029,10 @@ export default class ExpressionParser extends LValParser {
   // Parses await expression inside async function.
 
   parseAwait(): N.AwaitExpression {
-    const node = this.startNode();
-
-    if (
-      this.state.maybeInArrowParameters &&
-      // We only set yieldOrAwaitInPossibleArrowParameters if we haven't already
-      // found a possible invalid AwaitExpression.
-      !this.state.yieldOrAwaitInPossibleArrowParameters
-    ) {
-      this.state.yieldOrAwaitInPossibleArrowParameters = node;
+    if (!this.state.awaitPos) {
+      this.state.awaitPos = this.state.start;
     }
+    const node = this.startNode();
 
     this.next();
 
@@ -2064,18 +2056,13 @@ export default class ExpressionParser extends LValParser {
   // Parses yield expression inside generator.
 
   parseYield(noIn?: ?boolean): N.YieldExpression {
+    if (!this.state.yieldPos) {
+      this.state.yieldPos = this.state.start;
+    }
     const node = this.startNode();
 
     if (this.state.inParameters) {
       this.raise(node.start, "yield is not allowed in generator parameters");
-    }
-    if (
-      this.state.maybeInArrowParameters &&
-      // We only set yieldOrAwaitInPossibleArrowParameters if we haven't already
-      // found a possible invalid YieldExpression.
-      !this.state.yieldOrAwaitInPossibleArrowParameters
-    ) {
-      this.state.yieldOrAwaitInPossibleArrowParameters = node;
     }
 
     this.next();

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -969,9 +969,13 @@ export default class StatementParser extends ExpressionParser {
     const oldInAsync = this.state.inAsync;
     const oldInGenerator = this.state.inGenerator;
     const oldInClassProperty = this.state.inClassProperty;
+    const oldYieldPos = this.state.yieldPos;
+    const oldAwaitPos = this.state.awaitPos;
     this.state.inFunction = true;
     this.state.inMethod = false;
     this.state.inClassProperty = false;
+    this.state.yieldPos = 0;
+    this.state.awaitPos = 0;
 
     this.initFunction(node, isAsync);
 
@@ -1021,6 +1025,8 @@ export default class StatementParser extends ExpressionParser {
     this.state.inAsync = oldInAsync;
     this.state.inGenerator = oldInGenerator;
     this.state.inClassProperty = oldInClassProperty;
+    this.state.yieldPos = oldYieldPos;
+    this.state.awaitPos = oldAwaitPos;
 
     return node;
   }
@@ -1037,6 +1043,7 @@ export default class StatementParser extends ExpressionParser {
     );
 
     this.state.inParameters = oldInParameters;
+    this.checkYieldAwaitInDefaultParams();
   }
 
   // Parse a class declaration or literal (depending on the

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -147,4 +147,22 @@ export default class UtilParser extends Tokenizer {
       );
     }
   }
+
+  checkYieldAwaitInDefaultParams() {
+    if (
+      this.state.yieldPos &&
+      (!this.state.awaitPos || this.state.yieldPos < this.state.awaitPos)
+    ) {
+      this.raise(
+        this.state.yieldPos,
+        "Yield cannot be used as name inside a generator function",
+      );
+    }
+    if (this.state.awaitPos) {
+      this.raise(
+        this.state.awaitPos,
+        "Await cannot be used as name inside an async function",
+      );
+    }
+  }
 }

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -102,13 +102,9 @@ export default class State {
   // where @foo belongs to the outer class and @bar to the inner
   decoratorStack: Array<Array<N.Decorator>> = [[]];
 
-  // The first yield or await expression inside parenthesized expressions
-  // and arrow function parameters. It is used to disallow yield and await in
-  // arrow function parameters.
-  yieldOrAwaitInPossibleArrowParameters:
-    | N.YieldExpression
-    | N.AwaitExpression
-    | null = null;
+  // Positions to delayed-check that yield/await does not exist in default parameters.
+  yieldPos: number = 0;
+  awaitPos: number = 0;
 
   // Token store.
   tokens: Array<Token | N.Comment> = [];

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-1/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-1/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:7)"
+  "throws": "Yield cannot be used as name inside a generator function (2:7)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-2/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-2/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:15)"
+  "throws": "Yield cannot be used as name inside a generator function (2:15)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-3/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-3/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:7)"
+  "throws": "Yield cannot be used as name inside a generator function (2:7)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-4/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-4/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:17)"
+  "throws": "Yield cannot be used as name inside a generator function (2:17)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-5/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-5/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:8)"
+  "throws": "Yield cannot be used as name inside a generator function (2:8)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-6/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-default-inside-arrow-inside-generator-6/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:8)"
+  "throws": "Yield cannot be used as name inside a generator function (2:8)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-1/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-1/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:3)"
+  "throws": "Yield cannot be used as name inside a generator function (2:3)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-2/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-2/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:3)"
+  "throws": "Yield cannot be used as name inside a generator function (2:3)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-3/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/yield/parameter-name-arrow-inside-generator-3/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (2:9)"
+  "throws": "Yield cannot be used as name inside a generator function (2:9)"
 }

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arguments-of-async-call-inside-parameters-of-async-arrow-function/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-arguments-of-async-call-inside-parameters-of-async-arrow-function/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "await is not allowed in the parameters of an arrow function inside an async function (2:23)"
+  "throws": "Await cannot be used as name inside an async function (2:23)"
 }

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-arrow-function/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-arrow-function/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "await is not allowed in the parameters of an arrow function inside an async function (2:7)"
+  "throws": "Await cannot be used as name inside an async function (2:7)"
 }

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-async-arrow-function/options.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-parameters-of-nested-async-arrow-function/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "await is not allowed in the parameters of an arrow function inside an async function (2:13)"
+  "throws": "Await cannot be used as name inside an async function (2:13)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-default/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-default/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (1:21)"
+  "throws": "Yield cannot be used as name inside a generator function (1:21)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameter/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (1:16)"
+  "throws": "Yield cannot be used as name inside a generator function (1:16)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameters/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameters/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (1:25)"
+  "throws": "Yield cannot be used as name inside a generator function (1:25)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/yield-generator-arrow-default/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/yield-generator-arrow-default/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "yield is not allowed in the parameters of an arrow function inside a generator (1:21)"
+  "throws": "Yield cannot be used as name inside a generator function (1:21)"
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |n
| Major: Breaking Change?  |n
| Minor: New Feature?      |n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This simply changes the tracking for yield and await to only have the position in state instead of the whole nodes. It also changes where the params are checked.
