### PR TITLE
Fix strict mode prescanning with EmptyStatement

### DIFF
--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -5,7 +5,7 @@ import Tokenizer from "../tokenizer";
 import type { Node } from "../types";
 import { lineBreak, skipWhiteSpace } from "../util/whitespace";
 
-const literal = /^(?:;|('|")((?:\\?.)*?)\1)/;
+const literal = /^('|")((?:\\?.)*?)\1/;
 
 // ## Parser utilities
 
@@ -170,6 +170,7 @@ export default class UtilParser extends Tokenizer {
 
   strictDirective(start: number): boolean {
     for (;;) {
+      // Try to find string literal.
       skipWhiteSpace.lastIndex = start;
       // $FlowIgnore
       start += skipWhiteSpace.exec(this.state.input)[0].length;
@@ -177,6 +178,14 @@ export default class UtilParser extends Tokenizer {
       if (!match) break;
       if (match[2] === "use strict") return true;
       start += match[0].length;
+
+      // Skip semicolon, if any.
+      skipWhiteSpace.lastIndex = start;
+      // $FlowIgnore
+      start += skipWhiteSpace.exec(this.state.input)[0].length;
+      if (this.state.input[start] === ";") {
+        start++;
+      }
     }
 
     return false;

--- a/packages/babel-parser/test/fixtures/core/regression/use-strict-with-pre-semi/input.js
+++ b/packages/babel-parser/test/fixtures/core/regression/use-strict-with-pre-semi/input.js
@@ -1,0 +1,3 @@
+function a ([a] = []) {
+ ; 'use strict'; with ({}) {}
+}

--- a/packages/babel-parser/test/fixtures/core/regression/use-strict-with-pre-semi/output.json
+++ b/packages/babel-parser/test/fixtures/core/regression/use-strict-with-pre-semi/output.json
@@ -1,0 +1,252 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 55,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 55,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 55,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 10,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 10
+            },
+            "identifierName": "a"
+          },
+          "name": "a"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "AssignmentPattern",
+            "start": 12,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 1,
+                "column": 20
+              }
+            },
+            "left": {
+              "type": "ArrayPattern",
+              "start": 12,
+              "end": 15,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 12
+                },
+                "end": {
+                  "line": 1,
+                  "column": 15
+                }
+              },
+              "elements": [
+                {
+                  "type": "Identifier",
+                  "start": 13,
+                  "end": 14,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 14
+                    },
+                    "identifierName": "a"
+                  },
+                  "name": "a"
+                }
+              ]
+            },
+            "right": {
+              "type": "ArrayExpression",
+              "start": 18,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 18
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                }
+              },
+              "elements": []
+            }
+          }
+        ],
+        "body": {
+          "type": "BlockStatement",
+          "start": 22,
+          "end": 55,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 22
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "EmptyStatement",
+              "start": 25,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 1
+                },
+                "end": {
+                  "line": 2,
+                  "column": 2
+                }
+              }
+            },
+            {
+              "type": "ExpressionStatement",
+              "start": 27,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 3
+                },
+                "end": {
+                  "line": 2,
+                  "column": 16
+                }
+              },
+              "expression": {
+                "type": "StringLiteral",
+                "start": 27,
+                "end": 39,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 15
+                  }
+                },
+                "extra": {
+                  "rawValue": "use strict",
+                  "raw": "'use strict'"
+                },
+                "value": "use strict"
+              }
+            },
+            {
+              "type": "WithStatement",
+              "start": 41,
+              "end": 53,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 17
+                },
+                "end": {
+                  "line": 2,
+                  "column": 29
+                }
+              },
+              "object": {
+                "type": "ObjectExpression",
+                "start": 47,
+                "end": 49,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 25
+                  }
+                },
+                "properties": []
+              },
+              "body": {
+                "type": "BlockStatement",
+                "start": 51,
+                "end": 53,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 29
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Correctly prescan for use strict directives.

For example this should work, because the "use strict" is not a directive, because an EmptyStatement is in front of it. (Currently throws, about non-simple parameters in strict mode)

```js
function a ([a] = []) {
 ; 'use strict'; with ({}) {}
}
```
