### PR TITLE
avoid exceptions for control flow

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1469,35 +1469,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       );
     }
 
-    tsTryParseTypeArguments(): ?N.TsTypeParameterInstantiation {
-      if (!this.isRelational("<")) {
-        return undefined;
-      }
-      const state = this.state.clone();
-      const node = this.startNode();
-      const params = this.tsInType(() =>
-        // Temporarily remove a JSX parsing context, which makes us scan different tokens.
-        this.tsInNoContext(() => {
-          this.next();
-          return this.tsTryParseDelimitedList(
-            "TypeParametersOrArguments",
-            this.tsParseType.bind(this),
-          );
-        }),
-      );
-      if (params) {
-        node.params = params;
-        // This reads the next token after the `>` too, so do this in the enclosing context.
-        // But be sure not to parse a regex in the jsx expression `<C<number> />`, so set exprAllowed = false
-        this.state.exprAllowed = false;
-        if (this.eatRelational(">")) {
-          return this.finishNode(node, "TSTypeParameterInstantiation");
-        }
-      }
-      this.state = state;
-      return undefined;
-    }
-
     tsParseTypeArguments(): N.TsTypeParameterInstantiation {
       const node = this.startNode();
       node.params = this.tsInType(() =>
@@ -1656,28 +1627,27 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           const node: N.CallExpression = this.startNodeAt(startPos, startLoc);
           node.callee = base;
 
-          const typeArguments = this.tsTryParseTypeArguments();
-          if (!typeArguments) {
-            return undefined;
-          }
+          const typeArguments = this.tsParseTypeArguments();
 
-          if (!noCalls && this.eat(tt.parenL)) {
-            // possibleAsync always false here, because we would have handled it above.
-            // $FlowIgnore (won't be any undefined arguments)
-            node.arguments = this.parseCallExpressionArguments(
-              tt.parenR,
-              /* possibleAsync */ false,
-            );
-            node.typeParameters = typeArguments;
-            return this.finishCallExpression(node);
-          } else if (this.match(tt.backQuote)) {
-            return this.parseTaggedTemplateExpression(
-              startPos,
-              startLoc,
-              base,
-              state,
-              typeArguments,
-            );
+          if (typeArguments) {
+            if (!noCalls && this.eat(tt.parenL)) {
+              // possibleAsync always false here, because we would have handled it above.
+              // $FlowIgnore (won't be any undefined arguments)
+              node.arguments = this.parseCallExpressionArguments(
+                tt.parenR,
+                /* possibleAsync */ false,
+              );
+              node.typeParameters = typeArguments;
+              return this.finishCallExpression(node);
+            } else if (this.match(tt.backQuote)) {
+              return this.parseTaggedTemplateExpression(
+                startPos,
+                startLoc,
+                base,
+                state,
+                typeArguments,
+              );
+            }
           }
 
           this.unexpected();
@@ -2473,8 +2443,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     jsxParseOpeningElementAfterName(
       node: N.JSXOpeningElement,
     ): N.JSXOpeningElement {
-      const typeArguments = this.tsTryParseTypeArguments();
-      if (typeArguments) node.typeParameters = typeArguments;
+      if (this.isRelational("<")) {
+        const typeArguments = this.tsTryParseAndCatch(() =>
+          this.tsParseTypeArguments(),
+        );
+        if (typeArguments) node.typeParameters = typeArguments;
+      }
       return super.jsxParseOpeningElementAfterName(node);
     }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1478,12 +1478,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       const params = this.tsInType(() =>
         // Temporarily remove a JSX parsing context, which makes us scan different tokens.
         this.tsInNoContext(() => {
-          if (this.eatRelational("<")) {
-            return this.tsTryParseDelimitedList(
-              "TypeParametersOrArguments",
-              this.tsParseType.bind(this),
-            );
-          }
+          this.next();
+          return this.tsTryParseDelimitedList(
+            "TypeParametersOrArguments",
+            this.tsParseType.bind(this),
+          );
         }),
       );
       if (params) {

--- a/packages/babel-parser/test/fixtures/typescript/regression/less-than-edge-case/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/regression/less-than-edge-case/input.js
@@ -1,0 +1,3 @@
+for (let i = 0; i < require('foo').bar; i++) {
+    x(i);
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/less-than-edge-case/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/less-than-edge-case/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["typescript", "jsx"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/regression/less-than-edge-case/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/less-than-edge-case/output.json
@@ -1,0 +1,358 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 58,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 58,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ForStatement",
+        "start": 0,
+        "end": 58,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "init": {
+          "type": "VariableDeclaration",
+          "start": 5,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start": 9,
+              "end": 14,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 14
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 10,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "identifierName": "i"
+                },
+                "name": "i"
+              },
+              "init": {
+                "type": "NumericLiteral",
+                "start": 13,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 14
+                  }
+                },
+                "extra": {
+                  "rawValue": 0,
+                  "raw": "0"
+                },
+                "value": 0
+              }
+            }
+          ],
+          "kind": "let"
+        },
+        "test": {
+          "type": "BinaryExpression",
+          "start": 16,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 1,
+              "column": 38
+            }
+          },
+          "left": {
+            "type": "Identifier",
+            "start": 16,
+            "end": 17,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 16
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              },
+              "identifierName": "i"
+            },
+            "name": "i"
+          },
+          "operator": "<",
+          "right": {
+            "type": "MemberExpression",
+            "start": 20,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 38
+              }
+            },
+            "object": {
+              "type": "CallExpression",
+              "start": 20,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 20
+                },
+                "end": {
+                  "line": 1,
+                  "column": 34
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 20,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "identifierName": "require"
+                },
+                "name": "require"
+              },
+              "arguments": [
+                {
+                  "type": "StringLiteral",
+                  "start": 28,
+                  "end": 33,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 28
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 33
+                    }
+                  },
+                  "extra": {
+                    "rawValue": "foo",
+                    "raw": "'foo'"
+                  },
+                  "value": "foo"
+                }
+              ]
+            },
+            "property": {
+              "type": "Identifier",
+              "start": 35,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 35
+                },
+                "end": {
+                  "line": 1,
+                  "column": 38
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            },
+            "computed": false
+          }
+        },
+        "update": {
+          "type": "UpdateExpression",
+          "start": 40,
+          "end": 43,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 40
+            },
+            "end": {
+              "line": 1,
+              "column": 43
+            }
+          },
+          "operator": "++",
+          "prefix": false,
+          "argument": {
+            "type": "Identifier",
+            "start": 40,
+            "end": 41,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 40
+              },
+              "end": {
+                "line": 1,
+                "column": 41
+              },
+              "identifierName": "i"
+            },
+            "name": "i"
+          }
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 45,
+          "end": 58,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 45
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 51,
+              "end": 56,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 9
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 51,
+                "end": 55,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 51,
+                  "end": 52,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 5
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "arguments": [
+                  {
+                    "type": "Identifier",
+                    "start": 53,
+                    "end": 54,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "identifierName": "i"
+                    },
+                    "name": "i"
+                  }
+                ]
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9972 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

This commit optimizes the performance of the typescript parser plugin by avoiding exceptions for control flow. Currently, the typescript parser is filled with code branches that look something like this:

```js
const state = this.state.clone();
try {
  this.parseSomething();
} catch (e) {
  if (!(e instanceof SyntaxError)) {
    // something is actually wrong
    throw e;
  }
  // we are just bailing out of a lookahead branch
  this.state = state;
}
```

Throwing exceptions in node is expensive so this commit adds a few conditionals to avoid throwing where possible. The most common issue was related to type argument parsing, which had many false positives due to less-than binary expressions (eg `const y = x <` could be `const y = x <z>();` but it much more likely to be `const y = x < 10;`), so I added  a new `tsTryParseTypeArguments` that resets state and returns `undefined` instead of throwing.
