### PR TITLE
Upgrade lodash to 4.17.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lerna": "^3.14.2",
     "lerna-changelog": "^0.5.0",
     "lint-staged": "^8.1.7",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "merge-stream": "^1.0.1",
     "output-file-sync": "^2.0.0",
     "prettier": "^1.17.1",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -23,7 +23,7 @@
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "mkdirp": "^0.5.1",
     "output-file-sync": "^2.0.0",
     "slash": "^2.0.0",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -43,7 +43,7 @@
     "convert-source-map": "^1.1.0",
     "debug": "^4.1.0",
     "json5": "^2.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/types": "^7.5.0",
     "jsesc": "^2.5.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "source-map": "^0.5.0",
     "trim-right": "^1.0.1"
   },

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@babel/helper-function-name": "^7.1.0",
     "@babel/types": "^7.4.4",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.13"
   }
 }

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-fixtures",
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "semver": "^5.3.0",
     "try-resolve": "^1.0.0"
   }

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -16,6 +16,6 @@
     "@babel/helper-split-export-declaration": "^7.4.4",
     "@babel/template": "^7.4.4",
     "@babel/types": "^7.4.4",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.13"
   }
 }

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.13"
   }
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -18,7 +18,7 @@
     "babel-check-duplicated-nodes": "^1.0.0",
     "jest": "^24.8.0",
     "jest-diff": "^24.8.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "resolve": "^1.3.2",
     "source-map": "^0.5.0"
   }

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -22,7 +22,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/register": "^7.0.0",
     "commander": "^2.8.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "node-environment-flags": "^1.0.5",
     "v8flags": "^3.1.1"
   },

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.13"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.13"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "core-js": "^3.0.0",
     "find-cache-dir": "^2.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "mkdirp": "^0.5.1",
     "pirates": "^4.0.0",
     "source-map-support": "^0.5.9"

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -19,7 +19,7 @@
     "@babel/types": "^7.5.0",
     "debug": "^4.1.0",
     "globals": "^11.1.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.13"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "^7.0.0"

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -10,7 +10,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "esutils": "^2.0.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "to-fast-properties": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6465,10 +6465,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
+  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -6948,12 +6948,7 @@ node-fetch@^1.7.0:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.3.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
-  integrity sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==
-
-node-fetch@^2.5.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==


### PR DESCRIPTION
As @jdalton [said](https://twitter.com/jdalton/status/1148833761301164032), it's time to update lodash so that we can fix [the security vulnerability](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/) reported by Snyk.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Upgrade all `lodash` to `4.17.13`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
