### PR TITLE
preset-env: minimally supporting version

### DIFF
--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -214,10 +214,10 @@
     "opera": "50",
     "edge": "12",
     "firefox": "5",
-    "safari": "10.1",
+    "safari": "12",
     "node": "10",
     "ie": "9",
-    "ios": "10.3",
+    "ios": "12",
     "electron": "3.1"
   },
   "es6.array.species": {
@@ -317,7 +317,7 @@
   "es6.function.name": {
     "chrome": "5",
     "opera": "10.50",
-    "edge": "12",
+    "edge": "14",
     "firefox": "2",
     "safari": "4",
     "node": "0.10",
@@ -432,7 +432,7 @@
     "firefox": "23",
     "safari": "7",
     "node": "0.12",
-    "android": "4.4",
+    "android": "4.4_3",
     "ios": "7",
     "opera": "17",
     "electron": "0.2"
@@ -729,7 +729,7 @@
   "es6.object.get-prototype-of": {
     "chrome": "44",
     "edge": "12",
-    "firefox": "3.5",
+    "firefox": "35",
     "safari": "9",
     "node": "4",
     "ios": "9",

--- a/packages/babel-preset-env/data/built-ins.json
+++ b/packages/babel-preset-env/data/built-ins.json
@@ -432,7 +432,7 @@
     "firefox": "23",
     "safari": "7",
     "node": "0.12",
-    "android": "4.4_3",
+    "android": "4.4",
     "ios": "7",
     "opera": "17",
     "electron": "0.2"

--- a/packages/babel-preset-env/data/plugins.json
+++ b/packages/babel-preset-env/data/plugins.json
@@ -3,9 +3,7 @@
     "chrome": "41",
     "edge": "13",
     "firefox": "34",
-    "safari": "9",
     "node": "4",
-    "ios": "9",
     "opera": "28",
     "electron": "0.24"
   },

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -67,7 +67,7 @@
     "@babel/helper-fixtures": "^7.2.0",
     "@babel/helper-plugin-test-runner": "^7.0.0",
     "caniuse-db": "1.0.30000938",
-    "compat-table": "kangax/compat-table#1e7b377fbdda9243cf9602872fcb493cdbdd565f",
+    "compat-table": "kangax/compat-table#6d012ba020fa7415e8a2d29e87924bab79b128a3",
     "electron-to-chromium": "1.3.113"
   }
 }

--- a/packages/babel-preset-env/scripts/build-data.js
+++ b/packages/babel-preset-env/scripts/build-data.js
@@ -203,7 +203,7 @@ const getLowestImplementedVersion = ({ features }, env) => {
     const reportedVersions = Object.keys(test)
       .filter(t => t.startsWith(env))
       .map(t => {
-        const version = t.replace("_", ".").replace(env, "");
+        const version = t.replace(/_/g, ".").replace(env, "");
         return {
           version,
           semver: semver.coerce(version) || version,

--- a/packages/babel-preset-env/scripts/build-data.js
+++ b/packages/babel-preset-env/scripts/build-data.js
@@ -217,16 +217,26 @@ const getLowestImplementedVersion = ({ features }, env) => {
           unreleasedLabelForEnv === version.version ||
           !isNaN(parseFloat(version.version))
       )
-      // Sort in asc order, with unreleasedLabelForEnv coming last.
+      // Sort in desc order, with unreleasedLabelForEnv coming last.
       .sort(({ semver: av }, { semver: bv }) => {
-        if (av === unreleasedLabelForEnv) return 1;
-        if (bv === unreleasedLabelForEnv) return -1;
-        if (semver.gt(av, bv)) return 1;
-        if (semver.gt(bv, av)) return -1;
+        if (av === unreleasedLabelForEnv) return -1;
+        if (bv === unreleasedLabelForEnv) return 1;
+        if (semver.gt(av, bv)) return -1;
+        if (semver.gt(bv, av)) return 1;
         return 0;
       });
 
-    return reportedVersions.find(version => version.implements);
+    // Find the lowest version such that all lower versions implement it.
+    // Eg, given { chrome70: true, chrome60: false, chrome50: true }, the
+    // lowest version is chrome70, not chrome50.
+    let lowest = null;
+    for (const version of reportedVersions) {
+      if (!version.implements) {
+        break;
+      }
+      lowest = version;
+    }
+    return lowest;
   });
 
   const envFiltered = envTests.filter(t => t);

--- a/packages/babel-preset-env/scripts/build-data.js
+++ b/packages/babel-preset-env/scripts/build-data.js
@@ -226,7 +226,7 @@ const getLowestImplementedVersion = ({ features }, env) => {
         return 0;
       });
 
-    // Find the lowest version such that all lower versions implement it.
+    // Find the lowest version such that all higher versions implement it.
     // Eg, given { chrome70: true, chrome60: false, chrome50: true }, the
     // lowest version is chrome70, not chrome50.
     let lowest = null;

--- a/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/specific-targets/stdout.txt
@@ -13,7 +13,7 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-template-literals { "ie":"10", "safari":"7" }
+  transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
   transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
   transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-arrow-functions { "ie":"10", "ios":"9", "safari":"7" }
@@ -59,7 +59,7 @@ Using polyfills with `entry` option:
   es6.date.to-json { "ios":"9", "safari":"7" }
   es6.date.to-primitive { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   es6.function.has-instance { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  es6.function.name { "ie":"10" }
+  es6.function.name { "edge":"13", "ie":"10" }
   es6.map { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   es6.math.acosh { "ie":"10", "safari":"7" }
   es6.math.asinh { "ie":"10", "safari":"7" }

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/input.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/input.js
@@ -1,0 +1,1 @@
+tag`Safari 12 borked`;

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/options.json
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": {
+          "browsers": "safari 9"
+        },
+        "shippedProposals": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-tagged-template-literals/output.js
@@ -1,0 +1,13 @@
+function _templateObject() {
+  var data = _taggedTemplateLiteral(["Safari 12 borked"]);
+
+  _templateObject = function _templateObject() {
+    return data;
+  };
+
+  return data;
+}
+
+function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
+
+tag(_templateObject());


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

This changes the "does browser support X" algorithm to "lowest version such that all higher versions support it".

Eg, given `{ chrome70: true, chrome60: false, chrome50: true }`, the lowest version is chrome70, not chrome50.

This is done to remove Tagged Template Literal support from Safari, which introduced a bug in Safari 12 but correctly implemented the feature in Safari 11-9.
