### PR TITLE
Upgrade browserslist and caniuse in preset-env

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-transform-typeof-symbol": "^7.2.0",
     "@babel/plugin-transform-unicode-regex": "^7.2.0",
     "@babel/types": "^7.4.0",
-    "browserslist": "^4.4.2",
+    "browserslist": "^4.5.2",
     "core-js-compat": "^3.0.0",
     "invariant": "^2.2.2",
     "js-levenshtein": "^1.1.3",
@@ -69,7 +69,7 @@
     "@babel/helper-fixtures": "^7.2.0",
     "@babel/helper-plugin-test-runner": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-    "caniuse-db": "1.0.30000938",
+    "caniuse-db": "1.0.30000951",
     "compat-table": "kangax/compat-table#6d012ba020fa7415e8a2d29e87924bab79b128a3",
     "electron-to-chromium": "1.3.113"
   }


### PR DESCRIPTION

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?         | y

<!-- Describe your changes below in as much detail as possible -->

There is a corrupt version of caniuse-lite that will cause installs with
yarn to fail. Upgrading these dependencies makes sure that the version
of caniuse-lite will not be the corrupt version.
