### PR TITLE
fix: Add missing dependency @babel/types

### DIFF
--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -27,6 +27,9 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "dependencies": {
+    "@babel/types": "^7.4.4"
+  },
   "devDependencies": {
     "@babel/code-frame": "^7.0.0",
     "@babel/helper-fixtures": "^7.4.4",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This fixes an issue where '@babel/types' cannot be resolved when using
strict package managers like pnpm, e.g.

    /path/to/project/node_modules/.registry.npmjs.org/@babel/parser/7.4.4/node_modules/@babel/parser/typings/babel-parser.d.ts
    ERROR in /path/to/project/node_modules/.registry.npmjs.org/@babel/parser/7.4.4/node_modules/@babel/parser/typings/babel-parser.d.ts(11,71):
    TS2307: Cannot find module '@babel/types'.

    > Build error occurred
    Error: > Build failed because of webpack errors
        at Object.build [as default] (/path/to/project/node_modules/.registry.npmjs.org/next/8.1.0_react-dom@16.8.6+react@16.8.6/node_modules/next/dist/build/index.js:192:15)