### PR TITLE
Destructuring: Fix array unpacking assignments with holes on RHS

### DIFF
--- a/packages/babel-plugin-transform-destructuring/src/index.js
+++ b/packages/babel-plugin-transform-destructuring/src/index.js
@@ -83,7 +83,11 @@ export default declare((api, options) => {
 
       if (op) {
         node = t.expressionStatement(
-          t.assignmentExpression(op, id, t.cloneNode(init)),
+          t.assignmentExpression(
+            op,
+            id,
+            t.cloneNode(init) || this.scope.buildUndefinedNode(),
+          ),
         );
       } else {
         node = t.variableDeclaration(this.kind, [

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/input.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/input.js
@@ -11,3 +11,7 @@ var [a, b] = [...foo, bar];
 var [a, b] = [foo(), bar];
 var [a, b] = [clazz.foo(), bar];
 var [a, b] = [clazz.foo, bar];
+var [a, b] = [, 2];
+[a, b] = [1, 2];
+[a, b] = [, 2];
+; // Avoid completion record special case

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-unpack-optimisation/output.js
@@ -34,3 +34,10 @@ var _ref7 = [clazz.foo(), bar],
 var _ref8 = [clazz.foo, bar],
     a = _ref8[0],
     b = _ref8[1];
+var a,
+    b = 2;
+a = 1;
+b = 2;
+a = void 0;
+b = 2;
+; // Avoid completion record special case


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | described in PR
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This fixes an issue where destructuring assignments eligible for the "array unpacking" optimization would fail to compile when the array literal on the right-hand side of the expression contained holes.

Example input:
```js
[a, b] = [, 2];
; // Avoid completion record special case
```

The error message was `Property right of AssignmentExpression expected node to be of a type ["Expression"] but instead got null`.

Now the above code compiles to:
```js
a = void 0;
b = 2;
;
```

This PR also adds a couple of related test cases that were missing, to ensure the change doesn't regress them:
* Normal assignment expression with unpacking
* Declaration with unpacking and a hole on RHS