### PR TITLE
Fix wrong minimum dependency version

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -58,7 +58,7 @@
     "core-js-compat": "^3.0.0",
     "invariant": "^2.2.2",
     "js-levenshtein": "^1.1.3",
-    "semver": "^5.3.0"
+    "semver": "^5.5.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Any Dependency Changes?  | Yes
| License                  | MIT

The minimum version of the package `semver` is not correct. The package `@babel/preset-env` uses the function `coerce` which was introduced in version 5.5.0 of the package `semver` (see: https://github.com/npm/node-semver/blob/master/CHANGELOG.md#55).

In my case this caused an issue because I had another package with a pinned version of the `semver` package.