### PR TITLE
Remove `transform-classes` plugin from private method tests

### DIFF
--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/basic/output.js
@@ -1,10 +1,5 @@
-var Cl =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Cl() {
-    babelHelpers.classCallCheck(this, Cl);
+class Cl {
+  constructor() {
     Object.defineProperty(this, _privateFieldValue, {
       get: _get_privateFieldValue,
       set: _set_privateFieldValue
@@ -16,19 +11,15 @@ function () {
     this.publicField = "not secret string";
   }
 
-  babelHelpers.createClass(Cl, [{
-    key: "publicGetPrivateField",
-    value: function publicGetPrivateField() {
-      return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
-    }
-  }, {
-    key: "publicSetPrivateField",
-    value: function publicSetPrivateField(newValue) {
-      babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
-    }
-  }]);
-  return Cl;
-}();
+  publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+  }
+
+  publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
+  }
+
+}
 
 var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/get-only-setter/output.js
@@ -1,16 +1,16 @@
-var Cl = function Cl() {
-  "use strict";
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      set: _set_privateFieldValue
+    });
+    Object.defineProperty(this, _privateField, {
+      writable: true,
+      value: 0
+    });
+    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+  }
 
-  babelHelpers.classCallCheck(this, Cl);
-  Object.defineProperty(this, _privateFieldValue, {
-    set: _set_privateFieldValue
-  });
-  Object.defineProperty(this, _privateField, {
-    writable: true,
-    value: 0
-  });
-  this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
-};
+}
 
 var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/options.json
@@ -8,7 +8,6 @@
     ],
     ["proposal-private-methods", { "loose": true }],
     ["proposal-class-properties", { "loose": true }],
-    "transform-classes",
     "transform-block-scoping",
     "syntax-class-properties"
   ]

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/set-only-getter/output.js
@@ -1,16 +1,16 @@
-var Cl = function Cl() {
-  "use strict";
+class Cl {
+  constructor() {
+    Object.defineProperty(this, _privateFieldValue, {
+      get: _get_privateFieldValue
+    });
+    Object.defineProperty(this, _privateField, {
+      writable: true,
+      value: 0
+    });
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = 1;
+  }
 
-  babelHelpers.classCallCheck(this, Cl);
-  Object.defineProperty(this, _privateFieldValue, {
-    get: _get_privateFieldValue
-  });
-  Object.defineProperty(this, _privateField, {
-    writable: true,
-    value: 0
-  });
-  babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = 1;
-};
+}
 
 var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors-loose/updates/output.js
@@ -1,10 +1,5 @@
-var Cl =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Cl() {
-    babelHelpers.classCallCheck(this, Cl);
+class Cl {
+  constructor() {
     Object.defineProperty(this, _privateFieldValue, {
       get: _get_privateFieldValue,
       set: _set_privateFieldValue
@@ -16,41 +11,36 @@ function () {
     this.publicField = "not secret string";
   }
 
-  babelHelpers.createClass(Cl, [{
-    key: "publicGetPrivateField",
-    value: function publicGetPrivateField() {
-      return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
-    }
-  }, {
-    key: "publicSetPrivateField",
-    value: function publicSetPrivateField(newValue) {
-      babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
-    }
-  }, {
-    key: "testUpdates",
-    value: function testUpdates() {
-      babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = 0;
-      this.publicField = 0;
-      babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]++;
-      this.publicFieldValue = this.publicFieldValue++;
-      ++babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
-      ++this.publicFieldValue;
-      babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] += 1;
-      this.publicFieldValue += 1;
-      babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = -(babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] ** babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]);
-      this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
-    }
-  }, {
-    key: "publicFieldValue",
-    get: function () {
-      return this.publicField;
-    },
-    set: function (newValue) {
-      this.publicField = newValue;
-    }
-  }]);
-  return Cl;
-}();
+  publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+  }
+
+  publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
+  }
+
+  get publicFieldValue() {
+    return this.publicField;
+  }
+
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+
+  testUpdates() {
+    babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = 0;
+    this.publicField = 0;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]++;
+    this.publicFieldValue = this.publicFieldValue++;
+    ++babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
+    ++this.publicFieldValue;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] += 1;
+    this.publicFieldValue += 1;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = -(babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] ** babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]);
+    this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
+  }
+
+}
 
 var _privateField = babelHelpers.classPrivateFieldLooseKey("privateField");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/basic/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/basic/output.js
