### PR TITLE
Fix duplicate definition error in private class methods

### DIFF
--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/scopable/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/scopable/exec.js
@@ -1,0 +1,17 @@
+class Foo {
+  #privateMethodA() {
+    const i = 40;
+    return i;
+  }
+
+  #privateMethodB() {
+    const i = 2;
+    return i;
+  }
+
+  publicMethod() {
+    return this.#privateMethodA() + this.#privateMethodB();
+  }
+}
+
+expect((new Foo).publicMethod()).toEqual(42);

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -146,7 +146,7 @@ defineType("OptionalCallExpression", {
 defineType("ClassPrivateProperty", {
   visitor: ["key", "value"],
   builder: ["key", "value"],
-  aliases: ["Property", "Private"],
+  aliases: ["Scopable", "Property", "Private"],
   fields: {
     key: {
       validate: assertNodeType("PrivateName"),
@@ -168,7 +168,7 @@ defineType("ClassPrivateMethod", {
     "returnType",
     "typeParameters",
   ],
-  aliases: ["Method", "Private", "Function"],
+  aliases: ["Scopable", "Method", "Private", "Function"],
   fields: {
     ...classMethodOrDeclareMethodCommon,
     key: {

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -146,7 +146,7 @@ defineType("OptionalCallExpression", {
 defineType("ClassPrivateProperty", {
   visitor: ["key", "value"],
   builder: ["key", "value"],
-  aliases: ["Scopable", "Property", "Private"],
+  aliases: ["Property", "Private"],
   fields: {
     key: {
       validate: assertNodeType("PrivateName"),
@@ -168,7 +168,14 @@ defineType("ClassPrivateMethod", {
     "returnType",
     "typeParameters",
   ],
-  aliases: ["Scopable", "Method", "Private", "Function"],
+  aliases: [
+    "Function",
+    "Scopable",
+    "BlockParent",
+    "FunctionParent",
+    "Method",
+    "Private",
+  ],
   fields: {
     ...classMethodOrDeclareMethodCommon,
     key: {

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3283,7 +3283,9 @@ export function isScopable(node: Object, opts?: Object): boolean {
     "ClassDeclaration" === nodeType ||
     "ClassExpression" === nodeType ||
     "ForOfStatement" === nodeType ||
-    "ClassMethod" === nodeType
+    "ClassMethod" === nodeType ||
+    "ClassPrivateProperty" === nodeType ||
+    "ClassPrivateMethod" === nodeType
   ) {
     if (typeof opts === "undefined") {
       return true;

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -3284,7 +3284,6 @@ export function isScopable(node: Object, opts?: Object): boolean {
     "ClassExpression" === nodeType ||
     "ForOfStatement" === nodeType ||
     "ClassMethod" === nodeType ||
-    "ClassPrivateProperty" === nodeType ||
     "ClassPrivateMethod" === nodeType
   ) {
     if (typeof opts === "undefined") {
@@ -3315,7 +3314,8 @@ export function isBlockParent(node: Object, opts?: Object): boolean {
     "WhileStatement" === nodeType ||
     "ArrowFunctionExpression" === nodeType ||
     "ForOfStatement" === nodeType ||
-    "ClassMethod" === nodeType
+    "ClassMethod" === nodeType ||
+    "ClassPrivateMethod" === nodeType
   ) {
     if (typeof opts === "undefined") {
       return true;
@@ -3593,7 +3593,8 @@ export function isFunctionParent(node: Object, opts?: Object): boolean {
     "FunctionExpression" === nodeType ||
     "ObjectMethod" === nodeType ||
     "ArrowFunctionExpression" === nodeType ||
-    "ClassMethod" === nodeType
+    "ClassMethod" === nodeType ||
+    "ClassPrivateMethod" === nodeType
   ) {
     if (typeof opts === "undefined") {
       return true;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9267 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Added to `ClassPrivateMethod` same `aliases` as `ClassMethod`. 