### PR TITLE
Upgrade to @babel/preset-typescript to use @babel/plugin-transform-typescript@^7.3.2

### DIFF
--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-transform-typescript": "^7.1.0"
+    "@babel/plugin-transform-typescript": "^7.3.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No?
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Bumps to 7.3.2 the version of `@babel/plugin-transform-typescript` used by `@babel/preset-typescript`.

This allows us to use `@babel/preset-typescript` and pick up at least one useful bug fix (#9095).

A similar PR (#9181) was closed as it bumped to a version that didn't have changes. However reading the comments from that PR, I get the sense that bumping the version in this manner should not be necessary, and should be handled by Lerna. Is this correct?

Please let me know if I can make any improvements to this PR, the description or if there's anything else I can do to help.