### PR TITLE
Create a new release after a v*.*.* commit instead of the tag

### DIFF
--- a/.github/actions/filter-commit-message/Dockerfile
+++ b/.github/actions/filter-commit-message/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stable-slim
+
+LABEL "name"="filter"
+LABEL "version"="1.1.0"
+
+LABEL "com.github.actions.name"="Filter commit message"
+LABEL "com.github.actions.description"="Stop a workflow if the message of the current commit doesn't match the pattern"
+LABEL "com.github.actions.icon"="filter"
+LABEL "com.github.actions.color"="gray-dark"
+
+ADD entrypoint.sh /action/entrypoint.sh
+
+RUN chmod +x /action/entrypoint.sh
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
+ENTRYPOINT ["/action/entrypoint.sh"]

--- a/.github/actions/filter-commit-message/entrypoint.sh
+++ b/.github/actions/filter-commit-message/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+pattern=$1
+message=$(git log --oneline --format=%B -1 $GITHUB_SHA)
+
+if echo "$message" | grep -Pq "$pattern"; then
+  echo "INFO: $message matches $pattern"
+  exit 0
+else
+  echo "INFO: $message does not match $pattern"
+  # 78 is the "neutral" exit status
+  exit 78
+fi

--- a/.github/actions/trigger-github-release/entrypoint.sh
+++ b/.github/actions/trigger-github-release/entrypoint.sh
@@ -5,12 +5,18 @@ set -e
 echo "INFO: Installing action dependencies..."
 (cd /action; npm ci)
 
-echo "INFO: Checking out current tag..."
-git -c advice.detachedHead=false checkout $GITHUB_REF
+# GitHub doesn't support running actions on new tags yet: we need to run it on the commit.
+# For this reason, we can't be sure that the tag already exists. We can use the commit
+# message to create the tag. If the tag already exists locally, they won't conflict because
+# they have the same name and are on the same commit.
+echo "INFO: Getting release version..."
+# current_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA)
+current_tag=$(git log --oneline --format=%B -1 $GITHUB_SHA)
 
-echo "INFO: Getting tag info..."
-current_tag=$(git describe --abbrev=0 --tags)
-last_tag=$(git describe --abbrev=0 --tags HEAD^)
+echo "INFO: Creating new tag..."
+git tag $current_tag $GITHUB_SHA
+
+last_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA^)
 echo "INFO: New version is $current_tag; last version is $last_tag."
 
 echo "INFO: Generating the changelog..."

--- a/.github/actions/trigger-github-release/entrypoint.sh
+++ b/.github/actions/trigger-github-release/entrypoint.sh
@@ -5,18 +5,21 @@ set -e
 echo "INFO: Installing action dependencies..."
 (cd /action; npm ci)
 
+echo "INFO: Checking out current commit..."
+git -c advice.detachedHead=false checkout $GITHUB_SHA
+
 # GitHub doesn't support running actions on new tags yet: we need to run it on the commit.
 # For this reason, we can't be sure that the tag already exists. We can use the commit
 # message to create the tag. If the tag already exists locally, they won't conflict because
 # they have the same name and are on the same commit.
 echo "INFO: Getting release version..."
-# current_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA)
-current_tag=$(git log --oneline --format=%B -1 $GITHUB_SHA)
+# current_tag=$(git describe --abbrev=0 --tags HEAD)
+current_tag=$(git log --oneline --format=%B -1 HEAD)
 
 echo "INFO: Creating new tag..."
-git tag $current_tag $GITHUB_SHA
+(git tag $current_tag $GITHUB_SHA) || echo "INFO: Tag already exists"
 
-last_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA^)
+last_tag=$(git describe --abbrev=0 --tags HEAD^)
 echo "INFO: New version is $current_tag; last version is $last_tag."
 
 echo "INFO: Generating the changelog..."

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -19,7 +19,7 @@ action "Is version commit" {
   uses = "./.github/actions/filter-commit-message"
   # This regex is run using "grep -P".
   # The (-\\S+) part is for 7.0.0-beta.1 releases.
-  args = "^v(\\d+\\.)*\\d+(-\\S+)?$"
+  args = "^v(\\d+\\.){2}\\d+(-\\S+)?$"
 }
 
 action "On master branch" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -10,14 +10,16 @@ action "Trigger GitHub release" {
   # When GitHub Actions will support the "release" event for public
   # repositories, we won't need these checks anymore.
   needs = [
-    "Is version tag",
+    "Is version commit",
     "On master branch",
   ]
 }
 
-action "Is version tag" {
-  uses = "actions/bin/filter@master"
-  args = "tag v*"
+action "Is version commit" {
+  uses = "./.github/actions/filter-commit-message"
+  # This regex is run using "grep -P".
+  # The (-\\S+) part is for 7.0.0-beta.1 releases.
+  args = "^v(\\d+\\.)*\\d+(-\\S+)?$"
 }
 
 action "On master branch" {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The release action was never triggered because GitHub doesn't trigger the "push" event when tags are pushed. This PR changes the approach: the release is triggered when there is a `v*.*.*` commit, and it creates the tag.

Commits after "v0.0.8" in https://github.com/babel/test-github-actions/commits/master (private repo, sorry) test this PR.