### PR TITLE
Fix handling of class property value this in module transforms.

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-this.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.js
@@ -17,4 +17,7 @@ const rewriteThisVisitor = {
   ClassProperty(path) {
     path.skip();
   },
+  ClassPrivateProperty(path) {
+    path.skip();
+  },
 };

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/options.json
@@ -1,0 +1,6 @@
+{
+  "parserOpts": {
+    "plugins": ["classProperties", "classPrivateProperties", "classPrivateMethods"]
+  },
+  "plugins": ["transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private-method/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private-method/input.mjs
@@ -1,0 +1,5 @@
+class Example {
+  #method() {
+    console.log(this);
+  }
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private-method/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private-method/output.js
@@ -1,0 +1,8 @@
+"use strict";
+
+class Example {
+  #method() {
+    console.log(this);
+  }
+
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private/input.mjs
@@ -1,0 +1,3 @@
+class Example {
+  #property = this;
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/private/output.js
@@ -1,0 +1,5 @@
+"use strict";
+
+class Example {
+  #property = this;
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/public/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/public/input.mjs
@@ -1,0 +1,3 @@
+class Example {
+  property = this;
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/public/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/public/output.js
@@ -1,0 +1,5 @@
+"use strict";
+
+class Example {
+  property = this;
+}


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #9856
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | :+1:
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Prevent module transforms from rewriting `this` to `void 0` when found in the values of private class properties.  Add tests to prevent regressions.