### PR TITLE
Minify bundles on circle for repl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: yarn --version
       - run: make test-ci-coverage
       # Builds babel-standalone with the regular Babel config
-      - run: make build
+      - run: IS_PUBLISH=true make build
       # test-ci-coverage doesn't test babel-standalone, as trying to gather coverage
       # data for a JS file that's several megabytes large is bound to fail. Here,
       # we just run the babel-standalone test separately.


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Seems I did not think of that the bundles build on circle are used in the repl. So currently the `min` bundle is not minified.