### PR TITLE
Update CHANGELOG.md using the "Trigger GitHub release" action

### DIFF
--- a/.github/actions/trigger-github-release/Dockerfile
+++ b/.github/actions/trigger-github-release/Dockerfile
@@ -12,6 +12,7 @@ ADD entrypoint.sh /action/entrypoint.sh
 ADD package.json /action/package.json
 ADD package-lock.json /action/package-lock.json
 ADD release.js /action/release.js
+ADD update-changelog.js /action/update-changelog.js
 
 RUN chmod +x /action/entrypoint.sh
 

--- a/.github/actions/trigger-github-release/entrypoint.sh
+++ b/.github/actions/trigger-github-release/entrypoint.sh
@@ -5,21 +5,18 @@ set -e
 echo "INFO: Installing action dependencies..."
 (cd /action; npm ci)
 
-echo "INFO: Checking out current commit..."
-git -c advice.detachedHead=false checkout $GITHUB_SHA
-
 # GitHub doesn't support running actions on new tags yet: we need to run it on the commit.
 # For this reason, we can't be sure that the tag already exists. We can use the commit
 # message to create the tag. If the tag already exists locally, they won't conflict because
 # they have the same name and are on the same commit.
 echo "INFO: Getting release version..."
-# current_tag=$(git describe --abbrev=0 --tags HEAD)
-current_tag=$(git log --oneline --format=%B -1 HEAD)
+# current_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA)
+current_tag=$(git log --oneline --format=%B -1 $GITHUB_SHA)
 
 echo "INFO: Creating new tag..."
 (git tag $current_tag $GITHUB_SHA) || echo "INFO: Tag already exists"
 
-last_tag=$(git describe --abbrev=0 --tags HEAD^)
+last_tag=$(git describe --abbrev=0 --tags $current_tag^)
 echo "INFO: New version is $current_tag; last version is $last_tag."
 
 echo "INFO: Generating the changelog..."
@@ -34,5 +31,16 @@ changelog=$(
 
 echo "INFO: Publishing the new GitHub release..."
 echo "$changelog" | node /action/release $current_tag
+
+echo "INFO: Updating CHANGELOG.md..."
+echo "$changelog" | node /action/update-changelog
+
+echo "INFO: Committing changelog..."
+git add CHANGELOG.md
+git -c user.name="$COMMIT_AUTHOR_NAME" -c user.email="$COMMIT_AUTHOR_EMAIL" \
+  commit -m "Add $current_tag to CHANGELOG.md [skip ci]" --no-verify --quiet
+
+echo "INFO: Pushing updates..."
+git push "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" master
 
 echo "INFO: Done! Don't forget to thank new contributors :)"

--- a/.github/actions/trigger-github-release/update-changelog.js
+++ b/.github/actions/trigger-github-release/update-changelog.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const getStdin = require("get-stdin");
+const fs = require("fs").promises;
+const path = require("path");
+
+const { GITHUB_WORKSPACE } = process.env;
+
+const INSERTION_POINT = "<!-- insert-new-changelog-here -->";
+const CHANGELOG = path.resolve(GITHUB_WORKSPACE, "CHANGELOG.md");
+
+main();
+async function main() {
+  let [stdin, changelog] = await Promise.all([
+    getStdin(),
+    fs.readFile(CHANGELOG, "utf8"),
+  ]);
+
+  if (!changelog.includes(INSERTION_POINT)) {
+    throw new Error(`Missing "${INSERTION_POINT}" in CHANGELOG.md`);
+  }
+
+  // Remove committers
+  stdin = stdin.split("\n\n#### Committers")[0];
+  changelog = changelog.replace(
+    INSERTION_POINT,
+    INSERTION_POINT + "\n" + stdin
+  );
+
+  await fs.writeFile(CHANGELOG, changelog);
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -7,6 +7,11 @@ action "Trigger GitHub release" {
   uses = "./.github/actions/trigger-github-release/"
   secrets = ["GITHUB_TOKEN"]
 
+  env = {
+    COMMIT_AUTHOR_NAME  = "Babel Bot"
+    COMMIT_AUTHOR_EMAIL = "babel@hopeinsource.com"
+  }
+
   # When GitHub Actions will support the "release" event for public
   # repositories, we won't need these checks anymore.
   needs = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ See [CHANGELOG - v4](/.github/CHANGELOG-v4.md), [CHANGELOG - v5](/.github/CHANGE
 See [CHANGELOG - 6to5](/.github/CHANGELOG-6to5.md) for the pre-4.0.0 version changelog.
 See [Babylon's CHANGELOG](packages/babylon/CHANGELOG.md) for the Babylon pre-7.0.0-beta.29 version changelog.
 
+<!-- DO NOT CHANGE THESE COMMENTS - See .github/actions/trigger-github-release/update-changelog.js -->
+<!-- insert-new-changelog-here -->
+
 ## v7.3.3 (2019-02-15)
 
 #### :eyeglasses: Spec Compliancy


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

We haven't been very good at keeping `CHANGELOG.md` updated (2 days ago I added the changelog for versions 7.2.2-7.2.3 21eb0837e8d367b2aa0d2ecffed5ec648f9e0bbc, and the previus commit was for versions 7.1.3-7.2.1 b60adce4cb4e0c705cb308b6eacf36605ed61db8).

This PR updates the action we use to generate the GitHub release so that it also updates `CHANGELOG.md` (commit author: @babel-bot :smile:). Btw, I'm trying to understand how I can test this action which chages the git tree and makes requests to the GH api, but I'm not doing it in this PR since it will take a lot of time to properly set up.

<!-- Describe your changes below in as much detail as possible -->
