### PR TITLE
Mark FOO in "var { x: FOO }˝ as a binding, not as a reference

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -2,6 +2,17 @@ import { declare } from "@babel/helper-plugin-utils";
 import syntaxObjectRestSpread from "@babel/plugin-syntax-object-rest-spread";
 import { types as t } from "@babel/core";
 
+// TODO: Remove in Babel 8
+// @babel/types <=7.3.3 counts FOO as referenced in var { x: FOO }.
+// We need to detect this bug to know if "unused" means 0 or 1 references.
+const ZERO_REFS = (() => {
+  const node = t.identifier("a");
+  const property = t.objectProperty(t.identifier("key"), node);
+  const pattern = t.objectPattern([property]);
+
+  return t.isReferenced(node, property, pattern) ? 1 : 0;
+})();
+
 export default declare((api, opts) => {
   api.assertVersion(7);
 
@@ -98,7 +109,7 @@ export default declare((api, opts) => {
     Object.keys(bindings).forEach(bindingName => {
       const bindingParentPath = bindings[bindingName].parentPath;
       if (
-        path.scope.getBinding(bindingName).references > 1 ||
+        path.scope.getBinding(bindingName).references > ZERO_REFS ||
         !bindingParentPath.isObjectProperty()
       ) {
         return;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/import-const-throw/output.js
@@ -18,24 +18,32 @@ _baz.Baz = (44, function () {
   throw new Error('"' + "Baz" + '" is read-only.');
 }());
 ({
-  Foo: _foo.default
-} = {});
+  Foo
+} = ({}, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}()));
 ({
   Bar
 } = ({}, function () {
   throw new Error('"' + "Bar" + '" is read-only.');
 }()));
 ({
-  Baz: _baz.Baz
-} = {});
+  Baz
+} = ({}, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}()));
 ({
-  prop: _foo.default
-} = {});
+  prop: Foo
+} = ({}, function () {
+  throw new Error('"' + "Foo" + '" is read-only.');
+}()));
 ({
   prop: Bar
 } = ({}, function () {
   throw new Error('"' + "Bar" + '" is read-only.');
 }()));
 ({
-  prop: _baz.Baz
-} = {});
+  prop: Baz
+} = ({}, function () {
+  throw new Error('"' + "Baz" + '" is read-only.');
+}()));

