### PR TITLE
Add duplicate-package-checker-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chalk": "^2.3.2",
     "charcodes": "^0.2.0",
     "derequire": "^2.0.2",
+    "duplicate-package-checker-webpack-plugin": "^2.1.0",
     "enhanced-resolve": "^3.0.0",
     "eslint": "^5.12.1",
     "eslint-config-babel": "^8.0.2",

--- a/scripts/gulp-tasks.js
+++ b/scripts/gulp-tasks.js
@@ -17,9 +17,9 @@ const chalk = require("chalk");
 const through = require("through2");
 const fancyLog = require("fancy-log");
 const rename = require("gulp-rename");
-const RootMostResolvePlugin = require("webpack-dependency-suite")
-  .RootMostResolvePlugin;
 const webpack = require("webpack");
+const { RootMostResolvePlugin } = require("webpack-dependency-suite");
+const DuplicatePackageCheckerPlugin = require("duplicate-package-checker-webpack-plugin");
 const webpackStream = require("webpack-stream");
 const uglify = require("gulp-uglify");
 
@@ -62,6 +62,7 @@ function webpackBuild(opts) {
       libraryTarget: "umd",
     },
     plugins: [
+      new DuplicatePackageCheckerPlugin(),
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": '"production"',
         "process.env": JSON.stringify({ NODE_ENV: "production" }),
@@ -92,8 +93,11 @@ function webpackBuild(opts) {
   return webpackStream(config, webpack);
   // To write JSON for debugging:
   /*return webpackStream(config, webpack, (err, stats) => {
-    require('fancy-log')(stats.toString({colors: true}));
-    require('fs').writeFileSync('webpack-debug.json', JSON.stringify(stats.toJson()));
+    require("fancy-log")(stats.toString({ colors: true }));
+    require("fs").writeFileSync(
+      "webpack-debug.json",
+      JSON.stringify(stats.toJson())
+    );
   });*/
 }
 

--- a/scripts/gulp-tasks.js
+++ b/scripts/gulp-tasks.js
@@ -62,7 +62,11 @@ function webpackBuild(opts) {
       libraryTarget: "umd",
     },
     plugins: [
-      new DuplicatePackageCheckerPlugin(),
+      new DuplicatePackageCheckerPlugin({
+        exclude(instance) {
+          return instance.name === "semver";
+        },
+      }),
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": '"production"',
         "process.env": JSON.stringify({ NODE_ENV: "production" }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,6 +2239,15 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
@@ -3129,6 +3138,16 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplicate-package-checker-webpack-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-2.1.0.tgz#6723ee32d89947997470778973c10788cb69e496"
+  integrity sha512-Blok+Cb8zDavYQyeTtSkmNp/aiyRn5+JV/4EhDDH5VJChnyIzPhq+S5MyWnFpqpv8jNKmD3cXmXFEVU509pzXQ==
+  dependencies:
+    chalk "^2.3.0"
+    find-root "^1.0.0"
+    lodash "^4.17.4"
+    semver "^5.4.1"
+
 each-props@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/each-props/-/each-props-1.3.1.tgz#fc138f51e3a2774286d4858e02d6e7de462de158"
@@ -3748,6 +3767,11 @@ find-npm-prefix@^1.0.2:
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
+find-root@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As suggested by @danez, this can help preventing problems like #9516.

```
babel on  master [$+?] via ⬢ v10.14.2 
➜ make build-standalone           
./node_modules/.bin/gulp build-babel-standalone
[10:43:51] Using gulpfile ~/Documenti/dev/babel/babel/Gulpfile.js
[10:43:51] Starting 'build-babel-standalone'...
[10:44:00] Version: webpack 3.11.0
   Asset     Size  Chunks                    Chunk Names
babel.js  2.87 MB       0  [emitted]  [big]  main

WARNING in semver
  Multiple versions of semver found:
    5.5.0 ./~/semver
    5.6.0 ./packages/babel-plugin-transform-runtime/~/semver

Check how you can resolve duplicate packages: 
https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolving-duplicate-packages-in-your-bundle

[10:44:00] Skipped minification of 'packages/babel-standalone/babel.js' because not publishing
[10:44:00] Finished 'build-babel-standalone' after 9.14 s



babel on  master [$!?] via ⬢ v10.14.2 took 9s 
➜ make build-preset-env-standalone
./node_modules/.bin/gulp build-babel-preset-env-standalone
[10:43:25] Using gulpfile ~/Documenti/dev/babel/babel/Gulpfile.js
[10:43:25] Starting 'build-babel-preset-env-standalone'...
[10:43:32] Version: webpack 3.11.0
              Asset    Size  Chunks                    Chunk Names
babel-preset-env.js  2.1 MB       0  [emitted]  [big]  main
[10:43:32] Skipped minification of 'packages/babel-preset-env-standalone/babel-preset-env.js' because not publishing
[10:43:32] Finished 'build-babel-preset-env-standalone' after 6.93 s

```

We are duplicating semver. It's such a small package that I don't think that it is worth spending much time trying to understand why.