### PR TITLE
[legacy decorators] Allow decorating generator methods

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -390,7 +390,7 @@ export default class StatementParser extends ExpressionParser {
       node.expression = this.parseMaybeDecoratorArguments(expr);
       this.state.decoratorStack.pop();
     } else {
-      node.expression = this.parseMaybeAssign();
+      node.expression = this.parseExprSubscripts();
     }
     return this.finishNode(node, "Decorator");
   }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/method-generator-decorator/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/method-generator-decorator/input.js
@@ -1,0 +1,4 @@
+class Foo {
+  @deco
+  *generatorMethod() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/method-generator-decorator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/method-generator-decorator/output.json
@@ -1,0 +1,175 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 45,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 45,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 45,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            },
+            "identifierName": "Foo"
+          },
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 10,
+          "end": 45,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 14,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 23
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 14,
+                  "end": 19,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 7
+                    }
+                  },
+                  "expression": {
+                    "type": "Identifier",
+                    "start": 15,
+                    "end": 19,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "identifierName": "deco"
+                    },
+                    "name": "deco"
+                  }
+                }
+              ],
+              "static": false,
+              "kind": "method",
+              "key": {
+                "type": "Identifier",
+                "start": 23,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 18
+                  },
+                  "identifierName": "generatorMethod"
+                },
+                "name": "generatorMethod"
+              },
+              "computed": false,
+              "id": null,
+              "generator": true,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 41,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 23
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/scripts/tests/flow/flow_tests_whitelist.txt
+++ b/scripts/tests/flow/flow_tests_whitelist.txt
@@ -22,7 +22,6 @@ class_properties/migrated_0016.js
 class_properties/migrated_0021.js
 class_properties/migrated_0026.js
 decorators/migrated_0003.js
-decorators/migrated_0007.js
 private_class_properties/multiple.js
 private_class_properties/super.js
 types/member/reserved_words.js


### PR DESCRIPTION
The old proposal used LeftHandSideExpression (instead of
AssignmentExpression) to satisfy this usecase:
https://github.com/wycats/javascript-decorators/commit/e240cbc91a45d87b07fb2ba6fd7a499e4bf27e46

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9852
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR will break the code of people doing things like
```js
class A {
  @foo && bar
  method() {}
}
```

I don't think that it is a problem because:
1) I have never seen that pattern anywhere
2) Prettier inserts parentheses, which still work (`@(foo && bar)`)
3) The "legacy" proposal disallows that code.