### PR TITLE
Pull in chokidar 2.0.4 to pull in patched braces

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -30,7 +30,7 @@
     "source-map": "^0.5.0"
   },
   "optionalDependencies": {
-    "chokidar": "^2.0.3"
+    "chokidar": "^2.0.4"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8034
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/A
| Documentation PR Link    | No
| Any Dependency Changes?  | Yes, chokidar.
| License                  | MIT

chokidar 2.0.3 pulled in an older version of braces which is vulnerable to https://www.npmjs.com/advisories/786, this upgrades chokidar up a patch version where its dependencies have been updated resolving this vulnerability. 
