### PR TITLE
Publish to npm using a GitHub action

### DIFF
--- a/.github/actions/create-release-tag/Dockerfile
+++ b/.github/actions/create-release-tag/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stable-slim
+
+LABEL "name"="create-release-tag"
+LABEL "version"="0.0.1"
+
+LABEL "com.github.actions.name"="Create release tag"
+LABEL "com.github.actions.description"="Creates a release tag equal to the last commit message"
+LABEL "com.github.actions.icon"="tag"
+LABEL "com.github.actions.color"="gray-dark"
+
+ADD entrypoint.sh /action/entrypoint.sh
+
+RUN chmod +x /action/entrypoint.sh
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
+ENTRYPOINT ["/action/entrypoint.sh"]

--- a/.github/actions/create-release-tag/entrypoint.sh
+++ b/.github/actions/create-release-tag/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+# GitHub doesn't support running actions on new tags yet: we need to run it on the commit.
+# For this reason, we can't be sure that the tag already exists. We can use the commit
+# message to create the tag. If the tag already exists locally, they won't conflict because
+# they have the same name and are on the same commit.
+
+echo "INFO: Getting release version..."
+tag_name=$(git log --oneline --format=%B -1 $GITHUB_SHA)
+
+echo "INFO: Creating new tag..."
+(git tag $tag_name $GITHUB_SHA) || echo "INFO: Tag already exists"

--- a/.github/actions/trigger-github-release/entrypoint.sh
+++ b/.github/actions/trigger-github-release/entrypoint.sh
@@ -5,16 +5,8 @@ set -e
 echo "INFO: Installing action dependencies..."
 (cd /action; npm ci)
 
-# GitHub doesn't support running actions on new tags yet: we need to run it on the commit.
-# For this reason, we can't be sure that the tag already exists. We can use the commit
-# message to create the tag. If the tag already exists locally, they won't conflict because
-# they have the same name and are on the same commit.
 echo "INFO: Getting release version..."
-# current_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA)
-current_tag=$(git log --oneline --format=%B -1 $GITHUB_SHA)
-
-echo "INFO: Creating new tag..."
-(git tag $current_tag $GITHUB_SHA) || echo "INFO: Tag already exists"
+current_tag=$(git describe --abbrev=0 --tags $GITHUB_SHA)
 
 last_tag=$(git describe --abbrev=0 --tags $current_tag^)
 echo "INFO: New version is $current_tag; last version is $last_tag."

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "Release" {
   on = "push"
-  resolves = ["Trigger GitHub release"]
+  resolves = ["Trigger GitHub release", "Publish to npm"]
 }
 
 action "Trigger GitHub release" {
@@ -12,8 +12,28 @@ action "Trigger GitHub release" {
     COMMIT_AUTHOR_EMAIL = "babel@hopeinsource.com"
   }
 
-  # When GitHub Actions will support the "release" event for public
-  # repositories, we won't need these checks anymore.
+  needs = ["Create release tag"]
+}
+
+action "Publish to npm" {
+  uses = "docker://node:10"
+  secrets = ["NPM_TOKEN"]
+
+  runs = "make"
+  args = "publish"
+
+  env = {
+    CI = "true"
+  }
+
+  needs = ["Create release tag"]
+}
+
+# When GitHub Actions will support the "release" event for public
+# repositories, we won't need this checks anymore.
+action "Create release tag" {
+  uses ="./.github/actions/create-release-tag"
+
   needs = [
     "Is version commit",
     "On master branch",

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,12 @@ prepublish-build:
 	make clone-license
 
 prepublish:
-	git pull --rebase
+	make bootstrap-only
 	make prepublish-build
 	make test
 
 new-version:
+	git pull --rebase
 	./node_modules/.bin/lerna version --force-publish="@babel/runtime,@babel/runtime-corejs2,@babel/standalone,@babel/preset-env-standalone"
 
 # NOTE: Run make new-version first
@@ -138,9 +139,11 @@ publish: prepublish
 	./node_modules/.bin/lerna publish from-git --require-scripts
 	make clean
 
-bootstrap: clean-all
+bootstrap-only: clean-all
 	yarn --ignore-engines
 	./node_modules/.bin/lerna bootstrap -- --ignore-engines
+
+bootstrap: bootstrap-only
 	make build
 	cd packages/babel-plugin-transform-runtime; \
 	node scripts/build-dist.js


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is the most important PR regarding the "Release" GitHub action: the publishing process is now just `make new-version && git push` :slightly_smiling_face: 

I have tested this locally and it worked, but I used `prepublish` instead of `publish` (to avoid accidentally pushing something to npm). In case it won't work, `make bootstrap` takes so long that every other task in this action will complete before that it fails, so I can just run `make publish` locally as I was doing for previous releases.
