### PR TITLE
[plugin-transform-typescript] Fix transpiling of TS abstract classes with decorators 

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -137,7 +137,6 @@ export default declare((api, { jsxPragma = "React" }) => {
           path.remove();
           return;
         }
-        if (node.abstract) node.abstract = null;
       },
 
       Class(path) {
@@ -146,6 +145,7 @@ export default declare((api, { jsxPragma = "React" }) => {
         if (node.typeParameters) node.typeParameters = null;
         if (node.superTypeParameters) node.superTypeParameters = null;
         if (node.implements) node.implements = null;
+        if (node.abstract) node.abstract = null;
 
         // Similar to the logic in `transform-flow-strip-types`, we need to
         // handle `TSParameterProperty` and `ClassProperty` here because the

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-method/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-method/input.mjs
@@ -1,0 +1,5 @@
+import { computed } from 'mobx';
+
+abstract class Foo {
+  @computed get id() {}
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-method/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-method/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "transform-typescript",
+    [
+      "proposal-decorators",
+      {
+        "legacy": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-method/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-method/output.mjs
@@ -1,0 +1,9 @@
+var _class;
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
+
+import { computed } from 'mobx';
+let Foo = (_class = class Foo {
+  get id() {}
+
+}, (_applyDecoratedDescriptor(_class.prototype, "id", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "id"), _class.prototype)), _class);

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-parameter/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-parameter/input.mjs
@@ -1,0 +1,5 @@
+import { observable } from 'mobx';
+
+abstract class Foo {
+  @observable id = null;
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-parameter/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-parameter/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "transform-typescript",
+    [
+      "proposal-decorators",
+      {
+        "legacy": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-parameter/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated-parameter/output.mjs
@@ -1,0 +1,17 @@
+var _class, _descriptor;
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object['ke' + 'ys'](descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object['define' + 'Property'](target, property, desc); desc = null; } return desc; }
+
+function _initializerWarningHelper(descriptor, context) { throw new Error('Decorating class property failed. Please ensure that ' + 'proposal-class-properties is enabled and set to use loose mode. ' + 'To use proposal-class-properties in spec mode with decorators, wait for ' + 'the next major version of decorators in stage 2.'); }
+
+import { observable } from 'mobx';
+let Foo = (_class = class Foo {
+  id = _initializerWarningHelper(_descriptor, this);
+}, (_descriptor = _applyDecoratedDescriptor(_class.prototype, "id", [observable], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: function () {
+    return null;
+  }
+})), _class);

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/input.mjs
@@ -1,0 +1,4 @@
+import { observer } from 'mobx-react';
+
+@observer
+abstract class Foo {}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "transform-typescript",
+    [
+      "proposal-decorators",
+      {
+        "legacy": true
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/abstract-class-decorated/output.mjs
@@ -1,0 +1,5 @@
+var _class;
+
+import { observer } from 'mobx-react';
+
+let Foo = observer(_class = class Foo {}) || _class;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/8172
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Added, not passing 😞
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

When `["@babel/plugin-proposal-decorators", { "legacy": true }]` and `@babel/preset-typescript` plugins are in use, using decorators with or within Typescript abstract classes causes generation of wrong syntax and preserves non-JS compliant `abstract` specification for class.

E.g. of code:

```typescript
export default abstract class SyncableEntity {
  @observable id: string;
}
```

becomes:
```javascript
let SyncableEntity = (_class = (_temp = abstract class SyncableEntity {
    _initializerDefineProperty(this, "id", _descriptor, this);
    // ...
}
```

This PR resolves it this issue by removing `abstract` property from `Class` visitor of `@babel/plugin-transform-typescript`.

I am having a trouble with tests, though - used in [test](https://github.com/babel/babel/pull/9693/files#diff-fac3cd7bf646c91b08f78aa272cd4a72R1) syntax is not accepted by parser:

```typescript
var foo = abstract class Foo {}
```

I get `BABEL_PARSE_ERROR`. Please help! 