### PR TITLE
removed duplicate tests for @babel/highlight getChalk method

### DIFF
--- a/packages/babel-highlight/test/index.js
+++ b/packages/babel-highlight/test/index.js
@@ -94,8 +94,8 @@ describe("@babel/highlight", function() {
       });
     });
 
-    describe("when colors are supported", function() {
-      stubColorSupport(true);
+    describe("when colors are not supported", function() {
+      stubColorSupport(false);
 
       describe("when forceColor is not passed", function() {
         it("returns a Chalk instance", function() {


### PR DESCRIPTION
Removed duplicate tests for the @babel/highlight getChalk method.
