### PR TITLE
Do not use lookahead when parsing imports in declare module in flow

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -293,14 +293,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         let bodyNode = this.startNode();
 
         if (this.match(tt._import)) {
-          const lookahead = this.lookahead();
-          if (lookahead.value !== "type" && lookahead.value !== "typeof") {
+          this.next();
+          if (!this.isContextual("type") && !this.isContextual("typeof")) {
             this.unexpected(
-              null,
+              this.state.lastTokStart,
               "Imports within a `declare module` body must always be `import type` or `import typeof`",
             );
           }
-          this.next();
           this.parseImport(bodyNode);
         } else {
           this.expectContextual(


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Just noticed there is another obvious case that can be change and as the other PR already had a review I did not want to add it there.
