### PR TITLE
Migrate some duplicate binding tests to traverse

### DIFF
--- a/codemods/babel-plugin-codemod-optional-catch-binding/test/fixtures/codemod-optional-catch-binding/try-catch-block-duplicate-variable-declaration/input.js
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/test/fixtures/codemod-optional-catch-binding/try-catch-block-duplicate-variable-declaration/input.js
@@ -1,5 +1,0 @@
-try {
-  throw 0;
-} catch (e) {
-  let e = new TypeError('Duplicate variable declaration; will throw an error.');
-}

--- a/codemods/babel-plugin-codemod-optional-catch-binding/test/fixtures/codemod-optional-catch-binding/try-catch-block-duplicate-variable-declaration/options.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/test/fixtures/codemod-optional-catch-binding/try-catch-block-duplicate-variable-declaration/options.json
@@ -1,4 +1,0 @@
-{
-  "plugins": ["../../../../lib"],
-  "throws": "Duplicate declaration \"e\""
-}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-classes/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-classes/input.js
@@ -1,5 +1,0 @@
-const MULTIPLIER = 5;
-
-class MULTIPLIER {
-
-}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-classes/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-classes/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Duplicate declaration \"MULTIPLIER\""
-}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-declaration/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-declaration/input.js
@@ -1,3 +1,0 @@
-const MULTIPLIER = 5;
-
-var MULTIPLIER = "overwrite";

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-declaration/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-declaration/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Duplicate declaration \"MULTIPLIER\""
-}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-functions/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-functions/input.js
@@ -1,5 +1,0 @@
-const MULTIPLIER = 5;
-
-function MULTIPLIER() {
-
-}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-functions/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/const-violations/no-functions/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Duplicate declaration \"MULTIPLIER\""
-}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-5979/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-5979/input.js
@@ -1,1 +1,0 @@
-try {} catch (a) { let a }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-5979/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-5979/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Duplicate declaration \"a\""
-}

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -349,9 +349,6 @@ export default class Scope {
     // class expression
     if (local.kind === "local") return;
 
-    // ignore hoisted functions if there's also a local let
-    if (kind === "hoisted" && local.kind === "let") return;
-
     const duplicate =
       // don't allow duplicate bindings to exist alongside
       kind === "let" ||

--- a/packages/babel-traverse/test/__snapshots__/scope.js.snap
+++ b/packages/babel-traverse/test/__snapshots__/scope.js.snap
@@ -4,14 +4,22 @@ exports[`scope duplicate bindings catch const 1`] = `"Duplicate declaration \\"e
 
 exports[`scope duplicate bindings catch let 1`] = `"Duplicate declaration \\"e\\""`;
 
-exports[`scope duplicate bindings global const class 1`] = `"Duplicate declaration \\"foo\\""`;
+exports[`scope duplicate bindings global class/function 1`] = `"Duplicate declaration \\"foo\\""`;
 
-exports[`scope duplicate bindings global const function 1`] = `"Duplicate declaration \\"foo\\""`;
+exports[`scope duplicate bindings global const/class 1`] = `"Duplicate declaration \\"foo\\""`;
 
-exports[`scope duplicate bindings global const var 1`] = `"Duplicate declaration \\"foo\\""`;
+exports[`scope duplicate bindings global const/const 1`] = `"Duplicate declaration \\"foo\\""`;
 
-exports[`scope duplicate bindings global let class 1`] = `"Duplicate declaration \\"foo\\""`;
+exports[`scope duplicate bindings global const/function 1`] = `"Duplicate declaration \\"foo\\""`;
 
-exports[`scope duplicate bindings global let function 1`] = `"Duplicate declaration \\"foo\\""`;
+exports[`scope duplicate bindings global const/let 1`] = `"Duplicate declaration \\"foo\\""`;
 
-exports[`scope duplicate bindings global let var 1`] = `"Duplicate declaration \\"foo\\""`;
+exports[`scope duplicate bindings global const/var 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let/class 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let/function 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let/let 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let/var 1`] = `"Duplicate declaration \\"foo\\""`;

--- a/packages/babel-traverse/test/__snapshots__/scope.js.snap
+++ b/packages/babel-traverse/test/__snapshots__/scope.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`scope duplicate bindings catch const 1`] = `"Duplicate declaration \\"e\\""`;
+
+exports[`scope duplicate bindings catch let 1`] = `"Duplicate declaration \\"e\\""`;
+
+exports[`scope duplicate bindings catch var 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "block": Object {
+        "body": Array [],
+        "directives": Array [],
+        "type": "BlockStatement",
+      },
+      "finalizer": null,
+      "handler": Object {
+        "body": Object {
+          "body": Array [
+            Object {
+              "declarations": Array [
+                Object {
+                  "id": Object {
+                    "name": "e",
+                    "type": "Identifier",
+                  },
+                  "init": null,
+                  "type": "VariableDeclarator",
+                },
+              ],
+              "kind": "var",
+              "type": "VariableDeclaration",
+            },
+          ],
+          "directives": Array [],
+          "type": "BlockStatement",
+        },
+        "param": Object {
+          "name": "e",
+          "type": "Identifier",
+        },
+        "type": "CatchClause",
+      },
+      "type": "TryStatement",
+    },
+  ],
+  "directives": Array [],
+  "interpreter": null,
+  "sourceType": "script",
+  "type": "Program",
+}
+`;

--- a/packages/babel-traverse/test/__snapshots__/scope.js.snap
+++ b/packages/babel-traverse/test/__snapshots__/scope.js.snap
@@ -24,7 +24,10 @@ Object {
                     "name": "e",
                     "type": "Identifier",
                   },
-                  "init": null,
+                  "init": Object {
+                    "type": "StringLiteral",
+                    "value": "1",
+                  },
                   "type": "VariableDeclarator",
                 },
               ],
@@ -50,3 +53,15 @@ Object {
   "type": "Program",
 }
 `;
