### PR TITLE
Check shadow variable to identifier in default parameters

### DIFF
--- a/packages/babel-plugin-transform-parameters/src/params.js
+++ b/packages/babel-plugin-transform-parameters/src/params.js
@@ -32,7 +32,11 @@ function isSafeBinding(scope, node) {
 const iifeVisitor = {
   ReferencedIdentifier(path, state) {
     const { scope, node } = path;
-    if (node.name === "eval" || !isSafeBinding(scope, node)) {
+    if (
+      node.name === "eval" ||
+      !isSafeBinding(scope, node) ||
+      !isSafeBinding(state.scope, node)
+    ) {
       state.iife = true;
       path.stop();
     }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-9947/input.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-9947/input.js
@@ -1,0 +1,6 @@
+let x = "outside";
+function outer(a = () => x) {
+  let x = "inside";
+  return a();
+}
+outer();

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-9947/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/default-iife-9947/output.js
@@ -1,0 +1,13 @@
+var x = "outside";
+
+function outer() {
+  var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : function () {
+    return x;
+  };
+  return function () {
+    var x = "inside";
+    return a();
+  }();
+}
+
+outer();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9947 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When there is a variable declaration inside the function body, which shares its name to a referenced identifier in default parameter expression, the function body should be wrapped into iife, otherwise the binding in default parameter scope will be shadowed by function body.

On the example, 
```js
// scope P
let x = "outside";
function outer(a = () => x // scope B) { // scope A
  let x = "inside";
  return a();
}
outer();
```

As is illustrated, there are 3 scopes in this program. Variable `x` in scope B will borrow from scope P. However, since there is `x` declared in scope A, we should wrap body in scope A to IIFE, otherwise the transformed code will have `x` in scope B borrowed from scope A, which is incorrect.

Here we check if it is a safe binding with respect to the function scope. Note that unlike the path scope changing within the traverse, this scope reference is invariant and always refers to the function declaration scope (in our example, it is scope A).