@@ -1,11 +1,5 @@
-var Cl =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Cl() {
-    babelHelpers.classCallCheck(this, Cl);
-
+class Cl {
+  constructor() {
     _privateFieldValue.set(this, {
       get: _get_privateFieldValue,
       set: _set_privateFieldValue
@@ -19,19 +13,15 @@ function () {
     this.publicField = "not secret string";
   }
 
-  babelHelpers.createClass(Cl, [{
-    key: "publicGetPrivateField",
-    value: function publicGetPrivateField() {
-      return babelHelpers.classPrivateFieldGet(this, _privateFieldValue);
-    }
-  }, {
-    key: "publicSetPrivateField",
-    value: function publicSetPrivateField(newValue) {
-      babelHelpers.classPrivateFieldSet(this, _privateFieldValue, newValue);
-    }
-  }]);
-  return Cl;
-}();
+  publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldGet(this, _privateFieldValue);
+  }
+
+  publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldSet(this, _privateFieldValue, newValue);
+  }
+
+}
 
 var _privateField = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/get-only-setter/output.js
@@ -1,19 +1,18 @@
-var Cl = function Cl() {
-  "use strict";
+class Cl {
+  constructor() {
+    _privateFieldValue.set(this, {
+      set: _set_privateFieldValue
+    });
 
-  babelHelpers.classCallCheck(this, Cl);
+    _privateField.set(this, {
+      writable: true,
+      value: 0
+    });
 
-  _privateFieldValue.set(this, {
-    set: _set_privateFieldValue
-  });
+    this.publicField = babelHelpers.classPrivateFieldGet(this, _privateFieldValue);
+  }
 
-  _privateField.set(this, {
-    writable: true,
-    value: 0
-  });
-
-  this.publicField = babelHelpers.classPrivateFieldGet(this, _privateFieldValue);
-};
+}
 
 var _privateField = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/options.json
@@ -8,7 +8,6 @@
     ],
     "proposal-private-methods",
     "proposal-class-properties",
-    "transform-classes",
     "transform-block-scoping",
     "syntax-class-properties"
   ]

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -1,19 +1,18 @@
-var Cl = function Cl() {
-  "use strict";
+class Cl {
+  constructor() {
+    _privateFieldValue.set(this, {
+      get: _get_privateFieldValue
+    });
 
-  babelHelpers.classCallCheck(this, Cl);
+    _privateField.set(this, {
+      writable: true,
+      value: 0
+    });
 
-  _privateFieldValue.set(this, {
-    get: _get_privateFieldValue
-  });
+    babelHelpers.classPrivateMethodSet();
+  }
 
-  _privateField.set(this, {
-    writable: true,
-    value: 0
-  });
-
-  babelHelpers.classPrivateMethodSet();
-};
+}
 
 var _privateField = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/updates/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/accessors/updates/output.js
