### PR TITLE
Update publishing command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,12 @@ prepublish:
 	make prepublish-build
 	make test
 
+new-version:
+	./node_modules/.bin/lerna version --force-publish="@babel/runtime,@babel/runtime-corejs2,@babel/standalone,@babel/preset-env-standalone"
+
+# NOTE: Run make new-version fisrt
 publish: prepublish
-	./node_modules/.bin/lerna publish --force-publish="@babel/runtime,@babel/runtime-corejs2,@babel/standalone,@babel/preset-env-standalone" --require-scripts
+	./node_modules/.bin/lerna publish from-git --require-scripts
 	make clean
 
 bootstrap: clean-all

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ prepublish:
 new-version:
 	./node_modules/.bin/lerna version --force-publish="@babel/runtime,@babel/runtime-corejs2,@babel/standalone,@babel/preset-env-standalone"
 
-# NOTE: Run make new-version fisrt
+# NOTE: Run make new-version first
 publish: prepublish
 	./node_modules/.bin/lerna publish from-git --require-scripts
 	make clean


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

This reflects how I have been releasing the last versions (https://github.com/babel/notes/issues/78#issuecomment-449519007).

In the future, we'll only need to run `make new-version && git push --tags` and it will run `make publish` from CI/Actions.
