### PR TITLE
change var name for coherence

### DIFF
--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -368,7 +368,7 @@ export default class Printer {
 
     const loc = t.isProgram(node) || t.isFile(node) ? null : node.loc;
     this.withSource("start", loc, () => {
-      printMethod(node, parent);
+      printMethod.call(this, node, parent);
     });
 
     this._printTrailingComments(node);

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -338,7 +338,6 @@ export default class Printer {
     }
 
     const printMethod = this[node.type];
-    
     if (!printMethod) {
       throw new ReferenceError(
         `unknown node of type ${JSON.stringify(

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -337,8 +337,9 @@ export default class Printer {
       this.format.concise = true;
     }
 
-    const isNodeTypeKnown = this[node.type];
-    if (!isNodeTypeKnown) {
+    const printMethod = this[node.type];
+    
+    if (!printMethod) {
       throw new ReferenceError(
         `unknown node of type ${JSON.stringify(
           node.type,
@@ -367,7 +368,7 @@ export default class Printer {
 
     const loc = t.isProgram(node) || t.isFile(node) ? null : node.loc;
     this.withSource("start", loc, () => {
-      this[node.type](node, parent);
+      printMethod(node, parent);
     });
 
     this._printTrailingComments(node);

--- a/packages/babel-generator/src/printer.js
+++ b/packages/babel-generator/src/printer.js
@@ -337,8 +337,8 @@ export default class Printer {
       this.format.concise = true;
     }
 
-    const printMethod = this[node.type];
-    if (!printMethod) {
+    const isNodeTypeKnown = this[node.type];
+    if (!isNodeTypeKnown) {
       throw new ReferenceError(
         `unknown node of type ${JSON.stringify(
           node.type,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |<!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

I was reding the code to understand how it worked, but I enciuntered this variable name called `printMethod` and I thought it was going to be used afterwards, but it turned out it as only to test that the function existed, so I think it makes more sense to name it as a boolean.
