### PR TITLE
Babel cli test correction

### DIFF
--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -171,12 +171,12 @@ const buildTest = function(binName, testName, opts) {
 };
 
 fs.readdirSync(fixtureLoc).forEach(function(binName) {
-  if (binName[0] === ".") return;
+  if (binName.startsWith(".")) return;
 
   const suiteLoc = path.join(fixtureLoc, binName);
   describe("bin/" + binName, function() {
     fs.readdirSync(suiteLoc).forEach(function(testName) {
-      if (testName[0] === ".") return;
+      if (testName.startsWith(".")) return;
 
       const testLoc = path.join(suiteLoc, testName);
 

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -86,7 +86,7 @@ const assertTest = function(stdout, stderr, opts, cwd) {
   }
 
   if (opts.outFiles) {
-    const actualFiles = readDir(path.join(tmpLoc), fileFilter);
+    const actualFiles = readDir(tmpLoc, fileFilter);
 
     Object.keys(actualFiles).forEach(function(filename) {
       if (


### PR DESCRIPTION
Removed some redundant method call in the babel-cli test and also made some string comparison more explicit.