### PR TITLE
Prevent JSX pragma detection in transform-typescript from leaking between files

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -74,7 +74,10 @@ export default declare((api, { jsxPragma = "React" }) => {
               // just bail if there is no binding, since chances are good that if
               // the import statement was injected then it wasn't a typescript type
               // import anyway.
-              if (binding && isImportTypeOnly(file, binding, state.programPath)) {
+              if (
+                binding &&
+                isImportTypeOnly(file, binding, state.programPath)
+              ) {
                 importsToRemove.push(binding.path);
               } else {
                 allElided = false;

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -43,7 +43,6 @@ export default declare((api, { jsxPragma = "React" }) => {
 
         const { file } = state;
 
-        // find the JSX pragma from comments or reset to the initial one
         if (file.ast.comments) {
           for (const comment of (file.ast.comments: Array<Object>)) {
             const jsxMatches = JSX_ANNOTATION_REGEX.exec(comment.value);

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -26,6 +26,7 @@ export default declare((api, { jsxPragma = "React" }) => {
   api.assertVersion(7);
 
   const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/;
+  let currentJsxPragma = jsxPragma;
 
   return {
     name: "transform-typescript",
@@ -42,11 +43,13 @@ export default declare((api, { jsxPragma = "React" }) => {
 
         const { file } = state;
 
+        // find the JSX pragma from comments or reset to the initial one
+        currentJsxPragma = jsxPragma;
         if (file.ast.comments) {
           for (const comment of (file.ast.comments: Array<Object>)) {
             const jsxMatches = JSX_ANNOTATION_REGEX.exec(comment.value);
             if (jsxMatches) {
-              jsxPragma = jsxMatches[1];
+              currentJsxPragma = jsxMatches[1];
             }
           }
         }
@@ -320,7 +323,7 @@ export default declare((api, { jsxPragma = "React" }) => {
       }
     }
 
-    if (binding.identifier.name !== jsxPragma) {
+    if (binding.identifier.name !== currentJsxPragma) {
       return true;
     }
 


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Bug Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No test added
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

This PR fixes a bug in support of JSX pragma in Typescript (introduced in https://github.com/babel/babel/pull/9095).

We've noticed this bug while building a large codebase with webpack+babel+typescript. Some files from our projects are using `/** @jsx h*/` to use a custom function for JSX syntax; and some others are using the React syntax.

We've noticed that our react imports were being removed by babel because the plugin instance was being reused by `babel-loader` and webpack; and it was causing an error :

```
ReferenceError: React is not defined
```

This PR resets the `jsxPragma` being used to the initial value for each new file being processed.

I can't add a unit test for this bug because it requires processing 2 files (one with `/** @jsx something */` then one with the react syntax).

I've tested a build of this PR and it correctly fixes the issue for us.
