### PR TITLE
Fix typo in cloneNode.

### DIFF
--- a/packages/babel-types/src/clone/cloneNode.js
+++ b/packages/babel-types/src/clone/cloneNode.js
@@ -66,7 +66,7 @@ export default function cloneNode<T: Object>(node: T, deep: boolean = true): T {
     newNode.leadingComments = node.leadingComments;
   }
   if (has(node, "innerComments")) {
-    newNode.innerComments = node.innerCmments;
+    newNode.innerComments = node.innerComments;
   }
   if (has(node, "trailingComments")) {
     newNode.trailingComments = node.trailingComments;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9828
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No (Unable to run tests on Windows)
| Documentation PR Link    | No
| Any Dependency Changes?  | No
| License                  | MIT

Fixed  a typo in the cloneNode function. Changed `innerCmments` to `innerComments`.