### PR TITLE
Use proxy wrap instead of function wrap for function.sent generator proposal

### DIFF
--- a/packages/babel-helper-proxy-wrap-function/.npmignore
+++ b/packages/babel-helper-proxy-wrap-function/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/babel-helper-proxy-wrap-function/README.md
+++ b/packages/babel-helper-proxy-wrap-function/README.md
@@ -1,0 +1,19 @@
+# @babel/helper-proxy-wrap-function
+
+> Helper to wrap functions inside a proxy apply handler.
+
+See our website [@babel/helper-proxy-wrap-function](https://babeljs.io/docs/en/next/babel-helper-proxy-wrap-function.html) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/helper-proxy-wrap-function
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/helper-proxy-wrap-function --dev
+```

--- a/packages/babel-helper-proxy-wrap-function/package.json
+++ b/packages/babel-helper-proxy-wrap-function/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@babel/helper-proxy-wrap-function",
+  "version": "7.2.0",
+  "description": "Helper to wrap functions inside a function call.",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-proxy-wrap-function",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "@babel/helper-function-name": "^7.1.0",
+    "@babel/template": "^7.1.0",
+    "@babel/traverse": "^7.1.0",
+    "@babel/types": "^7.2.0"
+  }
+}

--- a/packages/babel-helper-proxy-wrap-function/src/index.js
+++ b/packages/babel-helper-proxy-wrap-function/src/index.js
@@ -1,132 +1,158 @@
 import type { NodePath } from "@babel/traverse";
-import nameFunction from "@babel/helper-function-name";
 import template from "@babel/template";
 import * as t from "@babel/types";
-
-const buildAnonymousExpressionWrapper = template.expression(`
-  (function () {
-    var REF = FUNCTION;
-    return function NAME(PARAMS) {
-      return REF.apply(this, arguments);
-    };
-  })()
-`);
-
-const buildNamedExpressionWrapper = template.expression(`
-  (function () {
-    var REF = FUNCTION;
-    function NAME(PARAMS) {
-      return REF.apply(this, arguments);
-    }
-    return NAME;
-  })()
-`);
-
-const buildDeclarationWrapper = template(`
-function NAME(PARAMS) { return REF.apply(this, arguments); }
-function REF() {
-  REF = FUNCTION;
-  return REF.apply(this, arguments);
-}
-`);
-
-function classOrObjectMethod(path: NodePath, callId: Object) {
-  const node = path.node;
-  const body = node.body;
-
-  const container = t.functionExpression(
-    null,
-    [],
-    t.blockStatement(body.body),
-    true,
-  );
-  body.body = [
-    t.returnStatement(
-      t.callExpression(t.callExpression(callId, [container]), []),
+const immediatelyInvokedFunction = function(body) {
+  return t.callExpression(
+    t.parenthesizedExpression(
+      t.functionExpression(null, [], t.blockStatement(body)),
     ),
-  ];
+    [],
+  );
+};
 
-  // Regardless of whether or not the wrapped function is a an async method
-  // or generator the outer function should not be
-  node.async = false;
-  node.generator = false;
-
-  // Unwrap the wrapper IIFE's environment so super and this and such still work.
-  path
-    .get("body.body.0.argument.callee.arguments.0")
-    .unwrapFunctionEnvironment();
-}
-
-function plainFunction(path: NodePath, callId: Object) {
-  const node = path.node;
-  const isDeclaration = path.isFunctionDeclaration();
-  const functionId = node.id;
-  const wrapper = isDeclaration
-    ? buildDeclarationWrapper
-    : functionId
-    ? buildNamedExpressionWrapper
-    : buildAnonymousExpressionWrapper;
-
-  if (path.isArrowFunctionExpression()) {
-    path.arrowFunctionToExpression();
-  }
-
-  node.id = null;
-
-  if (isDeclaration) {
-    node.type = "FunctionExpression";
-  }
-
-  const built = t.callExpression(callId, [node]);
-  const container = wrapper({
-    NAME: functionId || null,
-    REF: path.scope.generateUidIdentifier(functionId ? functionId.name : "ref"),
-    FUNCTION: built,
-    PARAMS: node.params.reduce(
-      (acc, param) => {
-        acc.done =
-          acc.done || t.isAssignmentPattern(param) || t.isRestElement(param);
-
-        if (!acc.done) {
-          acc.params.push(path.scope.generateUidIdentifier("x"));
-        }
-
-        return acc;
-      },
-      {
-        params: [],
-        done: false,
-      },
-    ).params,
-  });
-
-  if (isDeclaration) {
-    path.replaceWith(container[0]);
-    path.insertAfter(container[1]);
-  } else {
-    const retFunction = container.callee.body.body[1].argument;
-    if (!functionId) {
-      nameFunction({
-        node: retFunction,
-        parent: path.parent,
-        scope: path.scope,
-      });
+const proxyWrap = template(`
+  let ORIGINAL_REF = ORIGINAL_FUNCTION, MODIFIED_REF = MODIFIED_FUNCTION;
+  new Proxy(ORIGINAL_REF, {
+    apply(target, thisArgument, argumentsList) {
+      return Reflect.apply(MODIFIED_REF, thisArgument, argumentsList)
     }
+  })
+`);
 
-    if (!retFunction || retFunction.id || node.params.length) {
-      // we have an inferred function id or params so we need this wrapper
-      path.replaceWith(container);
-    } else {
-      // we can omit this wrapper as the conditions it protects for do not apply
-      path.replaceWith(built);
-    }
-  }
-}
-
-export default function wrapFunction(path: NodePath, callId: Object) {
+export default function wrapProxy(path: NodePath, callId: Object) {
   if (path.isClassMethod() || path.isObjectMethod()) {
-    classOrObjectMethod(path, callId);
+    const body = path.node.body;
+    const methodIdentifier = path.node.key;
+    const params = path.node.params;
+
+    const originalReference = path.scope.generateUidIdentifier(
+      methodIdentifier ? `original_${methodIdentifier.name}` : "ref",
+    );
+    const modifiedReference = path.scope.generateUidIdentifier(
+      methodIdentifier ? `modified_${methodIdentifier.name}` : "ref",
+    );
+    const originalFunction = t.functionExpression(
+      path.node.key,
+      params,
+      t.blockStatement(body.body),
+      true,
+    );
+    const modifiedFunction = t.callExpression(callId, [originalReference]);
+    const placeholders = {
+      ORIGINAL_REF: originalReference,
+      MODIFIED_REF: modifiedReference,
+      ORIGINAL_FUNCTION: originalFunction,
+      MODIFIED_FUNCTION: modifiedFunction,
+    };
+    const container = proxyWrap(placeholders);
+    const wrappedIIFE = immediatelyInvokedFunction([
+      container[0],
+      t.returnStatement(container[1].expression),
+    ]);
+
+    if (path.node.type == "ClassMethod") {
+      const classDeclaration = path.find(path => path.isClassDeclaration());
+      const className = classDeclaration.node.id.name;
+      const memberExpression = t.memberExpression(
+        t.memberExpression(t.identifier(className), t.identifier("prototype")),
+        methodIdentifier,
+        false,
+      );
+      const assignmentExpression = t.assignmentExpression(
+        "=",
+        memberExpression,
+        wrappedIIFE,
+      );
+      classDeclaration.insertAfter(assignmentExpression);
+      path.remove();
+    } else {
+      // const ObjectDeclaration = path.find(path => path.isObjectExpression());
+      const objectProperty = t.objectProperty(path.node.key, wrappedIIFE);
+      path.replaceWith(objectProperty);
+    }
   } else {
-    plainFunction(path, callId);
+    const functionId = path.node.id;
+    const originalReference = path.scope.generateUidIdentifier(
+      functionId ? `original_${functionId.name}` : "ref",
+    );
+    const modifiedReference = path.scope.generateUidIdentifier(
+      functionId ? `modified_${functionId.name}` : "ref",
+    );
+    const originalFunction = t.functionExpression(
+      path.node.id,
+      path.node.params,
+      path.node.body,
+      path.node.generator,
+      path.node.async,
+    );
+    const modifiedFunction = t.callExpression(callId, [originalReference]);
+    const nameIdentifier =
+      functionId || path.scope.generateUidIdentifier("ref");
+    const placeholders = {
+      ORIGINAL_REF: originalReference,
+      MODIFIED_REF: modifiedReference,
+      ORIGINAL_FUNCTION: originalFunction,
+      MODIFIED_FUNCTION: modifiedFunction,
+    };
+    const container = proxyWrap(placeholders);
+
+    if (path.isFunctionDeclaration()) {
+      const parent = path.parentPath;
+      let relationTarget;
+      if (parent.type != "Program" && parent.type != "BlockStatement") {
+        if (parent.type == "ExportNamedDeclaration") {
+          // let x = <proxy>;
+          const variableDeclaration = t.variableDeclaration("let", [
+            t.variableDeclarator(nameIdentifier, container[1].expression),
+          ]);
+          relationTarget = parent;
+          relationTarget.insertBefore(container[0]);
+          path.replaceWith(variableDeclaration);
+        } else {
+          // let x; x = <proxy>;
+          const variableDeclaration = t.variableDeclaration("let", [
+            t.variableDeclarator(nameIdentifier),
+          ]);
+          const assignmentExpression = t.expressionStatement(
+            t.assignmentExpression(
+              "=",
+              nameIdentifier,
+              container[1].expression,
+            ),
+          );
+
+          relationTarget = parent;
+          relationTarget.insertBefore(container[0]);
+          relationTarget.insertBefore(variableDeclaration);
+          relationTarget.insertBefore(assignmentExpression);
+          path.replaceWith(nameIdentifier);
+        }
+      } else {
+        const variableDeclaration = t.variableDeclaration("let", [
+          t.variableDeclarator(nameIdentifier),
+        ]);
+        const assignmentExpression = t.expressionStatement(
+          t.assignmentExpression("=", nameIdentifier, container[1].expression),
+        );
+        relationTarget = path;
+        relationTarget.insertBefore(container[0]);
+        relationTarget.insertBefore(variableDeclaration);
+        path.replaceWith(assignmentExpression);
+      }
+    } else {
+      const wrappedIIFE = immediatelyInvokedFunction([
+        container[0],
+        t.returnStatement(container[1].expression),
+      ]);
+      // const originalFunction = container.body.body[0].declarations[0].init
+      // if (!functionId) {
+      //   nameFunction({
+      //     node: originalFunction,
+      //     parent: path.parent,
+      //     scope: path.scope,
+      //   });
+      // }
+      path.replaceWith(wrappedIIFE);
+    }
   }
 }

--- a/packages/babel-helper-proxy-wrap-function/src/index.js
+++ b/packages/babel-helper-proxy-wrap-function/src/index.js
@@ -1,0 +1,132 @@
+import type { NodePath } from "@babel/traverse";
+import nameFunction from "@babel/helper-function-name";
+import template from "@babel/template";
+import * as t from "@babel/types";
+
+const buildAnonymousExpressionWrapper = template.expression(`
+  (function () {
+    var REF = FUNCTION;
+    return function NAME(PARAMS) {
+      return REF.apply(this, arguments);
+    };
+  })()
+`);
+
+const buildNamedExpressionWrapper = template.expression(`
+  (function () {
+    var REF = FUNCTION;
+    function NAME(PARAMS) {
+      return REF.apply(this, arguments);
+    }
+    return NAME;
+  })()
+`);
+
+const buildDeclarationWrapper = template(`
+function NAME(PARAMS) { return REF.apply(this, arguments); }
+function REF() {
+  REF = FUNCTION;
+  return REF.apply(this, arguments);
+}
+`);
+
+function classOrObjectMethod(path: NodePath, callId: Object) {
+  const node = path.node;
+  const body = node.body;
+
+  const container = t.functionExpression(
+    null,
+    [],
+    t.blockStatement(body.body),
+    true,
+  );
+  body.body = [
+    t.returnStatement(
+      t.callExpression(t.callExpression(callId, [container]), []),
+    ),
+  ];
+
+  // Regardless of whether or not the wrapped function is a an async method
+  // or generator the outer function should not be
+  node.async = false;
+  node.generator = false;
+
+  // Unwrap the wrapper IIFE's environment so super and this and such still work.
+  path
+    .get("body.body.0.argument.callee.arguments.0")
+    .unwrapFunctionEnvironment();
+}
+
+function plainFunction(path: NodePath, callId: Object) {
+  const node = path.node;
+  const isDeclaration = path.isFunctionDeclaration();
+  const functionId = node.id;
+  const wrapper = isDeclaration
+    ? buildDeclarationWrapper
+    : functionId
+    ? buildNamedExpressionWrapper
+    : buildAnonymousExpressionWrapper;
+
+  if (path.isArrowFunctionExpression()) {
+    path.arrowFunctionToExpression();
+  }
+
+  node.id = null;
+
+  if (isDeclaration) {
+    node.type = "FunctionExpression";
+  }
+
+  const built = t.callExpression(callId, [node]);
+  const container = wrapper({
+    NAME: functionId || null,
+    REF: path.scope.generateUidIdentifier(functionId ? functionId.name : "ref"),
+    FUNCTION: built,
+    PARAMS: node.params.reduce(
+      (acc, param) => {
+        acc.done =
+          acc.done || t.isAssignmentPattern(param) || t.isRestElement(param);
+
+        if (!acc.done) {
+          acc.params.push(path.scope.generateUidIdentifier("x"));
+        }
+
+        return acc;
+      },
+      {
+        params: [],
+        done: false,
+      },
+    ).params,
+  });
+
+  if (isDeclaration) {
+    path.replaceWith(container[0]);
+    path.insertAfter(container[1]);
+  } else {
+    const retFunction = container.callee.body.body[1].argument;
+    if (!functionId) {
+      nameFunction({
+        node: retFunction,
+        parent: path.parent,
+        scope: path.scope,
+      });
+    }
+
+    if (!retFunction || retFunction.id || node.params.length) {
+      // we have an inferred function id or params so we need this wrapper
+      path.replaceWith(container);
+    } else {
+      // we can omit this wrapper as the conditions it protects for do not apply
+      path.replaceWith(built);
+    }
+  }
+}
+
+export default function wrapFunction(path: NodePath, callId: Object) {
+  if (path.isClassMethod() || path.isObjectMethod()) {
+    classOrObjectMethod(path, callId);
+  } else {
+    plainFunction(path, callId);
+  }
+}

--- a/packages/babel-plugin-proposal-function-sent/src/index.js
+++ b/packages/babel-plugin-proposal-function-sent/src/index.js
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxFunctionSent from "@babel/plugin-syntax-function-sent";
-import wrapFunction from "@babel/helper-wrap-function";
+import proxyWrapFunction from "@babel/helper-proxy-wrap-function";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
@@ -57,7 +57,7 @@ export default declare(api => {
           ]),
         );
 
-        wrapFunction(fnPath, state.addHelper("skipFirstGeneratorNext"));
+        proxyWrapFunction(fnPath, state.addHelper("skipFirstGeneratorNext"));
       },
     },
   };

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/basic/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/basic/output.js
@@ -1,14 +1,16 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function gen() {
-  return _gen.apply(this, arguments);
-}
+let _original_gen = function* gen() {
+  let _functionSent = yield;
 
-function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
+  let sent = _functionSent;
+},
+    _modified_gen = _skipFirstGeneratorNext(_original_gen);
 
-    let sent = _functionSent;
-  });
-  return _gen.apply(this, arguments);
-}
+let gen;
+gen = new Proxy(_original_gen, {
+  apply(target, thisArgument, argumentsList) {
+    return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+  }
+
+});

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/multiple/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/multiple/output.js
@@ -1,13 +1,23 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-_skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+(function () {
+  let _ref = function* () {
+    let _functionSent = yield;
 
-  const a = _functionSent;
-  const b = _functionSent;
-  _functionSent = yield 4;
-  const c = _functionSent;
-  const d = _functionSent = yield;
-  const e = _functionSent;
-  return [a, b, c, d, e];
-})();
+    const a = _functionSent;
+    const b = _functionSent;
+    _functionSent = yield 4;
+    const c = _functionSent;
+    const d = _functionSent = yield;
+    const e = _functionSent;
+    return [a, b, c, d, e];
+  },
+      _ref2 = _skipFirstGeneratorNext(_ref);
+
+  return new Proxy(_ref, {
+    apply(target, thisArgument, argumentsList) {
+      return Reflect.apply(_ref2, thisArgument, argumentsList);
+    }
+
+  });
+})()();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/yield-function-sent/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/function-sent/yield-function-sent/output.js
@@ -1,7 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-_skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+(function () {
+  let _ref = function* () {
+    let _functionSent = yield;
 
-  _functionSent = yield _functionSent;
-})();
+    _functionSent = yield _functionSent;
+  },
+      _ref2 = _skipFirstGeneratorNext(_ref);
+
+  return new Proxy(_ref, {
+    apply(target, thisArgument, argumentsList) {
+      return Reflect.apply(_ref2, thisArgument, argumentsList);
+    }
+
+  });
+})()();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/async-generator/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/async-generator/output.js
@@ -21,10 +21,20 @@ function foo() {
 }
 
 function _foo() {
-  _foo = _wrapAsyncGenerator(_skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
+  _foo = _wrapAsyncGenerator((function () {
+    let _ref = function* () {
+      let _functionSent = yield;
 
-    _functionSent = yield _awaitAsyncGenerator(_functionSent);
-  }));
+      _functionSent = yield _awaitAsyncGenerator(_functionSent);
+    },
+        _ref2 = _skipFirstGeneratorNext(_ref);
+
+    return new Proxy(_ref, {
+      apply(target, thisArgument, argumentsList) {
+        return Reflect.apply(_ref2, thisArgument, argumentsList);
+      }
+
+    });
+  })());
   return _foo.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/class-method/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/class-method/output.js
@@ -1,12 +1,19 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-class Foo {
-  gen() {
-    return _skipFirstGeneratorNext(function* () {
-      let _functionSent = yield;
+class Foo {}
 
-      return _functionSent;
-    })();
-  }
+Foo.prototype.gen = (function () {
+  let _original_gen = function* gen() {
+    let _functionSent = yield;
 
-}
+    return _functionSent;
+  },
+      _modified_gen = _skipFirstGeneratorNext(_original_gen);
+
+  return new Proxy(_original_gen, {
+    apply(target, thisArgument, argumentsList) {
+      return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+    }
+
+  });
+})()

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-anonymous/output.mjs
@@ -1,14 +1,18 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export default function () {
-  return _ref.apply(this, arguments);
-}
+let _ref = function* () {
+  let _functionSent = yield;
 
-function _ref() {
-  _ref = _skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
+  return _functionSent;
+},
+    _ref2 = _skipFirstGeneratorNext(_ref);
 
-    return _functionSent;
-  });
-  return _ref.apply(this, arguments);
-}
+let _ref3;
+
+_ref3 = new Proxy(_ref, {
+  apply(target, thisArgument, argumentsList) {
+    return Reflect.apply(_ref2, thisArgument, argumentsList);
+  }
+
+});
+export default _ref3;

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-named/output.mjs
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export-default-named/output.mjs
@@ -1,14 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export default function gen() {
-  return _gen.apply(this, arguments);
-}
+let _original_gen = function* gen() {
+  let _functionSent = yield;
 
-function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
+  return _functionSent;
+},
+    _modified_gen = _skipFirstGeneratorNext(_original_gen);
 
-    return _functionSent;
-  });
-  return _gen.apply(this, arguments);
-}
+let gen;
+gen = new Proxy(_original_gen, {
+  apply(target, thisArgument, argumentsList) {
+    return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+  }
+
+});
+export default gen;

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export/output.mjs
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/export/output.mjs
@@ -1,14 +1,15 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-export function gen() {
-  return _gen.apply(this, arguments);
-}
+let _original_gen = function* gen() {
+  let _functionSent = yield;
 
-function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
+  return _functionSent;
+},
+    _modified_gen = _skipFirstGeneratorNext(_original_gen);
 
-    return _functionSent;
-  });
-  return _gen.apply(this, arguments);
-}
+export let gen = new Proxy(_original_gen, {
+  apply(target, thisArgument, argumentsList) {
+    return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+  }
+
+});

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-anonymous/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-anonymous/output.js
@@ -1,7 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-_skipFirstGeneratorNext(function* () {
-  let _functionSent = yield;
+(function () {
+  let _ref = function* () {
+    let _functionSent = yield;
 
-  return _functionSent;
-})();
+    return _functionSent;
+  },
+      _ref2 = _skipFirstGeneratorNext(_ref);
+
+  return new Proxy(_ref, {
+    apply(target, thisArgument, argumentsList) {
+      return Reflect.apply(_ref2, thisArgument, argumentsList);
+    }
+
+  });
+})()();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-named/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/expression-named/output.js
@@ -1,15 +1,17 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-const foo = function () {
-  var _gen = _skipFirstGeneratorNext(function* () {
+const foo = (function () {
+  let _original_gen = function* gen() {
     let _functionSent = yield;
 
     return _functionSent;
+  },
+      _modified_gen = _skipFirstGeneratorNext(_original_gen);
+
+  return new Proxy(_original_gen, {
+    apply(target, thisArgument, argumentsList) {
+      return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+    }
+
   });
-
-  function gen() {
-    return _gen.apply(this, arguments);
-  }
-
-  return gen;
-}();
+})();

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/object-method/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/object-method/output.js
@@ -1,12 +1,19 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
 const obj = {
-  gen() {
-    return _skipFirstGeneratorNext(function* () {
+  gen: (function () {
+    let _original_gen = function* gen() {
       let _functionSent = yield;
 
       return _functionSent;
-    })();
-  }
+    },
+        _modified_gen = _skipFirstGeneratorNext(_original_gen);
 
+    return new Proxy(_original_gen, {
+      apply(target, thisArgument, argumentsList) {
+        return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+      }
+
+    });
+  })()
 };

--- a/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/statement/output.js
+++ b/packages/babel-plugin-proposal-function-sent/test/fixtures/generator-kinds/statement/output.js
@@ -1,14 +1,16 @@
 function _skipFirstGeneratorNext(fn) { return function () { var it = fn.apply(this, arguments); it.next(); return it; }; }
 
-function gen() {
-  return _gen.apply(this, arguments);
-}
+let _original_gen = function* gen() {
+  let _functionSent = yield;
 
-function _gen() {
-  _gen = _skipFirstGeneratorNext(function* () {
-    let _functionSent = yield;
+  return _functionSent;
+},
+    _modified_gen = _skipFirstGeneratorNext(_original_gen);
 
-    return _functionSent;
-  });
-  return _gen.apply(this, arguments);
-}
+let gen;
+gen = new Proxy(_original_gen, {
+  apply(target, thisArgument, argumentsList) {
+    return Reflect.apply(_modified_gen, thisArgument, argumentsList);
+  }
+
+});


### PR DESCRIPTION
For `babel-plugin-proposal-function-sent` plugin the generator functions are wrap by a non generator function which prevents access to the original generator properties. Thus, detecting if a function is a generator after code transformation will be impossible. To solve this issue a proxy can be used to capture function calls through the `apply` handler, and reflect all other handlers to the original function.