### PR TITLE
Do not use lookahead when parsing declare module or declare module.exports in flow

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -240,12 +240,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       } else if (this.match(tt._var)) {
         return this.flowParseDeclareVariable(node);
       } else if (this.isContextual("module")) {
-        if (this.lookahead().type === tt.dot) {
+        this.next();
+        if (this.match(tt.dot)) {
           return this.flowParseDeclareModuleExports(node);
         } else {
           if (insideModule) {
             this.unexpected(
-              null,
+              this.state.lastTokStart,
               "`declare module` cannot be used inside another `declare module`",
             );
           }
@@ -276,8 +277,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     }
 
     flowParseDeclareModule(node: N.FlowDeclareModule): N.FlowDeclareModule {
-      this.next();
-
       this.scope.enter(SCOPE_OTHER);
 
       if (this.match(tt.string)) {
@@ -422,8 +421,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     flowParseDeclareModuleExports(
       node: N.FlowDeclareModuleExports,
     ): N.FlowDeclareModuleExports {
-      this.expectContextual("module");
-      this.expect(tt.dot);
+      this.next();
       this.expectContextual("exports");
       node.typeAnnotation = this.flowParseTypeAnnotation();
       this.semicolon();

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -239,8 +239,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return this.flowParseDeclareFunction(node);
       } else if (this.match(tt._var)) {
         return this.flowParseDeclareVariable(node);
-      } else if (this.isContextual("module")) {
-        this.next();
+      } else if (this.eatContextual("module")) {
         if (this.match(tt.dot)) {
           return this.flowParseDeclareModuleExports(node);
         } else {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT
