### PR TITLE
always throw when add missing helpers

### DIFF
--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -203,6 +203,9 @@ export default class File {
       if (res) return res;
     }
 
+    // make sure that the helper exists
+    helpers.ensure(name);
+
     const uid = (this.declarations[name] = this.scope.generateUidIdentifier(
       name,
     ));

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -788,4 +788,28 @@ describe("api", function() {
       );
     });
   });
+
+  describe("missing helpers", function() {
+    it("should always throw", function() {
+      expect(() =>
+        babel.transformSync(``, {
+          configFile: false,
+          plugins: [
+            function() {
+              return {
+                visitor: {
+                  Program(path) {
+                    try {
+                      path.pushContainer("body", this.addHelper("fooBar"));
+                    } catch {}
+                    path.pushContainer("body", this.addHelper("fooBar"));
+                  },
+                },
+              };
+            },
+          ],
+        }),
+      ).toThrow();
+    });
+  });
 });

--- a/packages/babel-helpers/src/index.js
+++ b/packages/babel-helpers/src/index.js
@@ -280,6 +280,10 @@ export function getDependencies(name: string): $ReadOnlyArray<string> {
   return Array.from(loadHelper(name).dependencies.values());
 }
 
+export function ensure(name: string) {
+  loadHelper(name);
+}
+
 export const list = Object.keys(helpers)
   .map(name => name.replace(/^_/, ""))
   .filter(name => name !== "__esModule");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10187
| Patch: Bug Fix?          | 👍 
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT


The problem with current addHelper is that [this line will get execute first](https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/file/file.js#L206), before knowing whether the helper existed:

```js
// 2) will short circuit if `this.declarations[name]` exists
const declar = this.declarations[name];
if (declar) return t.cloneNode(declar);

// 1) will set this.declarations[name] no matter helper exists
const uid = (this.declarations[name] = this.scope.generateUidIdentifier(
   name,
));
```

so i added a `helpers.ensure(name)` before `(1)`.

Since `loadHelper` is cached, it's okay to call it multiple times.