### PR TITLE
fix(rest-spread): Do not require `Symbol.iterator` for strings

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -933,24 +933,27 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 
 helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
+    // ES6 prototypes that use @@iterator
     const prototypeWhiteList = [
-      '[object Arguments]',
+      String.prototype,
+      Array.prototype,
+      // Map.prototype,
+      // Set.prototype,
     ];
-    let hasSymbol = false;
-    try {
-      if (Symbol.iterator in Object(iter)) {
-        hasSymbol = true;
-      }
-    } catch (e) {}
-    if (hasSymbol) {
-      // Return outside catch block to allow any errors to be thrown by Array.from 
+    const iterObject = Object(iter);
+    if (prototypeWhiteList.some(prototype => prototype.isPrototypeOf(iterObject))) {
       return Array.from(iter);
     }
-    // Fallback to whitelist
-    if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+
+    // IsArguments
+    if (iterObject.toString() === "[object Arguments]") {
       return Array.from(iter);
     }
-    return null;
+
+    // Check for custom iterator outside ES6 spec, iterable WeakMap, or iterable TypedArray
+    if (Symbol.iterator in iterObject) {
+      return Array.from(iter);
+    }
   }
 `;
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -933,25 +933,19 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 
 helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
-    // ES6 prototypes that use @@iterator
-    const prototypeWhiteList = [
-      String.prototype,
-      Array.prototype,
-      // Map.prototype,
-      // Set.prototype,
-    ];
-    const iterObject = Object(iter);
-    if (prototypeWhiteList.some(prototype => prototype.isPrototypeOf(iterObject))) {
+    // String.prototype
+    if (typeof iter === 'string') {
       return Array.from(iter);
     }
 
-    // IsArguments
-    if (iterObject.toString() === "[object Arguments]") {
+    // Function Arguments
+    if (Object.prototype.toString.call(iter) === "[object Arguments]") {
       return Array.from(iter);
     }
 
-    // Check for custom iterator outside ES6 spec, iterable WeakMap, or iterable TypedArray
-    if (Symbol.iterator in iterObject) {
+    // Check for iterable WeakMap, Map, Set, or TypedArray
+    // Check for custom iterator outside ES6 spec
+    if (Symbol.iterator in Object(iter)) {
       return Array.from(iter);
     }
   }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -933,10 +933,24 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 
 helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
-    if (
-      Symbol.iterator in Object(iter) ||
-      Object.prototype.toString.call(iter) === "[object Arguments]"
-    ) return Array.from(iter);
+    const prototypeWhiteList = [
+      '[object Arguments]',
+    ];
+    let hasSymbol = false;
+    try {
+      if (Symbol.iterator in Object(iter)) {
+        hasSymbol = true;
+      }
+    } catch (e) {}
+    if (hasSymbol) {
+      // Return outside catch block to allow any errors to be thrown by Array.from 
+      return Array.from(iter);
+    }
+    // Fallback to whitelist
+    if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+      return Array.from(iter);
+    }
+    return null;
   }
 `;
 

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -933,21 +933,11 @@ helpers.arrayWithHoles = helper("7.0.0-beta.0")`
 
 helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
-    // String.prototype
-    if (typeof iter === 'string') {
-      return Array.from(iter);
-    }
-
-    // Function Arguments
-    if (Object.prototype.toString.call(iter) === "[object Arguments]") {
-      return Array.from(iter);
-    }
-
-    // Check for iterable WeakMap, Map, Set, or TypedArray
-    // Check for custom iterator outside ES6 spec
-    if (Symbol.iterator in Object(iter)) {
-      return Array.from(iter);
-    }
+    if (
+      typeof iter === 'string'
+      || Object.prototype.toString.call(iter) === "[object Arguments]"
+      || Symbol.iterator in Object(iter)
+    ) return Array.from(iter);
   }
 `;
 

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-exec/exec.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-exec/exec.js
@@ -1,0 +1,9 @@
+function sum(x, y, z) {
+  return x + y + z;
+}
+function test() {
+  var args = arguments;
+  return sum(...args);
+}
+
+expect(test(1, 2, 3)).toBe(6);

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-exec/options.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/parameters-exec/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-object-rest-spread"]
+}

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/string-exec/exec.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-spread/string-exec/exec.js
@@ -1,0 +1,3 @@
+expect([...'']).toHaveLength(0);
+expect([...'abc']).toHaveLength(3);
+expect([...'def']).toMatchObject(['d','e','f']);

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,20 +1,15 @@
 import _isIterable from "../../core-js/is-iterable";
 import _Array$from from "../../core-js/array/from";
 export default function _iterableToArray(iter) {
-  var prototypeWhiteList = [String.prototype, Array.prototype];
-  var iterObject = Object(iter);
-
-  if (prototypeWhiteList.some(function (prototype) {
-    return prototype.isPrototypeOf(iterObject);
-  })) {
+  if (typeof iter === 'string') {
     return _Array$from(iter);
   }
 
-  if (iterObject.toString() === "[object Arguments]") {
+  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
     return _Array$from(iter);
   }
 
-  if (_isIterable(iterObject)) {
+  if (_isIterable(Object(iter))) {
     return _Array$from(iter);
   }
 }

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,5 +1,22 @@
 import _Array$from from "../../core-js/array/from";
 import _isIterable from "../../core-js/is-iterable";
 export default function _iterableToArray(iter) {
-  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  var prototypeWhiteList = ['[object Arguments]'];
+  var hasSymbol = false;
+
+  try {
+    if (_isIterable(Object(iter))) {
+      hasSymbol = true;
+    }
+  } catch (e) {}
+
+  if (hasSymbol) {
+    return _Array$from(iter);
+  }
+
+  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+    return _Array$from(iter);
+  }
+
+  return null;
 }

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,15 +1,5 @@
-import _isIterable from "../../core-js/is-iterable";
 import _Array$from from "../../core-js/array/from";
+import _isIterable from "../../core-js/is-iterable";
 export default function _iterableToArray(iter) {
-  if (typeof iter === 'string') {
-    return _Array$from(iter);
-  }
-
-  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
-    return _Array$from(iter);
-  }
-
-  if (_isIterable(Object(iter))) {
-    return _Array$from(iter);
-  }
+  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || _isIterable(Object(iter))) return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,22 +1,20 @@
-import _Array$from from "../../core-js/array/from";
 import _isIterable from "../../core-js/is-iterable";
