### PR TITLE
Remove dependency on home-or-tmp package

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "core-js": "^2.5.7",
     "find-cache-dir": "^2.0.0",
-    "home-or-tmp": "^3.0.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "pirates": "^4.0.0",

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -1,12 +1,12 @@
 import path from "path";
 import fs from "fs";
+import os from "os";
 import { sync as mkdirpSync } from "mkdirp";
-import homeOrTmp from "home-or-tmp";
 import * as babel from "@babel/core";
 import findCacheDir from "find-cache-dir";
 
 const DEFAULT_CACHE_DIR =
-  findCacheDir({ name: "@babel/register" }) || homeOrTmp;
+  findCacheDir({ name: "@babel/register" }) || os.homedir() || os.tmpdir();
 const DEFAULT_FILENAME = path.join(
   DEFAULT_CACHE_DIR,
   `.babel.${babel.version}.${babel.getEnv()}.json`,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9620 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Existing tests pass
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes, 'home-or-tmp'
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Removed `home-or-tmp` dependency from `babel-register` package. 
This dependency is not needed since node v2.3.0.