### PR TITLE
babel-traverse: fix order of exit callbacks

### DIFF
--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -4,15 +4,22 @@ import traverse from "../index";
 
 export function call(key): boolean {
   const opts = this.opts;
+  const order = opts.exitOrder || "direct";
 
   this.debug(key);
 
   if (this.node) {
     const common = opts[key];
     const typed = opts[this.node.type] && opts[this.node.type][key];
-    return key === "exit"
-      ? this._call(typed) || this._call(common)
-      : this._call(common) || this._call(typed);
+    if (key === "exit" && order === "reverse") {
+      return this._call(typed) || this._call(common);
+    }
+
+    if (key === "exit" && common && typed && !opts.exitOrder) {
+      // There we can show a warning about unexpected behavior
+    }
+
+    return this._call(common) || this._call(typed);
   }
 
   return false;

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -8,11 +8,11 @@ export function call(key): boolean {
   this.debug(key);
 
   if (this.node) {
-    if (this._call(opts[key])) return true;
-  }
-
-  if (this.node) {
-    return this._call(opts[this.node.type] && opts[this.node.type][key]);
+    const common = opts[key];
+    const typed = opts[this.node.type] && opts[this.node.type][key];
+    return key === "exit"
+      ? this._call(typed) || this._call(common)
+      : this._call(common) || this._call(typed);
   }
 
   return false;

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -270,11 +270,7 @@ function shouldIgnoreKey(key) {
   if (key === "enter" || key === "exit" || key === "shouldSkip") return true;
 
   // ignore other options
-  if (key === "blacklist" || key === "noScope" || key === "skipKeys") {
-    return true;
-  }
-
-  return false;
+  return ["blacklist", "noScope", "skipKeys", "exitOrder"].indexOf(key) !== -1;
 }
 
 function mergePair(dest, src) {

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -27,6 +27,32 @@ describe("traverse", function() {
     expect(ast2.body[1].expression.left.object).toBe(replacement);
   });
 
+  it("traverse order", function() {
+    let acc = "";
+    const ast2 = parse(`
+      "string literal";
+    `);
+    traverse(ast2.program, {
+      blacklist: ["DirectiveLiteral"],
+      enter: function() {
+        acc += "1";
+      },
+      exit: function() {
+        acc += "4";
+      },
+      Directive: {
+        enter: function() {
+          acc += "2";
+        },
+        exit: function() {
+          acc += "3";
+        },
+      },
+    });
+
+    expect(acc).toBe("1234");
+  });
+
   it("traverse", function() {
     const expected = [
       body[0],

--- a/packages/babel-traverse/test/traverse.js
+++ b/packages/babel-traverse/test/traverse.js
@@ -27,30 +27,51 @@ describe("traverse", function() {
     expect(ast2.body[1].expression.left.object).toBe(replacement);
   });
 
-  it("traverse order", function() {
-    let acc = "";
+  describe("traverse order", function() {
     const ast2 = parse(`
       "string literal";
     `);
-    traverse(ast2.program, {
-      blacklist: ["DirectiveLiteral"],
-      enter: function() {
-        acc += "1";
-      },
-      exit: function() {
-        acc += "4";
-      },
-      Directive: {
+    let acc = "";
+
+    const getVisitors = function(order) {
+      return {
+        blacklist: ["DirectiveLiteral"],
+        exitOrder: order,
         enter: function() {
-          acc += "2";
+          acc += "1";
         },
         exit: function() {
-          acc += "3";
+          acc += "4";
         },
-      },
+        Directive: {
+          enter: function() {
+            acc += "2";
+          },
+          exit: function() {
+            acc += "3";
+          },
+        },
+      };
+    };
+
+    beforeEach(function() {
+      acc = "";
     });
 
-    expect(acc).toBe("1234");
+    it("traverse default order", function() {
+      traverse(ast2.program, getVisitors());
+      expect(acc).toBe("1243");
+    });
+
+    it("traverse direct order", function() {
+      traverse(ast2.program, getVisitors("direct"));
+      expect(acc).toBe("1243");
+    });
+
+    it("traverse reverse order", function() {
+      traverse(ast2.program, getVisitors("reverse"));
+      expect(acc).toBe("1234");
+    });
   });
 
   it("traverse", function() {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

I've found a problem with the order of the tree traversing. Suppose we have a visitors configuration like this:
```
{
  enter() {
    // callback #1
  },
  exit() {
    // callback #4
  },
  Directive: {
    enter() {
      // callback #2
    },
    exit() {
      // callback #3
    },
  },
}
```

It is expected that 4th callback will be called after 3rd so we can do some common work before and after callbacks in Directive. However, exit callbacks are called in the same order as enter callbacks (eg. visitors from the example will be called in the order 1=>2=>4=>3).