### PR TITLE
Add back types to preset-env

### DIFF
--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -27,16 +27,31 @@ declare module "lodash/merge" {
 }
 
 declare module "semver" {
+  declare class SemVer {
+    build: Array<string>;
+    loose: ?boolean;
+    major: number;
+    minor: number;
+    patch: number;
+    prerelease: Array<string | number>;
+    raw: string;
+    version: string;
+
+    constructor(version: string | SemVer): SemVer;
+  }
+
   declare module.exports: {
-    valid(v: string): boolean;
+    SemVer: SemVer;
+
+    coerce(version: string | SemVer): SemVer | null;
     gt(v1: string, v2: string): boolean;
+    intersects(r1: string, r2: string): boolean;
     lt(v1: string, v2: string): boolean;
     major(v: string): number;
     minor(v: string): number;
     patch(v: string): number;
     satisfies(v1: string, r1: string): boolean;
-
-    intersects(r1: string, r2: string): boolean;
+    valid(v: string): boolean;
   }
 }
 
@@ -179,4 +194,12 @@ declare module "js-levenshtein" {
   declare module.exports: {
     (string, string): number,
   };
+}
+
+declare module "core-js-compat/data" {
+  declare module.exports: {
+    [key: string]: {
+      [target: string]: string;
+    }
+  }
 }

--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -197,9 +197,11 @@ declare module "js-levenshtein" {
 }
 
 declare module "core-js-compat/data" {
+  declare type Target = "node" | "chrome" | "opera" | "edge" | "firefox" | "safari" | "ie" | "ios" | "android" | "electron" | "samsung";
+
   declare module.exports: {
     [key: string]: {
-      [target: string]: string;
+      [target: Target]: string;
     }
   }
 }