+import _Array$from from "../../core-js/array/from";
 export default function _iterableToArray(iter) {
-  var prototypeWhiteList = ['[object Arguments]'];
-  var hasSymbol = false;
+  var prototypeWhiteList = [String.prototype, Array.prototype];
+  var iterObject = Object(iter);
 
-  try {
-    if (_isIterable(Object(iter))) {
-      hasSymbol = true;
-    }
-  } catch (e) {}
-
-  if (hasSymbol) {
+  if (prototypeWhiteList.some(function (prototype) {
+    return prototype.isPrototypeOf(iterObject);
+  })) {
     return _Array$from(iter);
   }
 
-  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+  if (iterObject.toString() === "[object Arguments]") {
     return _Array$from(iter);
   }
 
-  return null;
+  if (_isIterable(iterObject)) {
+    return _Array$from(iter);
+  }
 }

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -1,19 +1,9 @@
-var _isIterable = require("../core-js/is-iterable");
-
 var _Array$from = require("../core-js/array/from");
 
+var _isIterable = require("../core-js/is-iterable");
+
 function _iterableToArray(iter) {
-  if (typeof iter === 'string') {
-    return _Array$from(iter);
-  }
-
-  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
-    return _Array$from(iter);
-  }
-
-  if (_isIterable(Object(iter))) {
-    return _Array$from(iter);
-  }
+  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || _isIterable(Object(iter))) return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -1,26 +1,24 @@
-var _Array$from = require("../core-js/array/from");
-
 var _isIterable = require("../core-js/is-iterable");
 
