### PR TITLE
Fixed null error in plugin opts and added a test for it

### DIFF
--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -337,7 +337,7 @@ function assertPluginItem(loc: GeneralPath, value: mixed): PluginItem {
       if (
         opts !== undefined &&
         opts !== false &&
-        (typeof opts !== "object" || Array.isArray(opts))
+        (typeof opts !== "object" || Array.isArray(opts) || !opts)
       ) {
         throw new Error(
           `${msg(access(loc, 1))} must be an object, false, or undefined`,

--- a/packages/babel-core/src/config/validation/option-assertions.js
+++ b/packages/babel-core/src/config/validation/option-assertions.js
@@ -337,7 +337,7 @@ function assertPluginItem(loc: GeneralPath, value: mixed): PluginItem {
       if (
         opts !== undefined &&
         opts !== false &&
-        (typeof opts !== "object" || Array.isArray(opts) || !opts)
+        (typeof opts !== "object" || Array.isArray(opts) || opts === null)
       ) {
         throw new Error(
           `${msg(access(loc, 1))} must be an object, false, or undefined`,

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -38,6 +38,17 @@ describe("option-manager", () => {
       expect(calls).toEqual([]);
     });
 
+    it("throws for null options", () => {
+      const { calls, plugin } = makePlugin();
+      expect(() => {
+        loadOptions({
+          plugins: [[plugin, null]],
+        }).toThrow(/.plugins[0][1] must be an object, false, or undefined/);
+      });
+
+      expect(calls).toEqual([]);
+    });
+
     it("should not throw if a repeated plugin has a different name", () => {
       const { calls: calls1, plugin: plugin1 } = makePlugin();
       const { calls: calls2, plugin: plugin2 } = makePlugin();
@@ -87,7 +98,6 @@ describe("option-manager", () => {
       expect(calls1).toEqual([{ arg: 1 }]);
       expect(calls2).toEqual([{ arg: 2 }]);
     });
-
     it("should merge .env[] presets with parent presets", () => {
       const { calls: calls1, plugin: preset1 } = makePlugin();
       const { calls: calls2, plugin: preset2 } = makePlugin();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9936
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Note: this is my first PR, so I would welcome as much feedback as possible to learn as quickly as possible.

As described in #9936, there is an error when a null option is passed with a plugin in someone's .babelrc file. As suggested by @nicolo-ribaudo, I made a small change to check for the null value in packages/babel-core/src/config/validation/option-assertions.js and added the appropriate test in packages/babel-core/test/option-manager.js. The test only checks one plugin, as the error would just extend to multiple plugins, if that is the case.