### PR TITLE
feat(errors): validate preset when filename is absent

### DIFF
--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -284,9 +284,18 @@ const validateIfOptionNeedsFilename = (
   descriptor: UnloadedDescriptor,
 ): void => {
   if (options.test || options.include || options.exclude) {
+    const formattedPresetName = descriptor.name
+      ? `"${descriptor.name}"`
+      : "/* your preset */";
     throw new Error(
-      `Preset ${descriptor.name ||
-        ""} requires filename, but it was not passed.`.replace(/\s{2}/, " "),
+      [
+        `Preset ${formattedPresetName} requires a filename be set.`,
+        `For example, if you are calling Babel directly`,
+        `\`\`\``,
+        `babel.transform(code, { filename: 'file.js', presets: [${formattedPresetName}] });`,
+        `\`\`\``,
+        `See https://babeljs.io/docs/en/options#filename for more information.`,
+      ].join("\n"),
     );
   }
 };

--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -278,6 +278,22 @@ const instantiatePlugin = makeWeakCache(
   },
 );
 
+const validatePreset = (
+  preset: PresetInstance,
+  context: ConfigContext,
+  descriptor: UnloadedDescriptor,
+): void => {
+  if (!context.filename) {
+    const { options } = preset;
+    if (options.test || options.include || options.exclude) {
+      throw new Error(
+        `Preset ${descriptor.name ||
+          ""} requires filename, but it was not passed.`.replace(/\s{2}/, " "),
+      );
+    }
+  }
+};
+
 /**
  * Generate a config object that will act as the root of a new nested config.
  */
@@ -285,10 +301,9 @@ const loadPresetDescriptor = (
   descriptor: UnloadedDescriptor,
   context: ConfigContext,
 ): ConfigChain | null => {
-  return buildPresetChain(
-    instantiatePreset(loadDescriptor(descriptor, context)),
-    context,
-  );
+  const preset = instantiatePreset(loadDescriptor(descriptor, context));
+  validatePreset(preset, context, descriptor);
+  return buildPresetChain(preset, context);
 };
 
 const instantiatePreset = makeWeakCache(

--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -289,10 +289,9 @@ const validateIfOptionNeedsFilename = (
       : "/* your preset */";
     throw new Error(
       [
-        `Preset ${formattedPresetName} requires a filename be set.`,
-        `For example, if you are calling Babel directly`,
+        `Preset ${formattedPresetName} requires a filename to be set when babel is called directly,`,
         `\`\`\``,
-        `babel.transform(code, { filename: 'file.js', presets: [${formattedPresetName}] });`,
+        `babel.transform(code, { filename: 'file.ts', presets: [${formattedPresetName}] });`,
         `\`\`\``,
         `See https://babeljs.io/docs/en/options#filename for more information.`,
       ].join("\n"),

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1049,5 +1049,19 @@ describe("buildConfigChain", function() {
         loadOptions({ filename, cwd: path.dirname(filename) }),
       ).toThrow(/Error while parsing JSON - /);
     });
+
+    it("should throw when `test` presents but `filename` is not passed", () => {
+      expect(() => loadOptions({ test: /\.ts$/, plugins: [] })).toThrow(
+        /Configuration contains string\/RegExp pattern/,
+      );
+    });
+
+    it("should throw when `preset` requires `filename` but it was not passed", () => {
+      expect(() => {
+        loadOptions({
+          presets: [require("./fixtures/config-loading/preset4")],
+        });
+      }).toThrow(/Preset requires filename/);
+    });
   });
 });

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1061,7 +1061,7 @@ describe("buildConfigChain", function() {
         loadOptions({
           presets: [require("./fixtures/config-loading/preset4")],
         });
-      }).toThrow(/Preset requires filename/);
+      }).toThrow(/Preset \/\* your preset \*\/ requires a filename/);
     });
 
     it("should throw when `preset.overrides` requires `filename` but it was not passed", () => {
@@ -1069,7 +1069,7 @@ describe("buildConfigChain", function() {
         loadOptions({
           presets: [require("./fixtures/config-loading/preset5")],
         });
-      }).toThrow(/Preset requires filename/);
+      }).toThrow(/Preset \/\* your preset \*\/ requires a filename/);
     });
   });
 });

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1063,5 +1063,13 @@ describe("buildConfigChain", function() {
         });
       }).toThrow(/Preset requires filename/);
     });
+
+    it("should throw when `preset.overrides` requires `filename` but it was not passed", () => {
+      expect(() => {
+        loadOptions({
+          presets: [require("./fixtures/config-loading/preset5")],
+        });
+      }).toThrow(/Preset requires filename/);
+    });
   });
 });

--- a/packages/babel-core/test/fixtures/config-loading/preset4.js
+++ b/packages/babel-core/test/fixtures/config-loading/preset4.js
@@ -1,0 +1,6 @@
+module.exports = function() {
+  return {
+    test: /\.ts$/,
+    plugins: []
+  }
+};

--- a/packages/babel-core/test/fixtures/config-loading/preset5.js
+++ b/packages/babel-core/test/fixtures/config-loading/preset5.js
@@ -1,0 +1,8 @@
+module.exports = function() {
+  return {
+    overrides: [{
+      test: /\.ts$/,
+      plugins: []
+    }]
+  }
+};


### PR DESCRIPTION
Closes #10154

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10154 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Validate preset before `buildPresetChain`, when it is the last chance we can get the `UnloadedDescriptor` and include preset name in error message. We may add more business logic inside `validatePreset` to print preset-specific error message.

I have also considered the following alternative designs:

1) Pass down descriptor name to `matchPattern`.
Pro: The missing filename errors are still thrown in `matchPattern`
Cons: Introduce unnecessary signature complexity as this is not our primary execution path

2) Add descriptor name to `ConfigContext`
Pro: The missing filename errors are still thrown in `matchPattern`
Cons: ConfigContext has to be mutated or cloned when running `buildPresetChain`. The `ConfigContext` is widely used across config chain building but descriptor name is only used to print this error.

3) tryCatch `buildPresetChain`
Pros: Intuitive and fewer execution path
Cons: Any error from `buildPresetChain ` has to be matched once before they are re-thrown.