### PR TITLE
Transform Tagged Template Literals in Safari

### DIFF
--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -3,9 +3,7 @@
     "chrome": "41",
     "edge": "13",
     "firefox": "34",
-    "safari": "9",
     "node": "4",
-    "ios": "9",
     "opera": "28",
     "electron": "0.24"
   },


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/a
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Safari 12 has a [bug](https://bugs.webkit.org/show_bug.cgi?id=190756) that breaks caching of `TaggedTemplateExpression`s.

Ideally, we'd be able to break up the template literals feature into
two:

1. Regular template literals
2. Tagged template literals

We only need to transform tagged template literals. Also, Safari 9-11
don't have this issue, so we could avoid transforming in all cases if
we could specify that in the json.

Un-transformed test: https://jsbin.com/leyusas/10/edit?js,console
Transform test: https://jsbin.com/leyusas/8/edit?js,console