### PR TITLE
Discussion: Make developing babel on Windows easier

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,125 +1,16 @@
 "use strict";
-
-const plumber = require("gulp-plumber");
-const through = require("through2");
-const chalk = require("chalk");
-const newer = require("gulp-newer");
-const babel = require("gulp-babel");
-const gulpWatch = require("gulp-watch");
-const fancyLog = require("fancy-log");
-const filter = require("gulp-filter");
 const gulp = require("gulp");
-const path = require("path");
-const webpack = require("webpack");
-const merge = require("merge-stream");
-const rollup = require("rollup");
-const rollupBabel = require("rollup-plugin-babel");
-const rollupNodeResolve = require("rollup-plugin-node-resolve");
-const { registerStandalonePackageTask } = require("./scripts/gulp-tasks");
+const requireDir = require("require-dir");
 
-const sources = ["codemods", "packages"];
+const tasks = requireDir("./scripts/gulp/tasks/");
+module.exports = exports = tasks;
 
-function swapSrcWithLib(srcPath) {
-  const parts = srcPath.split(path.sep);
-  parts[1] = "lib";
-  return parts.join(path.sep);
-}
+exports.build = gulp.parallel(exports.bundle, exports.buildCommonJs);
+exports.default = exports.build;
 
-function getGlobFromSource(source) {
-  return `./${source}/*/src/**/*.js`;
-}
+//gulp.task("build-no-bundle", () => buildBabel());
 
-function getIndexFromPackage(name) {
-  return `${name}/src/index.js`;
-}
-
-function compilationLogger() {
-  return through.obj(function(file, enc, callback) {
-    fancyLog(`Compiling '${chalk.cyan(file.relative)}'...`);
-    callback(null, file);
-  });
-}
-
-function errorsLogger() {
-  return plumber({
-    errorHandler(err) {
-      fancyLog(err.stack);
-    },
-  });
-}
-
-function rename(fn) {
-  return through.obj(function(file, enc, callback) {
-    file.path = fn(file);
-    callback(null, file);
-  });
-}
-
-function buildBabel(exclude) {
-  return merge(
-    sources.map(source => {
-      const base = path.join(__dirname, source);
-
-      let stream = gulp.src(getGlobFromSource(source), { base: base });
-
-      if (exclude) {
-        const filters = exclude.map(p => `!**/${p}/**`);
-        filters.unshift("**");
-        stream = stream.pipe(filter(filters));
-      }
-
-      return stream
-        .pipe(errorsLogger())
-        .pipe(newer({ dest: base, map: swapSrcWithLib }))
-        .pipe(compilationLogger())
-        .pipe(babel())
-        .pipe(
-          // Passing 'file.relative' because newer() above uses a relative
-          // path and this keeps it consistent.
-          rename(file => path.resolve(file.base, swapSrcWithLib(file.relative)))
-        )
-        .pipe(gulp.dest(base));
-    })
-  );
-}
-
-function buildRollup(packages) {
-  return Promise.all(
-    packages.map(pkg => {
-      const input = getIndexFromPackage(pkg);
-      fancyLog(`Compiling '${chalk.cyan(input)}' with rollup ...`);
-      return rollup
-        .rollup({
-          input,
-          plugins: [
-            rollupBabel({
-              envName: "babel-parser",
-            }),
-            rollupNodeResolve(),
-          ],
-        })
-        .then(bundle => {
-          return bundle.write({
-            file: path.join(pkg, "lib/index.js"),
-            format: "cjs",
-            name: "babel-parser",
-          });
-        });
-    })
-  );
-}
-
-const bundles = ["packages/babel-parser"];
-
-gulp.task("build-rollup", () => buildRollup(bundles));
-gulp.task("build-babel", () => buildBabel(/* exclude */ bundles));
-gulp.task("build", gulp.parallel("build-rollup", "build-babel"));
-
-gulp.task("default", gulp.series("build"));
-
-gulp.task("build-no-bundle", () => buildBabel());
-
-gulp.task(
+/*gulp.task(
   "watch",
   gulp.series("build-no-bundle", function watch() {
     gulpWatch(
@@ -167,3 +58,4 @@ registerStandalonePackageTask(
   require("./packages/babel-preset-env-standalone/package.json").version,
   presetEnvWebpackPlugins
 );
+*/

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,12 +1,12 @@
 "use strict";
 const gulp = require("gulp");
-const requireDir = require("require-dir");
 
-const tasks = requireDir("./scripts/gulp/tasks/");
-module.exports = exports = tasks;
+const tasks = require("./scripts/gulp/tasks");
 
-exports.build = gulp.parallel(exports.bundle, exports.buildCommonJs);
-exports.default = exports.build;
+tasks.build = gulp.parallel(tasks.bundle, tasks.buildCommonJs);
+tasks.default = tasks.build;
+
+module.exports = tasks;
 
 //gulp.task("build-no-bundle", () => buildBabel());
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "output-file-sync": "^2.0.0",
     "prettier": "^1.16.1",
     "pump": "^3.0.0",
+    "require-dir": "^1.2.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.6.0",
     "rollup-plugin-babel": "^4.0.0",

--- a/scripts/gulp/config.js
+++ b/scripts/gulp/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  workspaces: ["codemods", "packages"],
+  rollupBundles: ["packages/babel-parser"],
+};

