### PR TITLE
Correctly preserve reference to array in for-of loop

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1169/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1169/output.js
@@ -1,9 +1,10 @@
 function foo() {
   var input = ['a', 'b', 'c'];
   var output = {};
+  var _arr = input;
 
-  for (var _i = 0; _i < input.length; _i++) {
-    var c = input[_i];
+  for (var _i = 0; _i < _arr.length; _i++) {
+    var c = _arr[_i];
     var name = c;
     output[name] = name;
   }

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -118,18 +118,14 @@ export default declare((api, options) => {
 
   function _ForOfStatementArray(path) {
     const { node, scope } = path;
-    const nodes = [];
-    let right = node.right;
 
-    if (!t.isIdentifier(right) || !scope.hasBinding(right.name)) {
-      const uid = scope.generateUid("arr");
-      nodes.push(
-        t.variableDeclaration("var", [
-          t.variableDeclarator(t.identifier(uid), right),
-        ]),
-      );
-      right = t.identifier(uid);
-    }
+    const uid = scope.generateUid("arr");
+    const nodes = [
+      t.variableDeclaration("var", [
+        t.variableDeclarator(t.identifier(uid), node.right),
+      ]),
+    ];
+    const right = t.identifier(uid);
 
     const iterationKey = scope.generateUidIdentifier("i");
 

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/input.js
@@ -1,0 +1,3 @@
+for (let o of arr) {
+  const arr = o;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-of-redeclare/output.js
@@ -1,0 +1,4 @@
+for (let _i = 0, _arr = arr; _i < _arr.length; _i++) {
+  let o = _arr[_i];
+  const arr = o;
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/opt/array-binding/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/opt/array-binding/output.js
@@ -1,11 +1,13 @@
 const x = [];
+var _arr = x;
 
-for (var _i = 0; _i < x.length; _i++) {
-  const y = x[_i];
+for (var _i = 0; _i < _arr.length; _i++) {
+  const y = _arr[_i];
 }
 
 const arr = Object.entries(x);
+var _arr2 = arr;
 
-for (var _i2 = 0; _i2 < arr.length; _i2++) {
-  const y = arr[_i2];
+for (var _i2 = 0; _i2 < _arr2.length; _i2++) {
+  const y = _arr2[_i2];
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/input.js
@@ -1,0 +1,5 @@
+function f(...t) {
+  for (let o of t) {
+    const t = o;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
@@ -1,0 +1,8 @@
+function f(...t) {
+  var _arr = t;
+
+  for (var _i = 0; _i < _arr.length; _i++) {
+    let o = _arr[_i];
+    const t = o;
+  }
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/exec.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/exec.js
@@ -1,0 +1,9 @@
+var arr = [1, 2, 3];
+var results = [];
+
+for (let v of arr) {
+  results.push(v);
+  arr = null;
+}
+
+expect(results).toEqual([1, 2, 3]);

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/input.js
@@ -1,0 +1,6 @@
+var arr = [1,2,3]
+
+for (let v of arr) {
+  console.log(v)
+  arr = null
+}

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/output.js
@@ -1,0 +1,8 @@
+var arr = [1, 2, 3];
+var _arr = arr;
+
+for (var _i = 0; _i < _arr.length; _i++) {
+  let v = _arr[_i];
+  console.log(v);
+  arr = null;
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9696 Fixes #8913 Fixes #8920
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This change ensures that the reference to an array inside the header of an for-of loop cannot be unset.