--- a/packages/babel-traverse/src/path/lib/virtual-types.js
+++ b/packages/babel-traverse/src/path/lib/virtual-types.js
@@ -4,7 +4,8 @@ import * as t from "@babel/types";
 
 export const ReferencedIdentifier = {
   types: ["Identifier", "JSXIdentifier"],
-  checkPath({ node, parent }: NodePath, opts?: Object): boolean {
+  checkPath(path: NodePath, opts?: Object): boolean {
+    const { node, parent } = path;
     if (!t.isIdentifier(node, opts) && !t.isJSXMemberExpression(parent, opts)) {
       if (t.isJSXIdentifier(node, opts)) {
         if (react.isCompatTag(node.name)) return false;
@@ -15,7 +16,7 @@ export const ReferencedIdentifier = {
     }
 
     // check if node is referenced
-    return t.isReferenced(node, parent);
+    return t.isReferenced(node, parent, path.parentPath.parent);
   },
 };
 
@@ -28,8 +29,10 @@ export const ReferencedMemberExpression = {
 
 export const BindingIdentifier = {
   types: ["Identifier"],
-  checkPath({ node, parent }: NodePath): boolean {
-    return t.isIdentifier(node) && t.isBinding(node, parent);
+  checkPath(path: NodePath): boolean {
+    const { node, parent } = path;
+    const grandparent = path.parentPath.parent;
+    return t.isIdentifier(node) && t.isBinding(node, parent, grandparent);
   },
 };
 

--- a/packages/babel-types/src/validators/isBinding.js
+++ b/packages/babel-types/src/validators/isBinding.js
@@ -3,7 +3,22 @@ import getBindingIdentifiers from "../retrievers/getBindingIdentifiers";
 /**
  * Check if the input `node` is a binding identifier.
  */
-export default function isBinding(node: Object, parent: Object): boolean {
+export default function isBinding(
+  node: Object,
+  parent: Object,
+  grandparent?: Object,
+): boolean {
+  if (
+    grandparent &&
+    node.type === "Identifier" &&
+    parent.type === "ObjectProperty" &&
+    grandparent.type === "ObjectExpression"
+  ) {
+    // We need to special-case this, because getBindingIdentifiers
+    // has an ObjectProperty->value entry for destructuring patterns.
+    return false;
+  }
+
   const keys = getBindingIdentifiers.keys[parent.type];
   if (keys) {
     for (let i = 0; i < keys.length; i++) {

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -2,7 +2,11 @@
 /**
  * Check if the input `node` is a reference to a bound variable.
  */
-export default function isReferenced(node: Object, parent: Object): boolean {
+export default function isReferenced(
+  node: Object,
+  parent: Object,
+  grandparent?: Object,
+): boolean {
   switch (parent.type) {
     // yes: PARENT[NODE]
     // yes: NODE.child
@@ -37,6 +41,7 @@ export default function isReferenced(node: Object, parent: Object): boolean {
     // yes: { [NODE]: "" }
     // no: { NODE: "" }
     // depends: { NODE }
+    // depends: { key: NODE }
     case "ObjectProperty":
     // no: class { NODE = value; }
     // yes: class { [NODE] = value; }
@@ -51,7 +56,10 @@ export default function isReferenced(node: Object, parent: Object): boolean {
       if (parent.key === node) {
         return !!parent.computed;
       }
-      return parent.value === node;
+      if (parent.value === node) {
+        return !grandparent || grandparent.type !== "ObjectPattern";
+      }
+      return true;
 
     // no: class NODE {}
     // yes: class Foo extends NODE {}

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -139,6 +139,24 @@ describe("validators", function() {
     });
   });
 
+  describe("isBinding", function() {
+    it("returns false if node id a value of ObjectProperty of an expression", function() {
+      const node = t.identifier("a");
+      const parent = t.objectProperty(t.identifier("key"), node);
+      const grandparent = t.objectExpression([parent]);
+
+      expect(t.isBinding(node, parent, grandparent)).toBe(false);
+    });
+
+    it("returns true if node id a value of ObjectProperty of a pattern", function() {
+      const node = t.identifier("a");
+      const parent = t.objectProperty(t.identifier("key"), node);
+      const grandparent = t.objectPattern([parent]);
+
+      expect(t.isBinding(node, parent, grandparent)).toBe(true);
+    });
+  });
+
   describe("isType", function() {
     it("returns true if nodeType equals targetType", function() {
       expect(t.isType("Identifier", "Identifier")).toBe(true);

--- a/packages/babel-types/test/validators.js
+++ b/packages/babel-types/test/validators.js
@@ -121,6 +121,22 @@ describe("validators", function() {
 
       expect(t.isReferenced(node, parent)).toBe(true);
     });
+
+    it("returns true if node id a value of ObjectProperty of an expression", function() {
+      const node = t.identifier("a");
+      const parent = t.objectProperty(t.identifier("key"), node);
+      const grandparent = t.objectExpression([parent]);
+
+      expect(t.isReferenced(node, parent, grandparent)).toBe(true);
+    });
+
+    it("returns false if node id a value of ObjectProperty of a pattern", function() {
+      const node = t.identifier("a");
+      const parent = t.objectProperty(t.identifier("key"), node);
+      const grandparent = t.objectPattern([parent]);
+
+      expect(t.isReferenced(node, parent, grandparent)).toBe(false);
+    });
   });
 
   describe("isType", function() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Maybe? I'd consider this as a bug fix
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Before this PR, babel incorrectly marks `FOO` as a `ReferencedIdentifier` in `var { a: FOO }` and as a binding identifier in `({ a: FOO })`: this is because we needed to know not only the parent but also its grandparent to know it. Array patterns don't have this problem, since there isn't something like an `ArrayElement` node between the identifier and the pattern.

This code shows the bug; you can test the old version on ASTExplorer (https://astexplorer.net/#/gist/3dc1c7fd69ee5f7478c2229e4bdce428/latest)

<details>
<summary>Plugin</summary>

```js
function ({ types: t, template }) {
  let result = "";
  return {
    visitor: {
      Identifier(path) {
        if (path.node.name === "key") return;

        result += path.node.name +
          " - referenced: " + path.isReferencedIdentifier() +
          ", binding: " + path.isBindingIdentifier() + "\n";
      },
      Program: {
        exit() {
          alert(result);
        }
      }
    },
  };
}
```

</details>

<details>
<summary>Input code</summary>

```js
var a = 1;
var [ b ] = 1;
var { key: c } = 1;

x;
[ y ];
({ key: z });
```

</details>

<details>
<summary>Old output</summary>

```
a - referenced: false, binding: true
b - referenced: false, binding: true
c - referenced: true, binding: true
x - referenced: true, binding: false
y - referenced: true, binding: false
z - referenced: true, binding: true
```
</details>
<details>
<summary>New output</summary>

```
a - referenced: false, binding: true
b - referenced: false, binding: true
c - referenced: false, binding: true
x - referenced: true, binding: false
y - referenced: true, binding: false
z - referenced: true, binding: false
```
</details>
