### PR TITLE
FunctionDeclaration shouldn't be BlockScoped

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -701,11 +701,7 @@ class BlockScoping {
 
     const addDeclarationsFromChild = (path, node) => {
       node = node || path.node;
-      if (
-        t.isClassDeclaration(node) ||
-        t.isFunctionDeclaration(node) ||
-        isBlockScoped(node)
-      ) {
+      if (t.isClassDeclaration(node) || isBlockScoped(node)) {
         if (isBlockScoped(node)) {
           convertBlockScopedToVar(path, node, block, this.scope);
         }

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -131,6 +131,13 @@ const collectorVisitor = {
     scope.getBlockParent().registerDeclaration(path);
   },
 
+  FunctionDeclaration(path) {
+    const scope =
+      path.parentPath.scope.getFunctionParent() ||
+      path.parentPath.scope.getProgramParent();
+    scope.registerDeclaration(path);
+  },
+
   ClassDeclaration(path) {
     const id = path.node.id;
     if (!id) return;

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -312,7 +312,7 @@ describe("scope", () => {
       it(`${name} and function in sub scope`, () => {
         const ast = [
           t.variableDeclaration(name, [
-            t.variableDeclarator(t.identifier("foo")),
+            t.variableDeclarator(t.identifier("foo"), t.numericLiteral(2)),
           ]),
           t.blockStatement([
             t.functionDeclaration(

--- a/packages/babel-types/src/validators/isBlockScoped.js
+++ b/packages/babel-types/src/validators/isBlockScoped.js
@@ -1,10 +1,10 @@
 // @flow
-import { isClassDeclaration, isFunctionDeclaration } from "./generated";
+import { isClassDeclaration } from "./generated";
 import isLet from "./isLet";
 
 /**
  * Check if the input `node` is block scoped.
  */
 export default function isBlockScoped(node: Object): boolean {
-  return isFunctionDeclaration(node) || isClassDeclaration(node) || isLet(node);
+  return isClassDeclaration(node) || isLet(node);
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10046
| Patch: Bug Fix?          |Yes
| Major: Breaking Change?  |Unclear
| Minor: New Feature?      |No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |No
| License                  | MIT

WIP, this breaks some tests, but fixes the problems described below

Code sample:
```js
if(true) {
  function run() {
    return true;
  }
}

function test() {
  return run();
}
```
This should fix:
- `@babel/plugin-transform-block-scoping` renames `run` to a new unique name
- `run` isn't a binding in the babel-traverse's `program.scope` 