--- a/scripts/gulp/tasks/buildCommonJs.js
+++ b/scripts/gulp/tasks/buildCommonJs.js
@@ -11,6 +11,8 @@ const through = require("through2");
 
 const config = require("../config");
 
+const root = path.join(__dirname, "../../..");
+
 function rename(fn) {
   return through.obj(function(file, enc, callback) {
     file.path = fn(file);
@@ -27,9 +29,9 @@ function swapSrcWithLib(srcPath) {
 module.exports = function buildCommonJs(excludeBundles = true) {
   return merge(
     config.workspaces.map(source => {
-      const base = path.join(__dirname, source);
+      const base = path.join(root, source);
 
-      let stream = gulp.src(`./${source}/*/src/**/*.js`, { base: base });
+      let stream = gulp.src(`./${source}/*/src/**/*.js`, { base });
 
       if (excludeBundles) {
         const filters = config.rollupBundles.map(p => `!**/${p}/**`);

--- a/scripts/gulp/tasks/buildCommonJs.js
+++ b/scripts/gulp/tasks/buildCommonJs.js
@@ -1,0 +1,57 @@
+"use strict";
+const path = require("path");
+const gulp = require("gulp");
+const merge = require("merge-stream");
+const filter = require("gulp-filter");
+const babel = require("gulp-babel");
+const newer = require("gulp-newer");
+const log = require("fancy-log");
+const chalk = require("chalk");
+const through = require("through2");
+
+const config = require("../config");
+
+function rename(fn) {
+  return through.obj(function(file, enc, callback) {
+    file.path = fn(file);
+    callback(null, file);
+  });
+}
+
+function swapSrcWithLib(srcPath) {
+  const parts = srcPath.split(path.sep);
+  parts[1] = "lib";
+  return parts.join(path.sep);
+}
+
+module.exports = function buildCommonJs(excludeBundles = true) {
+  return merge(
+    config.workspaces.map(source => {
+      const base = path.join(__dirname, source);
+
+      let stream = gulp.src(`./${source}/*/src/**/*.js`, { base: base });
+
+      if (excludeBundles) {
+        const filters = config.rollupBundles.map(p => `!**/${p}/**`);
+        filters.unshift("**");
+        stream = stream.pipe(filter(filters));
+      }
+
+      return stream
+        .on("error", err => {
+          log.error(err);
+        })
+        .pipe(newer({ dest: base, map: swapSrcWithLib }))
+        .on("data", file => {
+          log(`Compiling '${chalk.cyan(file.relative)}'...`);
+        })
+        .pipe(babel())
+        .pipe(
+          // Passing 'file.relative' because newer() above uses a relative
+          // path and this keeps it consistent.
+          rename(file => path.resolve(file.base, swapSrcWithLib(file.relative)))
+        )
+        .pipe(gulp.dest(base));
+    })
+  );
+};

--- a/scripts/gulp/tasks/bundle.js
+++ b/scripts/gulp/tasks/bundle.js
@@ -1,0 +1,35 @@
+"use strict";
+const path = require("path");
+const rollup = require("rollup");
+const rollupBabel = require("rollup-plugin-babel");
+const rollupNodeResolve = require("rollup-plugin-node-resolve");
+const log = require("fancy-log");
+const chalk = require("chalk");
+
+const config = require("../config");
+
+module.exports = function bundle() {
+  return Promise.all(
+    config.rollupBundles.map(pkg => {
+      const input = `${pkg}/src/index.js`;
+      log(`Compiling '${chalk.cyan(input)}' with rollup ...`);
+      return rollup
+        .rollup({
+          input,
+          plugins: [
+            rollupBabel({
+              envName: "babel-parser",
+            }),
+            rollupNodeResolve(),
+          ],
+        })
+        .then(bundle => {
+          return bundle.write({
+            file: path.join(pkg, "lib/index.js"),
+            format: "cjs",
+            name: "babel-parser",
+          });
+        });
+    })
+  );
+};

--- a/scripts/gulp/tasks/index.js
+++ b/scripts/gulp/tasks/index.js
@@ -1,0 +1,4 @@
+"use strict";
+const requireDir = require("require-dir");
+
+module.exports = requireDir(".");

--- a/scripts/gulp/tasks/test.js
+++ b/scripts/gulp/tasks/test.js
@@ -1,0 +1,34 @@
+"use strict";
+const { spawn } = require("child_process");
+
+module.exports = function test() {
+  const nodeArgs = [];
+  const jestArgs = [];
+
+  if (process.env.CI) {
+    jestArgs.push("--maxWorkers=4");
+    jestArgs.push("--ci");
+  } else {
+    if (process.env.TEST_DEBUG) {
+      nodeArgs.push("--inspect-brk");
+      jestArgs.push("--runInBand");
+    }
+
+    if (process.env.TEST_GREP) {
+      jestArgs.push("-t");
+      jestArgs.push(`"process.env.TEST_GREP"`);
+    }
+
+    if (process.env.TEST_ONLY) {
+      jestArgs.push(`"(packages|codemods)/.*${process.env.TEST_ONLY}.*/test"`);
+    }
+  }
+
+  const child = spawn(
+    "node",
+    [...nodeArgs, "node_modules/jest/bin/jest.js", ...jestArgs],
+    { stdio: "inherit" }
+  );
+
+  return child;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8012,6 +8012,11 @@ request@^2.83.0, request@^2.87.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+require-dir@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-1.2.0.tgz#0d443b75e96012d3ca749cf19f529a789ae74817"
+  integrity sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"


### PR DESCRIPTION
We are still `make` for a lot of tasks we run for publish, build, test, etc right now. As we all know `make` is not necessarily a native thing on Windows and it has been brought up a couple of times internally as well as in pull requests/issues that this is not an ideal situation for Windows users. 

We had a PR (#4843) before which migrated the make file to npm scripts. This worked, but did not solve the problem completely, as bash - another non windows native -  was still required. And imho it was also not very easy to read and understand.

In our build and bundle process we  use `gulp` hidden behind `make`. I'm not sure where using two tools originated, but looks like another reason to me to tackle this topic and maybe settle on one tool to orchestrate all the tasks.

As `gulp` was already setup it was simple for me to see how gulp would work running without `make`.

### POC `make` => `gulp`

> This is a proof of concept and does not cover all our cases.

This PR is a POC how `gulp` could potentially be used to run all our tasks in a structured way. All I did in this PR is to come up with an infrastructure for tasks to be defined in `gulp` without having to have everything in one big file.
I tried different things like `gulp-hub` for example, which did not work with the recommended way of defining gulp tasks (which is simply exporting them). 
I ended up creating a folder where each file is a gulp task. This tasks are then loaded in the main gulpfile and simply reexported.

I converted the main build as well as the rollup task. Additionally I added a `test` task which does right now exactly what the shell script did. This task is to demonstrate how we can run shell scripts from within `gulp`

>Now this might not make much sense now that we have jest. We could simply add some npm scripts to `package.json` (`"test": "jest"`, `"test:ci": "jest --ci --maxWorkers=4"`, `"test-inspect": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand"`). This would cover all cases and make use of the `jest` cli instead of our `TEST_*` variables like `yarn test ./packages/babel-parser/` instead of `TEST_ONLY=babel-parser yarn test`

Other cli calls like `rm` and `mkdir` can be replaced with npm packages or node builtins. The only requirement left that I can currently see would be `git`, which everyone who has babel cloned obviously has. And `git` is only used for very specific tasks anyway (test262, flow tests and probably publish).

### Other task runners

Now I haven't looked at any other tools, but most that came to my mind require developers to install certain tool (e.g. `ant` or `gradle`) and I guess this is not any better, and require yet another language/syntax to handle. So having a tool where the configuration is in javascript seems like a big plus. Alternatives I know for `gulp` are `grunt` (which seems outdated and barely maintained) or `broccoli` (not sure how popular that is). To my knowledge `gulp` is the most prominent one.

### Questions

- Are there any other task runners we should consider or look at? 
- The approach I took for gulp is that the right direction?
- Does it make sense to have certain simple tools directly in `package.json`? Like `jest`? Or should we create a gulp task for everything no matter what?
- Is there something I missed? Anything that could be hard to do in `gulp`?
- Are there any *better* patterns to structure gulp tasks?
- Are there any big projects we could look at that solved this in a nice way?

> I'm happy for any input no matter if you are babel maintainer or first time contributor.