### PR TITLE
Only compute Position if not already in state

### DIFF
--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -13,8 +13,8 @@ export default class LocationParser extends CommentsParser {
   getLocationForPosition(pos: number): Position {
     let loc;
     if (pos === this.state.start) loc = this.state.startLoc;
-    else if (pos === this.state.end) loc = this.state.endLoc;
     else if (pos === this.state.lastTokStart) loc = this.state.lastTokStartLoc;
+    else if (pos === this.state.end) loc = this.state.endLoc;
     else if (pos === this.state.lastTokEnd) loc = this.state.lastTokEndLoc;
     else loc = getLineInfo(this.input, pos);
 

--- a/packages/babel-parser/src/parser/location.js
+++ b/packages/babel-parser/src/parser/location.js
@@ -10,6 +10,17 @@ import CommentsParser from "./comments";
 // message.
 
 export default class LocationParser extends CommentsParser {
+  getLocationForPosition(pos: number): Position {
+    let loc;
+    if (pos === this.state.start) loc = this.state.startLoc;
+    else if (pos === this.state.end) loc = this.state.endLoc;
+    else if (pos === this.state.lastTokStart) loc = this.state.lastTokStartLoc;
+    else if (pos === this.state.lastTokEnd) loc = this.state.lastTokEndLoc;
+    else loc = getLineInfo(this.input, pos);
+
+    return loc;
+  }
+
   raise(
     pos: number,
     message: string,
@@ -21,7 +32,8 @@ export default class LocationParser extends CommentsParser {
       code?: string,
     } = {},
   ): empty {
-    const loc = getLineInfo(this.input, pos);
+    const loc = this.getLocationForPosition(pos);
+
     message += ` (${loc.line}:${loc.column})`;
     // $FlowIgnore
     const err: SyntaxError & { pos: number, loc: Position } = new SyntaxError(

--- a/packages/babel-parser/test/unit/util/location.js
+++ b/packages/babel-parser/test/unit/util/location.js
@@ -1,0 +1,38 @@
+import { getLineInfo } from "../../../src/util/location";
+
+describe("getLineInfo", () => {
+  const input = "a\nb\nc\nd\ne\nf\ng\nh\ni";
+
+  it("reports correct position", () => {
+    expect(getLineInfo(input, 7)).toEqual({
+      column: 1,
+      line: 4,
+    });
+  });
+
+  it("reports correct position for first line", () => {
+    expect(getLineInfo(input, 0)).toEqual({
+      column: 0,
+      line: 1,
+    });
+  });
+
+  const inputArray = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+  const singleCharLineEndings = ["\n", "\r", "\u2028", "\u2029"];
+
+  singleCharLineEndings.forEach(ending => {
+    it(`supports ${escape(ending)} line ending`, () => {
+      expect(getLineInfo(inputArray.join(ending), 7)).toEqual({
+        column: 1,
+        line: 4,
+      });
+    });
+  });
+
+  it(`supports ${escape("\r\n")} line ending`, () => {
+    expect(getLineInfo(inputArray.join("\r\n"), 7)).toEqual({
+      column: 1,
+      line: 3,
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | n
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Because of #9974 I was curious why throwing an exception is slow. So I did some investigation and my first guess was maybe we do something really slow when throwing. Turns out we do. 😫Every time we throw an exception we do calculate the line and column based on the current position (index) in the input string.

So I was curious if that can be improved and after looking through StackOverflow for a long time :P I couldn't get this algorithm (https://github.com/babel/babel/blob/master/packages/babel-parser/src/util/location.js#L41) any significant faster.

For a short time I thought I got it faster by using `substring() + split('\n')` instead of the `for + regex`, but the speed improvement was only because I basically removed support for line endings besides \n. After changing to `split(regex)` it was slow again.

I was thinking more about it and I realized that actually most errors are thrown right when encountered, means the state is currently pointing to the error position. In this case and even in the case when the error is reported for the last token, we can easily reuse the location that is already in the state. No need for calculation at all.

> All benchmarks are node 12.2.0

<details><summary>Before</summary>

```
┌──────────────────────────┬───────────────────────────────┬─────────────────────────────┬─────────────────────────────┐
│ fixture                  │ babel                         │ babelWithFlow               │ babelWithTS                 │
├──────────────────────────┼───────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│ es5/angular.js           │ 26.54 ops/sec ±4.28% (38ms)   │ 11.1 ops/sec ±3.25% (90ms)  │ 4.76 ops/sec ±2.89% (210ms) │
├──────────────────────────┼───────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│ es5/ember.debug.js       │ 10.56 ops/sec ±2.77% (95ms)   │ 4.4 ops/sec ±2.91% (227ms)  │ 1.04 ops/sec ±9.82% (964ms) │
├──────────────────────────┼───────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│ es5/babylon-dist.js      │ 44.52 ops/sec ±5.35% (22ms)   │ 18.07 ops/sec ±2.87% (55ms) │ 16.17 ops/sec ±2.41% (62ms) │
├──────────────────────────┼───────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│ es5/jquery.js            │ 52.38 ops/sec ±5.04% (19ms)   │ 20.95 ops/sec ±4.67% (48ms) │ 16.15 ops/sec ±3.33% (62ms) │
├──────────────────────────┼───────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│ es5/backbone.js          │ 229 ops/sec ±24.19% (4.359ms) │ 90.2 ops/sec ±13.65% (11ms) │ 90.85 ops/sec ±2.16% (11ms) │
├──────────────────────────┼───────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│ es5/react-with-addons.js │ 24.81 ops/sec ±2.63% (40ms)   │ 10.44 ops/sec ±3.12% (96ms) │ 7.17 ops/sec ±2.35% (140ms) │
└──────────────────────────┴───────────────────────────────┴─────────────────────────────┴─────────────────────────────┘
```

</details>

<details><summary>After</summary>

```
┌──────────────────────────┬───────────────────────────────┬──────────────────────────────┬──────────────────────────────┐
│ fixture                  │ babel                         │ babelWithFlow                │ babelWithTS                  │
├──────────────────────────┼───────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/angular.js           │ 27.69 ops/sec ±4.56% (36ms)   │ 11.52 ops/sec ±3.56% (87ms)  │ 12.58 ops/sec ±2.87% (79ms)  │
├──────────────────────────┼───────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/ember.debug.js       │ 11.07 ops/sec ±3.31% (90ms)   │ 4.48 ops/sec ±3.77% (223ms)  │ 4.95 ops/sec ±2.51% (202ms)  │
├──────────────────────────┼───────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/babylon-dist.js      │ 46.94 ops/sec ±1.58% (21ms)   │ 18.49 ops/sec ±2.76% (54ms)  │ 20 ops/sec ±4.82% (50ms)     │
├──────────────────────────┼───────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/jquery.js            │ 56.61 ops/sec ±1.66% (18ms)   │ 21.94 ops/sec ±4.18% (46ms)  │ 23.57 ops/sec ±4.7% (42ms)   │
├──────────────────────────┼───────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/backbone.js          │ 230 ops/sec ±28.92% (4.351ms) │ 95.37 ops/sec ±13.28% (10ms) │ 108 ops/sec ±1.79% (9.263ms) │
├──────────────────────────┼───────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/react-with-addons.js │ 26.29 ops/sec ±3.04% (38ms)   │ 10.98 ops/sec ±3.16% (91ms)  │ 12.07 ops/sec ±2.86% (83ms)  │
└──────────────────────────┴───────────────────────────────┴──────────────────────────────┴──────────────────────────────┘
```

</details>

So together with #9974 this should give a good boost for ts in certain situations

@matthewrobertson Can you check if that improves your reported case even further?
