### PR TITLE
Add editorconfig for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,8 @@ end_of_line = lf
 indent_style = space
 indent_size = 2
 
+[Makefile]
+indent_style = tab
+
 [*.{md,markdown}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

I guess most editors know that Makefiles are tabs-based, but to be completely sure.
