### PR TITLE
fix: Don't transpile ES2018 symbol properties

### DIFF
--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -19,7 +19,15 @@ writeHelpers("@babel/runtime-corejs2", { corejs: 2 });
 function writeCoreJS2(runtimeName) {
   const pkgDirname = getRuntimeRoot(runtimeName);
 
-  const paths = ["is-iterable", "get-iterator"];
+  const paths = [
+    "is-iterable",
+    "get-iterator",
+
+    // This was previously in definitions, but was removed to work around
+    // zloirock/core-js#262. We need to keep it in @babel/runtime-corejs2 to
+    // avoid a breaking change there.
+    "symbol/async-iterator",
+  ];
 
   Object.keys(corejs2Definitions.builtins).forEach(key => {
     const path = corejs2Definitions.builtins[key];

--- a/packages/babel-plugin-transform-runtime/src/definitions.js
+++ b/packages/babel-plugin-transform-runtime/src/definitions.js
@@ -109,7 +109,7 @@ export default runtimeVersion => {
         : {}),
 
       Symbol: {
-        // FIXME: Disabled to work zloirock/core-js#262.
+        // FIXME: Disabled to work around zloirock/core-js#262.
         // asyncIterator: "symbol/async-iterator",
         for: "symbol/for",
         hasInstance: "symbol/has-instance",

--- a/packages/babel-plugin-transform-runtime/src/definitions.js
+++ b/packages/babel-plugin-transform-runtime/src/definitions.js
@@ -109,7 +109,8 @@ export default runtimeVersion => {
         : {}),
 
       Symbol: {
-        asyncIterator: "symbol/async-iterator",
+        // FIXME: Disabled to work zloirock/core-js#262.
+        // asyncIterator: "symbol/async-iterator",
         for: "symbol/for",
         hasInstance: "symbol/has-instance",
         isConcatSpreadable: "symbol/is-concat-spreadable",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #4783 (again)
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No, per #5195
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This is a repeat of #5195 to work around the same upstream issue.