### PR TITLE
Dedupe Babel in @babel/standalone

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -18,7 +18,8 @@
     "@babel/helper-member-expression-to-functions": "^7.0.0",
     "@babel/helper-optimise-call-expression": "^7.0.0",
     "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-replace-supers": "^7.2.3"
+    "@babel/helper-replace-supers": "^7.2.3",
+    "@babel/helper-split-export-declaration": "^7.0.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-proposal-json-strings": "^7.2.0",
     "@babel/plugin-proposal-logical-assignment-operators": "^7.2.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.2.0",
+    "@babel/plugin-proposal-numeric-separator": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`@babel/standalone` is 30% smaller :sunglasses: 

:warning: In the first screenshot `node_modules` is on the left, while in the second one it is on the right.

Before (4.2 MB unminified, 2.3 MB minified):
![schermata da 2019-02-14 23-24-04](https://user-images.githubusercontent.com/7000710/52824727-05bf8a80-30ba-11e9-80f8-a1c3f5d3e64c.png)

After (2.8 MB unminified, 1.6 MB minified):

![schermata da 2019-02-15 00-27-01](https://user-images.githubusercontent.com/7000710/52824726-05bf8a80-30ba-11e9-99b8-e4f9e0e0662c.png)


The problem was that those two packages "leaked" and imported the version of Babel used to build our code (so an older version, not the one from packages/)