### PR TITLE
[runtime-corejs3] Only polyfill instance methods when it might be needed

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/helpers.js
+++ b/packages/babel-plugin-transform-runtime/src/helpers.js
@@ -1,4 +1,5 @@
 import semver from "semver";
+import { types as t } from "@babel/core";
 
 export function hasMinVersion(minVersion, runtimeVersion) {
   // If the range is unavailable, we're running the script during Babel's
@@ -29,4 +30,17 @@ export function hasMinVersion(minVersion, runtimeVersion) {
     !semver.intersects(`<${minVersion}`, runtimeVersion) &&
     !semver.intersects(`>=8.0.0`, runtimeVersion)
   );
+}
+
+// Note: We can't use NodePath#couldBeBaseType because it doesn't support arrays.
+// Even if we added support for arrays, this package needs to be compatible with
+// ^7.0.0 so we can't rely on it.
+export function typeAnnotationToString(node) {
+  switch (node.type) {
+    case "GenericTypeAnnotation":
+      if (t.isIdentifier(node.id, { name: "Array" })) return "array";
+      break;
+    case "StringTypeAnnotation":
+      return "string";
+  }
 }

--- a/packages/babel-plugin-transform-runtime/src/runtime-corejs3-definitions.js
+++ b/packages/babel-plugin-transform-runtime/src/runtime-corejs3-definitions.js
@@ -180,12 +180,16 @@ export default () => {
       },
     },
 
+    // NOTE: You can specify the object types whose method needs to be polyfilled.
+    // e.g.  concat: { types: ["array"] }
+    // See ./helpers.js@typeAnnotationToString for the supported types
+
     InstanceProperties: {
       at: { stable: false, path: "at" },
       bind: { stable: true, path: "bind" },
       codePointAt: { stable: true, path: "code-point-at" },
       codePoints: { stable: false, path: "code-points" },
-      concat: { stable: true, path: "concat" },
+      concat: { stable: true, path: "concat", types: ["array"] },
       copyWithin: { stable: true, path: "copy-within" },
       endsWith: { stable: true, path: "ends-with" },
       entries: { stable: true, path: "entries" },

--- a/packages/babel-plugin-transform-runtime/test/fixtures/regression/issue-9753-webpack-require-template-compatibility/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/regression/issue-9753-webpack-require-template-compatibility/input.js
@@ -1,0 +1,1 @@
+require(`./locale/${lan}`);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/regression/issue-9753-webpack-require-template-compatibility/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/regression/issue-9753-webpack-require-template-compatibility/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["transform-runtime", { "corejs": 3 }],
+    "transform-template-literals"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/regression/issue-9753-webpack-require-template-compatibility/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/regression/issue-9753-webpack-require-template-compatibility/output.js
@@ -1,0 +1,1 @@
+require("./locale/".concat(lan));

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/instance-inference-optimization/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/instance-inference-optimization/input.js
@@ -1,0 +1,3 @@
+"".concat(b);
+[].concat(b);
+a.concat(b);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/instance-inference-optimization/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/instance-inference-optimization/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-runtime", { "corejs": 3 }]]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/instance-inference-optimization/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/instance-inference-optimization/output.js
@@ -1,0 +1,9 @@
+var _concatInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/instance/concat");
+
+var _context;
+
+"".concat(b);
+
+_concatInstanceProperty(_context = []).call(_context, b);
+
+_concatInstanceProperty(a).call(a, b);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9753
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes?
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR allows instance methods polyfills to specify on which base type they need to be applied. If Babel is 100% that it is called on another instance type, it will avoid polyfilling it.

For example, `"".concat` doesn't need to be polyfilled but `foo.concat` does because `foo` might be an array.
#9753 shows that polyfilling `.concat` breaks webpack logic to handle `require` calls with template literals.

Other instance methods could be optimized, but if this PR lands I'll leave it as a `[good first issue]` PR.