### PR TITLE
Fix super method call in private instance method calling overridden method

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -501,7 +501,9 @@ function replaceThisContext(path, ref, superRef, file, loose) {
     file,
     getObjectRef() {
       state.needsClassRef = true;
-      return path.node.static ? ref : t.thisExpression();
+      return path.node.static
+        ? ref
+        : t.memberExpression(ref, t.identifier("prototype"));
     },
   });
   replacer.replace();

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/exec.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  superMethod() {
+    return 'bad';
+  }
+
   #privateMethod() {
     return super.superMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/exec.js
@@ -1,6 +1,6 @@
 class Base {
   superMethod() {
-    return 1017;
+    return 'good';
   }
 }
 
@@ -14,4 +14,4 @@ class Sub extends Base {
   }
 }
 
-expect((new Sub()).publicMethod()).toEqual(1017);
+expect((new Sub()).publicMethod()).toEqual('good');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/input.js
@@ -1,6 +1,6 @@
 class Base {
   superMethod() {
-    return 1017;
+    return 'good';
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/input.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  superMethod() {
+    return 'bad';
+  }
+
   #privateMethod() {
     return super.superMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
@@ -1,6 +1,6 @@
 class Base {
   superMethod() {
-    return 1017;
+    return 'good';
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method-loose/super/output.js
@@ -13,6 +13,10 @@ class Sub extends Base {
     });
   }
 
+  superMethod() {
+    return 'bad';
+  }
+
   publicMethod() {
     return babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/exec.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  superMethod() {
+    return 'bad';
+  }
+
   #privateMethod() {
     return super.superMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/exec.js
@@ -1,6 +1,6 @@
 class Base {
   superMethod() {
-    return 1017;
+    return 'good';
   }
 }
 
@@ -14,4 +14,4 @@ class Sub extends Base {
   }
 }
 
-expect((new Sub()).publicMethod()).toEqual(1017);
+expect((new Sub()).publicMethod()).toEqual('good');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/input.js
@@ -1,6 +1,6 @@
 class Base {
   superMethod() {
-    return 1017;
+    return 'good';
   }
 }
 

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/input.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  superMethod() {
+    return 'bad';
+  }
+
   #privateMethod() {
     return super.superMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
@@ -12,6 +12,10 @@ class Sub extends Base {
     _privateMethod.add(this);
   }
 
+  superMethod() {
+    return 'bad';
+  }
+
   publicMethod() {
     return babelHelpers.classPrivateMethodGet(this, _privateMethod, _privateMethod2).call(this);
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
@@ -1,6 +1,6 @@
 class Base {
   superMethod() {
-    return 1017;
+    return 'good';
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-method/super/output.js
@@ -21,5 +21,5 @@ class Sub extends Base {
 var _privateMethod = new WeakSet();
 
 var _privateMethod2 = function _privateMethod2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(this), "superMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(Sub.prototype), "superMethod", this).call(this);
 };

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/exec.js
@@ -1,5 +1,7 @@
 class Base {
-  static basePublicStaticMethod() { return 1017; }
+  static basePublicStaticMethod() {
+    return 'good';
+  }
 }
 
 class Sub extends Base {
@@ -12,4 +14,4 @@ class Sub extends Base {
   }
 }
 
-expect(Sub.check()).toEqual(1017);
+expect(Sub.check()).toEqual('good');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/exec.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
   static #subStaticPrivateMethod() {
     return super.basePublicStaticMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/input.js
@@ -1,5 +1,7 @@
 class Base {
-  static basePublicStaticMethod() { return 1017; }
+  static basePublicStaticMethod() {
+    return 'good';
+  }
 }
 
 class Sub extends Base {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/input.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
   static #subStaticPrivateMethod() {
     return super.basePublicStaticMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
@@ -1,6 +1,6 @@
 class Base {
   static basePublicStaticMethod() {
-    return 1017;
+    return 'good';
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method-loose/super/output.js
@@ -6,6 +6,10 @@ class Base {
 }
 
 class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
   static check() {
     babelHelpers.classPrivateFieldLooseBase(Sub, _subStaticPrivateMethod)[_subStaticPrivateMethod]();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/exec.js
@@ -1,5 +1,7 @@
 class Base {
-  static basePublicStaticMethod() { return 1017; }
+  static basePublicStaticMethod() {
+    return 'good';
+  }
 }
 
 class Sub extends Base {
@@ -12,4 +14,4 @@ class Sub extends Base {
   }
 }
 
-expect(Sub.check()).toEqual(1017);
+expect(Sub.check()).toEqual('good');

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/exec.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/exec.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
   static #subStaticPrivateMethod() {
     return super.basePublicStaticMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/input.js
@@ -1,5 +1,7 @@
 class Base {
-  static basePublicStaticMethod() { return 1017; }
+  static basePublicStaticMethod() {
+    return 'good';
+  }
 }
 
 class Sub extends Base {

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/input.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/input.js
@@ -5,6 +5,10 @@ class Base {
 }
 
 class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
   static #subStaticPrivateMethod() {
     return super.basePublicStaticMethod();
   }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/output.js
@@ -1,6 +1,6 @@
 class Base {
   static basePublicStaticMethod() {
-    return 1017;
+    return 'good';
   }
 
 }

--- a/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/output.js
+++ b/packages/babel-plugin-proposal-private-methods/test/fixtures/private-static-method/super/output.js
@@ -6,6 +6,10 @@ class Base {
 }
 
 class Sub extends Base {
+  static basePublicStaticMethod() {
+    return 'bad';
+  }
+
   static check() {
     babelHelpers.classStaticPrivateMethodGet(Sub, Sub, _subStaticPrivateMethod).call(Sub);
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #9788 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

Previously, we transpiled the following code:
```js
class Sub extends Base {
  #privateMethod() {
    return super.superMethod();
  }
}
```
to:
```js
var _privateMethod2 = function _privateMethod2() {
  return babelHelpers.get(babelHelpers.getPrototypeOf(this), "superMethod", this).call(this);
};
```
This is incorrect: the lookup happens on the wrong prototype. The prototype chain of `this` looks something like:
```
this ---> Sub.prototype ---> Base.prototype ---> Object.prototype ---> null
```
`getPrototypeOf(this) === Sub.prototype`, so we look up `Sub.prototype.superMethod`. This may be overridden by `Sub`, so it's incorrect for the `super` call.

With this PR, the transpiled code becomes:
```js
var _privateMethod2 = function _privateMethod2() {
  return babelHelpers.get(babelHelpers.getPrototypeOf(Sub.prototype), "superMethod", this).call(this);
};
```
`getPrototypeOf(Sub.prototype) === Base.prototype`, so we look up `Base.prototype.superMethod`. This is the expected method for the `super` call.