### PR TITLE
[preset-env] Don't use async-to-generator when already using regenerator

### DIFF
--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
@@ -1,7 +1,3 @@
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
-
 var Example =
 /*#__PURE__*/
 function () {
@@ -11,33 +7,21 @@ function () {
 
   var _proto = Example.prototype;
 
-  _proto.test1 =
-  /*#__PURE__*/
-  function () {
-    var _test = _asyncToGenerator(
-    /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee() {
-      return regeneratorRuntime.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              _context.next = 2;
-              return Promise.resolve(2);
+  _proto.test1 = function test1() {
+    return regeneratorRuntime.async(function test1$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.next = 2;
+            return regeneratorRuntime.awrap(Promise.resolve(2));
 
-            case 2:
-            case "end":
-              return _context.stop();
-          }
+          case 2:
+          case "end":
+            return _context.stop();
         }
-      }, _callee);
-    }));
-
-    function test1() {
-      return _test.apply(this, arguments);
-    }
-
-    return test1;
-  }();
+      }
+    });
+  };
 
   _proto.test2 =
   /*#__PURE__*/

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
@@ -1,26 +1,17 @@
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
-
 function test(fn) {
-  return (
-    /*#__PURE__*/
-    _asyncToGenerator(
-    /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee() {
-      var _args = arguments;
-      return regeneratorRuntime.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              return _context.abrupt("return", fn.apply(void 0, _args));
+  return function _callee() {
+    var _args = arguments;
+    return regeneratorRuntime.async(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            return _context.abrupt("return", fn.apply(void 0, _args));
 
-            case 1:
-            case "end":
-              return _context.stop();
-          }
+          case 1:
+          case "end":
+            return _context.stop();
         }
-      }, _callee);
-    }))
-  );
+      }
+    });
+  };
 }

--- a/packages/babel-preset-env/data/overlapping-plugins.js
+++ b/packages/babel-preset-env/data/overlapping-plugins.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = new Map();
+
+// async -> regenerator is better than async -> generator -> regenerator
+ifIncluded("transform-regenerator")
+  .isUnnecessary("transform-async-to-generator");
+
+function ifIncluded(name) {
+  const set = new Set();
+  module.exports.set(name, set);
+  return {
+    isUnnecessary(name) { set.add(name); return this; }
+  };
+}

--- a/packages/babel-preset-env/src/filter-items.js
+++ b/packages/babel-preset-env/src/filter-items.js
@@ -85,3 +85,13 @@ export default function(
 
   return result;
 }
+
+export function removeUnnecessaryItems(
+  items: Set<string>,
+  overlapping: Map<string, Set<string>>,
+) {
+  items.forEach(item => {
+    const names = overlapping.get(item);
+    if (names) names.forEach(name => items.delete(name));
+  });
+}

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -3,11 +3,12 @@
 import { SemVer } from "semver";
 import { logPluginOrPolyfill } from "./debug";
 import getOptionSpecificExcludesFor from "./get-option-specific-excludes";
-import filterItems from "./filter-items";
+import filterItems, { removeUnnecessaryItems } from "./filter-items";
 import moduleTransformations from "./module-transformations";
 import normalizeOptions from "./normalize-options";
 import pluginList from "../data/plugins.json";
 import { proposalPlugins, pluginSyntaxMap } from "../data/shipped-proposals";
+import overlappingPlugins from "../data/overlapping-plugins";
 
 import addCoreJS2UsagePlugin from "./polyfills/corejs2/usage-plugin";
 import addCoreJS3UsagePlugin from "./polyfills/corejs3/usage-plugin";
@@ -236,6 +237,7 @@ export default declare((api, opts) => {
     getOptionSpecificExcludesFor({ loose }),
     pluginSyntaxMap,
   );
+  removeUnnecessaryItems(pluginNames, overlappingPlugins);
 
   const polyfillPlugins = getPolyfillPlugins({
     useBuiltIns,

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async/output.mjs
@@ -1,28 +1,13 @@
 import "regenerator-runtime/runtime";
-import "core-js/modules/es6.promise";
-import "core-js/modules/es6.object.to-string";
-
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
 function a() {
-  return _a.apply(this, arguments);
-}
-
-function _a() {
-  _a = _asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-          case "end":
-            return _context.stop();
-        }
+  return regeneratorRuntime.async(function a$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+        case "end":
+          return _context.stop();
       }
-    }, _callee);
-  }));
-  return _a.apply(this, arguments);
+    }
+  });
 }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async/output.mjs
