### PR TITLE
[TS] Correctly forget `await`s after parsing async arrows with type args

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -6,13 +6,7 @@ import { types as ct } from "../tokenizer/context";
 import * as N from "../types";
 import type { Pos, Position } from "../util/location";
 import Parser from "../parser";
-import {
-  type BindingTypes,
-  functionFlags,
-  BIND_NONE,
-  SCOPE_ARROW,
-  SCOPE_OTHER,
-} from "../util/scopeflags";
+import { type BindingTypes, BIND_NONE, SCOPE_OTHER } from "../util/scopeflags";
 
 type TsModifier =
   | "readonly"
@@ -1381,14 +1375,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return undefined;
       }
 
-      this.scope.enter(functionFlags(true, false) | SCOPE_ARROW);
-
-      res.id = null;
-      res.generator = false;
-      res.expression = true; // May be set again by parseFunctionBody.
-      res.async = true;
-      this.parseFunctionBody(res, true);
-      return this.finishNode(res, "ArrowFunctionExpression");
+      return this.parseArrowExpression(
+        res,
+        /* params are already set */ null,
+        /* async */ true,
+      );
     }
 
     tsParseTypeArguments(): N.TsTypeParameterInstantiation {

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/output.json
@@ -93,7 +93,6 @@
           "params": [],
           "id": null,
           "generator": false,
-          "expression": true,
           "async": true,
           "body": {
             "type": "AwaitExpression",

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic/output.json
@@ -205,7 +205,6 @@
           },
           "id": null,
           "generator": false,
-          "expression": true,
           "async": true,
           "body": {
             "type": "Identifier",

--- a/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/input.js
@@ -1,0 +1,8 @@
+class Cl {
+  a = async<T>() => {
+    await 0;
+  };
+
+  b = async<T>() => {
+  };
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["typescript", "classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/output.json
@@ -1,0 +1,342 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 80,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 80,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 8,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 80,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 8,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 8,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 8
+            },
+            "identifierName": "Cl"
+          },
+          "name": "Cl"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 9,
+          "end": 80,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 8,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 13,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 4
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 13,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "computed": false,
+              "value": {
+                "type": "ArrowFunctionExpression",
+                "start": 17,
+                "end": 49,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                },
+                "typeParameters": {
+                  "type": "TSTypeParameterDeclaration",
+                  "start": 22,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 14
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TSTypeParameter",
+                      "start": 23,
+                      "end": 24,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 12
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 13
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "params": [],
+                "id": null,
+                "generator": false,
+                "async": true,
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 31,
+                  "end": 49,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 3
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "start": 37,
+                      "end": 45,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 12
+                        }
+                      },
+                      "expression": {
+                        "type": "AwaitExpression",
+                        "start": 37,
+                        "end": 44,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 11
+                          }
+                        },
+                        "argument": {
+                          "type": "NumericLiteral",
+                          "start": 43,
+                          "end": 44,
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 10
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 11
+                            }
+                          },
+                          "extra": {
+                            "rawValue": 0,
+                            "raw": "0"
+                          },
+                          "value": 0
+                        }
+                      }
+                    }
+                  ],
+                  "directives": []
+                }
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start": 54,
+              "end": 78,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 2
+                },
+                "end": {
+                  "line": 7,
+                  "column": 4
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 54,
+                "end": 55,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 3
+                  },
+                  "identifierName": "b"
+                },
+                "name": "b"
+              },
+              "computed": false,
+              "value": {
+                "type": "ArrowFunctionExpression",
+                "start": 58,
+                "end": 77,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 3
+                  }
+                },
+                "typeParameters": {
+                  "type": "TSTypeParameterDeclaration",
+                  "start": 63,
+                  "end": 66,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 14
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TSTypeParameter",
+                      "start": 64,
+                      "end": 65,
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 12
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 13
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "params": [],
+                "id": null,
+                "generator": false,
+                "async": true,
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 72,
+                  "end": 77,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 3
+                    }
+                  },
+                  "body": [],
+                  "directives": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9560
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The problem was that we didn't reset `state.awaitPos = 0` after parsing `async <T>() =>` arrow functions, and thus the following async function thought that `await` was used in its parameters. I reused an existing function to parse arrow bodies.
