### PR TITLE
react-display-name: add names to lazy() components

### DIFF
--- a/packages/babel-plugin-transform-react-display-name/README.md
+++ b/packages/babel-plugin-transform-react-display-name/README.md
@@ -1,6 +1,6 @@
 # @babel/plugin-transform-react-display-name
 
-> Add displayName to React.createClass calls
+> Add displayName to React.createClass and React.lazy calls
 
 See our website [@babel/plugin-transform-react-display-name](https://babeljs.io/docs/en/next/babel-plugin-transform-react-display-name.html) for more information.
 

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@babel/plugin-transform-react-display-name",
   "version": "7.2.0",
-  "description": "Add displayName to React.createClass calls",
+  "description": "Add displayName to React.createClass and React.lazy calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-plugin-transform-react-display-name/src/index.js
+++ b/packages/babel-plugin-transform-react-display-name/src/index.js
@@ -52,59 +52,162 @@ export default declare(api => {
     return true;
   }
 
+  function isReactLazy(node) {
+    if (!node || !t.isCallExpression(node)) return false;
+
+    if (!t.matchesPattern(node.callee, "React.lazy")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  function displayNameFromFilename(filename) {
+    if (!filename) {
+      return null;
+    }
+
+    let displayName = path.basename(filename, path.extname(filename));
+
+    // ./{module name}/index.js
+    if (displayName === "index") {
+      displayName = path.basename(path.dirname(filename));
+    }
+
+    return displayName;
+  }
+
+  function displayNameFromAncestors(path) {
+    let id;
+
+    // crawl up the ancestry looking for possible candidates for displayName inference
+    path.find(function(path) {
+      if (path.isAssignmentExpression()) {
+        id = path.node.left;
+      } else if (path.isObjectProperty()) {
+        id = path.node.key;
+      } else if (path.isVariableDeclarator()) {
+        id = path.node.id;
+      } else if (path.isStatement()) {
+        // we've hit a statement, we should stop crawling up
+        return true;
+      }
+
+      // we've got an id! no need to continue
+      if (id) return true;
+    });
+
+    // ensure that we have an identifier we can inherit from
+    if (!id) return;
+
+    // foo.bar -> bar
+    if (t.isMemberExpression(id)) {
+      id = id.property;
+    }
+
+    // identifiers are the only thing we can reliably get a name from
+    if (t.isIdentifier(id)) {
+      return id.name;
+    }
+
+    return null;
+  }
+
+  function transformLazyReference(idPath, state) {
+    const callPath = idPath.parentPath;
+    if (!callPath.isCallExpression() || idPath.key !== "callee") {
+      return;
+    }
+    if (
+      callPath.parentPath.parentPath &&
+      callPath.parentPath.parentPath.isSequenceExpression()
+    ) {
+      return;
+    }
+    let displayName;
+    if (
+      callPath.parentPath.isExportDefaultDeclaration() &&
+      callPath.key === "declaration"
+    ) {
+      displayName = displayNameFromFilename(state.filename);
+    } else {
+      displayName = displayNameFromAncestors(callPath);
+    }
+    if (!displayName) {
+      let maybeImportCall, maybeImportFilename;
+      if (
+        callPath.node.arguments.length === 1 &&
+        t.isArrowFunctionExpression(callPath.node.arguments[0])
+      ) {
+        maybeImportCall = callPath.node.arguments[0].body;
+      }
+      if (
+        maybeImportCall &&
+        t.isCallExpression(maybeImportCall) &&
+        t.isImport(maybeImportCall.callee) &&
+        maybeImportCall.arguments.length === 1
+      ) {
+        maybeImportFilename = maybeImportCall.arguments[0];
+      }
+      if (maybeImportFilename && t.isStringLiteral(maybeImportFilename)) {
+        displayName = displayNameFromFilename(maybeImportFilename.value);
+      }
+    }
+    if (!displayName) {
+      return;
+    }
+    const { scope } = callPath;
+    const id = scope.generateDeclaredUidIdentifier(displayName);
+    scope.push({ id });
+    callPath.replaceWith(
+      t.sequenceExpression([
+        t.assignmentExpression("=", id, callPath.node),
+        t.assignmentExpression(
+          "=",
+          t.memberExpression(id, t.identifier("displayName"), false, false),
+          t.stringLiteral(displayName),
+        ),
+        id,
+      ]),
+    );
+  }
+
   return {
     name: "transform-react-display-name",
 
     visitor: {
-      ExportDefaultDeclaration({ node }, state) {
-        if (isCreateClass(node.declaration)) {
-          const filename = state.filename || "unknown";
-
-          let displayName = path.basename(filename, path.extname(filename));
-
-          // ./{module name}/index.js
-          if (displayName === "index") {
-            displayName = path.basename(path.dirname(filename));
+      ImportSpecifier(path, state) {
+        if (
+          path.parent.source.value === "react" &&
+          path.node.imported.name === "lazy"
+        ) {
+          const binding = path.scope.getBinding(path.node.local.name);
+          for (const lazyIdPath of binding.referencePaths) {
+            transformLazyReference(lazyIdPath, state);
           }
-
-          addDisplayName(displayName, node.declaration);
         }
       },
 
-      CallExpression(path) {
+      ExportDefaultDeclaration(path, state) {
         const { node } = path;
-        if (!isCreateClass(node)) return;
+        if (isCreateClass(node.declaration)) {
+          const displayName =
+            displayNameFromFilename(state.filename) || "unknown";
 
-        let id;
-
-        // crawl up the ancestry looking for possible candidates for displayName inference
-        path.find(function(path) {
-          if (path.isAssignmentExpression()) {
-            id = path.node.left;
-          } else if (path.isObjectProperty()) {
-            id = path.node.key;
-          } else if (path.isVariableDeclarator()) {
-            id = path.node.id;
-          } else if (path.isStatement()) {
-            // we've hit a statement, we should stop crawling up
-            return true;
-          }
-
-          // we've got an id! no need to continue
-          if (id) return true;
-        });
-
-        // ensure that we have an identifier we can inherit from
-        if (!id) return;
-
-        // foo.bar -> bar
-        if (t.isMemberExpression(id)) {
-          id = id.property;
+          addDisplayName(displayName, node.declaration);
+        } else if (isReactLazy(node.declaration)) {
+          transformLazyReference(path.get("declaration").get("callee"), state);
         }
+      },
 
-        // identifiers are the only thing we can reliably get a name from
-        if (t.isIdentifier(id)) {
-          addDisplayName(id.name, node);
+      CallExpression(path, state) {
+        const { node } = path;
+        if (isCreateClass(node)) {
+          const displayName = displayNameFromAncestors(path);
+
+          addDisplayName(displayName, node);
+        } else if (isReactLazy(node)) {
+          transformLazyReference(path.get("callee"), state);
         }
       },
     },

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/lazy/input.js
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/lazy/input.js
@@ -1,0 +1,48 @@
+{
+  // `React.lazy`
+  foo = React.lazy(() => import("./file1.js"));
+  var foo = qux(React.lazy(() => import("./file2.js")));
+  ({
+    foo: React.lazy(() => import("./file3.js"))
+  });
+  var foo = React.lazy(() => import("./file4.js"));
+  fn(React.lazy(() => import("./foo.js")));
+}
+
+import { lazy } from "react";
+// Importing `lazy` from the 'react' package
+{
+  foo = lazy(() => import("./file1.js"));
+  var foo = qux(lazy(() => import("./file2.js")));
+  ({
+    foo: lazy(() => import("./file3.js"))
+  });
+  var foo = lazy(() => import("./file4.js"));
+  fn(lazy(() => import("./foo.js")));
+}
+
+import { lazy as lazyAlias } from "react";
+// Importing `lazy` from the 'react' package with a local alias
+{
+  foo = lazyAlias(() => import("./file1.js"));
+  var foo = qux(lazyAlias(() => import("./file2.js")));
+  ({
+    foo: lazyAlias(() => import("./file3.js"))
+  });
+  var foo = lazyAlias(() => import("./file4.js"));
+  fn(lazyAlias(() => import("./foo.js")));
+}
+
+{
+  // Don't add another displayName if we somehow transform twice
+  foo =
+    ((_fooAlreadyTransformed = React.lazy(() => import("./file1.js"))),
+    (_fooAlreadyTransformed.displayName = "dontChangeMe"),
+    _fooAlreadyTransformed);
+}
+
+{
+  // Add our displayName before the user's
+  foo = React.lazy(import("./file1.js"));
+  foo.displayName = "dontChangeMe";
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/lazy/output.mjs
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/lazy/output.mjs
@@ -1,0 +1,49 @@
+{
+  var _foo, _foo, _foo2, _foo2, _foo3, _foo3, _foo4, _foo4, _foo5, _foo5;
+
+  // `React.lazy`
+  foo = (_foo = React.lazy(() => import("./file1.js")), _foo.displayName = "foo", _foo);
+  var foo = qux((_foo2 = React.lazy(() => import("./file2.js")), _foo2.displayName = "foo", _foo2));
+  ({
+    foo: (_foo3 = React.lazy(() => import("./file3.js")), _foo3.displayName = "foo", _foo3)
+  });
+  var foo = (_foo4 = React.lazy(() => import("./file4.js")), _foo4.displayName = "foo", _foo4);
+  fn((_foo5 = React.lazy(() => import("./foo.js")), _foo5.displayName = "foo", _foo5));
+}
+import { lazy } from "react"; // Importing `lazy` from the 'react' package
+
+{
+  var _foo6, _foo6, _foo7, _foo7, _foo8, _foo8, _foo9, _foo9, _foo10, _foo10;
+
+  foo = (_foo6 = lazy(() => import("./file1.js")), _foo6.displayName = "foo", _foo6);
+  var foo = qux((_foo7 = lazy(() => import("./file2.js")), _foo7.displayName = "foo", _foo7));
+  ({
+    foo: (_foo8 = lazy(() => import("./file3.js")), _foo8.displayName = "foo", _foo8)
+  });
+  var foo = (_foo9 = lazy(() => import("./file4.js")), _foo9.displayName = "foo", _foo9);
+  fn((_foo10 = lazy(() => import("./foo.js")), _foo10.displayName = "foo", _foo10));
+}
+import { lazy as lazyAlias } from "react"; // Importing `lazy` from the 'react' package with a local alias
+
+{
+  var _foo11, _foo11, _foo12, _foo12, _foo13, _foo13, _foo14, _foo14, _foo15, _foo15;
+
+  foo = (_foo11 = lazyAlias(() => import("./file1.js")), _foo11.displayName = "foo", _foo11);
+  var foo = qux((_foo12 = lazyAlias(() => import("./file2.js")), _foo12.displayName = "foo", _foo12));
+  ({
+    foo: (_foo13 = lazyAlias(() => import("./file3.js")), _foo13.displayName = "foo", _foo13)
+  });
+  var foo = (_foo14 = lazyAlias(() => import("./file4.js")), _foo14.displayName = "foo", _foo14);
+  fn((_foo15 = lazyAlias(() => import("./foo.js")), _foo15.displayName = "foo", _foo15));
+}
+{
+  // Don't add another displayName if we somehow transform twice
+  foo = (_fooAlreadyTransformed = React.lazy(() => import("./file1.js")), _fooAlreadyTransformed.displayName = "dontChangeMe", _fooAlreadyTransformed);
+}
+{
+  var _foo16, _foo16;
+
+  // Add our displayName before the user's
+  foo = (_foo16 = React.lazy(import("./file1.js")), _foo16.displayName = "foo", _foo16);
+  foo.displayName = "dontChangeMe";
+}

--- a/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/options.json
+++ b/packages/babel-plugin-transform-react-display-name/test/fixtures/display-name/options.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["transform-react-display-name"]
+  "plugins": ["syntax-dynamic-import", "transform-react-display-name"],
+  "sourceType": "unambiguous"
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2060
| Any Dependency Changes?  |
| License                  | MIT

https://github.com/facebook/react/pull/16104 (NOTE: not yet merged) adds support for setting `displayName` on the return value of `React.lazy()`:

```js
const Foo = React.lazy(() => import('./FooImplementation'));
Foo.displayName = 'Foo';
```

This PR amends `@babel/plugin-transform-react-display-name` to do this automatically in common cases.
* We reuse the name inference logic used for `createReactClass`, but additionally fall back to deriving a name from the import path, if one is found.
* In addition to blindly matching on calls to `React.lazy`, we also support `import { lazy } from 'react'`.