### PR TITLE
update plugin-typescript-transform to support different pragma between files

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -25,6 +25,7 @@ const PARSED_PARAMS = new WeakSet();
 export default declare((api, { jsxPragma = "React" }) => {
   api.assertVersion(7);
 
+  const defaultPragma = jsxPragma;
   const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
 
   return {
@@ -42,14 +43,18 @@ export default declare((api, { jsxPragma = "React" }) => {
 
         const { file } = state;
 
+        let filePragma;
         if (file.ast.comments) {
           for (const comment of (file.ast.comments: Array<Object>)) {
             const jsxMatches = JSX_ANNOTATION_REGEX.exec(comment.value);
             if (jsxMatches) {
-              jsxPragma = jsxMatches[1];
+              filePragma = jsxMatches[1];
             }
           }
         }
+
+        // revert back to default pragma to support files with different types
+        jsxPragma = filePragma ? filePragma : defaultPragma;
 
         // remove type imports
         for (const stmt of path.get("body")) {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/in-files/src/a.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/in-files/src/a.mjs
@@ -1,0 +1,4 @@
+/* @jsx htm */
+// Don't elide htm if a JSX element appears somewhere.
+import { htm } from "fake-jsx-package";
+<div></div>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/in-files/src/b.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/in-files/src/b.mjs
@@ -1,0 +1,3 @@
+// Don't elide React if a JSX element appears somewhere.
+import * as React from "react";
+<div></div>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["src", "--out-dir", "lib"],
+  "plugins": [["transform-typescript", { "isTSX": true }]]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/out-files/lib/a.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/out-files/lib/a.js
@@ -1,0 +1,4 @@
+/* @jsx htm */
+// Don't elide htm if a JSX element appears somewhere.
+import { htm } from "fake-jsx-package";
+<div></div>;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/out-files/lib/b.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/multiple-pragma/out-files/lib/b.mjs
@@ -1,0 +1,3 @@
+// Don't elide React if a JSX element appears somewhere.
+import * as React from "react";
+<div></div>;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/9549
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  | 👎 
| Minor: New Feature?      | 👎 
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 👎 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
JSX pragma appears to be "sticky" between files (unsure if this is by design) when using the typescript-transform plugin. This PR: https://github.com/babel/babel/pull/9095 removed the need to assign your jsx (like what emotion.sh uses) to a variable, but in doing so broke files that would be just React (or whatever the initial jsxPragma was). Could get around this by having different builds/folders for different pragmas, but seems like an unnecessary step. 