### PR TITLE
Remove guardedHandlers from ASTs

### DIFF
--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -22,10 +22,6 @@ import {
   SCOPE_SUPER,
 } from "../util/scopeflags";
 
-// Reused empty array added for node fields that are always empty.
-
-const empty = [];
-
 const loopLabel = { kind: "loop" },
   switchLabel = { kind: "switch" };
 
@@ -683,7 +679,6 @@ export default class StatementParser extends ExpressionParser {
       node.handler = this.finishNode(clause, "CatchClause");
     }
 
-    node.guardedHandlers = empty;
     node.finalizer = this.eat(tt._finally) ? this.parseBlock() : null;
 
     if (!node.handler && !node.finalizer) {

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -263,8 +263,6 @@ export type TryStatement = NodeBase & {
   block: BlockStatement,
   handler: CatchClause | null,
   finalizer: BlockStatement | null,
-
-  guardedHandlers: $ReadOnlyArray<empty>, // TODO: Not in spec
 };
 
 export type CatchClause = NodeBase & {

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-hang-func/output.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-hang-func/output.json
@@ -198,7 +198,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-let-outside/output.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-let-outside/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       },
       {

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var-nested/output.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var-nested/output.json
@@ -238,14 +238,12 @@
                     "directives": []
                   }
                 },
-                "guardedHandlers": [],
                 "finalizer": null
               }
             ],
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var-outside/output.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var-outside/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       },
       {

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var/output.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var/output.json
@@ -161,7 +161,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/uncategorised/276/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/276/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/uncategorised/277/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/277/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/uncategorised/278/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/278/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/uncategorised/279/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/279/output.json
@@ -176,7 +176,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/uncategorised/280/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/280/output.json
@@ -61,7 +61,6 @@
           "directives": []
         },
         "handler": null,
-        "guardedHandlers": [],
         "finalizer": {
           "type": "BlockStatement",
           "start": 16,

--- a/packages/babel-parser/test/fixtures/core/uncategorised/281/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/281/output.json
@@ -225,7 +225,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/core/uncategorised/282/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/282/output.json
@@ -225,7 +225,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": {
           "type": "BlockStatement",
           "start": 47,

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/313/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/313/output.json
@@ -164,7 +164,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/es2019/optional-catch-binding/no-binding-finally/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/optional-catch-binding/no-binding-finally/output.json
@@ -93,7 +93,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": {
           "type": "BlockStatement",
           "start": 28,

--- a/packages/babel-parser/test/fixtures/es2019/optional-catch-binding/no-binding/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/optional-catch-binding/no-binding/output.json
@@ -93,7 +93,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/empty-pattern-catch-param/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/empty-pattern-catch-param/output.json
@@ -108,7 +108,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/patterned-catch/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/patterned-catch/output.json
@@ -476,7 +476,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/with-default-catch-param/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/with-default-catch-param/output.json
@@ -161,7 +161,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-pattern/empty-catch-param/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-pattern/empty-catch-param/output.json
@@ -108,7 +108,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-yield/yield-catch-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-yield/yield-catch-parameter/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0000/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0000/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0001/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0001/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0002/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0002/output.json
@@ -109,7 +109,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0003/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0003/output.json
@@ -176,7 +176,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0004/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0004/output.json
@@ -61,7 +61,6 @@
           "directives": []
         },
         "handler": null,
-        "guardedHandlers": [],
         "finalizer": {
           "type": "BlockStatement",
           "start": 16,

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0005/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0005/output.json
@@ -225,7 +225,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0006/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-try/migrated_0006/output.json
@@ -225,7 +225,6 @@
             "directives": []
           }
         },
-        "guardedHandlers": [],
         "finalizer": {
           "type": "BlockStatement",
           "start": 47,

--- a/packages/babel-parser/test/fixtures/experimental/class-private-methods/async-generator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-methods/async-generator/output.json
@@ -523,7 +523,6 @@
                       "directives": []
                     },
                     "handler": null,
-                    "guardedHandlers": [],
                     "finalizer": {
                       "type": "BlockStatement",
                       "start": 173,

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-do-expression,-try-statement,-outer-topic-reference-in-finally-clause-with-catch-and-finally/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-do-expression,-try-statement,-outer-topic-reference-in-finally-clause-with-catch-and-finally/output.json
@@ -398,7 +398,6 @@
                         "directives": []
                       }
                     },
-                    "guardedHandlers": [],
                     "finalizer": {
                       "type": "BlockStatement",
                       "start": 98,

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-do-expression,-try-statement,-outer-topic-reference-in-try-clause-with-catch-and-finally/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-do-expression,-try-statement,-outer-topic-reference-in-try-clause-with-catch-and-finally/output.json
@@ -396,7 +396,6 @@
                         "directives": []
                       }
                     },
-                    "guardedHandlers": [],
                     "finalizer": {
                       "type": "BlockStatement",
                       "start": 91,

--- a/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-do-expression,-try-statement,-outer-topic-reference-in-try-clause-with-catch/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/pipeline-operator/proposal-smart-topic-style,-do-expression,-try-statement,-outer-topic-reference-in-try-clause-with-catch/output.json
@@ -396,7 +396,6 @@
                         "directives": []
                       }
                     },
-                    "guardedHandlers": [],
                     "finalizer": null
                   }
                 ],

--- a/packages/babel-parser/test/fixtures/placeholders/try/try-catch-finally/output.json
+++ b/packages/babel-parser/test/fixtures/placeholders/try/try-catch-finally/output.json
@@ -125,7 +125,6 @@
             "expectedNode": "BlockStatement"
           }
         },
-        "guardedHandlers": [],
         "finalizer": {
           "type": "Placeholder",
           "start": 36,

--- a/packages/babel-parser/test/fixtures/placeholders/try/with-catch-param/output.json
+++ b/packages/babel-parser/test/fixtures/placeholders/try/with-catch-param/output.json
@@ -141,7 +141,6 @@
             "expectedNode": "BlockStatement"
           }
         },
-        "guardedHandlers": [],
         "finalizer": null
       }
     ],

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -166,6 +166,9 @@ function runTest(test, parseFunction) {
     const mis = misMatch(JSON.parse(test.expect.code), ast);
 
     if (mis) {
+      if (process.env.OVERWRITE) {
+        return save(test, ast);
+      }
       throw new Error(mis);
     }
   }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Refs #6677
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This field is never used, and always empty. It was also removed in acorn a while ago. https://github.com/acornjs/acorn/commit/1ecae1a15f7decacbe3afcc10c766426a19c3170
