### PR TITLE
add assertShape to validate templateElement

### DIFF
--- a/packages/babel-types/scripts/utils/stringifyValidator.js
+++ b/packages/babel-types/scripts/utils/stringifyValidator.js
@@ -33,14 +33,24 @@ module.exports = function stringifyValidator(validator, nodePrefix) {
 
   if (validator.shapeOf) {
     return (
-      "{" +
+      "{ " +
       Object.keys(validator.shapeOf)
-        .map(
-          shapeKey =>
-            shapeKey + ":" + stringifyValidator(validator.shapeOf[shapeKey])
-        )
+        .map(shapeKey => {
+          const propertyDefinition = validator.shapeOf[shapeKey];
+          if (propertyDefinition.validate) {
+            const isOptional =
+              propertyDefinition.optional || propertyDefinition.default != null;
+            return (
+              shapeKey +
+              (isOptional ? "?: " : ": ") +
+              stringifyValidator(propertyDefinition.validate)
+            );
+          }
+          return null;
+        })
+        .filter(Boolean)
         .join(", ") +
-      "}"
+      " }"
     );
   }
 

--- a/packages/babel-types/scripts/utils/stringifyValidator.js
+++ b/packages/babel-types/scripts/utils/stringifyValidator.js
@@ -31,6 +31,19 @@ module.exports = function stringifyValidator(validator, nodePrefix) {
     return validator.type;
   }
 
+  if (validator.shapeOf) {
+    return (
+      "{" +
+      Object.keys(validator.shapeOf)
+        .map(
+          shapeKey =>
+            shapeKey + ":" + stringifyValidator(validator.shapeOf[shapeKey])
+        )
+        .join(", ") +
+      "}"
+    );
+  }
+
   return ["any"];
 };
 

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -539,8 +539,13 @@ defineType("TemplateElement", {
   fields: {
     value: {
       validate: assertShape({
-        raw: assertValueType("string"),
-        cooked: assertValueType("string"),
+        raw: {
+          validate: assertValueType("string"),
+        },
+        cooked: {
+          validate: assertValueType("string"),
+          optional: true,
+        },
       }),
     },
     tail: {

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -1,5 +1,6 @@
 // @flow
 import defineType, {
+  assertShape,
   assertNodeType,
   assertValueType,
   chain,
@@ -537,7 +538,10 @@ defineType("TemplateElement", {
   builder: ["value", "tail"],
   fields: {
     value: {
-      // todo: flatten `raw` into main node
+      validate: assertShape({
+        raw: assertValueType("string"),
+        cooked: assertValueType("string"),
+      }),
     },
     tail: {
       validate: assertValueType("boolean"),

--- a/packages/babel-types/src/definitions/utils.js
+++ b/packages/babel-types/src/definitions/utils.js
@@ -161,7 +161,7 @@ export function assertValueType(type: string): Validator {
   return validate;
 }
 
-export function assertShape(shape: {| [string]: Validator |}): Validator {
+export function assertShape(shape: { [string]: Validator }): Validator {
   function validate(node, key, val) {
     const errors = [];
     for (const property of Object.keys(shape)) {

--- a/packages/babel-types/src/definitions/utils.js
+++ b/packages/babel-types/src/definitions/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import is from "../validators/is";
+import { validateField } from "../validators/validate";
 
 export const VISITOR_KEYS: { [string]: Array<string> } = {};
 export const ALIAS_KEYS: { [string]: Array<string> } = {};
@@ -161,13 +162,12 @@ export function assertValueType(type: string): Validator {
   return validate;
 }
 
-export function assertShape(shape: { [string]: Validator }): Validator {
+export function assertShape(shape: { [string]: FieldOptions }): Validator {
   function validate(node, key, val) {
     const errors = [];
     for (const property of Object.keys(shape)) {
       try {
-        const validator = shape[property];
-        validator(node, property, val[property]);
+        validateField(node, property, val[property], shape[property]);
       } catch (error) {
         if (error instanceof TypeError) {
           errors.push(error.message);

--- a/packages/babel-types/src/definitions/utils.js
+++ b/packages/babel-types/src/definitions/utils.js
@@ -161,6 +161,35 @@ export function assertValueType(type: string): Validator {
   return validate;
 }
 
+export function assertShape(shape: {| [string]: Validator |}): Validator {
+  function validate(node, key, val) {
+    const errors = [];
+    for (const property of Object.keys(shape)) {
+      try {
+        const validator = shape[property];
+        validator(node, property, val[property]);
+      } catch (error) {
+        if (error instanceof TypeError) {
+          errors.push(error.message);
+          continue;
+        }
+        throw error;
+      }
+    }
+    if (errors.length) {
+      throw new TypeError(
+        `Property ${key} of ${
+          node.type
+        } expected to have the following:\n${errors.join("\n")}`,
+      );
+    }
+  }
+
+  validate.shapeOf = shape;
+
+  return validate;
+}
+
 export function chain(...fns: Array<Validator>): Validator {
   function validate(...args) {
     for (const fn of fns) {

--- a/packages/babel-types/src/validators/validate.js
+++ b/packages/babel-types/src/validators/validate.js
@@ -8,6 +8,15 @@ export default function validate(node?: Object, key: string, val: any): void {
   if (!fields) return;
 
   const field = fields[key];
+  validateField(node, key, val, field);
+}
+
+export function validateField(
+  node?: Object,
+  key: string,
+  val: any,
+  field: any,
+): void {
   if (!field || !field.validate) return;
   if (field.optional && val == null) return;
 

--- a/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
+++ b/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builders es2015 templateElement should validate 1`] = `
+Object {
+  "tail": false,
+  "type": "TemplateElement",
+  "value": Object {
+    "cooked": "foo",
+    "raw": "foo",
+  },
+}
+`;
+
+exports[`builders es2015 templateElement should validate 2`] = `
+Object {
+  "tail": false,
+  "type": "TemplateElement",
+  "value": Object {
+    "raw": "foo",
+  },
+}
+`;
+
+exports[`builders es2015 templateElement should validate 3`] = `
+"Property value of TemplateElement expected to have the following:
+Property raw expected type of string but got number"
+`;
+
+exports[`builders es2015 templateElement should validate 4`] = `
+"Property value of TemplateElement expected to have the following:
+Property cooked expected type of string but got number"
+`;
+
+exports[`builders es2015 templateElement should validate 5`] = `
+"Property value of TemplateElement expected to have the following:
+Property raw expected type of string but got undefined"
+`;

--- a/packages/babel-types/test/builders/es2015/templateElement.js
+++ b/packages/babel-types/test/builders/es2015/templateElement.js
@@ -1,0 +1,25 @@
+import * as t from "../../..";
+
+describe("builders", function() {
+  describe("es2015", function() {
+    describe("templateElement", function() {
+      it("should validate", function() {
+        expect(
+          t.templateElement({ raw: "foo", cooked: "foo" }),
+        ).toMatchSnapshot();
+
+        expect(t.templateElement({ raw: "foo" })).toMatchSnapshot();
+
+        expect(() =>
+          t.templateElement({ raw: 1 }),
+        ).toThrowErrorMatchingSnapshot();
+
+        expect(() =>
+          t.templateElement({ raw: "foo", cooked: 1 }),
+        ).toThrowErrorMatchingSnapshot();
+
+        expect(() => t.templateElement("foo")).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Should we update the `templateElement`'s validator and [update the docs as well](https://github.com/babel/website/pull/2061)?

@sebmck need your advice, because i saw you left a `TODO` there.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10195 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
