### PR TITLE
Also check AssignmentPatterns for duplicate export name

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1816,7 +1816,9 @@ export default class StatementParser extends ExpressionParser {
   }
 
   checkDeclaration(node: N.Pattern | N.ObjectProperty): void {
-    if (node.type === "ObjectPattern") {
+    if (node.type === "Identifier") {
+      this.checkDuplicateExports(node, node.name);
+    } else if (node.type === "ObjectPattern") {
       for (const prop of node.properties) {
         this.checkDeclaration(prop);
       }
@@ -1830,8 +1832,8 @@ export default class StatementParser extends ExpressionParser {
       this.checkDeclaration(node.value);
     } else if (node.type === "RestElement") {
       this.checkDeclaration(node.argument);
-    } else if (node.type === "Identifier") {
-      this.checkDuplicateExports(node, node.name);
+    } else if (node.type === "AssignmentPattern") {
+      this.checkDeclaration(node.left);
     }
   }
 

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring-assignment/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring-assignment/input.js
@@ -1,0 +1,2 @@
+export { foo };
+export const { foo = 1 } = bar;

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring-assignment/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring-assignment/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "`foo` has already been exported. Exported identifiers must be unique. (2:15)"
+}


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This handles this case that currently parses correctly but should fail:

```
export { foo };
export const { foo = 1 } = bar;
```
