### PR TITLE
Enforce publish of previously missed packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -21,7 +21,7 @@
         "test/**",
         "codemods/**",
         "# We ignore every JSON file, except for built-in-modules, built-ins and plugins defined in babel-preset-env/data.",
-        "@(!(built-in-modules|built-ins|plugins)).json"
+        "@(!(built-in-modules|built-ins|plugins|package)).json"
       ]
     }
   },

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/cli",
-  "version": "7.2.3",
+  "version": "7.3.4",
   "description": "Babel command line.",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/helper-fixtures",
-  "version": "7.2.0",
+  "version": "7.3.3",
   "description": "Helper function to support fixtures",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/helper-module-transforms",
-  "version": "7.2.2",
+  "version": "7.3.3",
   "description": "Babel helper functions for implementing ES6 module transformations",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/helper-regex",
-  "version": "7.0.0",
+  "version": "7.3.3",
   "description": "Helper function to check for literal RegEx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/helper-transform-fixture-test-runner",
-  "version": "7.1.2",
+  "version": "7.3.3",
   "description": "Transform test runner for @babel/helper-fixtures module",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/plugin-proposal-nullish-coalescing-operator",
-  "version": "7.2.0",
+  "version": "7.2.2",
   "description": "Remove nullish coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-nullish-coalescing-operator",
   "license": "MIT",

--- a/packages/babel-plugin-syntax-bigint/package.json
+++ b/packages/babel-plugin-syntax-bigint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/plugin-syntax-bigint",
-  "version": "7.2.0",
+  "version": "7.2.2",
   "description": "Allow parsing of BigInt literals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint",
   "license": "MIT",

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/plugin-transform-dotall-regex",
-  "version": "7.2.0",
+  "version": "7.4.0",
   "description": "Compile regular expressions using the `s` (`dotAll`) flag to ES5.",
   "homepage": "https://babeljs.io/",
   "license": "MIT",

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/plugin-transform-proto-to-assign",
-  "version": "7.2.0",
+  "version": "7.3.4",
   "description": "Babel plugin for turning __proto__ into a shallow property clone",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
   "license": "MIT",

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babel/plugin-transform-unicode-regex",
-  "version": "7.2.0",
+  "version": "7.4.0",
   "description": "Compile ES2015 Unicode regex to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
   "license": "MIT",


### PR DESCRIPTION
This change ensures that all packages which we did not publish because of the package.json ignore will be published in the next version. I simply increased the version to the version the package should be at right now, and this change will be picked up by lerna in the next release.

I thought about publishing each of this packages by hand, but I guess it is more safe to do it with the next patch release.

This also includes a change for the lerna ignores to not ignore package.json.

Fixes #9787