### PR TITLE
Create drafts instead of finished releases

### DIFF
--- a/.github/actions/trigger-github-release/release.js
+++ b/.github/actions/trigger-github-release/release.js
@@ -18,6 +18,7 @@ getStdin()
     repo: repoName,
     tag_name: tag,
     body: changelog,
+    draft: true,
   }))
   .catch(err => {
     console.error(err);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT


Currently, the "Trigger GitHub release" and "Publish to npm" actions
are run in parallel. Publishing to npm takes about 15 mins (it needs to
run `make bootstrap`), so everyone watching the npm repo for
releases would get the notification before that the new version is
available on npm.

This commit marks the automatically generated GitHub releases as draft,
which then need to be manually "finalized" by real people. This will also
avoid notifying people when for some reason a publish fails.

<!-- Describe your changes below in as much detail as possible -->
