### PR TITLE
Do not trust Scope when removing TypeScript types

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -23,7 +23,20 @@ const GLOBAL_TYPES = new WeakMap();
 
 function isGlobalType(path, name) {
   const program = path.find(path => path.isProgram()).node;
-  return GLOBAL_TYPES.get(program).has(name) && !path.scope.hasOwnBinding(name);
+  if (path.scope.hasOwnBinding(name)) return false;
+  if (GLOBAL_TYPES.get(program).has(name)) return true;
+
+  console.warn(
+    `The exported identifier "${name}" is not declared in Babel's scope tracker\n` +
+      `as a JavaScript value binding, but "@babel/plugin-transform-typescript"\n` +
+      `never encountered it as a TypeScript type declaration.\n` +
+      `It will be treated as a JavaScript value.\n\n` +
+      `This problem is likely caused by another plugin plugin which is injecting\n` +
+      `"${name}" without registering it in the scope tracker. If you are the author\n` +
+      ` of that plugin, please use "scope.registerDeclaration(declarationPath)".`,
+  );
+
+  return false;
 }
 
 function registerGlobalType(programScope, name) {

--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -28,10 +28,10 @@ function isGlobalType(path, name) {
 
   console.warn(
     `The exported identifier "${name}" is not declared in Babel's scope tracker\n` +
-      `as a JavaScript value binding, but "@babel/plugin-transform-typescript"\n` +
+      `as a JavaScript value binding, and "@babel/plugin-transform-typescript"\n` +
       `never encountered it as a TypeScript type declaration.\n` +
       `It will be treated as a JavaScript value.\n\n` +
-      `This problem is likely caused by another plugin plugin which is injecting\n` +
+      `This problem is likely caused by another plugin injecting\n` +
       `"${name}" without registering it in the scope tracker. If you are the author\n` +
       ` of that plugin, please use "scope.registerDeclaration(declarationPath)".`,
   );

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/input.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/input.mjs
@@ -1,0 +1,1 @@
+export default 2;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin.js", "transform-typescript"]
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/output.mjs
@@ -1,0 +1,3 @@
+const foo = 2;
+export default foo;
+["The exported identifier \"foo\" is not declared in Babel's scope tracker\nas a JavaScript value binding, and \"@babel/plugin-transform-typescript\"\nnever encountered it as a TypeScript type declaration.\nIt will be treated as a JavaScript value.\n\nThis problem is likely caused by another plugin injecting\n\"foo\" without registering it in the scope tracker. If you are the author\n of that plugin, please use \"scope.registerDeclaration(declarationPath)\"."];

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/plugin.js
@@ -13,10 +13,8 @@ module.exports = function({ template, types: t }) {
     post({ path }) {
       console.warn = consoleWarn;
 
-      path.pushContainer(
-        "body",
-        t.expressionStatement(t.valueToNode(warnings)),
-      );
+      const stmt = t.expressionStatement(t.valueToNode(warnings));
+      path.pushContainer("body", stmt);
     },
 
     visitor: {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/plugin.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/regression/10162/plugin.js
@@ -1,0 +1,32 @@
+"use strict";
+
+module.exports = function({ template, types: t }) {
+  const warnings = [];
+  let consoleWarn;
+
+  return {
+    pre() {
+      consoleWarn = console.warn;
+      console.warn = msg => warnings.push(msg);
+    },
+
+    post({ path }) {
+      console.warn = consoleWarn;
+
+      path.pushContainer(
+        "body",
+        t.expressionStatement(t.valueToNode(warnings)),
+      );
+    },
+
+    visitor: {
+      ExportDefaultDeclaration(path) {
+        path.insertBefore(template.statement.ast`
+          const foo = ${path.node.declaration};
+        `);
+
+        path.node.declaration = t.identifier("foo");
+      },
+    },
+  };
+};


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/10162, fixes https://github.com/gatsbyjs/gatsby/issues/1542v
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In v7.5.0, we migrated the TypeScript plugin to use Scope to remove exported types. We assumed that if a node wasn't in the scope, it was a type. While this is _in theory_ true, plugins never did a good job at maintaining this "invariant".
Not only popular community plugins (e.g. https://github.com/gaearon/react-hot-loader/pull/1293), but also our own plugins (e.g. https://github.com/babel/babel/pull/10172).

While updating those plugins makes the scope more reliable, we can't drop support with older versions since it would be a breaking change.

This PR changes the TypeScript plugin so that it removes an export only if
1. It isn't registered in the scope
2. We saw it in a type declaration.

2 without 1 isn't enough, because we shouldn't remove the export in cases like this:
```js
var a = 1;
type a = 2;

export { a };
```

If others agree that this is the correct solution, I will release v7.5.2 as soon as this is merged.

cc @Wolvereness (author of the initial TS update), @JLHwung (fixed https://github.com/babel/babel/pull/10172), @theKashey (created https://github.com/gaearon/react-hot-loader/pull/1293).