+
+exports[`scope duplicate bindings global const class 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global const function 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global const var 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let class 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let function 1`] = `"Duplicate declaration \\"foo\\""`;
+
+exports[`scope duplicate bindings global let var 1`] = `"Duplicate declaration \\"foo\\""`;

--- a/packages/babel-traverse/test/__snapshots__/scope.js.snap
+++ b/packages/babel-traverse/test/__snapshots__/scope.js.snap
@@ -4,56 +4,6 @@ exports[`scope duplicate bindings catch const 1`] = `"Duplicate declaration \\"e
 
 exports[`scope duplicate bindings catch let 1`] = `"Duplicate declaration \\"e\\""`;
 
-exports[`scope duplicate bindings catch var 1`] = `
-Object {
-  "body": Array [
-    Object {
-      "block": Object {
-        "body": Array [],
-        "directives": Array [],
-        "type": "BlockStatement",
-      },
-      "finalizer": null,
-      "handler": Object {
-        "body": Object {
-          "body": Array [
-            Object {
-              "declarations": Array [
-                Object {
-                  "id": Object {
-                    "name": "e",
-                    "type": "Identifier",
-                  },
-                  "init": Object {
-                    "type": "StringLiteral",
-                    "value": "1",
-                  },
-                  "type": "VariableDeclarator",
-                },
-              ],
-              "kind": "var",
-              "type": "VariableDeclaration",
-            },
-          ],
-          "directives": Array [],
-          "type": "BlockStatement",
-        },
-        "param": Object {
-          "name": "e",
-          "type": "Identifier",
-        },
-        "type": "CatchClause",
-      },
-      "type": "TryStatement",
-    },
-  ],
-  "directives": Array [],
-  "interpreter": null,
-  "sourceType": "script",
-  "type": "Program",
-}
-`;
-
 exports[`scope duplicate bindings global const class 1`] = `"Duplicate declaration \\"foo\\""`;
 
 exports[`scope duplicate bindings global const function 1`] = `"Duplicate declaration \\"foo\\""`;

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -304,7 +304,26 @@ describe("scope", () => {
       it("var", () => {
         const ast = createTryCatch("var");
 
-        expect(getPath(ast).node).toMatchSnapshot();
+        expect(() => getPath(ast)).not.toThrow();
+      });
+    });
+
+    ["let", "const"].forEach(name => {
+      it(`${name} and function in sub scope`, () => {
+        const ast = [
+          t.variableDeclaration(name, [
+            t.variableDeclarator(t.identifier("foo")),
+          ]),
+          t.blockStatement([
+            t.functionDeclaration(
+              t.identifier("foo"),
+              [],
+              t.blockStatement([]),
+            ),
+          ]),
+        ];
+
+        expect(() => getPath(ast)).not.toThrow();
       });
     });
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | ?
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

The main goal here was to transfer all the tests which test duplicate bindings. They were in different transforms, although the code was in `@babel/traverse` and the transforms have no impact on that behavior, and imho also shouldn't. 

While doing this I discovered, that on case wasn't throwing an error:

```js
let foo;
function foo(){};
```

see inline comment.
