### PR TITLE
Version bump of lodash 

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -43,7 +43,7 @@
     "convert-source-map": "^1.1.0",
     "debug": "^4.1.0",
     "json5": "^2.1.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/types": "^7.3.2",
     "jsesc": "^2.5.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "source-map": "^0.5.0",
     "trim-right": "^1.0.1"
   },

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@babel/helper-function-name": "^7.1.0",
     "@babel/types": "^7.0.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "semver": "^5.3.0",
     "try-resolve": "^1.0.0"
   }

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -16,6 +16,6 @@
     "@babel/helper-split-export-declaration": "^7.0.0",
     "@babel/template": "^7.2.2",
     "@babel/types": "^7.2.2",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -18,7 +18,7 @@
     "babel-check-duplicated-nodes": "^1.0.0",
     "jest": "^22.4.2",
     "jest-diff": "^22.4.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "resolve": "^1.3.2",
     "source-map": "^0.5.0"
   }

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -22,7 +22,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/register": "^7.0.0",
     "commander": "^2.8.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "v8flags": "^3.1.1"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -16,7 +16,7 @@
     "core-js": "^2.5.7",
     "find-cache-dir": "^2.0.0",
     "home-or-tmp": "^3.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "pirates": "^4.0.0",
     "source-map-support": "^0.5.9"

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -19,7 +19,7 @@
     "@babel/types": "^7.2.2",
     "debug": "^4.1.0",
     "globals": "^11.1.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "^7.0.0"

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -10,7 +10,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "esutils": "^2.0.2",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "to-fast-properties": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9505
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Lodash 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Upgrading lodash to pull in 4.17.11 instead of 4.17.10 in babel Core, babel generator, babel register, babel traverse, and babel types 