### PR TITLE
Optimize parseBindingAtom code to get better error messages

### DIFF
--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -231,9 +231,6 @@ export default class LValParser extends NodeUtils {
   // Parses lvalue (assignable) atom.
   parseBindingAtom(): Pattern {
     switch (this.state.type) {
-      case tt.name:
-        return this.parseIdentifier();
-
       case tt.bracketL: {
         const node = this.startNode();
         this.next();
@@ -243,10 +240,9 @@ export default class LValParser extends NodeUtils {
 
       case tt.braceL:
         return this.parseObj(true);
-
-      default:
-        throw this.unexpected();
     }
+
+    return this.parseIdentifier();
   }
 
   parseBindingList(

--- a/packages/babel-parser/test/fixtures/core/uncategorised/382/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/382/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:4)"
+  "throws": "Unexpected keyword 'if' (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/397/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/397/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:11)"
+  "throws": "Unexpected keyword 'if' (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/398/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/398/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:11)"
+  "throws": "Unexpected keyword 'true' (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/399/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/399/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:11)"
+  "throws": "Unexpected keyword 'false' (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/400/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/400/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:11)"
+  "throws": "Unexpected keyword 'null' (1:11)"
 }

--- a/packages/babel-parser/test/fixtures/core/uncategorised/523/options.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/523/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:4)"
+  "throws": "Unexpected keyword 'this' (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/229/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/229/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:4)"
+  "throws": "Unexpected keyword 'super' (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/230/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/230/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:4)"
+  "throws": "Unexpected keyword 'default' (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/231/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/231/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:4)"
+  "throws": "Unexpected keyword 'default' (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/232/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/232/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:6)"
+  "throws": "Unexpected keyword 'default' (1:6)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0064/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0064/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:4)"
+  "throws": "Unexpected keyword 'if' (1:4)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0104/input.js
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0104/input.js
@@ -1,1 +1,0 @@
-function t(if) { }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0104/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0104/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:11)"
-}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0105/input.js
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0105/input.js
@@ -1,1 +1,0 @@
-function t(true) { }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0105/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0105/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:11)"
-}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0106/input.js
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0106/input.js
@@ -1,1 +1,0 @@
-function t(false) { }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0106/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0106/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:11)"
-}

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0107/input.js
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0107/input.js
@@ -1,1 +1,0 @@
-function t(null) { }

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0107/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0107/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:11)"
-}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This slightly changes `parseBindingAtom` to get better error messages.


There were also some duplicated tests that I removed.