### PR TITLE
Adding "[object NodeList]" === Object.prototype.toString.call(iter) t…

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -862,7 +862,8 @@ helpers.iterableToArray = helper("7.0.0-beta.0")`
   export default function _iterableToArray(iter) {
     if (
       Symbol.iterator in Object(iter) ||
-      Object.prototype.toString.call(iter) === "[object Arguments]"
+      Object.prototype.toString.call(iter) === "[object Arguments]" ||
+      Object.prototype.toString.call(iter) === "[object NodeList]"
     ) return Array.from(iter);
   }
 `;

--- a/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/esm/iterableToArray.js
@@ -1,5 +1,5 @@
 import _Array$from from "../../core-js/array/from";
 import _isIterable from "../../core-js/is-iterable";
 export default function _iterableToArray(iter) {
-  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]" || Object.prototype.toString.call(iter) === "[object NodeList]") return _Array$from(iter);
 }

--- a/packages/babel-runtime-corejs2/helpers/iterableToArray.js
+++ b/packages/babel-runtime-corejs2/helpers/iterableToArray.js
@@ -3,7 +3,7 @@ var _Array$from = require("../core-js/array/from");
 var _isIterable = require("../core-js/is-iterable");
 
 function _iterableToArray(iter) {
-  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]") return _Array$from(iter);
+  if (_isIterable(Object(iter)) || Object.prototype.toString.call(iter) === "[object Arguments]" || Object.prototype.toString.call(iter) === "[object NodeList]") return _Array$from(iter);
 }
 
 module.exports = _iterableToArray;

--- a/packages/babel-runtime/helpers/esm/iterableToArray.js
+++ b/packages/babel-runtime/helpers/esm/iterableToArray.js
@@ -1,3 +1,3 @@
 export default function _iterableToArray(iter) {
-  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]" || Object.prototype.toString.call(iter) === "[object NodeList]") return Array.from(iter);
 }

--- a/packages/babel-runtime/helpers/iterableToArray.js
+++ b/packages/babel-runtime/helpers/iterableToArray.js
@@ -1,5 +1,5 @@
 function _iterableToArray(iter) {
-  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]" || Object.prototype.toString.call(iter) === "[object NodeList]") return Array.from(iter);
 }
 
 module.exports = _iterableToArray;


### PR DESCRIPTION
```
Adding "[object NodeList]" === Object.prototype.toString.call(iter) to check if object is eligible for Array.from() call for _toConsumableArray(arr). In IE11, the object returns the former string rather than "[object Arguments]" as already covered.
```

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #9993 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When using the spread operator on an object to use as an array, the generated code passes the object to `_toConsumableArray()`. The function _toConsumableArray then decides how to handle the object, passing it to helper functions like `_iterableToArray(iter)`. One of the checks relies on `Object.prototype.toString.call(iter) === "[object Arguments]"`, which works in chrome. However in IE11 in Windows 8.1, `[object NodeList]` is returned instead and an exception is thrown, despite the object being processable by Array.from (or the replacement thereof). Since NodeLists are processable by Array.from, they should also be added to _iterableToArray.

edit: commit message put in code block