--- a/packages/babel-preset-env/src/available-plugins.js
+++ b/packages/babel-preset-env/src/available-plugins.js
@@ -1,3 +1,5 @@
+// @flow
+
 export default {
   "syntax-async-generators": require("@babel/plugin-syntax-async-generators"),
   "syntax-json-strings": require("@babel/plugin-syntax-json-strings"),

--- a/packages/babel-preset-env/src/debug.js
+++ b/packages/babel-preset-env/src/debug.js
@@ -1,14 +1,21 @@
+// @flow
 /*eslint quotes: ["error", "double", { "avoidEscape": true }]*/
 import semver from "semver";
 import { isUnreleasedVersion, prettifyVersion, semverify } from "./utils";
 
-const wordEnds = size => {
+import type { Targets } from "./types";
+
+const wordEnds = (size: number) => {
   return size > 1 ? "s" : "";
 };
 
 // Outputs a message that shows which target(s) caused an item to be included:
 // transform-foo { "edge":"13", "firefox":"49", "ie":"10" }
-export const logPluginOrPolyfill = (item, targetVersions, list) => {
+export const logPluginOrPolyfill = (
+  item: string,
+  targetVersions: Targets,
+  list: { [key: string]: Targets },
+) => {
   const minVersions = list[item] || {};
 
   const filteredList = Object.keys(targetVersions).reduce((result, env) => {
@@ -23,7 +30,8 @@ export const logPluginOrPolyfill = (item, targetVersions, list) => {
 
       if (
         !targetIsUnreleased &&
-        (minIsUnreleased || semver.lt(targetVersion, semverify(minVersion)))
+        (minIsUnreleased ||
+          semver.lt(targetVersion.toString(), semverify(minVersion)))
       ) {
         result[env] = prettifyVersion(targetVersion);
       }
@@ -41,12 +49,12 @@ export const logPluginOrPolyfill = (item, targetVersions, list) => {
 };
 
 export const logEntryPolyfills = (
-  polyfillName,
-  importPolyfillIncluded,
-  polyfills,
-  filename,
-  polyfillTargets,
-  allBuiltInsList,
+  polyfillName: string,
+  importPolyfillIncluded: boolean,
+  polyfills: Set<string>,
+  filename: string,
+  polyfillTargets: Targets,
+  allBuiltInsList: { [key: string]: Targets },
 ) => {
   if (!importPolyfillIncluded) {
     console.log(`\n[${filename}] Import of ${polyfillName} was not found.`);
@@ -70,10 +78,10 @@ export const logEntryPolyfills = (
 };
 
 export const logUsagePolyfills = (
-  polyfills,
-  filename,
-  polyfillTargets,
-  allBuiltInsList,
+  polyfills: Set<string>,
+  filename: string,
+  polyfillTargets: Targets,
+  allBuiltInsList: { [key: string]: Targets },
 ) => {
   if (!polyfills.size) {
     console.log(

--- a/packages/babel-preset-env/src/filter-items.js
+++ b/packages/babel-preset-env/src/filter-items.js
@@ -55,8 +55,8 @@ export default function(
   excludes: Set<string>,
   targets: Targets,
   defaultIncludes: Array<string> | null,
-  defaultExcludes: Array<string> | null,
-  pluginSyntaxMap: Map<string, string | null>,
+  defaultExcludes?: Array<string> | null,
+  pluginSyntaxMap?: Map<string, string | null>,
 ) {
   const result = new Set<string>();
 

--- a/packages/babel-preset-env/src/filter-items.js
+++ b/packages/babel-preset-env/src/filter-items.js
@@ -1,7 +1,13 @@
+// @flow
 import semver from "semver";
 import { semverify, isUnreleasedVersion } from "./utils";
 
-export function isPluginRequired(supportedEnvironments, plugin) {
+import type { Targets } from "./types";
+
+export function isPluginRequired(
+  supportedEnvironments: Targets,
+  plugin: Targets,
+) {
   const targetEnvironments = Object.keys(supportedEnvironments);
 
   if (targetEnvironments.length === 0) {
@@ -16,15 +22,18 @@ export function isPluginRequired(supportedEnvironments, plugin) {
 
     const lowestImplementedVersion = plugin[environment];
     const lowestTargetedVersion = supportedEnvironments[environment];
+
     // If targets has unreleased value as a lowest version, then don't require a plugin.
     if (isUnreleasedVersion(lowestTargetedVersion, environment)) {
       return false;
-      // Include plugin if it is supported in the unreleased environment, which wasn't specified in targets
-    } else if (isUnreleasedVersion(lowestImplementedVersion, environment)) {
+    }
+
+    // Include plugin if it is supported in the unreleased environment, which wasn't specified in targets
+    if (isUnreleasedVersion(lowestImplementedVersion, environment)) {
       return true;
     }
 
-    if (!semver.valid(lowestTargetedVersion)) {
+    if (!semver.valid(lowestTargetedVersion.toString())) {
       throw new Error(
         `Invalid version passed for target "${environment}": "${lowestTargetedVersion}". ` +
           "Versions must be in semver format (major.minor.patch)",
@@ -33,7 +42,7 @@ export function isPluginRequired(supportedEnvironments, plugin) {
 
     return semver.gt(
       semverify(lowestImplementedVersion),
-      lowestTargetedVersion,
+      lowestTargetedVersion.toString(),
     );
   });
 
@@ -41,15 +50,15 @@ export function isPluginRequired(supportedEnvironments, plugin) {
 }
 
 export default function(
-  list,
-  includes,
-  excludes,
-  targets,
-  defaultIncludes,
-  defaultExcludes,
-  pluginSyntaxMap,
+  list: { [feature: string]: Targets },
+  includes: Set<string>,
+  excludes: Set<string>,
+  targets: Targets,
+  defaultIncludes: Array<string> | null,
+  defaultExcludes: Array<string> | null,
+  pluginSyntaxMap: Map<string, string | null>,
 ) {
-  const result = new Set();
+  const result = new Set<string>();
 
   for (const item in list) {
     if (

--- a/packages/babel-preset-env/src/get-option-specific-excludes.js
+++ b/packages/babel-preset-env/src/get-option-specific-excludes.js
@@ -1,5 +1,7 @@
+// @flow
+
 const defaultExcludesForLooseMode = ["transform-typeof-symbol"];
 
-export default function({ loose }) {
+export default function({ loose }: { loose: boolean }): null | string[] {
   return loose ? defaultExcludesForLooseMode : null;
 }

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -37,12 +37,6 @@ const getPlugin = (pluginName: string) => {
   return plugin;
 };
 
-const getBuiltInTargets = targets => {
-  // eslint-disable-next-line no-unused-vars
-  const { uglify, ...builtInTargets } = targets;
-  return builtInTargets;
-};
-
 export const transformIncludesAndExcludes = (opts: Array<string>): Object => {
   return opts.reduce(
     (result, opt) => {
@@ -169,11 +163,9 @@ export default declare((api, opts) => {
   if (useBuiltIns === "usage" || useBuiltIns === "entry") {
     const regenerator = transformations.has("transform-regenerator");
 
-    const polyfillTargets = getBuiltInTargets(targets);
-
     const pluginOptions = {
       corejs,
-      polyfillTargets,
+      polyfillTargets: targets,
       include: include.builtIns,
       exclude: exclude.builtIns,
       proposals,

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -182,22 +182,24 @@ export default declare((api, opts) => {
       debug,
     };
 
-    if (useBuiltIns === "usage") {
-      if (corejs.major === 2) {
-        plugins.push([addCoreJS2UsagePlugin, pluginOptions]);
+    if (corejs) {
+      if (useBuiltIns === "usage") {
+        if (corejs.major === 2) {
+          plugins.push([addCoreJS2UsagePlugin, pluginOptions]);
+        } else {
+          plugins.push([addCoreJS3UsagePlugin, pluginOptions]);
+        }
+        if (regenerator) {
+          plugins.push([addRegeneratorUsagePlugin, pluginOptions]);
+        }
       } else {
-        plugins.push([addCoreJS3UsagePlugin, pluginOptions]);
-      }
-      if (regenerator) {
-        plugins.push([addRegeneratorUsagePlugin, pluginOptions]);
-      }
-    } else {
-      if (corejs.major === 2) {
-        plugins.push([replaceCoreJS2EntryPlugin, pluginOptions]);
-      } else {
-        plugins.push([replaceCoreJS3EntryPlugin, pluginOptions]);
-        if (!regenerator) {
-          plugins.push([removeRegeneratorEntryPlugin, pluginOptions]);
+        if (corejs.major === 2) {
+          plugins.push([replaceCoreJS2EntryPlugin, pluginOptions]);
+        } else {
+          plugins.push([replaceCoreJS3EntryPlugin, pluginOptions]);
+          if (!regenerator) {
+            plugins.push([removeRegeneratorEntryPlugin, pluginOptions]);
+          }
         }
       }
     }

--- a/packages/babel-preset-env/src/module-transformations.js
+++ b/packages/babel-preset-env/src/module-transformations.js
@@ -1,8 +1,12 @@
-export default {
+// @flow
+
+import typeof AvailablePlugins from "./available-plugins";
+
+export default ({
   auto: "transform-modules-commonjs",
   amd: "transform-modules-amd",
   commonjs: "transform-modules-commonjs",
   cjs: "transform-modules-commonjs",
   systemjs: "transform-modules-systemjs",
   umd: "transform-modules-umd",
-};
+}: { [transform: string]: $Keys<AvailablePlugins> });

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -1,15 +1,25 @@
-import { coerce } from "semver";
-import invariant from "invariant";
-import corejs2Polyfills from "../data/corejs2-built-ins.json";
-import { defaultWebIncludes } from "./polyfills/corejs2/get-platform-specific-default";
+// @flow
 import corejs3Polyfills from "core-js-compat/data";
+import invariant from "invariant";
+import { coerce, SemVer } from "semver";
+import corejs2Polyfills from "../data/corejs2-built-ins.json";
+import pluginsList from "../data/plugins.json";
 import moduleTransformations from "./module-transformations";
+import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
+import { defaultWebIncludes } from "./polyfills/corejs2/get-platform-specific-default";
 import { isBrowsersQueryValid } from "./targets-parser";
 import { findSuggestion } from "./utils";
-import pluginsList from "../data/plugins.json";
-import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
 
-const validateTopLevelOptions = options => {
+import type {
+  BuiltInsOption,
+  CorejsOption,
+  ModuleOption,
+  Options,
+  PluginListItem,
+  PluginListOption,
+} from "./types";
+
+const validateTopLevelOptions = (options: Options) => {
   const validOptions = Object.keys(TopLevelOptions);
 
   for (const option in options) {
@@ -40,7 +50,7 @@ const validIncludesAndExcludesWithCoreJS3 = new Set([
   ...Object.keys(corejs3Polyfills),
 ]);
 
-const pluginToRegExp = plugin => {
+const pluginToRegExp = (plugin: PluginListItem) => {
   if (plugin instanceof RegExp) return plugin;
   try {
     return new RegExp(`^${normalizePluginName(plugin)}$`);
@@ -49,7 +59,7 @@ const pluginToRegExp = plugin => {
   }
 };
 
-const selectPlugins = (regexp, corejs) =>
+const selectPlugins = (regexp: RegExp | null, corejs: number | false) =>
   Array.from(
     corejs
       ? corejs == 2
@@ -58,9 +68,13 @@ const selectPlugins = (regexp, corejs) =>
       : validIncludesAndExcludesWithoutCoreJS,
   ).filter(item => regexp instanceof RegExp && regexp.test(item));
 
-const flatten = array => [].concat(...array);
+const flatten = <T>(array: Array<Array<T>>): Array<T> => [].concat(...array);
 
-const expandIncludesAndExcludes = (plugins = [], type, corejs) => {
+const expandIncludesAndExcludes = (
+  plugins: PluginListOption = [],
+  type: "include" | "exclude",
+  corejs: number | false,
+) => {
   if (plugins.length === 0) return [];
 
   const selectedPlugins = plugins.map(plugin =>
@@ -78,13 +92,16 @@ const expandIncludesAndExcludes = (plugins = [], type, corejs) => {
     valid. Please check data/[plugin-features|built-in-features].js in babel-preset-env`,
   );
 
-  return flatten(selectedPlugins);
+  return flatten<string>(selectedPlugins);
 };
 
-export const normalizePluginName = plugin =>
+export const normalizePluginName = (plugin: string) =>
   plugin.replace(/^(@babel\/|babel-)(plugin-)?/, "");
 
-export const checkDuplicateIncludeExcludes = (include = [], exclude = []) => {
+export const checkDuplicateIncludeExcludes = (
+  include: Array<string> = [],
+  exclude: Array<string> = [],
+) => {
   const duplicates = include.filter(opt => exclude.indexOf(opt) >= 0);
 
   invariant(
@@ -106,7 +123,9 @@ const normalizeTargets = targets => {
   };
 };
 
-export const validateConfigPathOption = (configPath = process.cwd()) => {
+export const validateConfigPathOption = (
+  configPath: string = process.cwd(),
+) => {
   invariant(
     typeof configPath === "string",
     `Invalid Option: The configPath option '${configPath}' is invalid, only strings are allowed.`,
@@ -114,7 +133,11 @@ export const validateConfigPathOption = (configPath = process.cwd()) => {
   return configPath;
 };
 
-export const validateBoolOption = (name, value, defaultValue) => {
+export const validateBoolOption = (
+  name: string,
+  value?: boolean,
+  defaultValue: boolean,
+) => {
   if (typeof value === "undefined") {
     value = defaultValue;
   }
@@ -126,17 +149,21 @@ export const validateBoolOption = (name, value, defaultValue) => {
   return value;
 };
 
-export const validateIgnoreBrowserslistConfig = ignoreBrowserslistConfig =>
+export const validateIgnoreBrowserslistConfig = (
+  ignoreBrowserslistConfig: boolean,
+) =>
   validateBoolOption(
     TopLevelOptions.ignoreBrowserslistConfig,
     ignoreBrowserslistConfig,
     false,
   );
 
-export const validateModulesOption = (modulesOpt = ModulesOption.auto) => {
+export const validateModulesOption = (
+  modulesOpt: ModuleOption = ModulesOption.auto,
+) => {
   invariant(
-    ModulesOption[modulesOpt] ||
-      ModulesOption[modulesOpt] === ModulesOption.false,
+    ModulesOption[modulesOpt.toString()] ||
+      ModulesOption[modulesOpt.toString()] === ModulesOption.false,
     `Invalid Option: The 'modules' option must be one of \n` +
       ` - 'false' to indicate no module processing\n` +
       ` - a specific module type: 'commonjs', 'amd', 'umd', 'systemjs'` +
@@ -147,10 +174,12 @@ export const validateModulesOption = (modulesOpt = ModulesOption.auto) => {
   return modulesOpt;
 };
 
-export const validateUseBuiltInsOption = (builtInsOpt = false) => {
+export const validateUseBuiltInsOption = (
+  builtInsOpt: BuiltInsOption = false,
+) => {
   invariant(
-    UseBuiltInsOption[builtInsOpt] ||
-      UseBuiltInsOption[builtInsOpt] === UseBuiltInsOption.false,
+    UseBuiltInsOption[builtInsOpt.toString()] ||
+      UseBuiltInsOption[builtInsOpt.toString()] === UseBuiltInsOption.false,
     `Invalid Option: The 'useBuiltIns' option must be either
     'false' (default) to indicate no polyfill,
     '"entry"' to indicate replacing the entry polyfill, or
@@ -160,7 +189,15 @@ export const validateUseBuiltInsOption = (builtInsOpt = false) => {
   return builtInsOpt;
 };
 
-export function normalizeCoreJSOption(corejs, useBuiltIns) {
+type NormalizedCorejsOption = {
+  proposals: boolean,
+  version: typeof SemVer | null | false,
+};
+
+export function normalizeCoreJSOption(
+  corejs?: CorejsOption,
+  useBuiltIns: BuiltInsOption,
+): NormalizedCorejsOption {
   let proposals = false;
   let rawVersion;
 
@@ -189,7 +226,7 @@ export function normalizeCoreJSOption(corejs, useBuiltIns) {
   return { version, proposals };
 }
 
-export default function normalizeOptions(opts) {
+export default function normalizeOptions(opts: Options) {
   validateTopLevelOptions(opts);
 
   const useBuiltIns = validateUseBuiltInsOption(opts.useBuiltIns);
@@ -199,13 +236,13 @@ export default function normalizeOptions(opts) {
   const include = expandIncludesAndExcludes(
     opts.include,
     TopLevelOptions.include,
-    corejs.version && corejs.version.major,
+    !!corejs.version && corejs.version.major,
   );
 
   const exclude = expandIncludesAndExcludes(
     opts.exclude,
     TopLevelOptions.exclude,
-    corejs.version && corejs.version.major,
+    !!corejs.version && corejs.version.major,
   );
 
   checkDuplicateIncludeExcludes(include, exclude);

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -189,7 +189,7 @@ export const validateUseBuiltInsOption = (
   return builtInsOpt;
 };
 
-type NormalizedCorejsOption = {
+export type NormalizedCorejsOption = {
   proposals: boolean,
   version: typeof SemVer | null | false,
 };

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -5,14 +5,15 @@ import { defaultWebIncludes } from "./polyfills/corejs2/get-platform-specific-de
 import corejs3Polyfills from "core-js-compat/data";
 import moduleTransformations from "./module-transformations";
 import { isBrowsersQueryValid } from "./targets-parser";
-import { getValues, findSuggestion } from "./utils";
+import { findSuggestion } from "./utils";
 import pluginsList from "../data/plugins.json";
 import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
 
 const validateTopLevelOptions = options => {
+  const validOptions = Object.keys(TopLevelOptions);
+
   for (const option in options) {
     if (!TopLevelOptions[option]) {
-      const validOptions = getValues(TopLevelOptions);
       throw new Error(
         `Invalid Option: ${option} is not a valid top-level option.
         Maybe you meant to use '${findSuggestion(validOptions, option)}'?`,

--- a/packages/babel-preset-env/src/options.js
+++ b/packages/babel-preset-env/src/options.js
@@ -1,3 +1,5 @@
+// @flow
+
 export const TopLevelOptions = {
   configPath: "configPath",
   corejs: "corejs",
@@ -44,4 +46,7 @@ export const TargetNames = {
   android: "android",
   electron: "electron",
   samsung: "samsung",
+
+  // deprecated
+  uglify: "uglify",
 };

--- a/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js
@@ -1,3 +1,7 @@
+// @flow
+
+type ObjectMap<V> = { [name: string]: V };
+
 const ArrayNatureIterators = [
   "es6.object.to-string",
   "es6.array.iterator",
@@ -8,7 +12,7 @@ const CommonIterators = ["es6.string.iterator", ...ArrayNatureIterators];
 
 const PromiseDependencies = ["es6.object.to-string", "es6.promise"];
 
-export const BuiltIns = {
+export const BuiltIns: ObjectMap<string | string[]> = {
   DataView: "es6.typed.data-view",
   Float32Array: "es6.typed.float32-array",
   Float64Array: "es6.typed.float64-array",
@@ -29,7 +33,7 @@ export const BuiltIns = {
   WeakSet: ["es6.weak-set", ...CommonIterators],
 };
 
-export const InstanceProperties = {
+export const InstanceProperties: ObjectMap<string[]> = {
   __defineGetter__: ["es7.object.define-getter"],
   __defineSetter__: ["es7.object.define-setter"],
   __lookupGetter__: ["es7.object.lookup-getter"],
@@ -95,7 +99,7 @@ export const InstanceProperties = {
   values: ArrayNatureIterators,
 };
 
-export const StaticProperties = {
+export const StaticProperties: ObjectMap<ObjectMap<string | string[]>> = {
   Array: {
     from: ["es6.array.from", "es6.string.iterator"],
     isArray: "es6.array.is-array",

--- a/packages/babel-preset-env/src/polyfills/corejs2/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/entry-plugin.js
@@ -11,20 +11,18 @@ import {
 } from "../../utils";
 import { logEntryPolyfills } from "../../debug";
 
-import type { Targets } from "../../types";
+import type { InternalPluginOptions } from "../../types";
 import type { NodePath } from "@babel/traverse";
-
-type Options = {
-  include: Set<string>,
-  exclude: Set<string>,
-  polyfillTargets: Targets,
-  regenerator: boolean,
-  debug: boolean,
-};
 
 export default function(
   _: any,
-  { include, exclude, polyfillTargets, regenerator, debug }: Options,
+  {
+    include,
+    exclude,
+    polyfillTargets,
+    regenerator,
+    debug,
+  }: InternalPluginOptions,
 ) {
   const polyfills = filterItems(
     corejs2Polyfills,

--- a/packages/babel-preset-env/src/polyfills/corejs2/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/entry-plugin.js
@@ -1,3 +1,5 @@
+// @flow
+
 import corejs2Polyfills from "../../../data/corejs2-built-ins.json";
 import getPlatformSpecificDefaultFor from "./get-platform-specific-default";
 import filterItems from "../../filter-items";
@@ -9,9 +11,20 @@ import {
 } from "../../utils";
 import { logEntryPolyfills } from "../../debug";
 
+import type { Targets } from "../../types";
+import type { NodePath } from "@babel/traverse";
+
+type Options = {
+  include: Set<string>,
+  exclude: Set<string>,
+  polyfillTargets: Targets,
+  regenerator: boolean,
+  debug: boolean,
+};
+
 export default function(
-  _,
-  { include, exclude, polyfillTargets, regenerator, debug },
+  _: any,
+  { include, exclude, polyfillTargets, regenerator, debug }: Options,
 ) {
   const polyfills = filterItems(
     corejs2Polyfills,
@@ -22,12 +35,12 @@ export default function(
   );
 
   const isPolyfillImport = {
-    ImportDeclaration(path) {
+    ImportDeclaration(path: NodePath) {
       if (isPolyfillSource(getImportSource(path))) {
         this.replaceBySeparateModulesImport(path);
       }
     },
-    Program(path) {
+    Program(path: NodePath) {
       path.get("body").forEach(bodyPath => {
         if (isPolyfillSource(getRequireSource(bodyPath))) {
           this.replaceBySeparateModulesImport(bodyPath);

--- a/packages/babel-preset-env/src/polyfills/corejs2/get-platform-specific-default.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/get-platform-specific-default.js
@@ -1,10 +1,14 @@
+// @flow
+
+import type { Targets } from "../../types";
+
 export const defaultWebIncludes = [
   "web.timers",
   "web.immediate",
   "web.dom.iterable",
 ];
 
-export default function(targets) {
+export default function(targets: Targets): null | string[] {
   const targetNames = Object.keys(targets);
   const isAnyTarget = !targetNames.length;
   const isWebTarget = targetNames.some(name => name !== "node");

--- a/packages/babel-preset-env/src/polyfills/corejs2/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/usage-plugin.js
@@ -1,3 +1,5 @@
+// @flow
+
 import corejs2Polyfills from "../../../data/corejs2-built-ins.json";
 import getPlatformSpecificDefaultFor from "./get-platform-specific-default";
 import filterItems from "../../filter-items";
@@ -16,13 +18,23 @@ import {
 } from "../../utils";
 import { logUsagePolyfills } from "../../debug";
 
+import type { Targets } from "../../types";
+import type { NodePath } from "@babel/traverse";
+
 const NO_DIRECT_POLYFILL_IMPORT = `
   When setting \`useBuiltIns: 'usage'\`, polyfills are automatically imported when needed.
   Please remove the \`import '@babel/polyfill'\` call or use \`useBuiltIns: 'entry'\` instead.`;
 
+type Options = {
+  include: Set<string>,
+  exclude: Set<string>,
+  polyfillTargets: Targets,
+  debug: boolean,
+};
+
 export default function(
-  { types: t },
-  { include, exclude, polyfillTargets, debug },
+  { types: t }: { types: Object },
+  { include, exclude, polyfillTargets, debug }: Options,
 ) {
   const polyfills = filterItems(
     corejs2Polyfills,
@@ -33,14 +45,14 @@ export default function(
   );
 
   const addAndRemovePolyfillImports = {
-    ImportDeclaration(path) {
+    ImportDeclaration(path: NodePath) {
       if (isPolyfillSource(getImportSource(path))) {
         console.warn(NO_DIRECT_POLYFILL_IMPORT);
         path.remove();
       }
     },
 
-    Program(path) {
+    Program(path: NodePath) {
       path.get("body").forEach(bodyPath => {
         if (isPolyfillSource(getRequireSource(bodyPath))) {
           console.warn(NO_DIRECT_POLYFILL_IMPORT);
@@ -51,7 +63,7 @@ export default function(
 
     // Symbol()
     // new Promise
-    ReferencedIdentifier({ node: { name }, parent, scope }) {
+    ReferencedIdentifier({ node: { name }, parent, scope }: NodePath) {
       if (t.isMemberExpression(parent)) return;
       if (!has(BuiltIns, name)) return;
       if (scope.getBindingIdentifier(name)) return;
@@ -61,7 +73,7 @@ export default function(
     },
 
     // arr[Symbol.iterator]()
-    CallExpression(path) {
+    CallExpression(path: NodePath) {
       // we can't compile this
       if (path.node.arguments.length) return;
 
@@ -77,7 +89,7 @@ export default function(
     },
 
     // Symbol.iterator in arr
-    BinaryExpression(path) {
+    BinaryExpression(path: NodePath) {
       if (path.node.operator !== "in") return;
       if (!path.get("left").matchesPattern("Symbol.iterator")) return;
 
@@ -85,7 +97,7 @@ export default function(
     },
 
     // yield*
-    YieldExpression(path) {
+    YieldExpression(path: NodePath) {
       if (path.node.delegate) {
         this.addImport("web.dom.iterable");
       }
@@ -93,13 +105,13 @@ export default function(
 
     // Array.from
     MemberExpression: {
-      enter(path) {
+      enter(path: NodePath) {
         const { node } = path;
         const { object, property } = node;
 
         let evaluatedPropType = object.name;
         let propertyName = property.name;
-        let instanceType;
+        let instanceType = "";
 
         if (node.computed) {
           if (t.isStringLiteral(property)) {
@@ -141,7 +153,7 @@ export default function(
       },
 
       // Symbol.match
-      exit(path) {
+      exit(path: NodePath) {
         const { name } = path.node.object;
 
         if (!has(BuiltIns, name)) return;
@@ -153,7 +165,7 @@ export default function(
     },
 
     // var { repeat, startsWith } = String
-    VariableDeclarator(path) {
+    VariableDeclarator(path: NodePath) {
       const { node } = path;
       const { id, init } = node;
 
@@ -177,7 +189,7 @@ export default function(
 
   return {
     name: "corejs2-usage",
-    pre({ path }) {
+    pre({ path }: { path: NodePath }) {
       this.polyfillsSet = new Set();
 
       this.addImport = function(builtIn) {

--- a/packages/babel-preset-env/src/polyfills/corejs2/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/usage-plugin.js
@@ -18,23 +18,16 @@ import {
 } from "../../utils";
 import { logUsagePolyfills } from "../../debug";
 
-import type { Targets } from "../../types";
+import type { InternalPluginOptions } from "../../types";
 import type { NodePath } from "@babel/traverse";
 
 const NO_DIRECT_POLYFILL_IMPORT = `
   When setting \`useBuiltIns: 'usage'\`, polyfills are automatically imported when needed.
   Please remove the \`import '@babel/polyfill'\` call or use \`useBuiltIns: 'entry'\` instead.`;
 
-type Options = {
-  include: Set<string>,
-  exclude: Set<string>,
-  polyfillTargets: Targets,
-  debug: boolean,
-};
-
 export default function(
   { types: t }: { types: Object },
-  { include, exclude, polyfillTargets, debug }: Options,
+  { include, exclude, polyfillTargets, debug }: InternalPluginOptions,
 ) {
   const polyfills = filterItems(
     corejs2Polyfills,

--- a/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js
@@ -1,3 +1,7 @@
+// @flow
+
+type ObjectMap<V> = { [name: string]: V };
+
 const ArrayNatureIterators = [
   "es.array.iterator",
   "web.dom-collections.iterator",
@@ -113,7 +117,7 @@ const WeakSetDependencies = [
 
 const URLSearchParamsDependencies = ["web.url", ...CommonIteratorsWithTag];
 
-export const BuiltIns = {
+export const BuiltIns: ObjectMap<string[]> = {
   AggregateError: ["esnext.aggregate-error", ...CommonIterators],
   ArrayBuffer: [
     "es.array-buffer.constructor",
@@ -163,7 +167,7 @@ export const BuiltIns = {
   setImmediate: ["web.immediate"],
 };
 
-export const InstanceProperties = {
+export const InstanceProperties: ObjectMap<string[]> = {
   at: ["esnext.string.at"],
   anchor: ["es.string.anchor"],
   big: ["es.string.big"],
@@ -240,7 +244,7 @@ export const InstanceProperties = {
   __lookupSetter__: ["es.object.lookup-setter"],
 };
 
-export const StaticProperties = {
+export const StaticProperties: ObjectMap<ObjectMap<string | string[]>> = {
   Array: {
     from: ["es.array.from", "es.string.iterator"],
     isArray: ["es.array.is-array"],
@@ -422,7 +426,7 @@ export const StaticProperties = {
   Float64Array: TypedArrayStaticMethods,
 };
 
-export const CommonInstanceDependencies = new Set([
+export const CommonInstanceDependencies = new Set<string>([
   "es.object.to-string",
   "es.object.define-getter",
   "es.object.define-setter",
@@ -431,7 +435,7 @@ export const CommonInstanceDependencies = new Set([
   "es.regexp.exec",
 ]);
 
-export const PossibleGlobalObjects = new Set([
+export const PossibleGlobalObjects = new Set<string>([
   "global",
   "globalThis",
   "self",

--- a/packages/babel-preset-env/src/polyfills/corejs3/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/entry-plugin.js
@@ -90,7 +90,7 @@ export default function(
       if (debug) {
         logEntryPolyfills(
           "core-js",
-          this.polyfillsSet.size,
+          this.polyfillsSet.size > 0,
           filtered,
           this.file.opts.filename,
           polyfillTargets,

--- a/packages/babel-preset-env/src/polyfills/corejs3/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/entry-plugin.js
@@ -13,8 +13,7 @@ import {
 } from "../../utils";
 import { logEntryPolyfills } from "../../debug";
 
-import type { Targets } from "../../types";
-import type { NormalizedCorejsOption } from "../../normalize-options";
+import type { InternalPluginOptions } from "../../types";
 import type { NodePath } from "@babel/traverse";
 
 function isBabelPolyfillSource(source) {
@@ -29,17 +28,9 @@ const BABEL_POLYFILL_DEPRECATION = `
   \`@babel/polyfill\` is deprecated. Please, use required parts of \`core-js\`
   and \`regenerator-runtime/runtime\` separately`;
 
-type Options = {
-  corejs: NormalizedCorejsOption,
-  include: Set<string>,
-  exclude: Set<string>,
-  polyfillTargets: Targets,
-  debug: boolean,
-};
-
 export default function(
   _: any,
-  { corejs, include, exclude, polyfillTargets, debug }: Options,
+  { corejs, include, exclude, polyfillTargets, debug }: InternalPluginOptions,
 ) {
   const polyfills = filterItems(
     corejs3Polyfills,

--- a/packages/babel-preset-env/src/polyfills/corejs3/shipped-proposals.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/shipped-proposals.js
@@ -1,1 +1,3 @@
-export default ["esnext.global-this", "esnext.string.match-all"];
+// @flow
+
+export default (["esnext.global-this", "esnext.string.match-all"]: string[]);

--- a/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js
@@ -24,8 +24,7 @@ import {
 } from "../../utils";
 import { logUsagePolyfills } from "../../debug";
 
-import type { Targets } from "../../types";
-import type { NormalizedCorejsOption } from "../../normalize-options";
+import type { InternalPluginOptions } from "../../types";
 import type { NodePath } from "@babel/traverse";
 
 const NO_DIRECT_POLYFILL_IMPORT = `
@@ -47,16 +46,6 @@ const corejs3PolyfillsWithShippedProposals = corejs3ShippedProposalsList.reduce(
   { ...corejs3PolyfillsWithoutProposals },
 );
 
-type Options = {
-  corejs: NormalizedCorejsOption,
-  include: Set<string>,
-  exclude: Set<string>,
-  polyfillTargets: Targets,
-  debug: boolean,
-  proposals: boolean,
-  shippedProposals: boolean,
-};
-
 export default function(
   _: any,
   {
@@ -67,7 +56,7 @@ export default function(
     proposals,
     shippedProposals,
     debug,
-  }: Options,
+  }: InternalPluginOptions,
 ) {
   const polyfills = filterItems(
     proposals

--- a/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js
@@ -1,3 +1,5 @@
+// @flow
+
 import corejs3Polyfills from "core-js-compat/data";
 import corejs3ShippedProposalsList from "./shipped-proposals";
 import getModulesListForTargetVersion from "core-js-compat/get-modules-list-for-target-version";
@@ -22,6 +24,10 @@ import {
 } from "../../utils";
 import { logUsagePolyfills } from "../../debug";
 
+import type { Targets } from "../../types";
+import type { NormalizedCorejsOption } from "../../normalize-options";
+import type { NodePath } from "@babel/traverse";
+
 const NO_DIRECT_POLYFILL_IMPORT = `
   When setting \`useBuiltIns: 'usage'\`, polyfills are automatically imported when needed.
   Please remove the direct import of \`core-js\` or use \`useBuiltIns: 'entry'\` instead.`;
@@ -41,8 +47,18 @@ const corejs3PolyfillsWithShippedProposals = corejs3ShippedProposalsList.reduce(
   { ...corejs3PolyfillsWithoutProposals },
 );
 
+type Options = {
+  corejs: NormalizedCorejsOption,
+  include: Set<string>,
+  exclude: Set<string>,
+  polyfillTargets: Targets,
+  debug: boolean,
+  proposals: boolean,
+  shippedProposals: boolean,
+};
+
 export default function(
-  _,
+  _: any,
   {
     corejs,
     include,
@@ -51,7 +67,7 @@ export default function(
     proposals,
     shippedProposals,
     debug,
-  },
+  }: Options,
 ) {
   const polyfills = filterItems(
     proposals
@@ -62,6 +78,7 @@ export default function(
     include,
     exclude,
     polyfillTargets,
+    null,
   );
 
   const available = new Set(getModulesListForTargetVersion(corejs.version));
@@ -97,7 +114,7 @@ export default function(
 
   const addAndRemovePolyfillImports = {
     // import 'core-js'
-    ImportDeclaration(path) {
+    ImportDeclaration(path: NodePath) {
       if (isPolyfillSource(getImportSource(path))) {
         console.warn(NO_DIRECT_POLYFILL_IMPORT);
         path.remove();
@@ -105,7 +122,7 @@ export default function(
     },
 
     // require('core-js')
-    Program(path) {
+    Program(path: NodePath) {
       path.get("body").forEach(bodyPath => {
         if (isPolyfillSource(getRequireSource(bodyPath))) {
           console.warn(NO_DIRECT_POLYFILL_IMPORT);
@@ -119,7 +136,7 @@ export default function(
       this.addUnsupported(PromiseDependencies);
     },
 
-    Function({ node }) {
+    Function({ node }: NodePath) {
       // (async function () { }).finally(...)
       if (node.async) {
         this.addUnsupported(PromiseDependencies);
@@ -132,27 +149,27 @@ export default function(
     },
 
     // [...spread]
-    SpreadElement({ parentPath }) {
+    SpreadElement({ parentPath }: NodePath) {
       if (!parentPath.isObjectExpression()) {
         this.addUnsupported(CommonIterators);
       }
     },
 
     // yield*
-    YieldExpression({ node }) {
+    YieldExpression({ node }: NodePath) {
       if (node.delegate) {
         this.addUnsupported(CommonIterators);
       }
     },
 
     // Symbol(), new Promise
-    ReferencedIdentifier({ node: { name }, scope }) {
+    ReferencedIdentifier({ node: { name }, scope }: NodePath) {
       if (scope.getBindingIdentifier(name)) return;
 
       this.addBuiltInDependencies(name);
     },
 
-    MemberExpression(path) {
+    MemberExpression(path: NodePath) {
       const source = resolveSource(path.get("object"));
       const key = resolveKey(path.get("property"));
 
@@ -161,7 +178,7 @@ export default function(
       this.addPropertyDependencies(source, key);
     },
 
-    ObjectPattern(path) {
+    ObjectPattern(path: NodePath) {
       const { parentPath, parent, key } = path;
       let source;
 
@@ -190,7 +207,7 @@ export default function(
       }
     },
 
-    BinaryExpression(path) {
+    BinaryExpression(path: NodePath) {
       if (path.node.operator !== "in") return;
 
       const source = resolveSource(path.get("right"));
@@ -242,7 +259,7 @@ export default function(
         this.addUnsupported(InstancePropertyDependencies);
       };
     },
-    post({ path }) {
+    post({ path }: { path: NodePath }) {
       const filtered = intersection(polyfills, this.polyfillsSet, available);
       const reversed = Array.from(filtered).reverse();
 

--- a/packages/babel-preset-env/src/polyfills/regenerator/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/regenerator/entry-plugin.js
@@ -1,4 +1,7 @@
+// @flow
+
 import { getImportSource, getRequireSource } from "../../utils";
+import type { NodePath } from "@babel/traverse";
 
 function isRegeneratorSource(source) {
   return source === "regenerator-runtime/runtime";
@@ -6,13 +9,13 @@ function isRegeneratorSource(source) {
 
 export default function() {
   const visitor = {
-    ImportDeclaration(path) {
+    ImportDeclaration(path: NodePath) {
       if (isRegeneratorSource(getImportSource(path))) {
         this.regeneratorImportExcluded = true;
         path.remove();
       }
     },
-    Program(path) {
+    Program(path: NodePath) {
       path.get("body").forEach(bodyPath => {
         if (isRegeneratorSource(getRequireSource(bodyPath))) {
           this.regeneratorImportExcluded = true;

--- a/packages/babel-preset-env/src/polyfills/regenerator/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/regenerator/usage-plugin.js
@@ -1,4 +1,7 @@
+// @flow
+
 import { createImport } from "../../utils";
+import type { NodePath } from "@babel/traverse";
 
 export default function() {
   return {
@@ -7,7 +10,7 @@ export default function() {
       this.usesRegenerator = false;
     },
     visitor: {
-      Function(path) {
+      Function(path: NodePath) {
         const { node } = path;
 
         if (!this.usesRegenerator && (node.generator || node.async)) {

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -7,7 +7,6 @@ import {
   semverify,
   isUnreleasedVersion,
   getLowestUnreleased,
-  getValues,
   findSuggestion,
 } from "./utils";
 import browserModulesData from "../data/built-in-modules.json";
@@ -31,13 +30,13 @@ const objectToBrowserslist = (object: Targets): Array<string> => {
   }, []);
 };
 
-const validateTargetNames = (validTargets, targets) => {
+const validateTargetNames = (targets: Targets): void => {
+  const validTargets = Object.keys(TargetNames);
   for (const target in targets) {
     if (!TargetNames[target]) {
-      const validOptions = getValues(TargetNames);
       throw new Error(
         `Invalid Option: '${target}' is not a valid target
-        Maybe you meant to use '${findSuggestion(validOptions, target)}'?`,
+        Maybe you meant to use '${findSuggestion(validTargets, target)}'?`,
       );
     }
   }

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -1,7 +1,7 @@
 //@flow
 
 import { ModulesOption, UseBuiltInsOption } from "./options";
-import { NormalizedCorejsOption } from "./normalize-options";
+import type { NormalizedCorejsOption } from "./normalize-options";
 
 // Targets
 export type Target =

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -1,6 +1,7 @@
 //@flow
 
 import { ModulesOption, UseBuiltInsOption } from "./options";
+import { NormalizedCorejsOption } from "./normalized-options";
 
 // Targets
 export type Target =
@@ -53,3 +54,14 @@ export type Options = {
 
 // Babel
 export type Plugin = [Object, Object];
+
+export type InternalPluginOptions = {
+  corejs: NormalizedCorejsOption,
+  include: Set<string>,
+  exclude: Set<string>,
+  polyfillTargets: Targets,
+  debug: boolean,
+  proposals: boolean,
+  shippedProposals: boolean,
+  regenerator: boolean,
+};

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -5,7 +5,7 @@ import { TargetNames, ModulesOption, UseBuiltInsOption } from "./options";
 // Targets
 export type Target = $Keys<typeof TargetNames>;
 export type Targets = {
-  [target: Target]: string,
+  [target: Target]: string | number,
 };
 
 // Options

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -13,9 +13,11 @@ export type Targets = {
 export type ModuleOption = $Values<typeof ModulesOption>;
 export type BuiltInsOption = $Values<typeof UseBuiltInsOption>;
 
+type CorejsVersion = 2 | 3;
+
 export type Options = {
   configPath: string,
-  corejs: any,
+  corejs: CorejsVersion | { version: CorejsVersion, proposals: boolean },
   debug: boolean,
   exclude: Array<string | RegExp>,
   forceAllTransforms: boolean,

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -15,17 +15,22 @@ export type BuiltInsOption = $Values<typeof UseBuiltInsOption>;
 
 type CorejsVersion = 2 | 3 | string;
 
+export type CorejsOption =
+  | false
+  | CorejsVersion
+  | { version: CorejsVersion, proposals: boolean };
+
+export type PluginListItem = string | RegExp;
+export type PluginListOption = Array<PluginListItem>;
+
 export type Options = {
   configPath: string,
-  corejs:
-    | false
-    | CorejsVersion
-    | { version: CorejsVersion, proposals: boolean },
+  corejs: CorejsOption,
   debug: boolean,
-  exclude: Array<string | RegExp>,
+  exclude: PluginListOption,
   forceAllTransforms: boolean,
   ignoreBrowserslistConfig: boolean,
-  include: Array<string | RegExp>,
+  include: PluginListOption,
   loose: boolean,
   modules: ModuleOption,
   shippedProposals: boolean,

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -13,11 +13,14 @@ export type Targets = {
 export type ModuleOption = $Values<typeof ModulesOption>;
 export type BuiltInsOption = $Values<typeof UseBuiltInsOption>;
 
-type CorejsVersion = 2 | 3;
+type CorejsVersion = 2 | 3 | string;
 
 export type Options = {
   configPath: string,
-  corejs: CorejsVersion | { version: CorejsVersion, proposals: boolean },
+  corejs:
+    | false
+    | CorejsVersion
+    | { version: CorejsVersion, proposals: boolean },
   debug: boolean,
   exclude: Array<string | RegExp>,
   forceAllTransforms: boolean,

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -1,7 +1,7 @@
 //@flow
 
 import { ModulesOption, UseBuiltInsOption } from "./options";
-import { NormalizedCorejsOption } from "./normalized-options";
+import { NormalizedCorejsOption } from "./normalize-options";
 
 // Targets
 export type Target =

--- a/packages/babel-preset-env/src/types.js
+++ b/packages/babel-preset-env/src/types.js
@@ -1,11 +1,23 @@
 //@flow
 
-import { TargetNames, ModulesOption, UseBuiltInsOption } from "./options";
+import { ModulesOption, UseBuiltInsOption } from "./options";
 
 // Targets
-export type Target = $Keys<typeof TargetNames>;
+export type Target =
+  | "node"
+  | "chrome"
+  | "opera"
+  | "edge"
+  | "firefox"
+  | "safari"
+  | "ie"
+  | "ios"
+  | "android"
+  | "electron"
+  | "samsung";
+
 export type Targets = {
-  [target: Target]: string | number,
+  [target: Target]: string,
 };
 
 // Options

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -99,7 +99,10 @@ export function prettifyTargets(targets: Targets): Targets {
   }, {});
 }
 
-export function isUnreleasedVersion(version: string, env: string): boolean {
+export function isUnreleasedVersion(
+  version: string | number,
+  env: string,
+): boolean {
   const unreleasedLabel = unreleasedLabels[env];
   return (
     !!unreleasedLabel && unreleasedLabel === version.toString().toLowerCase()

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -147,7 +147,7 @@ export function getRequireSource({ node }: NodePath) {
   if (isRequire) return expression.arguments[0].value;
 }
 
-export function isPolyfillSource(source: string): boolean {
+export function isPolyfillSource(source: ?string): boolean {
   return source === "@babel/polyfill" || source === "core-js";
 }
 

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -65,7 +65,7 @@ export function findSuggestion(options: string[], option: string): string {
   }, undefined);
 }
 
-export function prettifyVersion(version: number | string) {
+export function prettifyVersion(version: string) {
   if (typeof version !== "string") {
     return version;
   }

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -41,10 +41,6 @@ export function semverify(version: number | string): string {
   return split.join(".");
 }
 
-export function getValues<T: Object>(object: T): $Values<T> {
-  return Object.keys(object).map(key => object[key]);
-}
-
 export function intersection<T>(
   first: Set<T>,
   second: Set<T>,


### PR DESCRIPTION
> NOTE: This PR isn't targeting master; it's targeting update-to-core-js-3

@existentialism If you want to help you can push here, just leave a comment. We'll merge this PR to the main PR (#7646) when we are done.

- [x] ./available-plugins.js
- [x] ./filter-items.js
- [x] ./index.js
- [x] ./get-option-specific-excludes.js
- [x] ./debug.js
- [x] ./types.js
- [x] ./utils.js
- [x] ./options.js
- [x] ./targets-parser.js
- [x] ./normalize-options.js
- [x] ./module-transformations.js

Maybe not needed:
- [x] ./polyfills/regenerator/entry-plugin.js
- [x] ./polyfills/regenerator/usage-plugin.js
- [x] ./polyfills/corejs2/entry-plugin.js
- [x] ./polyfills/corejs2/get-platform-specific-default.js
- [x] ./polyfills/corejs2/built-in-definitions.js
- [x] ./polyfills/corejs2/usage-plugin.js
- [x] ./polyfills/corejs3/entry-plugin.js
- [x] ./polyfills/corejs3/shipped-proposals.js
- [x] ./polyfills/corejs3/built-in-definitions.js
- [x] ./polyfills/corejs3/usage-plugin.js