### PR TITLE
Allow any reserved word in `export {} from` specifiers

### DIFF
--- a/packages/babel-parser/test/fixtures/es2015/modules/export-from-valid-reserved-word/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/modules/export-from-valid-reserved-word/input.js
@@ -1,0 +1,1 @@
+export { if } from 'foo'

--- a/packages/babel-parser/test/fixtures/es2015/modules/export-from-valid-reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/export-from-valid-reserved-word/output.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 24,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 24,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 24,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 9,
+            "end": 11,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 9,
+              "end": 11,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11
+                },
+                "identifierName": "if"
+              },
+              "name": "if"
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 9,
+              "end": 11,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11
+                },
+                "identifierName": "if"
+              },
+              "name": "if"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 19,
+          "end": 24,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 19
+            },
+            "end": {
+              "line": 1,
+              "column": 24
+            }
+          },
+          "extra": {
+            "rawValue": "foo",
+            "raw": "'foo'"
+          },
+          "value": "foo"
+        },
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-default-token/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-default-token/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "Unexpected token (1:17)"
+  "sourceType": "module",
+  "throws": "Unexpected token, expected \";\" (1:17)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-named-default/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-named-default/options.json
@@ -1,3 +1,4 @@
 {
-  "throws": "Unexpected token (1:16)"
+  "sourceType": "module",
+  "throws": "Unexpected keyword 'default' (1:8)"
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

Because `export from` is not binding anything in local scope it is allowed to use any reserved word in the export specifiers.
The spec only talks about  BindingReferences, which the specifier here is not `export { class } from ""`
https://www.ecma-international.org/ecma-262/9.0/index.html#sec-exports-static-semantics-early-errors

ref https://github.com/acornjs/acorn/issues/326#issuecomment-146957178
ref https://github.com/acornjs/acorn/issues/490