### PR TITLE
babel-types is* type checks accept null | undefiend as value TS type

### DIFF
--- a/packages/babel-types/scripts/generators/flow.js
+++ b/packages/babel-types/scripts/generators/flow.js
@@ -105,7 +105,7 @@ for (const type in t.NODE_FIELDS) {
 for (let i = 0; i < t.TYPES.length; i++) {
   let decl = `declare function is${
     t.TYPES[i]
-  }(node: Object, opts?: ?Object): boolean`;
+  }(node: ?Object, opts?: ?Object): boolean`;
 
   if (t.NODE_FIELDS[t.TYPES[i]]) {
     decl += ` %checks (node instanceof ${NODE_PREFIX}${t.TYPES[i]})`;

--- a/packages/babel-types/scripts/generators/generateValidators.js
+++ b/packages/babel-types/scripts/generators/generateValidators.js
@@ -11,7 +11,7 @@ function addIsHelper(type, aliasKeys, deprecated) {
       " === nodeType";
   }
 
-  return `export function is${type}(node: Object, opts?: Object): boolean {
+  return `export function is${type}(node: ?Object, opts?: Object): boolean {
     ${deprecated || ""}
     if (!node) return false;
 

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -106,7 +106,7 @@ for (const type in t.NODE_FIELDS) {
 for (let i = 0; i < t.TYPES.length; i++) {
   let decl = `export function is${
     t.TYPES[i]
-  }(node: any, opts?: object | null): `;
+  }(node: object | null | undefined, opts?: object | null): `;
 
   if (t.NODE_FIELDS[t.TYPES[i]]) {
     decl += `node is ${t.TYPES[i]};`;

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -106,7 +106,7 @@ for (const type in t.NODE_FIELDS) {
 for (let i = 0; i < t.TYPES.length; i++) {
   let decl = `export function is${
     t.TYPES[i]
-  }(node: object, opts?: object | null): `;
+  }(node: any, opts?: object | null): `;
 
   if (t.NODE_FIELDS[t.TYPES[i]]) {
     decl += `node is ${t.TYPES[i]};`;

--- a/packages/babel-types/src/validators/generated/index.js
+++ b/packages/babel-types/src/validators/generated/index.js
@@ -5,7 +5,7 @@
  */
 import shallowEqual from "../../utils/shallowEqual";
 
-export function isArrayExpression(node: Object, opts?: Object): boolean {
+export function isArrayExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -19,7 +19,7 @@ export function isArrayExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isAssignmentExpression(node: Object, opts?: Object): boolean {
+export function isAssignmentExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -33,7 +33,7 @@ export function isAssignmentExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBinaryExpression(node: Object, opts?: Object): boolean {
+export function isBinaryExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -47,7 +47,7 @@ export function isBinaryExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isInterpreterDirective(node: Object, opts?: Object): boolean {
+export function isInterpreterDirective(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -61,7 +61,7 @@ export function isInterpreterDirective(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDirective(node: Object, opts?: Object): boolean {
+export function isDirective(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -75,7 +75,7 @@ export function isDirective(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDirectiveLiteral(node: Object, opts?: Object): boolean {
+export function isDirectiveLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -89,7 +89,7 @@ export function isDirectiveLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBlockStatement(node: Object, opts?: Object): boolean {
+export function isBlockStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -103,7 +103,7 @@ export function isBlockStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBreakStatement(node: Object, opts?: Object): boolean {
+export function isBreakStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -117,7 +117,7 @@ export function isBreakStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isCallExpression(node: Object, opts?: Object): boolean {
+export function isCallExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -131,7 +131,7 @@ export function isCallExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isCatchClause(node: Object, opts?: Object): boolean {
+export function isCatchClause(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -145,7 +145,7 @@ export function isCatchClause(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isConditionalExpression(node: Object, opts?: Object): boolean {
+export function isConditionalExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -159,7 +159,7 @@ export function isConditionalExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isContinueStatement(node: Object, opts?: Object): boolean {
+export function isContinueStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -173,7 +173,7 @@ export function isContinueStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDebuggerStatement(node: Object, opts?: Object): boolean {
+export function isDebuggerStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -187,7 +187,7 @@ export function isDebuggerStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDoWhileStatement(node: Object, opts?: Object): boolean {
+export function isDoWhileStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -201,7 +201,7 @@ export function isDoWhileStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isEmptyStatement(node: Object, opts?: Object): boolean {
+export function isEmptyStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -215,7 +215,7 @@ export function isEmptyStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExpressionStatement(node: Object, opts?: Object): boolean {
+export function isExpressionStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -229,7 +229,7 @@ export function isExpressionStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFile(node: Object, opts?: Object): boolean {
+export function isFile(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -243,7 +243,7 @@ export function isFile(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isForInStatement(node: Object, opts?: Object): boolean {
+export function isForInStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -257,7 +257,7 @@ export function isForInStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isForStatement(node: Object, opts?: Object): boolean {
+export function isForStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -271,7 +271,7 @@ export function isForStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFunctionDeclaration(node: Object, opts?: Object): boolean {
+export function isFunctionDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -285,7 +285,7 @@ export function isFunctionDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFunctionExpression(node: Object, opts?: Object): boolean {
+export function isFunctionExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -299,7 +299,7 @@ export function isFunctionExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isIdentifier(node: Object, opts?: Object): boolean {
+export function isIdentifier(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -313,7 +313,7 @@ export function isIdentifier(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isIfStatement(node: Object, opts?: Object): boolean {
+export function isIfStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -327,7 +327,7 @@ export function isIfStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isLabeledStatement(node: Object, opts?: Object): boolean {
+export function isLabeledStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -341,7 +341,7 @@ export function isLabeledStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isStringLiteral(node: Object, opts?: Object): boolean {
+export function isStringLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -355,7 +355,7 @@ export function isStringLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isNumericLiteral(node: Object, opts?: Object): boolean {
+export function isNumericLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -369,7 +369,7 @@ export function isNumericLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isNullLiteral(node: Object, opts?: Object): boolean {
+export function isNullLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -383,7 +383,7 @@ export function isNullLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBooleanLiteral(node: Object, opts?: Object): boolean {
+export function isBooleanLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -397,7 +397,7 @@ export function isBooleanLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isRegExpLiteral(node: Object, opts?: Object): boolean {
+export function isRegExpLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -411,7 +411,7 @@ export function isRegExpLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isLogicalExpression(node: Object, opts?: Object): boolean {
+export function isLogicalExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -425,7 +425,7 @@ export function isLogicalExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isMemberExpression(node: Object, opts?: Object): boolean {
+export function isMemberExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -439,7 +439,7 @@ export function isMemberExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isNewExpression(node: Object, opts?: Object): boolean {
+export function isNewExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -453,7 +453,7 @@ export function isNewExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isProgram(node: Object, opts?: Object): boolean {
+export function isProgram(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -467,7 +467,7 @@ export function isProgram(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectExpression(node: Object, opts?: Object): boolean {
+export function isObjectExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -481,7 +481,7 @@ export function isObjectExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectMethod(node: Object, opts?: Object): boolean {
+export function isObjectMethod(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -495,7 +495,7 @@ export function isObjectMethod(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectProperty(node: Object, opts?: Object): boolean {
+export function isObjectProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -509,7 +509,7 @@ export function isObjectProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isRestElement(node: Object, opts?: Object): boolean {
+export function isRestElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -523,7 +523,7 @@ export function isRestElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isReturnStatement(node: Object, opts?: Object): boolean {
+export function isReturnStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -537,7 +537,7 @@ export function isReturnStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isSequenceExpression(node: Object, opts?: Object): boolean {
+export function isSequenceExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -551,7 +551,7 @@ export function isSequenceExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isSwitchCase(node: Object, opts?: Object): boolean {
+export function isSwitchCase(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -565,7 +565,7 @@ export function isSwitchCase(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isSwitchStatement(node: Object, opts?: Object): boolean {
+export function isSwitchStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -579,7 +579,7 @@ export function isSwitchStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isThisExpression(node: Object, opts?: Object): boolean {
+export function isThisExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -593,7 +593,7 @@ export function isThisExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isThrowStatement(node: Object, opts?: Object): boolean {
+export function isThrowStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -607,7 +607,7 @@ export function isThrowStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTryStatement(node: Object, opts?: Object): boolean {
+export function isTryStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -621,7 +621,7 @@ export function isTryStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isUnaryExpression(node: Object, opts?: Object): boolean {
+export function isUnaryExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -635,7 +635,7 @@ export function isUnaryExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isUpdateExpression(node: Object, opts?: Object): boolean {
+export function isUpdateExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -649,7 +649,7 @@ export function isUpdateExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isVariableDeclaration(node: Object, opts?: Object): boolean {
+export function isVariableDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -663,7 +663,7 @@ export function isVariableDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isVariableDeclarator(node: Object, opts?: Object): boolean {
+export function isVariableDeclarator(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -677,7 +677,7 @@ export function isVariableDeclarator(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isWhileStatement(node: Object, opts?: Object): boolean {
+export function isWhileStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -691,7 +691,7 @@ export function isWhileStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isWithStatement(node: Object, opts?: Object): boolean {
+export function isWithStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -705,7 +705,7 @@ export function isWithStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isAssignmentPattern(node: Object, opts?: Object): boolean {
+export function isAssignmentPattern(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -719,7 +719,7 @@ export function isAssignmentPattern(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isArrayPattern(node: Object, opts?: Object): boolean {
+export function isArrayPattern(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -734,7 +734,7 @@ export function isArrayPattern(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isArrowFunctionExpression(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -750,7 +750,7 @@ export function isArrowFunctionExpression(
 
   return false;
 }
-export function isClassBody(node: Object, opts?: Object): boolean {
+export function isClassBody(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -764,7 +764,7 @@ export function isClassBody(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClassDeclaration(node: Object, opts?: Object): boolean {
+export function isClassDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -778,7 +778,7 @@ export function isClassDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClassExpression(node: Object, opts?: Object): boolean {
+export function isClassExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -792,7 +792,7 @@ export function isClassExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExportAllDeclaration(node: Object, opts?: Object): boolean {
+export function isExportAllDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -807,7 +807,7 @@ export function isExportAllDeclaration(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isExportDefaultDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -823,7 +823,10 @@ export function isExportDefaultDeclaration(
 
   return false;
 }
-export function isExportNamedDeclaration(node: Object, opts?: Object): boolean {
+export function isExportNamedDeclaration(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -837,7 +840,7 @@ export function isExportNamedDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExportSpecifier(node: Object, opts?: Object): boolean {
+export function isExportSpecifier(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -851,7 +854,7 @@ export function isExportSpecifier(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isForOfStatement(node: Object, opts?: Object): boolean {
+export function isForOfStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -865,7 +868,7 @@ export function isForOfStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isImportDeclaration(node: Object, opts?: Object): boolean {
+export function isImportDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -879,7 +882,10 @@ export function isImportDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isImportDefaultSpecifier(node: Object, opts?: Object): boolean {
+export function isImportDefaultSpecifier(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -894,7 +900,7 @@ export function isImportDefaultSpecifier(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isImportNamespaceSpecifier(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -910,7 +916,7 @@ export function isImportNamespaceSpecifier(
 
   return false;
 }
-export function isImportSpecifier(node: Object, opts?: Object): boolean {
+export function isImportSpecifier(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -924,7 +930,7 @@ export function isImportSpecifier(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isMetaProperty(node: Object, opts?: Object): boolean {
+export function isMetaProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -938,7 +944,7 @@ export function isMetaProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClassMethod(node: Object, opts?: Object): boolean {
+export function isClassMethod(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -952,7 +958,7 @@ export function isClassMethod(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectPattern(node: Object, opts?: Object): boolean {
+export function isObjectPattern(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -966,7 +972,7 @@ export function isObjectPattern(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isSpreadElement(node: Object, opts?: Object): boolean {
+export function isSpreadElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -980,7 +986,7 @@ export function isSpreadElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isSuper(node: Object, opts?: Object): boolean {
+export function isSuper(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -995,7 +1001,7 @@ export function isSuper(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTaggedTemplateExpression(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1011,7 +1017,7 @@ export function isTaggedTemplateExpression(
 
   return false;
 }
-export function isTemplateElement(node: Object, opts?: Object): boolean {
+export function isTemplateElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1025,7 +1031,7 @@ export function isTemplateElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTemplateLiteral(node: Object, opts?: Object): boolean {
+export function isTemplateLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1039,7 +1045,7 @@ export function isTemplateLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isYieldExpression(node: Object, opts?: Object): boolean {
+export function isYieldExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1053,7 +1059,7 @@ export function isYieldExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isAnyTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isAnyTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1067,7 +1073,7 @@ export function isAnyTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isArrayTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isArrayTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1081,7 +1087,7 @@ export function isArrayTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBooleanTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isBooleanTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1096,7 +1102,7 @@ export function isBooleanTypeAnnotation(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isBooleanLiteralTypeAnnotation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1113,7 +1119,7 @@ export function isBooleanLiteralTypeAnnotation(
   return false;
 }
 export function isNullLiteralTypeAnnotation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1129,7 +1135,7 @@ export function isNullLiteralTypeAnnotation(
 
   return false;
 }
-export function isClassImplements(node: Object, opts?: Object): boolean {
+export function isClassImplements(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1143,7 +1149,7 @@ export function isClassImplements(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareClass(node: Object, opts?: Object): boolean {
+export function isDeclareClass(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1157,7 +1163,7 @@ export function isDeclareClass(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareFunction(node: Object, opts?: Object): boolean {
+export function isDeclareFunction(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1171,7 +1177,7 @@ export function isDeclareFunction(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareInterface(node: Object, opts?: Object): boolean {
+export function isDeclareInterface(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1185,7 +1191,7 @@ export function isDeclareInterface(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareModule(node: Object, opts?: Object): boolean {
+export function isDeclareModule(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1199,7 +1205,7 @@ export function isDeclareModule(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareModuleExports(node: Object, opts?: Object): boolean {
+export function isDeclareModuleExports(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1213,7 +1219,7 @@ export function isDeclareModuleExports(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareTypeAlias(node: Object, opts?: Object): boolean {
+export function isDeclareTypeAlias(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1227,7 +1233,7 @@ export function isDeclareTypeAlias(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareOpaqueType(node: Object, opts?: Object): boolean {
+export function isDeclareOpaqueType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1241,7 +1247,7 @@ export function isDeclareOpaqueType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclareVariable(node: Object, opts?: Object): boolean {
+export function isDeclareVariable(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1256,7 +1262,7 @@ export function isDeclareVariable(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isDeclareExportDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1273,7 +1279,7 @@ export function isDeclareExportDeclaration(
   return false;
 }
 export function isDeclareExportAllDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1289,7 +1295,7 @@ export function isDeclareExportAllDeclaration(
 
   return false;
 }
-export function isDeclaredPredicate(node: Object, opts?: Object): boolean {
+export function isDeclaredPredicate(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1303,7 +1309,7 @@ export function isDeclaredPredicate(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExistsTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isExistsTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1317,7 +1323,10 @@ export function isExistsTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFunctionTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isFunctionTypeAnnotation(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1331,7 +1340,7 @@ export function isFunctionTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFunctionTypeParam(node: Object, opts?: Object): boolean {
+export function isFunctionTypeParam(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1345,7 +1354,7 @@ export function isFunctionTypeParam(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isGenericTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isGenericTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1359,7 +1368,7 @@ export function isGenericTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isInferredPredicate(node: Object, opts?: Object): boolean {
+export function isInferredPredicate(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1373,7 +1382,7 @@ export function isInferredPredicate(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isInterfaceExtends(node: Object, opts?: Object): boolean {
+export function isInterfaceExtends(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1387,7 +1396,7 @@ export function isInterfaceExtends(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isInterfaceDeclaration(node: Object, opts?: Object): boolean {
+export function isInterfaceDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1402,7 +1411,7 @@ export function isInterfaceDeclaration(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isInterfaceTypeAnnotation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1419,7 +1428,7 @@ export function isInterfaceTypeAnnotation(
   return false;
 }
 export function isIntersectionTypeAnnotation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1435,7 +1444,7 @@ export function isIntersectionTypeAnnotation(
 
   return false;
 }
-export function isMixedTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isMixedTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1449,7 +1458,7 @@ export function isMixedTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isEmptyTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isEmptyTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1463,7 +1472,10 @@ export function isEmptyTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isNullableTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isNullableTypeAnnotation(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1478,7 +1490,7 @@ export function isNullableTypeAnnotation(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isNumberLiteralTypeAnnotation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1494,7 +1506,7 @@ export function isNumberLiteralTypeAnnotation(
 
   return false;
 }
-export function isNumberTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isNumberTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1508,7 +1520,7 @@ export function isNumberTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isObjectTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1522,7 +1534,10 @@ export function isObjectTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectTypeInternalSlot(node: Object, opts?: Object): boolean {
+export function isObjectTypeInternalSlot(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1536,7 +1551,10 @@ export function isObjectTypeInternalSlot(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectTypeCallProperty(node: Object, opts?: Object): boolean {
+export function isObjectTypeCallProperty(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1550,7 +1568,7 @@ export function isObjectTypeCallProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectTypeIndexer(node: Object, opts?: Object): boolean {
+export function isObjectTypeIndexer(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1564,7 +1582,7 @@ export function isObjectTypeIndexer(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectTypeProperty(node: Object, opts?: Object): boolean {
+export function isObjectTypeProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1579,7 +1597,7 @@ export function isObjectTypeProperty(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isObjectTypeSpreadProperty(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1595,7 +1613,7 @@ export function isObjectTypeSpreadProperty(
 
   return false;
 }
-export function isOpaqueType(node: Object, opts?: Object): boolean {
+export function isOpaqueType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1610,7 +1628,7 @@ export function isOpaqueType(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isQualifiedTypeIdentifier(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1627,7 +1645,7 @@ export function isQualifiedTypeIdentifier(
   return false;
 }
 export function isStringLiteralTypeAnnotation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1643,7 +1661,7 @@ export function isStringLiteralTypeAnnotation(
 
   return false;
 }
-export function isStringTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isStringTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1657,7 +1675,7 @@ export function isStringTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isThisTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isThisTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1671,7 +1689,7 @@ export function isThisTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTupleTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isTupleTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1685,7 +1703,7 @@ export function isTupleTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTypeofTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isTypeofTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1699,7 +1717,7 @@ export function isTypeofTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTypeAlias(node: Object, opts?: Object): boolean {
+export function isTypeAlias(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1713,7 +1731,7 @@ export function isTypeAlias(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1727,7 +1745,7 @@ export function isTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTypeCastExpression(node: Object, opts?: Object): boolean {
+export function isTypeCastExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1741,7 +1759,7 @@ export function isTypeCastExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTypeParameter(node: Object, opts?: Object): boolean {
+export function isTypeParameter(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1756,7 +1774,7 @@ export function isTypeParameter(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTypeParameterDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1773,7 +1791,7 @@ export function isTypeParameterDeclaration(
   return false;
 }
 export function isTypeParameterInstantiation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -1789,7 +1807,7 @@ export function isTypeParameterInstantiation(
 
   return false;
 }
-export function isUnionTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isUnionTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1803,7 +1821,7 @@ export function isUnionTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isVariance(node: Object, opts?: Object): boolean {
+export function isVariance(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1817,7 +1835,7 @@ export function isVariance(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isVoidTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isVoidTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1831,7 +1849,7 @@ export function isVoidTypeAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXAttribute(node: Object, opts?: Object): boolean {
+export function isJSXAttribute(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1845,7 +1863,7 @@ export function isJSXAttribute(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXClosingElement(node: Object, opts?: Object): boolean {
+export function isJSXClosingElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1859,7 +1877,7 @@ export function isJSXClosingElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXElement(node: Object, opts?: Object): boolean {
+export function isJSXElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1873,7 +1891,7 @@ export function isJSXElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXEmptyExpression(node: Object, opts?: Object): boolean {
+export function isJSXEmptyExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1887,7 +1905,10 @@ export function isJSXEmptyExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXExpressionContainer(node: Object, opts?: Object): boolean {
+export function isJSXExpressionContainer(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1901,7 +1922,7 @@ export function isJSXExpressionContainer(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXSpreadChild(node: Object, opts?: Object): boolean {
+export function isJSXSpreadChild(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1915,7 +1936,7 @@ export function isJSXSpreadChild(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXIdentifier(node: Object, opts?: Object): boolean {
+export function isJSXIdentifier(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1929,7 +1950,7 @@ export function isJSXIdentifier(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXMemberExpression(node: Object, opts?: Object): boolean {
+export function isJSXMemberExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1943,7 +1964,7 @@ export function isJSXMemberExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXNamespacedName(node: Object, opts?: Object): boolean {
+export function isJSXNamespacedName(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1957,7 +1978,7 @@ export function isJSXNamespacedName(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXOpeningElement(node: Object, opts?: Object): boolean {
+export function isJSXOpeningElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1971,7 +1992,7 @@ export function isJSXOpeningElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXSpreadAttribute(node: Object, opts?: Object): boolean {
+export function isJSXSpreadAttribute(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1985,7 +2006,7 @@ export function isJSXSpreadAttribute(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXText(node: Object, opts?: Object): boolean {
+export function isJSXText(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -1999,7 +2020,7 @@ export function isJSXText(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXFragment(node: Object, opts?: Object): boolean {
+export function isJSXFragment(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2013,7 +2034,7 @@ export function isJSXFragment(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXOpeningFragment(node: Object, opts?: Object): boolean {
+export function isJSXOpeningFragment(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2027,7 +2048,7 @@ export function isJSXOpeningFragment(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSXClosingFragment(node: Object, opts?: Object): boolean {
+export function isJSXClosingFragment(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2041,7 +2062,7 @@ export function isJSXClosingFragment(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isNoop(node: Object, opts?: Object): boolean {
+export function isNoop(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2056,7 +2077,7 @@ export function isNoop(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isParenthesizedExpression(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2072,7 +2093,7 @@ export function isParenthesizedExpression(
 
   return false;
 }
-export function isAwaitExpression(node: Object, opts?: Object): boolean {
+export function isAwaitExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2086,7 +2107,7 @@ export function isAwaitExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBindExpression(node: Object, opts?: Object): boolean {
+export function isBindExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2100,7 +2121,7 @@ export function isBindExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClassProperty(node: Object, opts?: Object): boolean {
+export function isClassProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2115,7 +2136,7 @@ export function isClassProperty(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isOptionalMemberExpression(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2132,7 +2153,7 @@ export function isOptionalMemberExpression(
   return false;
 }
 export function isPipelineTopicExpression(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2148,7 +2169,7 @@ export function isPipelineTopicExpression(
 
   return false;
 }
-export function isPipelineBareFunction(node: Object, opts?: Object): boolean {
+export function isPipelineBareFunction(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2163,7 +2184,7 @@ export function isPipelineBareFunction(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isPipelinePrimaryTopicReference(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2179,7 +2200,10 @@ export function isPipelinePrimaryTopicReference(
 
   return false;
 }
-export function isOptionalCallExpression(node: Object, opts?: Object): boolean {
+export function isOptionalCallExpression(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2193,7 +2217,7 @@ export function isOptionalCallExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClassPrivateProperty(node: Object, opts?: Object): boolean {
+export function isClassPrivateProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2207,7 +2231,7 @@ export function isClassPrivateProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClassPrivateMethod(node: Object, opts?: Object): boolean {
+export function isClassPrivateMethod(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2221,7 +2245,7 @@ export function isClassPrivateMethod(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isImport(node: Object, opts?: Object): boolean {
+export function isImport(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2235,7 +2259,7 @@ export function isImport(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDecorator(node: Object, opts?: Object): boolean {
+export function isDecorator(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2249,7 +2273,7 @@ export function isDecorator(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDoExpression(node: Object, opts?: Object): boolean {
+export function isDoExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2263,7 +2287,10 @@ export function isDoExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExportDefaultSpecifier(node: Object, opts?: Object): boolean {
+export function isExportDefaultSpecifier(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2278,7 +2305,7 @@ export function isExportDefaultSpecifier(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isExportNamespaceSpecifier(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2294,7 +2321,7 @@ export function isExportNamespaceSpecifier(
 
   return false;
 }
-export function isPrivateName(node: Object, opts?: Object): boolean {
+export function isPrivateName(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2308,7 +2335,7 @@ export function isPrivateName(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBigIntLiteral(node: Object, opts?: Object): boolean {
+export function isBigIntLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2322,7 +2349,7 @@ export function isBigIntLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSParameterProperty(node: Object, opts?: Object): boolean {
+export function isTSParameterProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2336,7 +2363,7 @@ export function isTSParameterProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSDeclareFunction(node: Object, opts?: Object): boolean {
+export function isTSDeclareFunction(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2350,7 +2377,7 @@ export function isTSDeclareFunction(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSDeclareMethod(node: Object, opts?: Object): boolean {
+export function isTSDeclareMethod(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2364,7 +2391,7 @@ export function isTSDeclareMethod(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSQualifiedName(node: Object, opts?: Object): boolean {
+export function isTSQualifiedName(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2379,7 +2406,7 @@ export function isTSQualifiedName(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTSCallSignatureDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2396,7 +2423,7 @@ export function isTSCallSignatureDeclaration(
   return false;
 }
 export function isTSConstructSignatureDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2412,7 +2439,7 @@ export function isTSConstructSignatureDeclaration(
 
   return false;
 }
-export function isTSPropertySignature(node: Object, opts?: Object): boolean {
+export function isTSPropertySignature(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2426,7 +2453,7 @@ export function isTSPropertySignature(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSMethodSignature(node: Object, opts?: Object): boolean {
+export function isTSMethodSignature(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2440,7 +2467,7 @@ export function isTSMethodSignature(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSIndexSignature(node: Object, opts?: Object): boolean {
+export function isTSIndexSignature(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2454,7 +2481,7 @@ export function isTSIndexSignature(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSAnyKeyword(node: Object, opts?: Object): boolean {
+export function isTSAnyKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2468,7 +2495,7 @@ export function isTSAnyKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSUnknownKeyword(node: Object, opts?: Object): boolean {
+export function isTSUnknownKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2482,7 +2509,7 @@ export function isTSUnknownKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSNumberKeyword(node: Object, opts?: Object): boolean {
+export function isTSNumberKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2496,7 +2523,7 @@ export function isTSNumberKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSObjectKeyword(node: Object, opts?: Object): boolean {
+export function isTSObjectKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2510,7 +2537,7 @@ export function isTSObjectKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSBooleanKeyword(node: Object, opts?: Object): boolean {
+export function isTSBooleanKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2524,7 +2551,7 @@ export function isTSBooleanKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSStringKeyword(node: Object, opts?: Object): boolean {
+export function isTSStringKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2538,7 +2565,7 @@ export function isTSStringKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSSymbolKeyword(node: Object, opts?: Object): boolean {
+export function isTSSymbolKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2552,7 +2579,7 @@ export function isTSSymbolKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSVoidKeyword(node: Object, opts?: Object): boolean {
+export function isTSVoidKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2566,7 +2593,7 @@ export function isTSVoidKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSUndefinedKeyword(node: Object, opts?: Object): boolean {
+export function isTSUndefinedKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2580,7 +2607,7 @@ export function isTSUndefinedKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSNullKeyword(node: Object, opts?: Object): boolean {
+export function isTSNullKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2594,7 +2621,7 @@ export function isTSNullKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSNeverKeyword(node: Object, opts?: Object): boolean {
+export function isTSNeverKeyword(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2608,7 +2635,7 @@ export function isTSNeverKeyword(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSThisType(node: Object, opts?: Object): boolean {
+export function isTSThisType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2622,7 +2649,7 @@ export function isTSThisType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSFunctionType(node: Object, opts?: Object): boolean {
+export function isTSFunctionType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2636,7 +2663,7 @@ export function isTSFunctionType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSConstructorType(node: Object, opts?: Object): boolean {
+export function isTSConstructorType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2650,7 +2677,7 @@ export function isTSConstructorType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeReference(node: Object, opts?: Object): boolean {
+export function isTSTypeReference(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2664,7 +2691,7 @@ export function isTSTypeReference(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypePredicate(node: Object, opts?: Object): boolean {
+export function isTSTypePredicate(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2678,7 +2705,7 @@ export function isTSTypePredicate(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeQuery(node: Object, opts?: Object): boolean {
+export function isTSTypeQuery(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2692,7 +2719,7 @@ export function isTSTypeQuery(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeLiteral(node: Object, opts?: Object): boolean {
+export function isTSTypeLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2706,7 +2733,7 @@ export function isTSTypeLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSArrayType(node: Object, opts?: Object): boolean {
+export function isTSArrayType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2720,7 +2747,7 @@ export function isTSArrayType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTupleType(node: Object, opts?: Object): boolean {
+export function isTSTupleType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2734,7 +2761,7 @@ export function isTSTupleType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSOptionalType(node: Object, opts?: Object): boolean {
+export function isTSOptionalType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2748,7 +2775,7 @@ export function isTSOptionalType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSRestType(node: Object, opts?: Object): boolean {
+export function isTSRestType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2762,7 +2789,7 @@ export function isTSRestType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSUnionType(node: Object, opts?: Object): boolean {
+export function isTSUnionType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2776,7 +2803,7 @@ export function isTSUnionType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSIntersectionType(node: Object, opts?: Object): boolean {
+export function isTSIntersectionType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2790,7 +2817,7 @@ export function isTSIntersectionType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSConditionalType(node: Object, opts?: Object): boolean {
+export function isTSConditionalType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2804,7 +2831,7 @@ export function isTSConditionalType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSInferType(node: Object, opts?: Object): boolean {
+export function isTSInferType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2818,7 +2845,7 @@ export function isTSInferType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSParenthesizedType(node: Object, opts?: Object): boolean {
+export function isTSParenthesizedType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2832,7 +2859,7 @@ export function isTSParenthesizedType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeOperator(node: Object, opts?: Object): boolean {
+export function isTSTypeOperator(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2846,7 +2873,7 @@ export function isTSTypeOperator(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSIndexedAccessType(node: Object, opts?: Object): boolean {
+export function isTSIndexedAccessType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2860,7 +2887,7 @@ export function isTSIndexedAccessType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSMappedType(node: Object, opts?: Object): boolean {
+export function isTSMappedType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2874,7 +2901,7 @@ export function isTSMappedType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSLiteralType(node: Object, opts?: Object): boolean {
+export function isTSLiteralType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2889,7 +2916,7 @@ export function isTSLiteralType(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTSExpressionWithTypeArguments(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -2905,7 +2932,10 @@ export function isTSExpressionWithTypeArguments(
 
   return false;
 }
-export function isTSInterfaceDeclaration(node: Object, opts?: Object): boolean {
+export function isTSInterfaceDeclaration(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2919,7 +2949,7 @@ export function isTSInterfaceDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSInterfaceBody(node: Object, opts?: Object): boolean {
+export function isTSInterfaceBody(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2933,7 +2963,10 @@ export function isTSInterfaceBody(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeAliasDeclaration(node: Object, opts?: Object): boolean {
+export function isTSTypeAliasDeclaration(
+  node: ?Object,
+  opts?: Object,
+): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2947,7 +2980,7 @@ export function isTSTypeAliasDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSAsExpression(node: Object, opts?: Object): boolean {
+export function isTSAsExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2961,7 +2994,7 @@ export function isTSAsExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeAssertion(node: Object, opts?: Object): boolean {
+export function isTSTypeAssertion(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2975,7 +3008,7 @@ export function isTSTypeAssertion(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSEnumDeclaration(node: Object, opts?: Object): boolean {
+export function isTSEnumDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -2989,7 +3022,7 @@ export function isTSEnumDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSEnumMember(node: Object, opts?: Object): boolean {
+export function isTSEnumMember(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3003,7 +3036,7 @@ export function isTSEnumMember(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSModuleDeclaration(node: Object, opts?: Object): boolean {
+export function isTSModuleDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3017,7 +3050,7 @@ export function isTSModuleDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSModuleBlock(node: Object, opts?: Object): boolean {
+export function isTSModuleBlock(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3031,7 +3064,7 @@ export function isTSModuleBlock(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSImportType(node: Object, opts?: Object): boolean {
+export function isTSImportType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3046,7 +3079,7 @@ export function isTSImportType(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTSImportEqualsDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -3063,7 +3096,7 @@ export function isTSImportEqualsDeclaration(
   return false;
 }
 export function isTSExternalModuleReference(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -3079,7 +3112,7 @@ export function isTSExternalModuleReference(
 
   return false;
 }
-export function isTSNonNullExpression(node: Object, opts?: Object): boolean {
+export function isTSNonNullExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3093,7 +3126,7 @@ export function isTSNonNullExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSExportAssignment(node: Object, opts?: Object): boolean {
+export function isTSExportAssignment(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3108,7 +3141,7 @@ export function isTSExportAssignment(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTSNamespaceExportDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -3124,7 +3157,7 @@ export function isTSNamespaceExportDeclaration(
 
   return false;
 }
-export function isTSTypeAnnotation(node: Object, opts?: Object): boolean {
+export function isTSTypeAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3139,7 +3172,7 @@ export function isTSTypeAnnotation(node: Object, opts?: Object): boolean {
   return false;
 }
 export function isTSTypeParameterInstantiation(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -3156,7 +3189,7 @@ export function isTSTypeParameterInstantiation(
   return false;
 }
 export function isTSTypeParameterDeclaration(
-  node: Object,
+  node: ?Object,
   opts?: Object,
 ): boolean {
   if (!node) return false;
@@ -3172,7 +3205,7 @@ export function isTSTypeParameterDeclaration(
 
   return false;
 }
-export function isTSTypeParameter(node: Object, opts?: Object): boolean {
+export function isTSTypeParameter(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3186,7 +3219,7 @@ export function isTSTypeParameter(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExpression(node: Object, opts?: Object): boolean {
+export function isExpression(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3244,7 +3277,7 @@ export function isExpression(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBinary(node: Object, opts?: Object): boolean {
+export function isBinary(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3262,7 +3295,7 @@ export function isBinary(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isScopable(node: Object, opts?: Object): boolean {
+export function isScopable(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3295,7 +3328,7 @@ export function isScopable(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBlockParent(node: Object, opts?: Object): boolean {
+export function isBlockParent(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3326,7 +3359,7 @@ export function isBlockParent(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isBlock(node: Object, opts?: Object): boolean {
+export function isBlock(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3344,7 +3377,7 @@ export function isBlock(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isStatement(node: Object, opts?: Object): boolean {
+export function isStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3406,7 +3439,7 @@ export function isStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTerminatorless(node: Object, opts?: Object): boolean {
+export function isTerminatorless(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3428,7 +3461,7 @@ export function isTerminatorless(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isCompletionStatement(node: Object, opts?: Object): boolean {
+export function isCompletionStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3448,7 +3481,7 @@ export function isCompletionStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isConditional(node: Object, opts?: Object): boolean {
+export function isConditional(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3466,7 +3499,7 @@ export function isConditional(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isLoop(node: Object, opts?: Object): boolean {
+export function isLoop(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3487,7 +3520,7 @@ export function isLoop(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isWhile(node: Object, opts?: Object): boolean {
+export function isWhile(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3505,7 +3538,7 @@ export function isWhile(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExpressionWrapper(node: Object, opts?: Object): boolean {
+export function isExpressionWrapper(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3524,7 +3557,7 @@ export function isExpressionWrapper(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFor(node: Object, opts?: Object): boolean {
+export function isFor(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3543,7 +3576,7 @@ export function isFor(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isForXStatement(node: Object, opts?: Object): boolean {
+export function isForXStatement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3561,7 +3594,7 @@ export function isForXStatement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFunction(node: Object, opts?: Object): boolean {
+export function isFunction(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3583,7 +3616,7 @@ export function isFunction(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFunctionParent(node: Object, opts?: Object): boolean {
+export function isFunctionParent(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3605,7 +3638,7 @@ export function isFunctionParent(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isPureish(node: Object, opts?: Object): boolean {
+export function isPureish(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3631,7 +3664,7 @@ export function isPureish(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isDeclaration(node: Object, opts?: Object): boolean {
+export function isDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3672,7 +3705,7 @@ export function isDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isPatternLike(node: Object, opts?: Object): boolean {
+export function isPatternLike(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3693,7 +3726,7 @@ export function isPatternLike(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isLVal(node: Object, opts?: Object): boolean {
+export function isLVal(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3716,7 +3749,7 @@ export function isLVal(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSEntityName(node: Object, opts?: Object): boolean {
+export function isTSEntityName(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3734,7 +3767,7 @@ export function isTSEntityName(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isLiteral(node: Object, opts?: Object): boolean {
+export function isLiteral(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3757,7 +3790,7 @@ export function isLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isImmutable(node: Object, opts?: Object): boolean {
+export function isImmutable(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3788,7 +3821,7 @@ export function isImmutable(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isUserWhitespacable(node: Object, opts?: Object): boolean {
+export function isUserWhitespacable(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3811,7 +3844,7 @@ export function isUserWhitespacable(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isMethod(node: Object, opts?: Object): boolean {
+export function isMethod(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3830,7 +3863,7 @@ export function isMethod(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isObjectMember(node: Object, opts?: Object): boolean {
+export function isObjectMember(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3848,7 +3881,7 @@ export function isObjectMember(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isProperty(node: Object, opts?: Object): boolean {
+export function isProperty(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3867,7 +3900,7 @@ export function isProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isUnaryLike(node: Object, opts?: Object): boolean {
+export function isUnaryLike(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3885,7 +3918,7 @@ export function isUnaryLike(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isPattern(node: Object, opts?: Object): boolean {
+export function isPattern(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3904,7 +3937,7 @@ export function isPattern(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isClass(node: Object, opts?: Object): boolean {
+export function isClass(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3922,7 +3955,7 @@ export function isClass(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isModuleDeclaration(node: Object, opts?: Object): boolean {
+export function isModuleDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3942,7 +3975,7 @@ export function isModuleDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isExportDeclaration(node: Object, opts?: Object): boolean {
+export function isExportDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3961,7 +3994,7 @@ export function isExportDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isModuleSpecifier(node: Object, opts?: Object): boolean {
+export function isModuleSpecifier(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -3983,7 +4016,7 @@ export function isModuleSpecifier(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFlow(node: Object, opts?: Object): boolean {
+export function isFlow(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4052,7 +4085,7 @@ export function isFlow(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFlowType(node: Object, opts?: Object): boolean {
+export function isFlowType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4091,7 +4124,7 @@ export function isFlowType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFlowBaseAnnotation(node: Object, opts?: Object): boolean {
+export function isFlowBaseAnnotation(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4116,7 +4149,7 @@ export function isFlowBaseAnnotation(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFlowDeclaration(node: Object, opts?: Object): boolean {
+export function isFlowDeclaration(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4145,7 +4178,7 @@ export function isFlowDeclaration(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isFlowPredicate(node: Object, opts?: Object): boolean {
+export function isFlowPredicate(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4163,7 +4196,7 @@ export function isFlowPredicate(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isJSX(node: Object, opts?: Object): boolean {
+export function isJSX(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4194,7 +4227,7 @@ export function isJSX(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isPrivate(node: Object, opts?: Object): boolean {
+export function isPrivate(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4213,7 +4246,7 @@ export function isPrivate(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSTypeElement(node: Object, opts?: Object): boolean {
+export function isTSTypeElement(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4234,7 +4267,7 @@ export function isTSTypeElement(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isTSType(node: Object, opts?: Object): boolean {
+export function isTSType(node: ?Object, opts?: Object): boolean {
   if (!node) return false;
 
   const nodeType = node.type;
@@ -4283,7 +4316,7 @@ export function isTSType(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isNumberLiteral(node: Object, opts?: Object): boolean {
+export function isNumberLiteral(node: ?Object, opts?: Object): boolean {
   console.trace(
     "The node type NumberLiteral has been renamed to NumericLiteral",
   );
@@ -4300,7 +4333,7 @@ export function isNumberLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isRegexLiteral(node: Object, opts?: Object): boolean {
+export function isRegexLiteral(node: ?Object, opts?: Object): boolean {
   console.trace("The node type RegexLiteral has been renamed to RegExpLiteral");
   if (!node) return false;
 
@@ -4315,7 +4348,7 @@ export function isRegexLiteral(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isRestProperty(node: Object, opts?: Object): boolean {
+export function isRestProperty(node: ?Object, opts?: Object): boolean {
   console.trace("The node type RestProperty has been renamed to RestElement");
   if (!node) return false;
 
@@ -4330,7 +4363,7 @@ export function isRestProperty(node: Object, opts?: Object): boolean {
 
   return false;
 }
-export function isSpreadProperty(node: Object, opts?: Object): boolean {
+export function isSpreadProperty(node: ?Object, opts?: Object): boolean {
   console.trace(
     "The node type SpreadProperty has been renamed to SpreadElement",
   );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9538
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/A typings only
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The `is*` functions for checking a node type in babel-types accept anything as the `value` argument, and will return `false` if `value` is `null` or `undefined` or anything which is not a valid node/path of that type.

The currently TypeScript definitions imply that the function does not accept anything which is not an `object` which is incorrect. Updating this to allow `any` as is actually the case.