### PR TITLE
fix exportKind declaration in babel-types

### DIFF
--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -837,7 +837,7 @@ export type ExportNamedDeclaration = NodeBase & {
   specifiers: $ReadOnlyArray<ExportSpecifier | ExportDefaultSpecifier>,
   source: ?Literal,
 
-  exportKind?: "type" | "value", // TODO: Not in spec
+  exportKind?: "type" | "value" | "let", // TODO: Not in spec
 };
 
 export type ExportSpecifier = NodeBase & {

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -837,7 +837,7 @@ export type ExportNamedDeclaration = NodeBase & {
   specifiers: $ReadOnlyArray<ExportSpecifier | ExportDefaultSpecifier>,
   source: ?Literal,
 
-  exportKind?: "type" | "value" | "let", // TODO: Not in spec
+  exportKind?: "type" | "value", // TODO: Not in spec
 };
 
 export type ExportSpecifier = NodeBase & {

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -261,7 +261,7 @@ defineType("ExportNamedDeclaration", {
       validate: assertNodeType("StringLiteral"),
       optional: true,
     },
-    exportKind: validateOptional(assertOneOf("type", "value", "let")),
+    exportKind: validateOptional(assertOneOf("type", "value")),
   },
 });
 

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -5,6 +5,7 @@ import defineType, {
   chain,
   assertEach,
   assertOneOf,
+  validateOptional,
 } from "./utils";
 import {
   functionCommon,
@@ -260,6 +261,7 @@ defineType("ExportNamedDeclaration", {
       validate: assertNodeType("StringLiteral"),
       optional: true,
     },
+    exportKind: validateOptional(assertOneOf("type", "value", "let")),
   },
 });
 

--- a/packages/babel-types/src/definitions/flow.js
+++ b/packages/babel-types/src/definitions/flow.js
@@ -150,7 +150,7 @@ defineType("DeclareExportAllDeclaration", {
   aliases: ["Flow", "FlowDeclaration", "Statement", "Declaration"],
   fields: {
     source: validateType("StringLiteral"),
-    exportKind: validateOptional(assertOneOf(["type", "value"])),
+    exportKind: validateOptional(assertOneOf("type", "value")),
   },
 });
 


### PR DESCRIPTION
`babel-types`:
- added `exportKind` for `ExportNamedDeclaration`
- fixed `exportKind` type for `DeclareExportAllDeclaration`

~`babel-parser`:~
~- updated types in to include `exportKind=let`~

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
