### PR TITLE
Remove process.exit(1) from babel-node

### DIFF
--- a/packages/babel-node/src/babel-node.js
+++ b/packages/babel-node/src/babel-node.js
@@ -103,9 +103,6 @@ getV8Flags(function(err, v8Flags) {
         }
       });
     });
-    process.on("SIGINT", () => {
-      proc.kill("SIGINT");
-      process.exit(1);
-    });
+    process.on("SIGINT", () => proc.kill("SIGINT"));
   }
 });


### PR DESCRIPTION
Because it breaked graceful shutdown of the sub process. For example, if you have an express server, catch the SIGINT signal and process.exit(0) after closing the server, the command would always return exit code 1. This PR allows the subprocess to decide how to exit itself.
