### PR TITLE
Don't watch files that are passed to `--ignore`.

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -135,6 +135,7 @@ export default async function({ cliOptions, babelOptions }) {
 
     filenames.forEach(function(filenameOrDir) {
       const watcher = chokidar.watch(filenameOrDir, {
+        ignored: babelOptions.ignore,
         persistent: true,
         ignoreInitial: true,
         awaitWriteFinish: {


### PR DESCRIPTION
I was hitting an error message of "System limit for number of file watchers reached", and it turns out that this was because I was doing something like:

```
npx babel . --out-dir=../es5 --watch --ignore="node_modules"
```

But, since `--ignore` was not getting passed to `chokidar`, it was trying to watch the entire `node_modules` directory!

---

I expect this could use a test or two, but it isn't clear to me how. The existing tests appear to check stderr, but what needs to be tested is the chokidar options. Suggestions?

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | no (suggestions for tests welcome!)
| Documentation PR Link    | n/a
| Any Dependency Changes?  | no
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
