### PR TITLE
add bigint-transform-bigint

### DIFF
--- a/packages/babel-plugin-transform-bigint/.npmignore
+++ b/packages/babel-plugin-transform-bigint/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/babel-plugin-transform-bigint/README.md
+++ b/packages/babel-plugin-transform-bigint/README.md
@@ -1,0 +1,19 @@
+# @babel/plugin-transform-bigint
+
+> Transform BigInt literal syntax into calls
+
+See our website [@babel/plugin-transform-bigint](https://babeljs.io/docs/en/next/babel-plugin-transform-bigint.html) for more information.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @babel/plugin-transform-bigint
+```
+
+or using yarn:
+
+```sh
+yarn add @babel/plugin-transform-bigint --dev
+```

--- a/packages/babel-plugin-transform-bigint/package.json
+++ b/packages/babel-plugin-transform-bigint/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@babel/plugin-transform-bigint",
+  "version": "7.4.5",
+  "description": "Transform BigInt literal syntax into calls",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-bigint",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin",
+    "bigint"
+  ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "^7.0.0",
+    "@babel/plugin-syntax-bigint": "^7.2.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.2.0",
+    "@babel/helper-plugin-test-runner": "^7.0.0"
+  }
+}

--- a/packages/babel-plugin-transform-bigint/src/index.js
+++ b/packages/babel-plugin-transform-bigint/src/index.js
@@ -1,0 +1,22 @@
+import { declare } from "@babel/helper-plugin-utils";
+import { types as t } from "@babel/core";
+import bigintSyntax from "@babel/plugin-syntax-bigint";
+
+export default declare(api => {
+  api.assertVersion(7);
+
+  return {
+    name: "transform-bigint",
+    inherits: bigintSyntax,
+
+    visitor: {
+      BigIntLiteral(path) {
+        const bigintCall = t.callExpression(t.identifier("BigInt"), [
+          t.stringLiteral(path.node.value),
+        ]);
+
+        path.replaceWith(bigintCall);
+      },
+    },
+  };
+});

--- a/packages/babel-plugin-transform-bigint/test/fixtures/bigint-literal/basic/input.js
+++ b/packages/babel-plugin-transform-bigint/test/fixtures/bigint-literal/basic/input.js
@@ -1,0 +1,17 @@
+function a(i = 4n) {
+  return i;
+}
++1n;
+-1n;
+1n - -1n;
+0n;
+0n == 0;
+1n < 2;
+[1n, 2n];
+a(1n);
+2n + 3n;
+BigInt(5n);
+0x0000000000080000n;
+1n.toString();
+-1n.toString();
++1n.toString();

--- a/packages/babel-plugin-transform-bigint/test/fixtures/bigint-literal/basic/options.json
+++ b/packages/babel-plugin-transform-bigint/test/fixtures/bigint-literal/basic/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-bigint"]
+}

--- a/packages/babel-plugin-transform-bigint/test/fixtures/bigint-literal/basic/output.js
+++ b/packages/babel-plugin-transform-bigint/test/fixtures/bigint-literal/basic/output.js
@@ -1,0 +1,18 @@
+function a(i = BigInt("4")) {
+  return i;
+}
+
++BigInt("1");
+-BigInt("1");
+BigInt("1") - -BigInt("1");
+BigInt("0");
+BigInt("0") == 0;
+BigInt("1") < 2;
+[BigInt("1"), BigInt("2")];
+a(BigInt("1"));
+BigInt("2") + BigInt("3");
+BigInt(BigInt("5"));
+BigInt("0x0000000000080000");
+BigInt("1").toString();
+-BigInt("1").toString();
++BigInt("1").toString();

--- a/packages/babel-plugin-transform-bigint/test/index.js
+++ b/packages/babel-plugin-transform-bigint/test/index.js
@@ -1,0 +1,2 @@
+import runner from "@babel/helper-plugin-test-runner";
+runner(__dirname);


### PR DESCRIPTION
Previsouly only the BigInt literal syntax was support by Babel
(babel-plugin-syntax-bigint). However, emiting this syntax might break
other tool's parsers.

This change adds a package that does the trivial transformation between
BigInt literal syntax (1n) to BigInt function call (BigInt("1)).

Polyfilling the BigInt Object is up to the user.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