@@ -1,11 +1,5 @@
-var Cl =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Cl() {
-    babelHelpers.classCallCheck(this, Cl);
-
+class Cl {
+  constructor() {
     _privateFieldValue.set(this, {
       get: _get_privateFieldValue,
       set: _set_privateFieldValue
@@ -19,43 +13,38 @@ function () {
     this.publicField = "not secret string";
   }
 
-  babelHelpers.createClass(Cl, [{
-    key: "publicGetPrivateField",
-    value: function publicGetPrivateField() {
-      return babelHelpers.classPrivateFieldGet(this, _privateFieldValue);
-    }
-  }, {
-    key: "publicSetPrivateField",
-    value: function publicSetPrivateField(newValue) {
-      babelHelpers.classPrivateFieldSet(this, _privateFieldValue, newValue);
-    }
-  }, {
-    key: "testUpdates",
-    value: function testUpdates() {
-      var _this$privateFieldVal, _this$privateFieldVal2;
+  publicGetPrivateField() {
+    return babelHelpers.classPrivateFieldGet(this, _privateFieldValue);
+  }
 
-      babelHelpers.classPrivateFieldSet(this, _privateField, 0);
-      this.publicField = 0;
-      babelHelpers.classPrivateFieldSet(this, _privateFieldValue, (babelHelpers.classPrivateFieldSet(this, _privateFieldValue, (_this$privateFieldVal2 = +babelHelpers.classPrivateFieldGet(this, _privateFieldValue)) + 1), _this$privateFieldVal2));
-      this.publicFieldValue = this.publicFieldValue++;
-      babelHelpers.classPrivateFieldSet(this, _privateFieldValue, +babelHelpers.classPrivateFieldGet(this, _privateFieldValue) + 1);
-      ++this.publicFieldValue;
-      babelHelpers.classPrivateFieldSet(this, _privateFieldValue, babelHelpers.classPrivateFieldGet(this, _privateFieldValue) + 1);
-      this.publicFieldValue += 1;
-      babelHelpers.classPrivateFieldSet(this, _privateFieldValue, -(babelHelpers.classPrivateFieldGet(this, _privateFieldValue) ** babelHelpers.classPrivateFieldGet(this, _privateFieldValue)));
-      this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
-    }
-  }, {
-    key: "publicFieldValue",
-    get: function () {
-      return this.publicField;
-    },
-    set: function (newValue) {
-      this.publicField = newValue;
-    }
-  }]);
-  return Cl;
-}();
+  publicSetPrivateField(newValue) {
+    babelHelpers.classPrivateFieldSet(this, _privateFieldValue, newValue);
+  }
+
+  get publicFieldValue() {
+    return this.publicField;
+  }
+
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+
+  testUpdates() {
+    var _this$privateFieldVal, _this$privateFieldVal2;
+
+    babelHelpers.classPrivateFieldSet(this, _privateField, 0);
+    this.publicField = 0;
+    babelHelpers.classPrivateFieldSet(this, _privateFieldValue, (babelHelpers.classPrivateFieldSet(this, _privateFieldValue, (_this$privateFieldVal2 = +babelHelpers.classPrivateFieldGet(this, _privateFieldValue)) + 1), _this$privateFieldVal2));
+    this.publicFieldValue = this.publicFieldValue++;
+    babelHelpers.classPrivateFieldSet(this, _privateFieldValue, +babelHelpers.classPrivateFieldGet(this, _privateFieldValue) + 1);
+    ++this.publicFieldValue;
+    babelHelpers.classPrivateFieldSet(this, _privateFieldValue, babelHelpers.classPrivateFieldGet(this, _privateFieldValue) + 1);
+    this.publicFieldValue += 1;
+    babelHelpers.classPrivateFieldSet(this, _privateFieldValue, -(babelHelpers.classPrivateFieldGet(this, _privateFieldValue) ** babelHelpers.classPrivateFieldGet(this, _privateFieldValue)));
+    this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
+  }
+
+}
 
 var _privateField = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/get-set/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/get-set/output.js
@@ -1,18 +1,17 @@
-var Cl = function Cl() {
-  "use strict";
+class Cl {
+  constructor() {
+    _getSet.set(this, {
+      get: _get_getSet,
+      set: _set_getSet
+    });
 
-  babelHelpers.classCallCheck(this, Cl);
+    _privateField.set(this, {
+      writable: true,
+      value: 0
+    });
+  }
 
-  _getSet.set(this, {
-    get: _get_getSet,
-    set: _set_getSet
-  });
-
-  _privateField.set(this, {
-    writable: true,
-    value: 0
-  });
-};
+}
 
 var _privateField = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/options.json
@@ -8,7 +8,6 @@
     ],
     "proposal-private-methods",
     "proposal-class-properties",
-    "transform-classes",
     "transform-block-scoping",
     "syntax-class-properties"
   ]

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/set-get/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/duplicated-names/set-get/output.js
@@ -1,18 +1,17 @@
-var Cl = function Cl() {
-  "use strict";
+class Cl {
+  constructor() {
+    _getSet.set(this, {
+      get: _get_getSet,
+      set: _set_getSet
+    });
 
-  babelHelpers.classCallCheck(this, Cl);
+    _privateField.set(this, {
+      writable: true,
+      value: 0
+    });
+  }
 
-  _getSet.set(this, {
-    get: _get_getSet,
-    set: _set_getSet
-  });
-
-  _privateField.set(this, {
-    writable: true,
-    value: 0
-  });
-};
+}
 
 var _privateField = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/assignment/output.js
@@ -1,12 +1,12 @@
-var Foo = function Foo() {
-  "use strict";
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
+  }
 
-  babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, _privateMethod, {
-    value: _privateMethod2
-  });
-  this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
-};
+}
 
 var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/before-fields/output.js
