### PR TITLE
[babel-node] Do not hardcode node flags

### DIFF
--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -23,6 +23,7 @@
     "@babel/register": "^7.0.0",
     "commander": "^2.8.1",
     "lodash": "^4.17.11",
+    "node-environment-flags": "^1.0.5",
     "v8flags": "^3.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8726, fixes #7384 (closes #7739)
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      | 
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Node 10.10 has a really nice feature, `process.allowedNodeEnvironmentFlags`, which is a Set containing all the valid node options. It is only supported since node 10.10, but there is a [shim](https://github.com/boneskull/node-environment-flags) for older versions.

Hopefully this will avoid any other "Please add support for `--new-node-option` to `babel-node`) :slightly_smiling_face: 