### PR TITLE
Show real version instead of core/preset-env versions in standalone pkgs

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -17,8 +17,7 @@ const source = require("vinyl-source-stream");
 const buffer = require("vinyl-buffer");
 const rollupBabel = require("rollup-plugin-babel");
 const rollupNodeResolve = require("rollup-plugin-node-resolve");
-const registerStandalonePackageTask = require("./scripts/gulp-tasks")
-  .registerStandalonePackageTask;
+const { registerStandalonePackageTask } = require("./scripts/gulp-tasks");
 
 const sources = ["codemods", "packages"];
 
@@ -138,7 +137,7 @@ registerStandalonePackageTask(
   "babel",
   "Babel",
   path.join(__dirname, "packages"),
-  require("./packages/babel-core/package.json").version
+  require("./packages/babel-standalone/package.json").version
 );
 
 const presetEnvWebpackPlugins = [
@@ -167,6 +166,6 @@ registerStandalonePackageTask(
   "babel-preset-env",
   "babelPresetEnv",
   path.join(__dirname, "packages"),
-  require("./packages/babel-preset-env/package.json").version,
+  require("./packages/babel-preset-env-standalone/package.json").version,
   presetEnvWebpackPlugins
 );


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes the fact that https://babeljs.io/repl/ shows 7.2.2 instead of 7.3.2. Maybe also fixes babel/website#1793 and closes babel/website#1488, I'm not sure. Also fixes #6174 and closes #7039.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In `@babel/standalone` we showed the `@babel/core` version, but it doesn't really make sense because often it contains packages which are at a newer version. The same applies to `@babel/preset-env-standalone`: the preset is never updated, so the version was always old.

Note that the gulp script is run _after_ updating the version, so it should get the new one. THose packages are always force-updated, so they will always show the last version.