### PR TITLE
@babel/traverse: Fix NodePath.getData

### DIFF
--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -116,7 +116,7 @@ export default class NodePath {
 
   getData(key: string, def?: any): any {
     let val = this.data[key];
-    if (!val && def) val = this.data[key] = def;
+    if (val === undefined && def) val = this.data[key] = def;
     return val;
   }
 

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -116,7 +116,7 @@ export default class NodePath {
 
   getData(key: string, def?: any): any {
     let val = this.data[key];
-    if (val === undefined && def) val = this.data[key] = def;
+    if (val === undefined && def !== undefined) val = this.data[key] = def;
     return val;
   }
 

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -28,7 +28,7 @@ export default class NodePath {
     this.parent = parent;
     this.hub = hub;
     this.contexts = [];
-    this.data = {};
+    this.data = Object.create(null);
     this.shouldSkip = false;
     this.shouldStop = false;
     this.removed = false;

--- a/packages/babel-traverse/test/path/index.js
+++ b/packages/babel-traverse/test/path/index.js
@@ -1,0 +1,37 @@
+import { NodePath } from "../../lib";
+
+describe("NodePath", () => {
+  describe("setData/getData", () => {
+    it("can set default value", function() {
+      const path = new NodePath({}, {});
+
+      expect(path.getData("foo", "test")).toBe("test");
+    });
+    it("can set false", function() {
+      const path = new NodePath({}, {});
+      path.setData("foo", false);
+
+      expect(path.getData("foo", true)).toBe(false);
+    });
+
+    it("can set true", function() {
+      const path = new NodePath({}, {});
+      path.setData("foo", true);
+
+      expect(path.getData("foo", false)).toBe(true);
+    });
+
+    it("can set null", function() {
+      const path = new NodePath({}, {});
+      path.setData("foo", null);
+
+      expect(path.getData("foo", true)).toBe(null);
+    });
+
+    it("does not use object base properties", function() {
+      const path = new NodePath({}, {});
+
+      expect(path.getData("__proto__", "test")).toBe("test");
+    });
+  });
+});

--- a/packages/babel-traverse/test/path/index.js
+++ b/packages/babel-traverse/test/path/index.js
@@ -2,33 +2,39 @@ import { NodePath } from "../../lib";
 
 describe("NodePath", () => {
   describe("setData/getData", () => {
-    it("can set default value", function() {
+    it("can set default value", () => {
       const path = new NodePath({}, {});
 
       expect(path.getData("foo", "test")).toBe("test");
     });
-    it("can set false", function() {
+    it("can set false", () => {
       const path = new NodePath({}, {});
       path.setData("foo", false);
 
       expect(path.getData("foo", true)).toBe(false);
     });
 
-    it("can set true", function() {
+    it("can set true", () => {
       const path = new NodePath({}, {});
       path.setData("foo", true);
 
       expect(path.getData("foo", false)).toBe(true);
     });
 
-    it("can set null", function() {
+    it("can set null", () => {
       const path = new NodePath({}, {});
       path.setData("foo", null);
 
       expect(path.getData("foo", true)).toBe(null);
     });
 
-    it("does not use object base properties", function() {
+    it("can use false as default", () => {
+      const path = new NodePath({}, {});
+
+      expect(path.getData("foo", false)).toBe(false);
+    });
+
+    it("does not use object base properties", () => {
       const path = new NodePath({}, {});
 
       expect(path.getData("__proto__", "test")).toBe("test");


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | None.
| Patch: Bug Fix?          | Yup.
| Major: Breaking Change?  | Nope.
| Minor: New Feature?      | Nope.
| Tests Added + Pass?      | Nope.
| Documentation PR Link    | N/A.
| Any Dependency Changes?  | Nope.
| License                  | MIT

Currently, if the obtained value is `false`, it will be replaced by the given default value, which is invalid. This makes sure that we only set the default value when the value is `undefined`, instead of falsy.