@@ -2,27 +2,14 @@ import "core-js/modules/es.object.to-string";
 import "core-js/modules/es.promise";
 import "regenerator-runtime/runtime";
 
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
-
 function a() {
-  return _a.apply(this, arguments);
-}
-
-function _a() {
-  _a = _asyncToGenerator(
-  /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-          case "end":
-            return _context.stop();
-        }
+  return regeneratorRuntime.async(function a$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+        case "end":
+          return _context.stop();
       }
-    }, _callee);
-  }));
-  return _a.apply(this, arguments);
+    }
+  });
 }

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -30,7 +30,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -30,7 +30,6 @@ Using plugins:
   transform-new-target { "android":"4" }
   transform-regenerator { "android":"4" }
   transform-exponentiation-operator { "android":"4" }
-  transform-async-to-generator { "android":"4" }
   proposal-async-generator-functions { "android":"4" }
   proposal-object-rest-spread { "android":"4" }
   proposal-unicode-property-regex { "android":"4" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -25,7 +25,6 @@ Using plugins:
   transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
   transform-exponentiation-operator { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
   proposal-async-generator-functions { "electron":"0.36" }
   proposal-object-rest-spread { "electron":"0.36" }
   proposal-unicode-property-regex { "electron":"0.36" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -30,7 +30,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions { "chrome":"55" }
   proposal-object-rest-spread { "chrome":"55" }
   proposal-unicode-property-regex { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -35,7 +35,6 @@ Using plugins:
   transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -41,7 +41,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
   transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -30,7 +30,6 @@ Using plugins:
   transform-new-target { "android":"4" }
   transform-regenerator { "android":"4" }
   transform-exponentiation-operator { "android":"4" }
-  transform-async-to-generator { "android":"4" }
   proposal-async-generator-functions { "android":"4" }
   proposal-object-rest-spread { "android":"4" }
   proposal-unicode-property-regex { "android":"4" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -25,7 +25,6 @@ Using plugins:
   transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
   transform-exponentiation-operator { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
   proposal-async-generator-functions { "electron":"0.36" }
   proposal-object-rest-spread { "electron":"0.36" }
   proposal-unicode-property-regex { "electron":"0.36" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -30,7 +30,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions { "chrome":"55" }
   proposal-object-rest-spread { "chrome":"55" }
   proposal-unicode-property-regex { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -35,7 +35,6 @@ Using plugins:
   transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -41,7 +41,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
   transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -28,7 +28,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions {}
   proposal-object-rest-spread {}
   proposal-unicode-property-regex {}

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -33,7 +33,6 @@ Using plugins:
   transform-new-target {}
   transform-regenerator {}
   transform-exponentiation-operator {}
-  transform-async-to-generator {}
   proposal-async-generator-functions { "chrome":"55" }
   proposal-object-rest-spread { "chrome":"55" }
   proposal-unicode-property-regex { "chrome":"55" }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -32,7 +32,6 @@ Using plugins:
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
   transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
   proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
   proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
   proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -31,7 +31,6 @@ Using plugins:
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
   transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/input.js
@@ -1,0 +1,1 @@
+async function foo() {}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [],
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": { "chrome": "49" }
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/output.js
@@ -1,0 +1,9 @@
+function foo() {
+  return regeneratorRuntime.async(function foo$(_context) {
+    while (1) switch (_context.prev = _context.next) {
+      case 0:
+      case "end":
+        return _context.stop();
+    }
+  }, null, this);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-49/output.js
@@ -5,5 +5,5 @@ function foo() {
       case "end":
         return _context.stop();
     }
-  }, null, this);
+  });
 }

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-50/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-50/input.js
@@ -1,0 +1,1 @@
+async function foo() {}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-50/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-50/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [],
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": { "chrome": "50" }
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-50/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-50/output.js
@@ -1,0 +1,12 @@
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(function* () {});
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-54/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-54/input.js
@@ -1,0 +1,1 @@
+async function foo() {}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-54/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-54/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [],
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": { "chrome": "54" }
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-54/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-54/output.js
@@ -1,0 +1,12 @@
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function foo() {
+  return _foo.apply(this, arguments);
+}
+
+function _foo() {
+  _foo = _asyncToGenerator(function* () {});
+  return _foo.apply(this, arguments);
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-55/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-55/input.js
@@ -1,0 +1,1 @@
+async function foo() {}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-55/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-55/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [],
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": { "chrome": "55" }
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-55/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-overlapping/chrome-55/output.js
@@ -1,0 +1,1 @@
+async function foo() {}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 
| Major: Breaking Change?  |
| Minor: New Feature?      | Maybe?
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Since regenerator handles async functions, there is no need to load an additional transform. You can see the benefits at [f087c3f](https://github.com/babel/babel/commit/f087c3f5bbcafd6d9689f261798ae809b9fb4fcc?w=1). `async-to-generator` will still be loaded when `regenerator` is not needed.

NOTE: It would be better to also transform async generators only using regenerator when possible, but we can't do that because regenerator doesn't support `for await`.