### PR TITLE
Add WarningsToErrorsPlugin to webpack to avoid missing build problems on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "through2": "^2.0.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
+    "warnings-to-errors-webpack-plugin": "^2.0.0",
     "webpack": "^3.4.1",
     "webpack-dependency-suite": "^2.4.4",
     "webpack-stream": "^4.0.0"

--- a/scripts/gulp-tasks.js
+++ b/scripts/gulp-tasks.js
@@ -20,6 +20,7 @@ const rename = require("gulp-rename");
 const webpack = require("webpack");
 const { RootMostResolvePlugin } = require("webpack-dependency-suite");
 const DuplicatePackageCheckerPlugin = require("duplicate-package-checker-webpack-plugin");
+const WarningsToErrorsPlugin = require("warnings-to-errors-webpack-plugin");
 const webpackStream = require("webpack-stream");
 const uglify = require("gulp-uglify");
 
@@ -62,6 +63,7 @@ function webpackBuild(opts) {
       libraryTarget: "umd",
     },
     plugins: [
+      new WarningsToErrorsPlugin(),
       new DuplicatePackageCheckerPlugin({
         exclude(instance) {
           return instance.name === "semver";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9047,6 +9047,11 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+warnings-to-errors-webpack-plugin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/warnings-to-errors-webpack-plugin/-/warnings-to-errors-webpack-plugin-2.0.0.tgz#1ce862fa845c77a3c21bb68c839efaa7ebbdb9fb"
+  integrity sha512-0Girb3F5xc5U1TpYMiLDcie5oB+Ko2EuujOYyS3aXpKS4Yp264WkIuJ+0vF8wnmkDkmZAOBxahBedEL0mLjHQA==
+
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This should break the build if there are warnings in the webpack build, which we currently have because of #9636 
Let's see.
