### PR TITLE
Workaround #10179 in proposal-object-rest-spread

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/src/index.js
@@ -455,6 +455,11 @@ export default declare((api, opts) => {
           try {
             helper = file.addHelper("objectSpread2");
           } catch {
+            // TODO: This is needed to workaround https://github.com/babel/babel/issues/10187
+            // and https://github.com/babel/babel/issues/10179 for older @babel/core versions
+            // where #10187 isn't fixed.
+            this.file.declarations["objectSpread2"] = null;
+
             // objectSpread2 has been introduced in v7.5.0
             // We have to maintain backward compatibility.
             helper = file.addHelper("objectSpread");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10179
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The real cause of this bug is in `@babel/core` (https://github.com/babel/babel/issues/10187), but even if we fixed it new versions of `plugin-proposal-object-rest-spread` wouldn't work with older versions of `@babel/core` and `@babel/helpers`.
This bug also needs to be fixed in `@babel/core` anyway, otherwise it will happen again.

I couldn't figure out how to add a test for this bug; I tested it manually with a `package.json` like this (it requires `yarn`):
```json
{
  "devDependencies": {
    "@babel/cli": "^7.5.0",
    "@babel/core": "7.4.0",
    "@babel/plugin-proposal-object-rest-spread": "file:../../babel/babel/packages/babel-plugin-proposal-object-rest-spread"
  },
  "resolutions": {
    "@babel/helpers": "7.4.0"
  }
}
```

<details>
<summary>Input</summary>

```js
void { ...foo };
void { ...bar };
```
</details>

<details>
<summary>Output before the fix</summary>

```js
function _objectSpread2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }

function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }

void _objectSpread2({}, foo);
void _objectSpread({}, bar);
```
</details>

<details>
<summary>Output after the fix</summary>

```js
function _objectSpread2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }

function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }

void _objectSpread2({}, foo);
void _objectSpread2({}, bar);
```
</details>

Note that in the fixed output the injected helper is called `_objectSpread2` only because Babel is trolling* us, that is the `_objectSpread` helper present in <7.5.0.

*trolling = In the "try" block it genertes an `_objectSpread` UUID which is then discarted, so it must create `_objectSpread2` the second time.