### PR TITLE
Fix incorrect usage of $o instead of %o in debug

### DIFF
--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -114,7 +114,7 @@ export function findRootConfig(
 
   const conf = readConfig(filepath, envName, caller);
   if (conf) {
-    debug("Found root config %o in $o.", BABEL_CONFIG_JS_FILENAME, dirname);
+    debug("Found root config %o in %o.", BABEL_CONFIG_JS_FILENAME, dirname);
   }
   return conf;
 }
@@ -132,7 +132,7 @@ export function loadConfig(
     throw new Error(`Config file ${filepath} contains no configuration data`);
   }
 
-  debug("Loaded config %o from $o.", name, dirname);
+  debug("Loaded config %o from %o.", name, dirname);
   return conf;
 }
 


### PR DESCRIPTION
It would end up printing the literal "$o" instead of the directory name.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

When running with debug I saw that the root config loader wouldn't print the directory properly, instead printing `$o`. In other words, it would print the following:

> babel:config:loading:files:configuration Found root config 'babel.config.js' in $o. C:\Src\Proj +0ms

Decided to do a quick fix.