### PR TITLE
Disable "Publish to npm" in the Release workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,12 @@
 workflow "Release" {
   on = "push"
-  resolves = ["Trigger GitHub release", "Publish to npm"]
+  resolves = [
+    "Trigger GitHub release",
+    # GitHub actions are too slow for this, it takes more than 15 mins.
+    # Publishing to npm from GH actions is a cool idea, but it's a lot faster to
+    # publish locally.
+    # "Publish to npm",
+   ]
 }
 
 action "Trigger GitHub release" {


### PR DESCRIPTION
GitHub actions are too slow for this, it takes more than 15 mins.
Publishing to npm from GH actions is a cool idea, but it's a lot faster to
publish locally.

Also, I think that since when I introduced this action I
always killed it; either because it was to slow or because I had to
make some manual tweaks during the release.

The action is still used to commit the changelog and generate the GitHub release.

<!-- Describe your changes below in as much detail as possible -->
