### PR TITLE
Set NPM_TOKEN in .npmrc when publishing

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -17,7 +17,7 @@ action "Publish to npm" {
   uses = "docker://node:10"
   secrets = ["NPM_TOKEN"]
   runs = "make"
-  args = "publish-c"
+  args = "publish-ci"
   env = {
     CI = "true"
   }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -17,7 +17,7 @@ action "Publish to npm" {
   uses = "docker://node:10"
   secrets = ["NPM_TOKEN"]
   runs = "make"
-  args = "publish"
+  args = "publish-c"
   env = {
     CI = "true"
   }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.npmrc
+
 .DS_Store
 /node_modules
 /.github/actions/*/node_modules

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ fix-json:
 	./node_modules/.bin/prettier "{packages,codemod}/*/test/fixtures/**/options.json" --write --loglevel warn
 
 clean: test-clean
+	rm -f .npmrc
 	rm -rf packages/babel-polyfill/browser*
 	rm -rf packages/babel-polyfill/dist
 	rm -rf coverage
@@ -138,6 +139,17 @@ new-version:
 # NOTE: Run make new-version first
 publish: prepublish
 	./node_modules/.bin/lerna publish from-git --require-scripts
+	make clean
+
+publish-ci: prepublish
+ifneq ("$(NPM_TOKEN)", "")
+	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+else
+	echo "Missing NPM_TOKEN env var"
+	exit 1
+endif
+	./node_modules/.bin/lerna publish from-git --require-scripts --yes
+	rm -f .npmrc
 	make clean
 
 bootstrap-only: clean-all


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As you can see in https://github.com/babel/babel/runs/82101132, the publish failed because of an auth error:
```
lerna ERR! EWHOAMI Authentication error. Use `npm whoami` to troubleshoot
```

I tought that a `NPM_TOKEN` env var was enought, but apparentely it isn't: https://github.com/npm/npm/issues/8356.

I don't think that this PR could cause a security problem, because the .npmrc file is generated right before running lerna and deleted right after.