### PR TITLE
Use `babel > ` as prompt in babel-node

### DIFF
--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -212,7 +212,7 @@ if (program.eval || program.print) {
 
 function replStart() {
   repl.start({
-    prompt: "> ",
+    prompt: "babel > ",
     input: process.stdin,
     output: process.stdout,
     eval: replEval,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Maybe No
| Minor: New Feature?      | Maybe yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In babel-node, use `babel > ` as prompt instead of simple ` > ` (to show `babel` brand specially)

FYI, `gatsby repl` just did in this way :)
https://github.com/gatsbyjs/gatsby/blob/cfc5126ba604ceaaf561d51007d6b67d115106b3/packages/gatsby/src/commands/repl.js#L36