@@ -1,10 +1,5 @@
-var Cl =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Cl() {
-    babelHelpers.classCallCheck(this, Cl);
+class Cl {
+  constructor() {
     Object.defineProperty(this, _method, {
       value: _method2
     });
@@ -15,14 +10,11 @@ function () {
     });
   }
 
-  babelHelpers.createClass(Cl, [{
-    key: "getPriv",
-    value: function getPriv() {
-      return babelHelpers.classPrivateFieldLooseBase(this, _priv)[_priv];
-    }
-  }]);
-  return Cl;
-}();
+  getPriv() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _priv)[_priv];
+  }
+
+}
 
 var _priv = babelHelpers.classPrivateFieldLooseKey("priv");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/context/output.js
@@ -1,48 +1,37 @@
-var Foo =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Foo(status) {
-    babelHelpers.classCallCheck(this, Foo);
+class Foo {
+  constructor(status) {
     Object.defineProperty(this, _getStatus, {
       value: _getStatus2
     });
     this.status = status;
   }
 
-  babelHelpers.createClass(Foo, [{
-    key: "getCurrentStatus",
-    value: function getCurrentStatus() {
-      return babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]();
-    }
-  }, {
-    key: "setCurrentStatus",
-    value: function setCurrentStatus(newStatus) {
-      this.status = newStatus;
-    }
-  }, {
-    key: "getFakeStatus",
-    value: function getFakeStatus(fakeStatus) {
-      var fakeGetStatus = babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus];
+  getCurrentStatus() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]();
+  }
 
-      return function () {
-        return fakeGetStatus.call({
-          status: fakeStatus
-        });
-      };
-    }
-  }, {
-    key: "getFakeStatusFunc",
-    value: function getFakeStatusFunc() {
-      return {
-        status: 'fake-status',
-        getFakeStatus: babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]
-      };
-    }
-  }]);
-  return Foo;
-}();
+  setCurrentStatus(newStatus) {
+    this.status = newStatus;
+  }
+
+  getFakeStatus(fakeStatus) {
+    var fakeGetStatus = babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus];
+
+    return function () {
+      return fakeGetStatus.call({
+        status: fakeStatus
+      });
+    };
+  }
+
+  getFakeStatusFunc() {
+    return {
+      status: 'fake-status',
+      getFakeStatus: babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]
+    };
+  }
+
+}
 
 var _getStatus = babelHelpers.classPrivateFieldLooseKey("getStatus");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/exfiltrated/output.js
@@ -1,17 +1,17 @@
 var exfiltrated;
 
-var Foo = function Foo() {
-  "use strict";
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
 
-  babelHelpers.classCallCheck(this, Foo);
-  Object.defineProperty(this, _privateMethod, {
-    value: _privateMethod2
-  });
-
-  if (exfiltrated === undefined) {
-    exfiltrated = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod];
+    if (exfiltrated === undefined) {
+      exfiltrated = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod];
+    }
   }
-};
+
+}
 
 var _privateMethod = babelHelpers.classPrivateFieldLooseKey("privateMethod");
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/options.json
@@ -8,7 +8,6 @@
     ],
     ["proposal-private-methods", { "loose": true }],
     ["proposal-class-properties", { "loose": true }],
-    "transform-classes",
     "transform-block-scoping",
     "syntax-class-properties"
   ]

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/assignment/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/assignment/output.js
@@ -1,12 +1,11 @@
-var Foo = function Foo() {
-  "use strict";
+class Foo {
+  constructor() {
+    _privateMethod.add(this);
 
-  babelHelpers.classCallCheck(this, Foo);
+    this.publicField = babelHelpers.classPrivateMethodGet(this, _privateMethod, _privateMethod2).call(this);
+  }
 
-  _privateMethod.add(this);
-
-  this.publicField = babelHelpers.classPrivateMethodGet(this, _privateMethod, _privateMethod2).call(this);
-};
+}
 
 var _privateMethod = new WeakSet();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/before-fields/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/before-fields/output.js
