### PR TITLE
Transpile babel-polyfill to es5, instead of targeting node 6

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,11 +5,12 @@ module.exports = function(api) {
 
   const includeCoverage = process.env.BABEL_COVERAGE === "true";
 
-  const envOpts = {
+  const envOptsNoTargets = {
     loose: true,
     modules: false,
     exclude: ["transform-typeof-symbol"],
   };
+  const envOpts = Object.assign({}, envOptsNoTargets);
 
   let convertESM = true;
   let ignoreLib = true;
@@ -96,6 +97,11 @@ module.exports = function(api) {
           // leading to dependency cycles.
           convertESM ? "@babel/transform-modules-commonjs" : null,
         ].filter(Boolean),
+      },
+      {
+        test: "./packages/babel-polyfill",
+        presets: [["@babel/env", envOptsNoTargets]],
+        plugins: [["@babel/transform-modules-commonjs", null]],
       },
       {
         // The vast majority of our src files are modules, but we use

--- a/babel.config.js
+++ b/babel.config.js
@@ -101,7 +101,7 @@ module.exports = function(api) {
       {
         test: "./packages/babel-polyfill",
         presets: [["@babel/env", envOptsNoTargets]],
-        plugins: [["@babel/transform-modules-commonjs", null]],
+        plugins: [["@babel/transform-modules-commonjs", { lazy: false }]],
       },
       {
         // The vast majority of our src files are modules, but we use


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Without this PR, `BABEL_ENV=production make build-dist` throws
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
