### PR TITLE
[preset-env] Add targets for dynamic import

### DIFF
--- a/packages/babel-preset-env/data/built-in-modules.json
+++ b/packages/babel-preset-env/data/built-in-modules.json
@@ -8,5 +8,15 @@
     "ios_saf": "10.3",
     "and_chr": "71",
     "and_ff": "64"
+  },
+  "dynamic-import": {
+    "edge": "75",
+    "firefox": "67",
+    "chrome": "63",
+    "safari": "11.1",
+    "opera": "50",
+    "ios_saf": "11.0",
+    "op_mob": "46",
+    "and_chr": "74"
   }
 }

--- a/packages/babel-preset-env/scripts/build-modules-support.js
+++ b/packages/babel-preset-env/scripts/build-modules-support.js
@@ -1,36 +1,46 @@
 const path = require("path");
 const fs = require("fs");
 
-const moduleSupport = require("caniuse-db/features-json/es6-module.json");
-
 const skipList = new Set(["android", "samsung"]);
-const acceptedWithCaveats = new Set(["safari", "ios_saf"]);
 
-const { stats } = moduleSupport;
+function generateData({ stats }, acceptedWithCaveats) {
+  const support = {};
 
-const allowedBrowsers = {};
+  Object.keys(stats).forEach(browser => {
+    if (!skipList.has(browser)) {
+      const browserVersions = stats[browser];
+      const allowedVersions = Object.keys(browserVersions)
+        .filter(version => {
+          const supported = browserVersions[version];
+          if (
+            acceptedWithCaveats &&
+            acceptedWithCaveats.has(browser) &&
+            supported.startsWith("a")
+          ) {
+            return true;
+          }
+          return supported.startsWith("y");
+        })
+        .sort((a, b) => a - b);
 
-Object.keys(stats).forEach(browser => {
-  if (!skipList.has(browser)) {
-    const browserVersions = stats[browser];
-    const allowedVersions = Object.keys(browserVersions)
-      .filter(value => {
-        // Edge 16/17 are marked as "y #6"
-        return acceptedWithCaveats.has(browser)
-          ? browserVersions[value][0] === "a"
-          : browserVersions[value].startsWith("y");
-      })
-      .sort((a, b) => a - b);
-
-    if (allowedVersions[0] !== undefined) {
-      // Handle cases where caniuse specifies version as: "11.0-11.2"
-      allowedBrowsers[browser] = allowedVersions[0].split("-")[0];
+      if (allowedVersions[0] !== undefined) {
+        // Handle cases where caniuse specifies version as: "11.0-11.2"
+        support[browser] = allowedVersions[0].split("-")[0];
+      }
     }
-  }
-});
+  });
+
+  return support;
+}
 
 const dataPath = path.join(__dirname, "../data/built-in-modules.json");
 const data = {
-  "es6.module": allowedBrowsers,
+  "es6.module": generateData(
+    require("caniuse-db/features-json/es6-module.json"),
+    new Set(["safari", "ios_saf"])
+  ),
+  "dynamic-import": generateData(
+    require("caniuse-db/features-json/es6-module-dynamic-import.json")
+  ),
 };
 fs.writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`);

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -2,11 +2,12 @@
 
 import { logPluginOrPolyfill } from "./debug";
 import getOptionSpecificExcludesFor from "./get-option-specific-excludes";
-import filterItems from "./filter-items";
+import filterItems, { isPluginRequired } from "./filter-items";
 import moduleTransformations from "./module-transformations";
 import normalizeOptions from "./normalize-options";
 import pluginList from "../data/plugins.json";
 import { proposalPlugins, pluginSyntaxMap } from "../data/shipped-proposals";
+import browserModulesData from "../data/built-in-modules.json";
 
 import addCoreJS2UsagePlugin from "./polyfills/corejs2/usage-plugin";
 import addCoreJS3UsagePlugin from "./polyfills/corejs3/usage-plugin";
@@ -134,7 +135,10 @@ export default declare((api, opts) => {
     const shouldTransformESM =
       modules !== "auto" || !api.caller || !api.caller(supportsStaticESM);
     const shouldTransformDynamicImport =
-      modules !== "auto" || !api.caller || !api.caller(supportsDynamicImport);
+      (modules !== "auto" ||
+        !api.caller ||
+        !api.caller(supportsDynamicImport)) &&
+      isPluginRequired(transformTargets, browserModulesData["dynamic-import"]);
 
     if (shouldTransformESM) {
       // NOTE: not giving spec here yet to avoid compatibility issues when

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/target-supported/input.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/target-supported/input.js
@@ -1,0 +1,1 @@
+import("./foo.mjs");

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/target-supported/options.json
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/target-supported/options.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["env", { "targets": { "chrome": 70 } }]]
+}

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/target-supported/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/target-supported/output.js
@@ -1,0 +1,1 @@
+import("./foo.mjs");

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/target-unsupported/input.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/target-unsupported/input.js
@@ -1,0 +1,1 @@
+import("./foo.mjs");

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/target-unsupported/options.json
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/target-unsupported/options.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["env", { "targets": { "chrome": 60 } }]]
+}

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/target-unsupported/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/target-unsupported/output.js
@@ -1,0 +1,3 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+Promise.resolve().then(() => _interopRequireWildcard(require("./foo.mjs")));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In engines which support `import()` natively, it doesn't need to be transpiled. For example, someone might write this code:
```js
import color from "./static-module";

main();
async function main() {
  if (!window.$) await import("jquery-cdn");

  $("body").css("background", color);
}
```

and it could safely become
```js
define(["./static-module", function(foo) {
  main();
  async function main() {
    if (!window.$) await import("jquery-cdn");

    $("body").css("background", color);
  }
});
```

NOTE: I'm not 100% sure that this PR is correct. If someone doesn't want `import()` to be transpiled, you might argue that they shouldn't transpile static imports neither and thus use `modules: false`