### PR TITLE
Allow context type annotation on getters/setters

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1547,19 +1547,18 @@ export default class ExpressionParser extends LValParser {
     );
   }
 
+  getGetterSetterExpectedParamCount(
+    method: N.ObjectMethod | N.ClassMethod,
+  ): number {
+    return method.kind === "get" ? 0 : 1;
+  }
+
   // get methods aren't allowed to have any parameters
   // set methods must have exactly 1 parameter which is not a rest parameter
   checkGetterSetterParams(method: N.ObjectMethod | N.ClassMethod): void {
-    const paramCount = method.kind === "get" ? 0 : 1;
+    const paramCount = this.getGetterSetterExpectedParamCount(method);
     const start = method.start;
-    // Allow `this` type annotation in TypeScript
-    if (
-      method.params.length === paramCount + 1 &&
-      method.params[0].type === "Identifier" &&
-      method.params[0].name === "this"
-    ) {
-      this.expectPlugin("typescript");
-    } else if (method.params.length !== paramCount) {
+    if (method.params.length !== paramCount) {
       if (method.kind === "get") {
         this.raise(start, "getter must not have any formal parameters");
       } else {

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1552,7 +1552,14 @@ export default class ExpressionParser extends LValParser {
   checkGetterSetterParams(method: N.ObjectMethod | N.ClassMethod): void {
     const paramCount = method.kind === "get" ? 0 : 1;
     const start = method.start;
-    if (method.params.length !== paramCount) {
+    // Allow `this` type annotation in TypeScript
+    if (
+      method.params.length === paramCount + 1 &&
+      method.params[0].type === "Identifier" &&
+      method.params[0].name === "this"
+    ) {
+      this.expectPlugin("typescript");
+    } else if (method.params.length !== paramCount) {
       if (method.kind === "get") {
         this.raise(start, "getter must not have any formal parameters");
       } else {
@@ -1560,7 +1567,10 @@ export default class ExpressionParser extends LValParser {
       }
     }
 
-    if (method.kind === "set" && method.params[0].type === "RestElement") {
+    if (
+      method.kind === "set" &&
+      method.params[method.params.length - 1].type === "RestElement"
+    ) {
       this.raise(
         start,
         "setter function argument must not be a rest parameter",

--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -2336,4 +2336,17 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (typeArguments) node.typeParameters = typeArguments;
       return super.jsxParseOpeningElementAfterName(node);
     }
+
+    getGetterSetterExpectedParamCount(
+      method: N.ObjectMethod | N.ClassMethod,
+    ): number {
+      const baseCount = super.getGetterSetterExpectedParamCount(method);
+      const firstParam = method.params[0];
+      const hasContextParam =
+        firstParam &&
+        firstParam.type === "Identifier" &&
+        firstParam.name === "this";
+
+      return hasContextParam ? baseCount + 1 : baseCount;
+    }
   };

--- a/packages/babel-parser/test/fixtures/typescript/function/getter-setter/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/function/getter-setter/input.js
@@ -1,0 +1,6 @@
+const g = {
+  get m(this: {}) {}
+};
+const s = {
+  set m(this: {}, value) {}
+};

--- a/packages/babel-parser/test/fixtures/typescript/function/getter-setter/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/function/getter-setter/output.json
@@ -1,0 +1,396 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 78,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 78,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 34,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                },
+                "identifierName": "g"
+              },
+              "name": "g"
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start": 10,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 3,
+                  "column": 1
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectMethod",
+                  "start": 14,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 20
+                    }
+                  },
+                  "method": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 18,
+                    "end": 19,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "identifierName": "m"
+                    },
+                    "name": "m"
+                  },
+                  "computed": false,
+                  "kind": "get",
+                  "id": null,
+                  "generator": false,
+                  "async": false,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 20,
+                      "end": 28,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 16
+                        },
+                        "identifierName": "this"
+                      },
+                      "name": "this",
+                      "typeAnnotation": {
+                        "type": "TSTypeAnnotation",
+                        "start": 24,
+                        "end": 28,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 16
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "TSTypeLiteral",
+                          "start": 26,
+                          "end": 28,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 14
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 16
+                            }
+                          },
+                          "members": []
+                        }
+                      }
+                    }
+                  ],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 30,
+                    "end": 32,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 18
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 20
+                      }
+                    },
+                    "body": [],
+                    "directives": []
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 36,
+        "end": 78,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 42,
+            "end": 77,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 6
+              },
+              "end": {
+                "line": 6,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 42,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 6
+                },
+                "end": {
+                  "line": 4,
+                  "column": 7
+                },
+                "identifierName": "s"
+              },
+              "name": "s"
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start": 46,
+              "end": 77,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 10
+                },
+                "end": {
+                  "line": 6,
+                  "column": 1
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectMethod",
+                  "start": 50,
+                  "end": 75,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 27
+                    }
+                  },
+                  "method": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 54,
+                    "end": 55,
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 7
+                      },
+                      "identifierName": "m"
+                    },
+                    "name": "m"
+                  },
+                  "computed": false,
+                  "kind": "set",
+                  "id": null,
+                  "generator": false,
+                  "async": false,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 56,
+                      "end": 64,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 16
+                        },
+                        "identifierName": "this"
+                      },
+                      "name": "this",
+                      "typeAnnotation": {
+                        "type": "TSTypeAnnotation",
+                        "start": 60,
+                        "end": 64,
+                        "loc": {
+                          "start": {
+                            "line": 5,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 16
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "TSTypeLiteral",
+                          "start": 62,
+                          "end": 64,
+                          "loc": {
+                            "start": {
+                              "line": 5,
+                              "column": 14
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 16
+                            }
+                          },
+                          "members": []
+                        }
+                      }
+                    },
+                    {
+                      "type": "Identifier",
+                      "start": 66,
+                      "end": 71,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 18
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 23
+                        },
+                        "identifierName": "value"
+                      },
+                      "name": "value"
+                    }
+                  ],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 73,
+                    "end": 75,
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 27
+                      }
+                    },
+                    "body": [],
+                    "directives": []
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/function/this-parameter/input.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/function/this-parameter/input.js
@@ -5,3 +5,9 @@ const o = {
 class C {
     m(this: {}) {}
 }
+const g = {
+    get m(this: {}) {}
+};
+const s = {
+    set m(this: {}, value: {}) {}
+};

--- a/packages/babel-plugin-transform-typescript/test/fixtures/function/this-parameter/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/function/this-parameter/output.js
@@ -9,3 +9,12 @@ class C {
   m() {}
 
 }
+
+const g = {
+  get m() {}
+
+};
+const s = {
+  set m(value) {}
+
+};


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8069
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Typescript allows adding [type annotations to the context (`this`) for functions](https://www.typescriptlang.org/docs/handbook/functions.html#this), including `get`ters and `set`ters. Presently, the [parser errors out](https://babeljs.io/repl/#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEAqCmEAu0DeAoa0Dm8VMSQAokALASwgC45CBKNTLaAJzwFcWA7aJF9-AG4mAX3QigA&debug=false&forceAllTransforms=false&shippedProposals=true&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=typescript%2Cenv&prettier=false&targets=Node-8.9&version=7.0.0-beta.41) when such an annotation is present on a getter or setter because it expects exactly 0 or 1 parameter, respectively.

This change causes the parser to allow an extra first parameter to getters and setters when using the `typescript` plugin and the parameter's `name` is `this`. 

`babel-plugin-transform-typescript` already strips the `this: ...` annotation from functions, including getters and setters, but I added a test to verify this in addition to the parser test.