### PR TITLE
fix: register injected importDeclaration

### DIFF
--- a/packages/babel-plugin-proposal-export-default-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.js
@@ -35,6 +35,11 @@ export default declare(api => {
 
         path.replaceWithMultiple(nodes);
       },
+      ImportDefaultSpecifier(path) {
+        if (!path.scope.hasOwnBinding(path.node.local.name)) {
+          path.scope.registerDeclaration(path.parentPath);
+        }
+      },
     },
   };
 });

--- a/packages/babel-plugin-proposal-export-default-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.js
@@ -33,12 +33,8 @@ export default declare(api => {
           nodes.push(node);
         }
 
-        path.replaceWithMultiple(nodes);
-      },
-      ImportDefaultSpecifier(path) {
-        if (!path.scope.hasOwnBinding(path.node.local.name)) {
-          path.scope.registerDeclaration(path.parentPath);
-        }
+        const [importDeclaration] = path.replaceWithMultiple(nodes);
+        path.scope.registerDeclaration(importDeclaration);
       },
     },
   };

--- a/packages/babel-plugin-proposal-export-default-from/test/fixtures/export-default/default-typescript/input.mjs
+++ b/packages/babel-plugin-proposal-export-default-from/test/fixtures/export-default/default-typescript/input.mjs
@@ -1,0 +1,1 @@
+export foo from "bar";

--- a/packages/babel-plugin-proposal-export-default-from/test/fixtures/export-default/default-typescript/options.json
+++ b/packages/babel-plugin-proposal-export-default-from/test/fixtures/export-default/default-typescript/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-export-default-from", "transform-typescript"]
+}

--- a/packages/babel-plugin-proposal-export-default-from/test/fixtures/export-default/default-typescript/output.mjs
+++ b/packages/babel-plugin-proposal-export-default-from/test/fixtures/export-default/default-typescript/output.mjs
@@ -1,0 +1,2 @@
+import _foo from "bar";
+export { _foo as foo };

--- a/packages/babel-plugin-proposal-export-namespace-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-namespace-from/src/index.js
@@ -45,6 +45,11 @@ export default declare(api => {
 
         path.replaceWithMultiple(nodes);
       },
+      ImportNamespaceSpecifier(path) {
+        if (!path.scope.hasOwnBinding(path.node.local.name)) {
+          path.scope.registerDeclaration(path.parentPath);
+        }
+      },
     },
   };
 });

--- a/packages/babel-plugin-proposal-export-namespace-from/src/index.js
+++ b/packages/babel-plugin-proposal-export-namespace-from/src/index.js
@@ -43,12 +43,8 @@ export default declare(api => {
           nodes.push(node);
         }
 
-        path.replaceWithMultiple(nodes);
-      },
-      ImportNamespaceSpecifier(path) {
-        if (!path.scope.hasOwnBinding(path.node.local.name)) {
-          path.scope.registerDeclaration(path.parentPath);
-        }
+        const [importDeclaration] = path.replaceWithMultiple(nodes);
+        path.scope.registerDeclaration(importDeclaration);
       },
     },
   };

--- a/packages/babel-plugin-proposal-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/input.mjs
+++ b/packages/babel-plugin-proposal-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/input.mjs
@@ -1,0 +1,1 @@
+export * as foo from "bar";

--- a/packages/babel-plugin-proposal-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/options.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-export-namespace-from", "transform-typescript"]
+}

--- a/packages/babel-plugin-proposal-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/output.mjs
+++ b/packages/babel-plugin-proposal-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/output.mjs
@@ -1,0 +1,2 @@
+import * as _foo from "bar";
+export { _foo as foo };


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | [REPL](https://babeljs.io/en/repl#?babili=false&browsers=ChromeAndroid%20versions&build=&builtIns=false&spec=false&loose=false&code_lz=KYDwDg9gTgLgBAIwIZTgMyhAtnARAOgHpkpcBuIA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.5.1&externalPlugins=%40babel%2Fplugin-proposal-export-default-from%407.2.0%2C%40babel%2Fplugin-transform-typescript%407.5.1)
| Patch: Bug Fix?          | ✅
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | ✅
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When `transform-typescript` combines with `proposal-export-default-from`, the `export { _foo as foo };` will be erased as it seems that `_foo` is not defined in its own scope. This PR register the injected importDeclaration so that it can work well with elideImports from `transform-typescript`.

Note that #7592 uses `scope.crawl()` to manually sync nodes to AST. As `crawl` will incur great performance overkill, our approach check the injected import specifier only and register when necessary.