### PR TITLE
Enable eqeqeq rule in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
       "files": ["packages/babel-plugin-*/src/index.js"],
       "excludedFiles": ["packages/babel-plugin-transform-regenerator/**/*.js"],
       "rules": {
-        "@babel/development/plugin-name": "error"
+        "@babel/development/plugin-name": "error",
+        "eqeqeq": ["error", "always", { "null": "ignore" }]
       }
     }
   ]

--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -31,8 +31,8 @@ export default declare((api, opts) => {
       Expression(path) {
         const parentType = path.parent.type;
         if (
-          (parentType == "AssignmentPattern" && path.key === "right") ||
-          (parentType == "ObjectProperty" &&
+          (parentType === "AssignmentPattern" && path.key === "right") ||
+          (parentType === "ObjectProperty" &&
             path.parent.computed &&
             path.key === "key")
         ) {

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.js
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.js
@@ -199,7 +199,7 @@ export default declare((api, options) => {
 
       ReferencedIdentifier(path, state) {
         if (
-          path.node.name == "__moduleName" &&
+          path.node.name === "__moduleName" &&
           !path.scope.hasBinding("__moduleName")
         ) {
           path.replaceWith(


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Enforce `===` and `!==` except when comparing to null.

We only had three cases that errored.
