### PR TITLE
Move array reference into `for` head initializer

### DIFF
--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1169/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1169/output.js
@@ -1,9 +1,8 @@
 function foo() {
   var input = ['a', 'b', 'c'];
   var output = {};
-  var _arr = input;
 
-  for (var _i = 0; _i < _arr.length; _i++) {
+  for (var _i = 0, _arr = input; _i < _arr.length; _i++) {
     var c = _arr[_i];
     var name = c;
     output[name] = name;

--- a/packages/babel-core/test/fixtures/transformation/misc/regression-1169/output.js
+++ b/packages/babel-core/test/fixtures/transformation/misc/regression-1169/output.js
@@ -2,8 +2,8 @@ function foo() {
   var input = ['a', 'b', 'c'];
   var output = {};
 
-  for (var _i = 0, _arr = input; _i < _arr.length; _i++) {
-    var c = _arr[_i];
+  for (var _i = 0, _input = input; _i < _input.length; _i++) {
+    var c = _input[_i];
     var name = c;
     output[name] = name;
   }

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -119,7 +119,7 @@ export default declare((api, options) => {
   function _ForOfStatementArray(path) {
     const { node, scope } = path;
 
-    const right = t.identifier(scope.generateUid("arr"));
+    const right = scope.generateUidIdentifierBasedOnNode(node.right, "arr");
     const iterationKey = scope.generateUidIdentifier("i");
 
     let loop = buildForOfArray({

--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -70,7 +70,7 @@ export default declare((api, options) => {
     : pushComputedPropsSpec;
 
   const buildForOfArray = template(`
-    for (var KEY = 0; KEY < ARR.length; KEY++) BODY;
+    for (var KEY = 0, NAME = ARR; KEY < NAME.length; KEY++) BODY;
   `);
 
   const buildForOfLoose = template(`
@@ -119,20 +119,14 @@ export default declare((api, options) => {
   function _ForOfStatementArray(path) {
     const { node, scope } = path;
 
-    const uid = scope.generateUid("arr");
-    const nodes = [
-      t.variableDeclaration("var", [
-        t.variableDeclarator(t.identifier(uid), node.right),
-      ]),
-    ];
-    const right = t.identifier(uid);
-
+    const right = t.identifier(scope.generateUid("arr"));
     const iterationKey = scope.generateUidIdentifier("i");
 
     let loop = buildForOfArray({
       BODY: node.body,
       KEY: iterationKey,
-      ARR: right,
+      NAME: right,
+      ARR: node.right,
     });
 
     t.inherits(loop, node);
@@ -160,9 +154,7 @@ export default declare((api, options) => {
       loop = t.labeledStatement(path.parentPath.node.label, loop);
     }
 
-    nodes.push(loop);
-
-    return nodes;
+    return [loop];
   }
 
   function replaceWithArray(path) {

--- a/packages/babel-plugin-transform-for-of/test/fixtures/opt/array-binding/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/opt/array-binding/output.js
@@ -1,11 +1,11 @@
 const x = [];
 
-for (var _i = 0, _arr = x; _i < _arr.length; _i++) {
-  const y = _arr[_i];
+for (var _i = 0, _x = x; _i < _x.length; _i++) {
+  const y = _x[_i];
 }
 
 const arr = Object.entries(x);
 
-for (var _i2 = 0, _arr2 = arr; _i2 < _arr2.length; _i2++) {
-  const y = _arr2[_i2];
+for (var _i2 = 0, _arr = arr; _i2 < _arr.length; _i2++) {
+  const y = _arr[_i2];
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/opt/array-binding/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/opt/array-binding/output.js
@@ -1,13 +1,11 @@
 const x = [];
-var _arr = x;
 
-for (var _i = 0; _i < _arr.length; _i++) {
+for (var _i = 0, _arr = x; _i < _arr.length; _i++) {
   const y = _arr[_i];
 }
 
 const arr = Object.entries(x);
-var _arr2 = arr;
 
-for (var _i2 = 0; _i2 < _arr2.length; _i2++) {
+for (var _i2 = 0, _arr2 = arr; _i2 < _arr2.length; _i2++) {
   const y = _arr2[_i2];
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/opt/built-ins/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/opt/built-ins/output.js
@@ -2,18 +2,18 @@ for (var _i = 0, _arr = []; _i < _arr.length; _i++) {
   const y = _arr[_i];
 }
 
-for (var _i2 = 0, _arr2 = Array.from(x); _i2 < _arr2.length; _i2++) {
-  const y = _arr2[_i2];
+for (var _i2 = 0, _Array$from = Array.from(x); _i2 < _Array$from.length; _i2++) {
+  const y = _Array$from[_i2];
 }
 
-for (var _i3 = 0, _arr3 = Object.keys(x); _i3 < _arr3.length; _i3++) {
-  const y = _arr3[_i3];
+for (var _i3 = 0, _Object$keys = Object.keys(x); _i3 < _Object$keys.length; _i3++) {
+  const y = _Object$keys[_i3];
 }
 
-for (var _i4 = 0, _arr4 = Object.values(x); _i4 < _arr4.length; _i4++) {
-  const y = _arr4[_i4];
+for (var _i4 = 0, _Object$values = Object.values(x); _i4 < _Object$values.length; _i4++) {
+  const y = _Object$values[_i4];
 }
 
-for (var _i5 = 0, _arr5 = Object.entries(x); _i5 < _arr5.length; _i5++) {
-  const y = _arr5[_i5];
+for (var _i5 = 0, _Object$entries = Object.entries(x); _i5 < _Object$entries.length; _i5++) {
+  const y = _Object$entries[_i5];
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/opt/built-ins/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/opt/built-ins/output.js
@@ -1,29 +1,19 @@
-var _arr = [];
-
-for (var _i = 0; _i < _arr.length; _i++) {
+for (var _i = 0, _arr = []; _i < _arr.length; _i++) {
   const y = _arr[_i];
 }
 
-var _arr2 = Array.from(x);
-
-for (var _i2 = 0; _i2 < _arr2.length; _i2++) {
+for (var _i2 = 0, _arr2 = Array.from(x); _i2 < _arr2.length; _i2++) {
   const y = _arr2[_i2];
 }
 
-var _arr3 = Object.keys(x);
-
-for (var _i3 = 0; _i3 < _arr3.length; _i3++) {
+for (var _i3 = 0, _arr3 = Object.keys(x); _i3 < _arr3.length; _i3++) {
   const y = _arr3[_i3];
 }
 
-var _arr4 = Object.values(x);
-
-for (var _i4 = 0; _i4 < _arr4.length; _i4++) {
+for (var _i4 = 0, _arr4 = Object.values(x); _i4 < _arr4.length; _i4++) {
   const y = _arr4[_i4];
 }
 
-var _arr5 = Object.entries(x);
-
-for (var _i5 = 0; _i5 < _arr5.length; _i5++) {
+for (var _i5 = 0, _arr5 = Object.entries(x); _i5 < _arr5.length; _i5++) {
   const y = _arr5[_i5];
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/opt/typeannotation/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/opt/typeannotation/output.js
@@ -1,6 +1,4 @@
-var _arr = b;
-
-for (var _i = 0; _i < _arr.length; _i++) {
+for (var _i = 0, _arr = b; _i < _arr.length; _i++) {
   const y = _arr[_i];
 }
 

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/if-block-label-3858/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/if-block-label-3858/output.js
@@ -1,7 +1,5 @@
 if (true) {
-  var _arr = [];
-
-  loop: for (var _i = 0; _i < _arr.length; _i++) {
+  loop: for (var _i = 0, _arr = []; _i < _arr.length; _i++) {
     let ch = _arr[_i];
   }
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/if-label-3858/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/if-label-3858/output.js
@@ -1,7 +1,5 @@
 if (true) {
-  var _arr = [];
-
-  loop: for (var _i = 0; _i < _arr.length; _i++) {
+  loop: for (var _i = 0, _arr = []; _i < _arr.length; _i++) {
     let ch = _arr[_i];
   }
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
@@ -1,7 +1,5 @@
 function f(...t) {
-  var _arr = t;
-
-  for (var _i = 0; _i < _arr.length; _i++) {
+  for (var _i = 0, _arr = t; _i < _arr.length; _i++) {
     let o = _arr[_i];
     const t = o;
   }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/redeclare-array-8913/output.js
@@ -1,6 +1,6 @@
 function f(...t) {
-  for (var _i = 0, _arr = t; _i < _arr.length; _i++) {
-    let o = _arr[_i];
+  for (var _i = 0, _t = t; _i < _t.length; _i++) {
+    let o = _t[_i];
     const t = o;
   }
 }

--- a/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/regression/scope-9696/output.js
@@ -1,7 +1,6 @@
 var arr = [1, 2, 3];
-var _arr = arr;
 
-for (var _i = 0; _i < _arr.length; _i++) {
+for (var _i = 0, _arr = arr; _i < _arr.length; _i++) {
   let v = _arr[_i];
   console.log(v);
   arr = null;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |n
| Major: Breaking Change?  |n
| Minor: New Feature?      |n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This moves the reference to the array of an for..of loop into the initializer of the transpiled for loop. Ass recommended in #9697

No functional change only moving the variable around.
