### PR TITLE
Only load es.symbol.description when using it.

### DIFF
--- a/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js
@@ -53,11 +53,7 @@ const PromiseDependenciesWithIterators = [
   ...CommonIterators,
 ];
 
-const SymbolDependencies = [
-  "es.symbol",
-  "es.symbol.description",
-  "es.object.to-string",
-];
+const SymbolDependencies = ["es.symbol", "es.object.to-string"];
 
 const MapDependencies = [
   "es.map",


### PR DESCRIPTION
:warning: This PR isn't targeting `master`, but the `update-to-core-js-3` branch.

@zloirock This was the change I was proposing earlier today on Slack. I don't think that this can cause missing polyfills or polyfills imported in the wrong order.

1)  `Symbol()`, chrome 40
    Before: es.symbol, es.symbol.description, es.object.to-string
    After: es.symbol, es.object.to-string

2) `Symbol()`, chrome 60
   Before: es.symbol.description
   After: (none)

3) `foo.description`, chrome 40
   Before: es.symbol, es.symbol.description
   After: es.symbol, es.symbol.description

3) `foo.description`, chrome 60
   Before: es.symbol.description
   After: es.symbol.description

I tried to do the same for Map/Set proposal methods, but I couldn't because whenever someone used the `[].filter` method it would have included the `es.map` polyfill (even if proposals were disabled).