### PR TITLE
Fix TSFunctionType visitors definition

### DIFF
--- a/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/input.ts
+++ b/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/input.ts
@@ -1,0 +1,1 @@
+let x: (number) => void;

--- a/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/options.json
+++ b/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-typescript", "./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/output.js
+++ b/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/output.js
@@ -1,0 +1,1 @@
+let x: (string) => void;

--- a/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/plugin.js
+++ b/packages/babel-traverse/test/fixtures/regression/visit-tsfunctiontype-parameters/plugin.js
@@ -1,0 +1,11 @@
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name == "number") {
+          path.node.name = "string";
+        }
+      }
+    }
+  };
+}

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -156,7 +156,7 @@ defineType("TSThisType", {
 
 const fnOrCtr = {
   aliases: ["TSType"],
-  visitor: ["typeParameters", "typeAnnotation"],
+  visitor: ["typeParameters", "parameters", "typeAnnotation"],
   fields: signatureDeclarationCommon,
 };
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9691
| Patch: Bug Fix?          | Unsure what the convention here is - it is a bug fix but it can break existing transforms if they assume the incorrect behavior that `TSFunctionType.parameters` shouldn't be visited.
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

When traversing a tree parsing for TypeScript syntax and hitting a `TSFunctionType` node, the `typeParameters` and `typeAnnotation` fields are correctly visited but the `parameters` field isn't. As a result visitors by default don't visit `foo` below:

```
var x: (foo) => void; // foo is never visited
```
```
module.exports = function() {
  return {
    visitor: {
      Identifier(path) {
        if (path.node.name == "foo") {
          // Never hit because it's nested within TSFunctionType.parameters
          path.node.name = "bar";
        }
      }
    }
  };
}
```

It appears to be a bug in babel-types/src/definitions/typescript.js which omits `parameters` in the visitors list for `fnOrCtr`. Fixed by adding it.