### PR TITLE
Remove core-js dependency from @babel/register

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,7 +13,6 @@
     "./lib/node.js": "./lib/browser.js"
   },
   "dependencies": {
-    "core-js": "^3.0.0",
     "find-cache-dir": "^2.0.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Existing tests pass
| Documentation PR Link    |
| Any Dependency Changes?  | :+1:
| License                  | MIT

The dependency `core-js` is not actually used by `@babel/register` so this PR removes it.