### PR TITLE
Update regenerator-runtime to latest version

### DIFF
--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -12,6 +12,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "core-js": "^2.5.7",
-    "regenerator-runtime": "^0.12.0"
+    "regenerator-runtime": "^0.13.2"
   }
 }

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -10,7 +10,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {
     "core-js": "^2.5.7",
-    "regenerator-runtime": "^0.12.0"
+    "regenerator-runtime": "^0.13.2"
   },
   "devDependencies": {
     "@babel/helpers": "^7.3.1"

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -9,7 +9,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-runtime",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "dependencies": {
-    "regenerator-runtime": "^0.12.0"
+    "regenerator-runtime": "^0.13.2"
   },
   "devDependencies": {
     "@babel/helpers": "^7.3.1"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | facebook/regenerator#336 facebook/regenerator#346 facebook/regenerator#353 facebook/regenerator#355 #1286 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Possibly, but probably not (facebook/regenerator#353)
| Minor: New Feature?      | No
| Tests Added + Pass?      | Existing tests pass
| Documentation PR Link    | No
| Any Dependency Changes?  | `regenerator-runtime` (minor)
| License                  | MIT

Update `regenerator-runtime` from version `0.12.0` to the latest version `0.13.1`.

facebook/regenerator#353 changes how the runtime defines the `regeneratorRuntime` global variable (when loaded as a script) or its module exports (when loaded as a CommonJS module). This obsoletes a previous attempt (facebook/regenerator#346) at fixing a CSP violation (facebook/regenerator#336). This change is a minor bump for `regenerator-runtime` (because it no longer has a separate `runtime-module.js`), but I don't think it will affect Babel users.

facebook/regenerator#355 fixes a regression where IE8 would throw a parse error when loading the runtime (#1286).