### PR TITLE
Fix peer deps

### DIFF
--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -33,7 +33,7 @@
     "chokidar": "^2.0.3"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -26,7 +26,7 @@
     "v8flags": "^3.1.1"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-syntax-async-generators": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -20,7 +20,7 @@
     "@babel/plugin-syntax-decorators": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-do-expressions": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-export-default-from": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-export-namespace-from": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-function-bind": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-syntax-function-sent": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-json-strings": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-logical-assignment-operators": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-numeric-separator": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-optional-chaining": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-pipeline-operator": "^7.3.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-private-methods/package.json
+++ b/packages/babel-plugin-proposal-private-methods/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-throw-expressions": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -27,7 +27,7 @@
     "regexpu-core": "^4.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-bigint/package.json
+++ b/packages/babel-plugin-syntax-bigint/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-dynamic-import/package.json
+++ b/packages/babel-plugin-syntax-dynamic-import/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-export-namespace-from/package.json
+++ b/packages/babel-plugin-syntax-export-namespace-from/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-import-meta/package.json
+++ b/packages/babel-plugin-syntax-import-meta/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-json-strings/package.json
+++ b/packages/babel-plugin-syntax-json-strings/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-optional-catch-binding/package.json
+++ b/packages/babel-plugin-syntax-optional-catch-binding/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-optional-chaining/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0"

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -17,7 +17,7 @@
     "@babel/helper-remap-async-to-generator": "^7.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -22,7 +22,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -26,7 +26,7 @@
     "regexpu-core": "^4.1.3"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-flow": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-flow": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -17,7 +17,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-replace-supers": "^7.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -17,7 +17,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-jsx": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-syntax-jsx": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-syntax-jsx": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -18,7 +18,7 @@
     "semver": "^5.5.1"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -16,7 +16,7 @@
     "@babel/helper-regex": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -16,7 +16,7 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-plugin-utils": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-syntax-typescript": "^7.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -17,7 +17,7 @@
     "regexpu-core": "^4.1.3"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -59,7 +59,7 @@
     "semver": "^5.3.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -20,7 +20,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-transform-react-jsx-source": "^7.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-transform-typescript": "^7.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -22,7 +22,7 @@
     "source-map-support": "^0.5.9"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION


| Q                        | A
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | `peerDependencies` updated
| License                  | MIT

Remove the -0 from all `peerDependencies` as it causes warnings when correct
babel/core@7 is installed.

I think this is just a continuation of @hzoo's work in #8445, `yarn` doesn't resolve `@babel/core 7.0.0` for `^7.0.0-0`. Which results in warnings like: 
```
warning "ember-cli > @babel/plugin-transform-modules-amd@7.2.0" has unmet peer dependency "@babel/core@^7.0.0-0".
```

With a depedency tree like
```
$yarn list
  yarn list v1.13.0
  ├─ @babel/code-frame@7.0.0
  │  └─ @babel/highlight@^7.0.0
  ├─ @babel/core@7.2.2
---snip
```
