### PR TITLE
Correctly output escapes in directives

### DIFF
--- a/packages/babel-generator/src/generators/base.js
+++ b/packages/babel-generator/src/generators/base.js
@@ -50,8 +50,35 @@ export function Directive(node: Object) {
   this.semicolon();
 }
 
+// These regexes match an even number of \ followed by a quote
+const unescapedSingleQuoteRE = /(?:^|[^\\])(?:\\\\)*'/;
+const unescapedDoubleQuoteRE = /(?:^|[^\\])(?:\\\\)*"/;
+
+export function DirectiveLiteral(node: Object) {
+  const raw = this.getPossibleRaw(node);
+  if (raw != null) {
+    this.token(raw);
+    return;
+  }
+
+  const { value } = node;
+
+  // NOTE: In directives we can't change escapings,
+  // because they change the behavior.
+  // e.g. "us\x65 string" (\x65 is e) is not a "use strict" directive.
+
+  if (!unescapedDoubleQuoteRE.test(value)) {
+    this.token(`"${value}"`);
+  } else if (!unescapedSingleQuoteRE.test(value)) {
+    this.token(`'${value}'`);
+  } else {
+    throw new Error(
+      "Malformed AST: it is not possible to print a directive containing" +
+        " both unescaped single and double quotes.",
+    );
+  }
+}
+
 export function InterpreterDirective(node: Object) {
   this.token(`#!${node.value}\n`);
 }
-
-export { StringLiteral as DirectiveLiteral } from "./types";

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape/input.js
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape/input.js
@@ -1,1 +1,2 @@
+0; // Not a directive
 "©";

--- a/packages/babel-generator/test/fixtures/escapes/jsonEscape/output.js
+++ b/packages/babel-generator/test/fixtures/escapes/jsonEscape/output.js
@@ -1,1 +1,2 @@
+0;// Not a directive
 "\u00A9";

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -384,6 +384,48 @@ describe("programmatic generation", function() {
   [key: any]: number
 }`);
   });
+
+  describe("directives", function() {
+    it("preserves escapes", function() {
+      const directive = t.directive(
+        t.directiveLiteral(String.raw`us\x65 strict`),
+      );
+      const output = generate(directive).code;
+
+      expect(output).toBe(String.raw`"us\x65 strict";`);
+    });
+
+    it("preserves escapes in minified output", function() {
+      // https://github.com/babel/babel/issues/4767
+
+      const directive = t.directive(t.directiveLiteral(String.raw`foo\n\t\r`));
+      const output = generate(directive, { minified: true }).code;
+
+      expect(output).toBe(String.raw`"foo\n\t\r";`);
+    });
+
+    it("unescaped single quote", function() {
+      const directive = t.directive(t.directiveLiteral(String.raw`'\'\"`));
+      const output = generate(directive).code;
+
+      expect(output).toBe(String.raw`"'\'\"";`);
+    });
+
+    it("unescaped double quote", function() {
+      const directive = t.directive(t.directiveLiteral(String.raw`"\'\"`));
+      const output = generate(directive).code;
+
+      expect(output).toBe(String.raw`'"\'\"';`);
+    });
+
+    it("unescaped single and double quotes together throw", function() {
+      const directive = t.directive(t.directiveLiteral(String.raw`'"`));
+
+      expect(() => {
+        generate(directive);
+      }).toThrow();
+    });
+  });
 });
 
 describe("CodeGenerator", function() {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #4767, closes #5935
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Before this PR, `@babel/generator` handled strings and directives using the same code. This causes problems because `@babel/parser` creates two different `node.value` ast properties: `"\n"` generates `node.value = "backslash-n"` for directives and `node.value = "newline"` for strings.
`@babel/parser` is correct: the important information for directives is their exact raw source value, not the resulting one. i.e. `"us\x65 strict" === "use strict"` (from a string pow they are the same thing), but `"us\x65 strict"` isn't a valid `use strict` directive.

The approach taken in #5935 only works with directives generated by `@babel/parser` and not with directives injected by Babel plugins, because it uses `node.extra.raw`. This PR has a fallback for programmatically-generated directives. Note that not every directive can be printed (e.g. `'"` can't be printed without adding escapes).

After commiting this changes I noticed https://github.com/babel/babylon/pull/712#issuecomment-327031261, where Logan proposed a simpler version of the function added by this PR.