### PR TITLE
Better error output in parser tests

### DIFF
--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@babel/helper-fixtures": "^7.2.0",
+    "@babel/code-frame": "^7.0.0",
     "charcodes": "0.1.0",
     "unicode-11.0.0": "^0.7.8"
   },


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This modifies how we output stacktraces when a test in babel-parser fails. It makes the link to the fixture clickable (at least in vscode), removes the fixture name from the error message (as it is now in the stacktrace) and shows the correct code frame for the fixture.

Before: 
<img width="901" alt="screen shot 2019-02-11 at 1 43 34 am" src="https://user-images.githubusercontent.com/231804/52555674-3bedc900-2d9f-11e9-9c98-508143061a4c.png">

After:
<img width="906" alt="screen shot 2019-02-11 at 1 42 35 am" src="https://user-images.githubusercontent.com/231804/52555686-414b1380-2d9f-11e9-9684-067da895c8cd.png">

