### PR TITLE
Remove always false param allowExpressionBody

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -881,7 +881,7 @@ export default class ExpressionParser extends LValParser {
           !this.canInsertSemicolon()
         ) {
           this.next();
-          return this.parseFunction(node, undefined, false, true);
+          return this.parseFunction(node, undefined, true);
         } else if (
           canBeArrow &&
           id.name === "async" &&
@@ -1804,10 +1804,9 @@ export default class ExpressionParser extends LValParser {
   parseFunctionBodyAndFinish(
     node: N.BodilessFunctionOrMethodBase,
     type: string,
-    allowExpressionBody?: boolean,
   ): void {
     // $FlowIgnore (node is not bodiless if we get here)
-    this.parseFunctionBody(node, allowExpressionBody);
+    this.parseFunctionBody(node);
     this.finishNode(node, type);
   }
 

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -548,7 +548,6 @@ export default class StatementParser extends ExpressionParser {
     return this.parseFunction(
       node,
       FUNC_STATEMENT | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT),
-      false,
       isAsync,
     );
   }
@@ -1013,7 +1012,6 @@ export default class StatementParser extends ExpressionParser {
   parseFunction<T: N.NormalFunction>(
     node: T,
     statement?: number = FUNC_NO_FLAGS,
-    allowExpressionBody?: boolean = false,
     isAsync?: boolean = false,
   ): T {
     const isStatement = statement & FUNC_STATEMENT;
@@ -1074,7 +1072,6 @@ export default class StatementParser extends ExpressionParser {
       this.parseFunctionBodyAndFinish(
         node,
         isStatement ? "FunctionDeclaration" : "FunctionExpression",
-        allowExpressionBody,
       );
     });
 
@@ -1753,7 +1750,6 @@ export default class StatementParser extends ExpressionParser {
       return this.parseFunction(
         expr,
         FUNC_STATEMENT | FUNC_NULLABLE_ID,
-        false,
         isAsync,
       );
     } else if (this.match(tt._class)) {

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -1557,10 +1557,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseFunctionBodyAndFinish(
       node: N.BodilessFunctionOrMethodBase,
       type: string,
-      allowExpressionBody?: boolean,
     ): void {
-      // For arrow functions, `parseArrow` handles the return type itself.
-      if (!allowExpressionBody && this.match(tt.colon)) {
+      if (this.match(tt.colon)) {
         const typeNode = this.startNode();
 
         [
@@ -1575,7 +1573,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           : null;
       }
 
-      super.parseFunctionBodyAndFinish(node, type, allowExpressionBody);
+      super.parseFunctionBodyAndFinish(node, type);
     }
 
     // interfaces

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -1481,10 +1481,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseFunctionBodyAndFinish(
       node: N.BodilessFunctionOrMethodBase,
       type: string,
-      allowExpressionBody?: boolean,
     ): void {
-      // For arrow functions, `parseArrow` handles the return type itself.
-      if (!allowExpressionBody && this.match(tt.colon)) {
+      if (this.match(tt.colon)) {
         node.returnType = this.tsParseTypeOrTypePredicateAnnotation(tt.colon);
       }
 
@@ -1499,7 +1497,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return;
       }
 
-      super.parseFunctionBodyAndFinish(node, type, allowExpressionBody);
+      super.parseFunctionBodyAndFinish(node, type);
     }
 
     parseSubscript(


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This param is always set to false.
