### PR TITLE
Don't use args rest/spread to hoist super method calls

### DIFF
--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/deeply-nested-asyncs/output.js
@@ -4,8 +4,8 @@ function s(_x) {
 
 function _s() {
   _s = babelHelpers.asyncToGenerator(function* (x) {
-    var _this = this,
-        _arguments = arguments;
+    var _arguments = arguments,
+        _this = this;
 
     for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
       args[_key - 1] = arguments[_key];

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
@@ -1,11 +1,12 @@
 class Foo extends class {} {
   method() {
-    var _superprop_getMethod = () => super.method;
+    var _superprop_getMethod = () => super.method,
+        _this = this;
 
     return babelHelpers.asyncToGenerator(function* () {
-      _superprop_getMethod().call(this);
+      _superprop_getMethod().call(_this);
 
-      var arrow = () => _superprop_getMethod().call(this);
+      var arrow = () => _superprop_getMethod().call(_this);
     })();
   }
 

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/object-method-with-super/output.js
@@ -1,11 +1,11 @@
 class Foo extends class {} {
   method() {
-    var _superprop_callMethod = (..._args) => super.method(..._args);
+    var _superprop_getMethod = () => super.method;
 
     return babelHelpers.asyncToGenerator(function* () {
-      _superprop_callMethod();
+      _superprop_getMethod().call(this);
 
-      var arrow = () => _superprop_callMethod();
+      var arrow = () => _superprop_getMethod().call(this);
     })();
   }
 

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/input.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/input.js
@@ -1,0 +1,7 @@
+class MyClass extends BaseClass {
+  async loadEntity() {
+    this.website = await this.loadWebsite();
+    this.report.setCompany(this.website.company);
+    super.loadEntity();
+  }
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/options.json
@@ -1,0 +1,16 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": [
+          "Chrome >= 60",
+          "Safari >= 11",
+          "iOS >= 10.3",
+          "Firefox >= 55",
+          "Edge >= 16"
+        ]
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/output.js
@@ -4,15 +4,15 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 class MyClass extends BaseClass {
   loadEntity() {
-    var _this = this,
-        _superprop_getLoadEntity = () => super.loadEntity;
+    var _superprop_getLoadEntity = () => super.loadEntity,
+        _this = this;
 
     return _asyncToGenerator(function* () {
       _this.website = yield _this.loadWebsite();
 
       _this.report.setCompany(_this.website.company);
 
-      _superprop_getLoadEntity().call(this);
+      _superprop_getLoadEntity().call(_this);
     })();
   }
 

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-9935/output.js
@@ -1,0 +1,19 @@
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+class MyClass extends BaseClass {
+  loadEntity() {
+    var _this = this,
+        _superprop_getLoadEntity = () => super.loadEntity;
+
+    return _asyncToGenerator(function* () {
+      _this.website = yield _this.loadWebsite();
+
+      _this.report.setCompany(_this.website.company);
+
+      _superprop_getLoadEntity().call(this);
+    })();
+  }
+
+}

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -549,10 +549,11 @@ describe("arrow function conversion", () => {
       () => super.foo();
     `,
       `
-      var _superprop_getFoo = () => super.foo;
+      var _superprop_getFoo = () => super.foo,
+          _this = this;
 
       (function () {
-        _superprop_getFoo().call(this);
+        _superprop_getFoo().call(_this);
       });
       super.foo();
       () => super.foo();
@@ -570,10 +571,11 @@ describe("arrow function conversion", () => {
       () => super.foo(a, b, ...c);
     `,
       `
-      var _superprop_getFoo = () => super.foo;
+      var _superprop_getFoo = () => super.foo,
+          _this = this;
 
       (function () {
-        _superprop_getFoo().call(this, a, b, ...c);
+        _superprop_getFoo().call(_this, a, b, ...c);
       });
       super.foo(a, b, ...c);
       () => super.foo(a, b, ...c);
@@ -591,10 +593,11 @@ describe("arrow function conversion", () => {
       () => super[foo]();
     `,
       `
-      var _superprop_get = _prop => super[_prop];
+      var _superprop_get = _prop => super[_prop],
+          _this = this;
 
       (function () {
-        _superprop_get(foo).call(this);
+        _superprop_get(foo).call(_this);
       });
       super[foo]();
       () => super[foo]();

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -539,7 +539,7 @@ describe("arrow function conversion", () => {
     );
   });
 
-  it("should convert super.prop() calls", () => {
+  it("should convert super.prop() calls without params", () => {
     assertConversion(
       `
       () => {
@@ -549,13 +549,34 @@ describe("arrow function conversion", () => {
       () => super.foo();
     `,
       `
-      var _superprop_callFoo = (..._args) => super.foo(..._args);
+      var _superprop_getFoo = () => super.foo;
 
       (function () {
-        _superprop_callFoo();
+        _superprop_getFoo().call(this);
       });
       super.foo();
       () => super.foo();
+    `,
+    );
+  });
+
+  it("should convert super.prop() calls with params", () => {
+    assertConversion(
+      `
+      () => {
+        super.foo(a, b, ...c);
+      };
+      super.foo(a, b, ...c);
+      () => super.foo(a, b, ...c);
+    `,
+      `
+      var _superprop_getFoo = () => super.foo;
+
+      (function () {
+        _superprop_getFoo().call(this, a, b, ...c);
+      });
+      super.foo(a, b, ...c);
+      () => super.foo(a, b, ...c);
     `,
     );
   });
@@ -570,10 +591,10 @@ describe("arrow function conversion", () => {
       () => super[foo]();
     `,
       `
-      var _superprop_call = (_prop, ..._args) => super[_prop](..._args);
+      var _superprop_get = _prop => super[_prop];
 
       (function () {
-        _superprop_call(foo);
+        _superprop_get(foo).call(this);
       });
       super[foo]();
       () => super[foo]();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9935 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I don't fully know `super.foo()` semantics, but I think that this PR is correct?