### PR TITLE
test: add parameter default test to renamer

### DIFF
--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -126,8 +126,8 @@ export default class Renamer {
         if (!state.paramDefaultOuterBinding) {
           if (
             right.isIdentifier() &&
-            right.node.body.name === oldName &&
-            !isSafeBinding(scope, right.node.body)
+            right.node.name === oldName &&
+            !isSafeBinding(scope, right.node)
           ) {
             state.paramDefaultOuterBinding = true;
             break;

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -43,9 +43,6 @@ const outerBindingVisitor = {
       path.stop();
     }
   },
-  Scope(path) {
-    path.skip();
-  },
 };
 
 const assignmentPatternVisitor = {

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -1,0 +1,10 @@
+let a = "outside";
+
+function f(g = () => a) {
+  let a = "inside";
+  return g();
+}
+
+function h(a, g = () => a) {
+  return g();
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -45,6 +45,10 @@ function o(g = (a = a) => a) {
   let a = "inside";
 }
 
-function p(a, g = (a = a) => a) {
+function q(a, g = (b = a) => b) {
+  g(a);
+}
+
+function r(a, g = (a, b = a) => a) {
   g(a);
 }

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -8,3 +8,8 @@ function f(g = () => a) {
 function h(a, g = () => a) {
   return g();
 }
+
+function j(g = a) {
+  let a = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -13,3 +13,10 @@ function j(g = a) {
   let a = "inside";
   return g;
 }
+
+function k({
+  g = a
+}) {
+  let a = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -8,7 +8,3 @@ function f(g = () => a) {
 function h(a, g = () => a) {
   return g();
 }
-
-function j(g = a) {
-  return g;
-}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -36,3 +36,11 @@ function m(g = {
   let a = "inside";
   return g;
 }
+
+function n(g = (a = a) => {}) {
+  let a = "inside";
+}
+
+function o(g = a => a) {
+  let a = "inside";
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -8,3 +8,7 @@ function f(g = () => a) {
 function h(a, g = () => a) {
   return g();
 }
+
+function j(g = a) {
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -41,6 +41,10 @@ function n(g = (a = a) => {}) {
   let a = "inside";
 }
 
-function o(g = a => a) {
+function o(g = (a = a) => a) {
   let a = "inside";
+}
+
+function p(a, g = (a = a) => a) {
+  g(a);
 }

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -27,3 +27,12 @@ function l([{
   let a = "inside";
   return g;
 }
+
+function m(g = {
+  [(({
+    [a]: x
+  }) => x)()]: "outside"
+}) {
+  let a = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/input.js
@@ -14,9 +14,16 @@ function j(g = a) {
   return g;
 }
 
-function k({
+function k([{
   g = a
-}) {
+}]) {
+  let a = "inside";
+  return g;
+}
+
+function l([{
+  [a]: g
+}]) {
   let a = "inside";
   return g;
 }

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -8,3 +8,7 @@ function f(g = () => a) {
 function h(z, g = () => z) {
   return g();
 }
+
+function j(g = a) {
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -45,6 +45,10 @@ function o(g = (a = a) => a) {
   let z = "inside";
 }
 
-function p(z, g = (a = z) => a) {
+function q(z, g = (b = z) => b) {
+  g(z);
+}
+
+function r(z, g = (a, b = a) => a) {
   g(z);
 }

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -14,9 +14,16 @@ function j(g = a) {
   return g;
 }
 
-function k({
+function k([{
   g = a
-}) {
+}]) {
+  let z = "inside";
+  return g;
+}
+
+function l([{
+  [a]: g
+}]) {
   let z = "inside";
   return g;
 }

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -13,3 +13,10 @@ function j(g = a) {
   let z = "inside";
   return g;
 }
+
+function k({
+  g = a
+}) {
+  let z = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -37,10 +37,14 @@ function m(g = {
   return g;
 }
 
-function n(g = (z = a) => {}) {
+function n(g = (a = a) => {}) {
   let z = "inside";
 }
 
-function o(g = z => z) {
+function o(g = (a = a) => a) {
   let z = "inside";
+}
+
+function p(z, g = (a = z) => a) {
+  g(z);
 }

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -1,0 +1,10 @@
+let a = "outside";
+
+function f(g = () => a) {
+  let z = "inside";
+  return g();
+}
+
+function h(z, g = () => z) {
+  return g();
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -8,7 +8,3 @@ function f(g = () => a) {
 function h(z, g = () => z) {
   return g();
 }
-
-function j(g = a) {
-  return g;
-}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -27,3 +27,12 @@ function l([{
   let z = "inside";
   return g;
 }
+
+function m(g = {
+  [(({
+    [a]: x
+  }) => x)()]: "outside"
+}) {
+  let z = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -8,3 +8,8 @@ function f(g = () => a) {
 function h(z, g = () => z) {
   return g();
 }
+
+function j(g = a) {
+  let z = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/output.js
@@ -36,3 +36,11 @@ function m(g = {
   let z = "inside";
   return g;
 }
+
+function n(g = (z = a) => {}) {
+  let z = "inside";
+}
+
+function o(g = z => z) {
+  let z = "inside";
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Reveal potential issue
| Patch: Bug Fix?          | Determined after further discussion
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a follow-up to https://github.com/babel/babel/pull/10053#pullrequestreview-245304223

Expected: 
- `Renamer` should not rename the bindings in the function default parameter if it is borrowed from parent scope
- `Renamer` should rename the bindings in the function default parameter if it is borrowed from the `param` binding in the function scope.

Actual:
- `Renamer` renames the bindings in the function default parameter even if it is borrowed from parent scope
- `Renamer` renames the bindings in the function default parameter when it is borrowed from the `param` binding in the function scope.

On the test example, we have renamer to rename `a` to `z` on `FunctionDeclaration` visitor.
In the first case,
```js
let a = "outside";
function f(g = () => a) {
  let a = "inside";
  return g();
}
```
The Renamer also rename `() => a` to `() => z`. This behavior is wrong since `a` is defined on global scope.

In the second case,
```js
function h(a, g = () => a) {
  return g();
}
```

The renamer should also `() => a` to `() => z` since `a` is a `param` binding now.

If we agree on the correctness of my proposed behavior, then this PR reveals a bug in `renamer` and should be fixed in later release.

Note that CI will break since the master does not conform to this behavior.