### PR TITLE
install polyfill & runtime to dependency instead of devDependency [skip ci]

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/README.md
+++ b/packages/babel-helper-create-class-features-plugin/README.md
@@ -1,19 +1,19 @@
-# @babel/plugin-class-features
+# @babel/helper-create-class-features-plugin
 
 > Compile class public and private fields, private methods and decorators to ES6
 
-See our website [@babel/plugin-class-features](https://babeljs.io/docs/en/next/babel-plugin-class-features.html) for more information.
+See our website [@babel/helper-create-class-features-plugin](https://babeljs.io/docs/en/next/babel-helper-create-class-features-plugin.html) for more information.
 
 ## Install
 
 Using npm:
 
 ```sh
-npm install --save-dev @babel/plugin-class-features
+npm install --save-dev @babel/helper-create-class-features-plugin
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/plugin-class-features --dev
+yarn add @babel/helper-create-class-features-plugin --dev
 ```

--- a/packages/babel-polyfill/README.md
+++ b/packages/babel-polyfill/README.md
@@ -15,7 +15,5 @@ npm install --save @babel/polyfill
 or using yarn:
 
 ```sh
-yarn add @babel/polyfill
+yarn add @babel/polyfill 
 ```
-
-> Because this is a polyfill (which will run before your source code), we need it to be a `dependency`, not a `devDependency`

--- a/packages/babel-polyfill/README.md
+++ b/packages/babel-polyfill/README.md
@@ -9,11 +9,13 @@ See our website [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill
 Using npm:
 
 ```sh
-npm install --save-dev @babel/polyfill
+npm install --save @babel/polyfill
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/polyfill --dev
+yarn add @babel/polyfill
 ```
+
+> Because this is a polyfill (which will run before your source code), we need it to be a `dependency`, not a `devDependency`

--- a/packages/babel-runtime/README.md
+++ b/packages/babel-runtime/README.md
@@ -9,13 +9,13 @@ See our website [@babel/runtime](https://babeljs.io/docs/en/next/babel-runtime.h
 Using npm:
 
 ```sh
-npm install --save @babel/polyfill
+npm install --save @babel/runtime
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/polyfill
+yarn add @babel/runtime
 ```
 
-> Because this is a polyfill (which will run before your source code), we need it to be a `dependency`, not a `devDependency`
+> This is meant to be used as a runtime `dependency` along with the Babel plugin [`@babel/plugin-transform-runtime`](plugin-transform-runtime.md).

--- a/packages/babel-runtime/README.md
+++ b/packages/babel-runtime/README.md
@@ -15,7 +15,5 @@ npm install --save @babel/runtime
 or using yarn:
 
 ```sh
-yarn add @babel/runtime
+yarn add @babel/runtime 
 ```
-
-> This is meant to be used as a runtime `dependency` along with the Babel plugin [`@babel/plugin-transform-runtime`](plugin-transform-runtime.md).

--- a/packages/babel-runtime/README.md
+++ b/packages/babel-runtime/README.md
@@ -9,11 +9,13 @@ See our website [@babel/runtime](https://babeljs.io/docs/en/next/babel-runtime.h
 Using npm:
 
 ```sh
-npm install --save-dev @babel/runtime
+npm install --save @babel/polyfill
 ```
 
 or using yarn:
 
 ```sh
-yarn add @babel/runtime --dev
+yarn add @babel/polyfill
 ```
+
+> Because this is a polyfill (which will run before your source code), we need it to be a `dependency`, not a `devDependency`

--- a/scripts/generators/readmes.js
+++ b/scripts/generators/readmes.js
@@ -13,12 +13,15 @@ const cwd = process.cwd();
 const packageDir = join(cwd, "packages");
 
 const packages = readdirSync(packageDir);
+const packagesInstalledToDep = ["@babel/polyfill", "@babel/runtime"];
 const getWebsiteLink = n => `https://babeljs.io/docs/en/next/${n}.html`;
 const getPackageJson = pkg => require(join(packageDir, pkg, "package.json"));
 const getIssueLabelLink = l =>
   `https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22${encodeURIComponent(
     l
   )}%22+is%3Aopen`;
+const getNpmInstall = name => `npm install ${packagesInstalledToDep.includes(name) ? "--save" : "--save-dev"} ${name}`;
+const getYarnAdd = name => `yarn add ${name} ${packagesInstalledToDep.includes(name) ? "" : "--dev"}`;
 
 const labels = {
   "babel-preset-flow": getIssueLabelLink("area: flow"),
@@ -54,13 +57,13 @@ See our website [${name}](${websiteLink}) for more information${
 Using npm:
 
 \`\`\`sh
-npm install --save-dev ${name}
+${getNpmInstall(name)}
 \`\`\`
 
 or using yarn:
 
 \`\`\`sh
-yarn add ${name} --dev
+${getYarnAdd(name)}
 \`\`\`
 `;
 


### PR DESCRIPTION
as per doc:
- https://babeljs.io/docs/en/next/babel-polyfill.html#installation
- https://babeljs.io/docs/en/next/babel-runtime.html#usage

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