@@ -1,11 +1,5 @@
-var Cl =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Cl() {
-    babelHelpers.classCallCheck(this, Cl);
-
+class Cl {
+  constructor() {
     _method.add(this);
 
     babelHelpers.defineProperty(this, "prop", babelHelpers.classPrivateMethodGet(this, _method, _method2).call(this, 1));
@@ -16,14 +10,11 @@ function () {
     });
   }
 
-  babelHelpers.createClass(Cl, [{
-    key: "getPriv",
-    value: function getPriv() {
-      return babelHelpers.classPrivateFieldGet(this, _priv);
-    }
-  }]);
-  return Cl;
-}();
+  getPriv() {
+    return babelHelpers.classPrivateFieldGet(this, _priv);
+  }
+
+}
 
 var _priv = new WeakMap();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/context/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/context/output.js
@@ -1,47 +1,35 @@
-var Foo =
-/*#__PURE__*/
-function () {
-  "use strict";
-
-  function Foo(status) {
-    babelHelpers.classCallCheck(this, Foo);
-
+class Foo {
+  constructor(status) {
     _getStatus.add(this);
 
     this.status = status;
   }
 
-  babelHelpers.createClass(Foo, [{
-    key: "getCurrentStatus",
-    value: function getCurrentStatus() {
-      return babelHelpers.classPrivateMethodGet(this, _getStatus, _getStatus2).call(this);
-    }
-  }, {
-    key: "setCurrentStatus",
-    value: function setCurrentStatus(newStatus) {
-      this.status = newStatus;
-    }
-  }, {
-    key: "getFakeStatus",
-    value: function getFakeStatus(fakeStatus) {
-      var fakeGetStatus = babelHelpers.classPrivateMethodGet(this, _getStatus, _getStatus2);
-      return function () {
-        return fakeGetStatus.call({
-          status: fakeStatus
-        });
-      };
-    }
-  }, {
-    key: "getFakeStatusFunc",
-    value: function getFakeStatusFunc() {
-      return {
-        status: 'fake-status',
-        getFakeStatus: babelHelpers.classPrivateMethodGet(this, _getStatus, _getStatus2)
-      };
-    }
-  }]);
-  return Foo;
-}();
+  getCurrentStatus() {
+    return babelHelpers.classPrivateMethodGet(this, _getStatus, _getStatus2).call(this);
+  }
+
+  setCurrentStatus(newStatus) {
+    this.status = newStatus;
+  }
+
+  getFakeStatus(fakeStatus) {
+    var fakeGetStatus = babelHelpers.classPrivateMethodGet(this, _getStatus, _getStatus2);
+    return function () {
+      return fakeGetStatus.call({
+        status: fakeStatus
+      });
+    };
+  }
+
+  getFakeStatusFunc() {
+    return {
+      status: 'fake-status',
+      getFakeStatus: babelHelpers.classPrivateMethodGet(this, _getStatus, _getStatus2)
+    };
+  }
+
+}
 
 var _getStatus = new WeakSet();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/exfiltrated/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/exfiltrated/output.js
@@ -1,16 +1,15 @@
 var exfiltrated;
 
-var Foo = function Foo() {
-  "use strict";
+class Foo {
+  constructor() {
+    _privateMethod.add(this);
 
-  babelHelpers.classCallCheck(this, Foo);
-
-  _privateMethod.add(this);
-
-  if (exfiltrated === undefined) {
-    exfiltrated = babelHelpers.classPrivateMethodGet(this, _privateMethod, _privateMethod2);
+    if (exfiltrated === undefined) {
+      exfiltrated = babelHelpers.classPrivateMethodGet(this, _privateMethod, _privateMethod2);
+    }
   }
-};
+
+}
 
 var _privateMethod = new WeakSet();
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/options.json
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/options.json
@@ -8,7 +8,6 @@
     ],
     "proposal-private-methods",
     "proposal-class-properties",
-    "transform-classes",
     "transform-block-scoping",
     "syntax-class-properties"
   ]


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | (just changes test output)
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

## Changes

Removes `transform-classes` plugin from class private methods tests. This makes the changes from the `babel-plugin-proposal-private-methods` package easier to read.

cc: @nicolo-ribaudo 