+var _Array$from = require("../core-js/array/from");
+
 function _iterableToArray(iter) {
-  var prototypeWhiteList = ['[object Arguments]'];
-  var hasSymbol = false;
+  var prototypeWhiteList = [String.prototype, Array.prototype];
+  var iterObject = Object(iter);
 
-  try {
-    if (_isIterable(Object(iter))) {
-      hasSymbol = true;
-    }
-  } catch (e) {}
-
-  if (hasSymbol) {
+  if (prototypeWhiteList.some(function (prototype) {
+    return prototype.isPrototypeOf(iterObject);
+  })) {
     return _Array$from(iter);
   }
 
-  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+  if (iterObject.toString() === "[object Arguments]") {
     return _Array$from(iter);
   }
 
-  return null;
+  if (_isIterable(iterObject)) {
+    return _Array$from(iter);
+  }
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -3,20 +3,15 @@ var _isIterable = require("../core-js/is-iterable");
 var _Array$from = require("../core-js/array/from");
 
 function _iterableToArray(iter) {
-  var prototypeWhiteList = [String.prototype, Array.prototype];
-  var iterObject = Object(iter);
-
-  if (prototypeWhiteList.some(function (prototype) {
-    return prototype.isPrototypeOf(iterObject);
-  })) {
+  if (typeof iter === 'string') {
     return _Array$from(iter);
   }
 
-  if (iterObject.toString() === "[object Arguments]") {
+  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
     return _Array$from(iter);
   }
 
-  if (_isIterable(iterObject)) {
+  if (_isIterable(Object(iter))) {
     return _Array$from(iter);
   }
 }

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -3,7 +3,24 @@ var _Array$from = require("../core-js/array/from");
 var _isIterable = require("../core-js/is-iterable");
 
 function _iterableToArray(iter) {
-  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  var prototypeWhiteList = ['[object Arguments]'];
+  var hasSymbol = false;
+
+  try {
+    if (_isIterable(Object(iter))) {
+      hasSymbol = true;
+    }
+  } catch (e) {}
+
+  if (hasSymbol) {
+    return _Array$from(iter);
+  }
+
+  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+    return _Array$from(iter);
+  }
+
+  return null;
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,13 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (typeof iter === 'string') {
-    return Array.from(iter);
-  }
-
-  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
-    return Array.from(iter);
-  }
-
-  if (Symbol.iterator in Object(iter)) {
-    return Array.from(iter);
-  }
+  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || Symbol.iterator in Object(iter)) return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,20 +1,18 @@
 export default function _iterableToArray(iter) {
-  var prototypeWhiteList = ['[object Arguments]'];
-  var hasSymbol = false;
+  var prototypeWhiteList = [String.prototype, Array.prototype];
+  var iterObject = Object(iter);
 
-  try {
-    if (Symbol.iterator in Object(iter)) {
-      hasSymbol = true;
-    }
-  } catch (e) {}
-
-  if (hasSymbol) {
+  if (prototypeWhiteList.some(function (prototype) {
+    return prototype.isPrototypeOf(iterObject);
+  })) {
     return Array.from(iter);
   }
 
-  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+  if (iterObject.toString() === "[object Arguments]") {
     return Array.from(iter);
   }
 
-  return null;
+  if (Symbol.iterator in iterObject) {
+    return Array.from(iter);
+  }
 }

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,20 @@
 export default function _iterableToArray(iter) {
-  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  var prototypeWhiteList = ['[object Arguments]'];
+  var hasSymbol = false;
+
+  try {
+    if (Symbol.iterator in Object(iter)) {
+      hasSymbol = true;
+    }
+  } catch (e) {}
+
+  if (hasSymbol) {
+    return Array.from(iter);
+  }
+
+  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+    return Array.from(iter);
+  }
+
+  return null;
 }

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,18 +1,13 @@
 export default function _iterableToArray(iter) {
-  var prototypeWhiteList = [String.prototype, Array.prototype];
-  var iterObject = Object(iter);
-
-  if (prototypeWhiteList.some(function (prototype) {
-    return prototype.isPrototypeOf(iterObject);
-  })) {
+  if (typeof iter === 'string') {
     return Array.from(iter);
   }
 
-  if (iterObject.toString() === "[object Arguments]") {
+  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
     return Array.from(iter);
   }
 
-  if (Symbol.iterator in iterObject) {
+  if (Symbol.iterator in Object(iter)) {
     return Array.from(iter);
   }
 }

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,22 +1,20 @@
 function _iterableToArray(iter) {
-  var prototypeWhiteList = ['[object Arguments]'];
-  var hasSymbol = false;
+  var prototypeWhiteList = [String.prototype, Array.prototype];
+  var iterObject = Object(iter);
 
-  try {
-    if (Symbol.iterator in Object(iter)) {
-      hasSymbol = true;
-    }
-  } catch (e) {}
-
-  if (hasSymbol) {
+  if (prototypeWhiteList.some(function (prototype) {
+    return prototype.isPrototypeOf(iterObject);
+  })) {
     return Array.from(iter);
   }
 
-  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+  if (iterObject.toString() === "[object Arguments]") {
     return Array.from(iter);
   }
 
-  return null;
+  if (Symbol.iterator in iterObject) {
+    return Array.from(iter);
+  }
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,18 +1,13 @@
 function _iterableToArray(iter) {
-  var prototypeWhiteList = [String.prototype, Array.prototype];
-  var iterObject = Object(iter);
-
-  if (prototypeWhiteList.some(function (prototype) {
-    return prototype.isPrototypeOf(iterObject);
-  })) {
+  if (typeof iter === 'string') {
     return Array.from(iter);
   }
 
-  if (iterObject.toString() === "[object Arguments]") {
+  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
     return Array.from(iter);
   }
 
-  if (Symbol.iterator in iterObject) {
+  if (Symbol.iterator in Object(iter)) {
     return Array.from(iter);
   }
 }

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,22 @@
 function _iterableToArray(iter) {
-  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  var prototypeWhiteList = ['[object Arguments]'];
+  var hasSymbol = false;
+
+  try {
+    if (Symbol.iterator in Object(iter)) {
+      hasSymbol = true;
+    }
+  } catch (e) {}
+
+  if (hasSymbol) {
+    return Array.from(iter);
+  }
+
+  if (prototypeWhiteList.indexOf(Object.prototype.toString.call(iter)) !== -1) {
+    return Array.from(iter);
+  }
+
+  return null;
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,15 +1,5 @@
 function _iterableToArray(iter) {
-  if (typeof iter === 'string') {
-    return Array.from(iter);
-  }
-
-  if (Object.prototype.toString.call(iter) === "[object Arguments]") {
-    return Array.from(iter);
-  }
-
-  if (Symbol.iterator in Object(iter)) {
-    return Array.from(iter);
-  }
+  if (typeof iter === 'string' || Object.prototype.toString.call(iter) === "[object Arguments]" || Symbol.iterator in Object(iter)) return Array.from(iter);
 }
 
 module.exports = _iterableToArray;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #9277
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  | No
| Minor: New Feature?      |  No
| Tests Added + Pass?      | Pass (with no tests added) 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This applies the same logic as other runtime helpers by checking if `typeof Symbol === 'function'` before using Symbol.iterator as seen here:

https://github.com/babel/babel/blob/3aaafae053fa75febb3aa45d45b6f00646e30ba4/packages/babel-helpers/src/helpers.js#L178

The CoreJS2 version of this example would be compiled as:

```
if (typeof _Symbol === "function" && _Symbol$asyncIterator) {
  AsyncGenerator.prototype[_Symbol$asyncIterator] = function () {
    return this;
  };
}
```

You can also see this at https://github.com/babel/babel/blob/3aaafae053fa75febb3aa45d45b6f00646e30ba4/packages/babel-helpers/src/helpers.js#L215

So I can confirm the syntax is correct. I've tested on IE11 and spread now works properly (after adding a polyfill for Array.from).

Tested with: 

```
function sum(x, y, z) {
  return x + y + z;
}

const numbers = [1, 2, 3];

console.log(sum(...numbers));
// expected output: 6
```

The only actual code change in `packages/babel-helpers/src/helpers.js` and everything else is auto generated by `make bootstrap`.