### PR TITLE
Fix scope check for 2nd+ lexical bindings

### DIFF
--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -117,8 +117,7 @@ export default class ScopeHandler {
         const scope = this.scopeStack[i];
         if (
           (scope.lexical.indexOf(name) > -1 &&
-            !(scope.flags & SCOPE_SIMPLE_CATCH) &&
-            scope.lexical[0] === name) ||
+            !(scope.flags & SCOPE_SIMPLE_CATCH && scope.lexical[0] === name)) ||
           (!this.treatFunctionsAsVarInScope(scope) &&
             scope.functions.indexOf(name) > -1)
         ) {

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex-nested/input.js
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex-nested/input.js
@@ -1,0 +1,5 @@
+{
+  let bar;
+  var foo = 1;
+  let foo = 1;
+}

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex-nested/options.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex-nested/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Identifier 'foo' has already been declared (4:6)"
+}

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex/input.js
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex/input.js
@@ -1,0 +1,3 @@
+let bar;
+var foo = 1;
+let foo = 1;

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex/options.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-lex/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Identifier 'foo' has already been declared (3:4)"
+}

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var-nested/input.js
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var-nested/input.js
@@ -1,0 +1,5 @@
+{
+  let bar;
+  let foo = 1;
+  var foo = 1;
+}

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var-nested/options.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var-nested/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Identifier 'foo' has already been declared (4:6)"
+}

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var/input.js
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var/input.js
@@ -1,0 +1,3 @@
+let bar;
+let foo = 1;
+var foo = 1;

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var/options.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-2nd-lvl-var/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Identifier 'foo' has already been declared (3:4)"
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT


The `scope.lexical[0] === name` is only meant for the catch checks.