### PR TITLE
Fix: PrivateName Identifier should not be isReferenced.

### DIFF
--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private-loose/canonical/output.js
@@ -3,7 +3,7 @@ var Point =
 function () {
   "use strict";
 
-  function Point(_x2 = 0, _y2 = 0) {
+  function Point(x = 0, y = 0) {
     babelHelpers.classCallCheck(this, Point);
     Object.defineProperty(this, _x, {
       writable: true,
@@ -13,8 +13,8 @@ function () {
       writable: true,
       value: void 0
     });
-    babelHelpers.classPrivateFieldLooseBase(this, _x)[_x] = +_x2;
-    babelHelpers.classPrivateFieldLooseBase(this, _y)[_y] = +_y2;
+    babelHelpers.classPrivateFieldLooseBase(this, _x)[_x] = +x;
+    babelHelpers.classPrivateFieldLooseBase(this, _y)[_y] = +y;
   }
 
   babelHelpers.createClass(Point, [{

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/canonical/output.js
@@ -3,7 +3,7 @@ var Point =
 function () {
   "use strict";
 
-  function Point(_x2 = 0, _y2 = 0) {
+  function Point(x = 0, y = 0) {
     babelHelpers.classCallCheck(this, Point);
 
     _x.set(this, {
@@ -16,8 +16,8 @@ function () {
       value: void 0
     });
 
-    babelHelpers.classPrivateFieldSet(this, _x, +_x2);
-    babelHelpers.classPrivateFieldSet(this, _y, +_y2);
+    babelHelpers.classPrivateFieldSet(this, _x, +x);
+    babelHelpers.classPrivateFieldSet(this, _y, +y);
   }
 
   babelHelpers.createClass(Point, [{

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/live-rewrite/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/live-rewrite/input.mjs
@@ -1,0 +1,14 @@
+import {test1, test2, test3, test4, test5, test6, test7, test8, test9} from 'anywhere';
+
+class Example {
+  #test1 = test1;
+  test2 = test2;
+  #test3() { return test3; }
+  test4() { return test4; }
+  get #test5() { return test5; }
+  get test6() { return test6; }
+
+  #test7 = this.#test1;
+  #test8() { return this.#test3(); }
+  get #test9() { return this.#test5(); }
+}

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/live-rewrite/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/class-properties/live-rewrite/output.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var _anywhere = require("anywhere");
+
+class Example {
+  #test1 = _anywhere.test1;
+  test2 = _anywhere.test2;
+
+  #test3() {
+    return _anywhere.test3;
+  }
+
+  test4() {
+    return _anywhere.test4;
+  }
+
+  get #test5() {
+    return _anywhere.test5;
+  }
+
+  get test6() {
+    return _anywhere.test6;
+  }
+
+  #test7 = this.#test1;
+
+  #test8() {
+    return this.#test3();
+  }
+
+  get #test9() {
+    return this.#test5();
+  }
+
+}

--- a/packages/babel-types/src/validators/isReferenced.js
+++ b/packages/babel-types/src/validators/isReferenced.js
@@ -38,6 +38,13 @@ export default function isReferenced(
       }
       return parent.local === node;
 
+    // no: class { #NODE; }
+    // no: class { get #NODE() {} }
+    // no: class { #NODE() {} }
+    // no: class { fn() { return this.#NODE; } }
+    case "PrivateName":
+      return false;
+
     // yes: { [NODE]: "" }
     // no: { NODE: "" }
     // depends: { NODE }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #9859
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | :+1:
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

This resolves an exception from `@babel/transform-module-commonjs` when any kind of class private field is declared with the same name as a named import.