### PR TITLE
Use NODE_PATHS environment value as extra module paths

### DIFF
--- a/packages/babel-core/src/config/files/plugins.js
+++ b/packages/babel-core/src/config/files/plugins.js
@@ -19,6 +19,8 @@ const OTHER_PLUGIN_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?![^/]*babel-plugin(?:-|\/|$
 const OTHER_PRESET_ORG_RE = /^(@(?!babel\/)[^/]+\/)(?![^/]*babel-preset(?:-|\/|$)|[^/]+\/)/;
 const OTHER_ORG_DEFAULT_RE = /^(@(?!babel$)[^/]+)$/;
 
+const nodePaths = process.env("NODE_PATH").split(":");
+
 export function resolvePlugin(name: string, dirname: string): string | null {
   return resolveStandardizedName("plugin", name, dirname);
 }
@@ -96,14 +98,17 @@ function resolveStandardizedName(
   const standardizedName = standardizeName(type, name);
 
   try {
-    return resolve.sync(standardizedName, { basedir: dirname });
+    return resolve.sync(standardizedName, {
+      basedir: dirname,
+      paths: nodePaths
+    });
   } catch (e) {
     if (e.code !== "MODULE_NOT_FOUND") throw e;
 
     if (standardizedName !== name) {
       let resolvedOriginal = false;
       try {
-        resolve.sync(name, { basedir: dirname });
+        resolve.sync(name, { basedir: dirname, paths: nodePaths });
         resolvedOriginal = true;
       } catch (e2) {}
 
@@ -116,6 +121,7 @@ function resolveStandardizedName(
     try {
       resolve.sync(standardizeName(type, "@babel/" + name), {
         basedir: dirname,
+        paths: nodePaths
       });
       resolvedBabel = true;
     } catch (e2) {}
@@ -127,7 +133,10 @@ function resolveStandardizedName(
     let resolvedOppositeType = false;
     const oppositeType = type === "preset" ? "plugin" : "preset";
     try {
-      resolve.sync(standardizeName(oppositeType, name), { basedir: dirname });
+      resolve.sync(standardizeName(oppositeType, name), {
+        basedir: dirname,
+        paths: nodePaths
+      });
       resolvedOppositeType = true;
     } catch (e2) {}
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #5618
| Patch: Bug Fix?          | *Depends*
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes *(sort of)*
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Added `resolve` `sync` argument `paths` (that is currently omitted) set to `NODE_PATH` environment variable
It is necessary to rebuild packages installed with `npm -g` without tampering with their `babel.config.js` (that may make for upstream incompatibility)
I suggest that the discussion proceed at #5618 