### PR TITLE
Fix duplicated assertThisInitialized calls in constructors

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
@@ -12,13 +12,13 @@ function (_Bar) {
 
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), _bar, {
+      Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
         writable: true,
         value: "foo"
       });
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), _bar, {
+      Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
         writable: true,
         value: "foo"
       });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/derived/output.js
@@ -22,7 +22,7 @@ function (_Foo) {
 
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
-    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _prop2, {
+    Object.defineProperty(babelHelpers.assertThisInitialized(_this), _prop2, {
       writable: true,
       value: "bar"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -10,7 +10,7 @@ function (_Parent) {
 
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
-    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _scopedFunctionWithThis, {
+    Object.defineProperty(babelHelpers.assertThisInitialized(_this), _scopedFunctionWithThis, {
       writable: true,
       value: function value() {
         _this.name = {};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-expression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _bar, {
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
       writable: true,
       value: "foo"
     }), _temp));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/super-statement/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-    Object.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), _bar, {
+    Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
       writable: true,
       value: "foo"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -13,14 +13,14 @@ function (_Bar) {
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), {
+      _bar.set(babelHelpers.assertThisInitialized(_this), {
         writable: true,
         value: "foo"
       });
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-      _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), {
+      _bar.set(babelHelpers.assertThisInitialized(_this), {
         writable: true,
         value: "foo"
       });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/derived/output.js
@@ -24,7 +24,7 @@ function (_Foo) {
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Bar).call(this, ...args));
 
-    _prop2.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _prop2.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,
       value: "bar"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/foobar/output.js
@@ -11,7 +11,7 @@ function (_Parent) {
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
 
-    _scopedFunctionWithThis.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _scopedFunctionWithThis.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,
       value: () => {
         _this.name = {};

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-call/output.js
@@ -29,7 +29,7 @@ function (_A) {
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
 
-    _foo.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _foo.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,
       value: babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this))
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-expression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), _bar.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,
       value: "foo"
     }), _temp));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/super-statement/output.js
@@ -11,7 +11,7 @@ function (_Bar) {
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
 
-    _bar.set(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), {
+    _bar.set(babelHelpers.assertThisInitialized(_this), {
       writable: true,
       value: "foo"
     });

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived-multiple-supers/output.js
@@ -12,10 +12,10 @@ function (_Bar) {
 
     if (condition) {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), "bar", "foo");
+      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     } else {
       _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))), "bar", "foo");
+      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     }
 
     return babelHelpers.possibleConstructorReturn(_this);

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/derived/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, ...args));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo");
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/foobar/output.js
@@ -10,7 +10,7 @@ function (_Parent) {
 
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Child).call(this));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "scopedFunctionWithThis", function () {
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "scopedFunctionWithThis", function () {
       _this.name = {};
     });
     return _this;

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-call/output.js
@@ -28,7 +28,7 @@ function (_A) {
 
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(B).call(this, ...args));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "foo", babelHelpers.get(babelHelpers.getPrototypeOf(B.prototype), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this)));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-expression/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _temp, _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo"), _temp));
+    foo((_temp = _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this)), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), _temp));
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/public/super-statement/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this)), "bar", "foo");
+    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
     return _this;
   }
 

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -2,11 +2,11 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -43,7 +43,7 @@ var Test = function Test() {
 
       _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(Other)).call.apply(_getPrototypeOf2, [this].concat(args)));
 
-      _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "a", function () {
+      _defineProperty(_assertThisInitialized(_this), "a", function () {
         return _get(_getPrototypeOf(Other.prototype), "test", _assertThisInitialized(_this));
       });
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
@@ -21,7 +21,7 @@ function (_b) {
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(a1).call(this));
 
     _this.x = function () {
-      return babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this));
+      return babelHelpers.assertThisInitialized(_this);
     };
 
     return _this;
@@ -42,7 +42,7 @@ function (_b2) {
     _this2 = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(a2).call(this));
 
     _this2.x = function () {
-      return babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this2));
+      return babelHelpers.assertThisInitialized(_this2);
     };
 
     return _this2;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))));
+    return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this, babelHelpers.assertThisInitialized(_this)));
   }
 
   return Foo;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var fn = () => babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this));
+    var fn = () => babelHelpers.assertThisInitialized(_this);
 
     fn();
     return _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-4/output.js
@@ -10,7 +10,7 @@ function (_Bar) {
 
     babelHelpers.classCallCheck(this, Foo);
 
-    var fn = () => babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this));
+    var fn = () => babelHelpers.assertThisInitialized(_this);
 
     _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo).call(this));
     fn();

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/output.js
@@ -9,7 +9,7 @@ function (_Bar) {
     var _this;
 
     babelHelpers.classCallCheck(this, Foo);
-    Foo[babelHelpers.assertThisInitialized(babelHelpers.assertThisInitialized(_this))];
+    Foo[babelHelpers.assertThisInitialized(_this)];
     return babelHelpers.possibleConstructorReturn(_this);
   }
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -21,11 +21,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -47,7 +47,7 @@ function (_Component) {
 
     _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(App)).call.apply(_getPrototypeOf2, [this].concat(args)));
 
-    _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "exportType", '');
+    _defineProperty(_assertThisInitialized(_this), "exportType", '');
 
     return _this;
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8335
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This removes duplicated (and redundant) calls to the `assertThisInitialized` helper in constructors for subclasses in loose mode.

I've moved the detection of `this` to a later point in the transformation of the class to find the ones that are also added by `super.` calls, and then replaced them all at the same place (removing the redundancy in some cases).
