### PR TITLE
Upgrade jest dependency for babel-helper-transform-fixture-test-runner

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -16,8 +16,8 @@
     "@babel/helper-fixtures": "^7.4.4",
     "@babel/polyfill": "^7.4.4",
     "babel-check-duplicated-nodes": "^1.0.0",
-    "jest": "^22.4.2",
-    "jest-diff": "^22.4.0",
+    "jest": "^24.8.0",
+    "jest-diff": "^24.8.0",
     "lodash": "^4.17.11",
     "resolve": "^1.3.2",
     "source-map": "^0.5.0"


### PR DESCRIPTION


| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            |  https://github.com/darkyndy/babel-plugin-auto-logger/issues/9 , https://github.com/darkyndy/babel-plugin-auto-logger/issues/10 , https://github.com/darkyndy/babel-plugin-auto-logger/issues/11
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | Yes
| License                  | MIT

There are some vulnerabilities in Jest@22.4.0 and by updating to Jest@24.8.0 they are fixed.

Once this changes are approved we can update the version of this package where it is used.
