### PR TITLE
Fix parsing typescript bodiless methods with the estree plugin also enabled

### DIFF
--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -220,7 +220,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         isAsync,
         isConstructor,
         allowsDirectSuper,
-        "MethodDefinition",
+        "ClassMethod",
         true,
       );
       if (method.typeParameters) {
@@ -293,13 +293,15 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         isAsync,
         isConstructor,
         allowDirectSuper,
-        "FunctionExpression",
+        type,
         inClassScope,
       );
+      funcNode.type = "FunctionExpression";
       delete funcNode.kind;
       // $FlowIgnore
       node.value = funcNode;
 
+      type = type === "ClassMethod" ? "MethodDefinition" : type;
       return this.finishNode(node, type);
     }
 

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript/input.js
@@ -1,0 +1,3 @@
+abstract class TSAbstractClass {
+  abstract foo(name: string): boolean;
+}

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["typescript", "estree"]
+}

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript/output.json
@@ -1,0 +1,219 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 73,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 73,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 73,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "abstract": true,
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 30
+            },
+            "identifierName": "TSAbstractClass"
+          },
+          "name": "TSAbstractClass"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 31,
+          "end": 73,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 31
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "MethodDefinition",
+              "start": 35,
+              "end": 71,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 38
+                }
+              },
+              "abstract": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 44,
+                "end": 47,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start": 47,
+                "end": 71,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 38
+                  }
+                },
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "start": 48,
+                    "end": 60,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      },
+                      "identifierName": "name"
+                    },
+                    "name": "name",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 52,
+                      "end": 60,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 27
+                        }
+                      },
+                      "typeAnnotation": {
+                        "type": "TSStringKeyword",
+                        "start": 54,
+                        "end": 60,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 21
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 27
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "returnType": {
+                  "type": "TSTypeAnnotation",
+                  "start": 61,
+                  "end": 70,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 28
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 37
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "TSBooleanKeyword",
+                    "start": 63,
+                    "end": 70,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 37
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This fixes parsing of typescript bodiless methods when the estree plugin is also enabled. For context, I am adding TS support to react-docgen, which uses babel-parser with recast and therefore requires estree. https://github.com/reactjs/react-docgen/pull/348

Currently, when both the typescript plugin and estree are enabled, code like the following causes a parsing error.

```typescript
abstract class TSAbstractClass {
  abstract foo(name: string): boolean;
}
```

The problem was that the type was overridden prior to parsing, and the typescript plugin uses the type to determine whether a bodiless method is allowed. The PR fixes this issue by passing the original type through and only overriding it afterward.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #9305
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT