### PR TITLE
Correctly parse TS TypeAssertions around arrow functions

### DIFF
--- a/packages/babel-parser/src/plugins/typescript.js
+++ b/packages/babel-parser/src/plugins/typescript.js
@@ -2121,7 +2121,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         // This is similar to TypeScript's `tryParseParenthesizedArrowFunctionExpression`.
         typeParameters = this.tsParseTypeParameters();
         arrowExpression = super.parseMaybeAssign(...args);
-        if (arrowExpression.type !== "ArrowFunctionExpression") {
+        if (
+          arrowExpression.type !== "ArrowFunctionExpression" ||
+          (arrowExpression.extra && arrowExpression.extra.parenthesized)
+        ) {
           this.unexpected(); // Go to the catch block (needs a SyntaxError).
         }
       } catch (err) {

--- a/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens-with-parens-node/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens-with-parens-node/input.js
@@ -1,0 +1,1 @@
+var asserted1 = <any>((n) => { return n; });

--- a/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens-with-parens-node/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens-with-parens-node/options.json
@@ -1,0 +1,4 @@
+{
+  "createParenthesizedExpressions": true,
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens-with-parens-node/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens-with-parens-node/output.json
@@ -1,0 +1,217 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 44,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 44
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 44,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 44
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 44,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 44
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 43,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 43
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "asserted1"
+              },
+              "name": "asserted1"
+            },
+            "init": {
+              "type": "TSTypeAssertion",
+              "start": 16,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 43
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSAnyKeyword",
+                "start": 17,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                }
+              },
+              "expression": {
+                "type": "ParenthesizedExpression",
+                "start": 21,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 43
+                  }
+                },
+                "expression": {
+                  "type": "ArrowFunctionExpression",
+                  "start": 22,
+                  "end": 42,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 42
+                    }
+                  },
+                  "id": null,
+                  "generator": false,
+                  "async": false,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 23,
+                      "end": 24,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 23
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 24
+                        },
+                        "identifierName": "n"
+                      },
+                      "name": "n"
+                    }
+                  ],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 29,
+                    "end": 42,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 42
+                      }
+                    },
+                    "body": [
+                      {
+                        "type": "ReturnStatement",
+                        "start": 31,
+                        "end": 40,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 31
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 40
+                          }
+                        },
+                        "argument": {
+                          "type": "Identifier",
+                          "start": 38,
+                          "end": 39,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 38
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 39
+                            },
+                            "identifierName": "n"
+                          },
+                          "name": "n"
+                        }
+                      }
+                    ],
+                    "directives": []
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens/input.js
@@ -1,0 +1,1 @@
+var asserted1 = <any>((n) => { return n; });

--- a/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/cast/arrow-in-parens/output.json
@@ -1,0 +1,206 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 44,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 44
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 44,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 44
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 44,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 44
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 43,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 43
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "asserted1"
+              },
+              "name": "asserted1"
+            },
+            "init": {
+              "type": "TSTypeAssertion",
+              "start": 16,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 43
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSAnyKeyword",
+                "start": 17,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                }
+              },
+              "expression": {
+                "type": "ArrowFunctionExpression",
+                "start": 22,
+                "end": 42,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 42
+                  }
+                },
+                "id": null,
+                "generator": false,
+                "async": false,
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "start": 23,
+                    "end": 24,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 24
+                      },
+                      "identifierName": "n"
+                    },
+                    "name": "n"
+                  }
+                ],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 29,
+                  "end": 42,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 42
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ReturnStatement",
+                      "start": 31,
+                      "end": 40,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 31
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 40
+                        }
+                      },
+                      "argument": {
+                        "type": "Identifier",
+                        "start": 38,
+                        "end": 39,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 38
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 39
+                          },
+                          "identifierName": "n"
+                        },
+                        "name": "n"
+                      }
+                    }
+                  ],
+                  "directives": []
+                },
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 21
+                }
+              }
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9324
| Patch: Bug Fix?          | 👻
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Prior to this change it would only work if `createParenthesizedExpressions` was true, because we already check if the node is not an `ArrowFunctionExpression`. Now it also works with this setting set to false.
