### PR TITLE
Exclude generate @babel/types files from coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,5 @@ coverage:
         target: "80%"
     patch:
       enabled: false
+ignore:
+  - packages/babel-types/src/*/generated/index.js


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I don't think that we should include these files in the coverage report, since testing them is not realistic anyway?
https://github.com/babel/babel/blob/master/packages/babel-types/src/validators/generated/index.js

Also, there are a lots of untested unused helpers in babel/types (e.g. https://codecov.io/gh/babel/babel/src/master/packages/babel-types/src/validators/isSpecifierDefault.js): we should check them one by one and decide if we want to deprecate them and remove in v8 or make `good first issue` issues to test them.