### PR TITLE
Do not remove comments

### DIFF
--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -141,9 +141,8 @@ export default class CommentsParser extends BaseParser {
     }
 
     if (lastChild) {
-      if (lastChild.leadingComments) {
+      if (lastChild.leadingComments && lastChild !== node) {
         if (
-          lastChild !== node &&
           lastChild.leadingComments.length > 0 &&
           last(lastChild.leadingComments).end <= node.start
         ) {


### PR DESCRIPTION
The fix for https://github.com/eslint/espree/issues/158 has an error; If
`lastChild === node` it ended up removing comments.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | For some reason I cannot test this in isolation
| Patch:          | Bug Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No. It is not clear why I'm hitting this code path
| Any Dependency Changes?  | No
| License                  | MIT

The fix for https://github.com/eslint/espree/issues/158 incorrectly removes comments under some circumstances.

I can only repro this with #9581  applied but the code is clearly wrong. It should not remove the comment like it did
