### PR TITLE
Idea: preset-env Option `target.intersectbrowser`

### DIFF
--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -200,6 +200,23 @@ export default declare((api, opts) => {
     console.log("");
   }
 
+  if (
+    optionsTargets &&
+    optionsTargets.esmodules &&
+    optionsTargets.intersectbrowsers
+  ) {
+    console.log("");
+    console.log(
+      "@babel/preset-env: esmodules and intersectbrowsers targets have been specified together.",
+    );
+    console.log(
+      `\`intersectbrowsers\` target, \`${
+        optionsTargets.intersectbrowsers
+      }\` will be ignored.`,
+    );
+    console.log("");
+  }
+
   const targets = getTargets(optionsTargets, {
     ignoreBrowserslistConfig,
     configPath,

--- a/packages/babel-preset-env/src/options.js
+++ b/packages/babel-preset-env/src/options.js
@@ -33,6 +33,7 @@ export const TargetNames = {
   esmodules: "esmodules",
   node: "node",
   browsers: "browsers",
+  intersectbrowsers: "intersectbrowsers",
   chrome: "chrome",
   opera: "opera",
   edge: "edge",

--- a/packages/babel-preset-env/test/targets-parser.spec.js
+++ b/packages/babel-preset-env/test/targets-parser.spec.js
@@ -235,6 +235,40 @@ describe("getTargets", () => {
         opera: "48.0.0",
       });
     });
+
+    it("ignores intersectbrowsers field", () => {
+      expect(
+        getTargets({
+          esmodules: true,
+          intersectbrowsers: "edge >= 18, firefox >= 57, chrome >= 70",
+          ie: 11,
+        }),
+      ).toEqual({
+        chrome: "61.0.0",
+        safari: "10.1.0",
+        ios: "10.3.0",
+        ie: "11.0.0",
+        edge: "16.0.0",
+        firefox: "60.0.0",
+        opera: "48.0.0",
+      });
+    });
+  });
+
+  describe("intersectbrowsers", () => {
+    it("returns browsers from browsers key intersected with intersectbrowsers", () => {
+      expect(
+        getTargets({
+          browsers: "ie >= 10, edge >= 14, chrome >= 70, safari >= 10",
+          intersectbrowsers:
+            "edge >= 16, firefox >= 60, chrome >= 61, safari >= 11, opera >= 48, ios_saf >= 11",
+        }),
+      ).toEqual({
+        chrome: "70.0.0",
+        safari: "11.0.0",
+        edge: "16.0.0",
+      });
+    });
   });
 
   describe("node", () => {


### PR DESCRIPTION
⚠️ This is merely an idea including code to foster discussion, the PR is NOT ready to merge as-is.

# Motivation

There is a trend for web apps to build both ES5 and ES2015+ flavors for production, so newer browsers can benefit from smaller downloads and faster parse and eval time.

Projects like [nuxt do this by using the `esmodules: true` option of preset-env](https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/index.js#L50) in combination with `<script nomodule>`. This is not ideal, because using `esmodules: true` in preset-env will completely ignore the `browsers` configuration (or `browserslistrc`), and always use these browsers: [edge>=16, firefox>=60, chrome>=61, safari>=10.1, opera>=48, ios_saf>=10.3, and_ff>=60](https://github.com/babel/babel/blob/master/packages/babel-preset-env/data/built-in-modules.json).
The problem is that these browsers grow older, and some of them might not be in scope for support for certain projects.

A project's `browserslistrc` might contain these browsers (simplified example): `ie>=11, chrome>=70`. The ES5 build would build for both browsers, but the ES2015+ would not only build for Chrome 70+, but also for Chrome 61, Edge 16, Firefox 60, etc. That would include a lot of unnecessary transformations and even polyfills if combined with `useBuiltIns: usage`.

# Proposal

Add a new option `target.browsersintersection` which allows clients to specify a set of browsers that should be intersected with the ones specified in `browsers` or `browserslistrc`. This option can be used by build tools to produce different sets of build flavors, supporting older or newer browsers respectively. This also plays nicely with `useBuiltIns: usage`.

Intersection means the following: if the client specifies browsers `A, B, C`, and the `target.browsersintersection` option specifies browsers `B, C, D`, then the result would be `B, C` (= the browsers / browser versions both have in common).

The code for the intersection could be integrated into the `browserslist` project if that project's maintainer allows it.

# Alternatives Considered

The behavior of `esmodules: true` could be changed to calculate the same intersection with the [predefined set of browsers](https://github.com/babel/babel/blob/master/packages/babel-preset-env/data/built-in-modules.json), but that would have 2 downsides:

1. It would be a non-backwards-compatible change, and might break client projects
2. It would not allow to provide custom intersection browsers. E.g. [Safari 10.1 only supports `nomodule` via a polyfill](https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc). Client projects might or might not want to include Safari 10.1 for modern builds. Or in the future, a project might want to make a third kind of build optimized for ES2016+ browsers, then this would be possible with the intersection option without changes to preset-env.