### PR TITLE
Change root package.json#name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@babel/core",
+  "name": "babel-core",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel",
+  "name": "@babel/core",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
I'm pretty sure GitHub's new Dependants feature is based on this package.json. I'm updating it here so it will reflect the new name for the core package.

![D680031B-947A-4DCB-9160-51C628EFD805](https://user-images.githubusercontent.com/952783/58342107-af728e00-7e04-11e9-8a2d-b4d67838f708.jpeg)
