### PR TITLE
[preset-env] Include / exclude module plugins properly

### DIFF
--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -22,7 +22,7 @@ import { filterStageFromList, prettifyTargets } from "./utils";
 import { declare } from "@babel/helper-plugin-utils";
 
 import typeof ModuleTransformationsType from "./module-transformations";
-import type { BuiltInsOption, Targets } from "./types";
+import type { BuiltInsOption, Targets, ModuleOption } from "./types";
 
 export { isPluginRequired } from "./filter-items";
 
@@ -61,26 +61,26 @@ export const transformIncludesAndExcludes = (opts: Array<string>): Object => {
 };
 
 export const getModulesPluginNames = ({
-  moduleTransformation,
+  modules,
+  transformations,
   shouldTransformESM,
   shouldTransformDynamicImport,
 }: {
-  moduleTransformation: $Values<ModuleTransformationsType> | null,
+  modules: ModuleOption,
+  transformations: ModuleTransformationsType,
   shouldTransformESM: boolean,
   shouldTransformDynamicImport: boolean,
 }) => {
   const modulesPluginNames = [];
-  if (moduleTransformation) {
+  if (modules !== false && transformations[modules]) {
     if (shouldTransformESM) {
-      // NOTE: not giving spec here yet to avoid compatibility issues when
-      // transform-modules-commonjs gets its spec mode
-      modulesPluginNames.push(moduleTransformation);
+      modulesPluginNames.push(transformations[modules]);
     }
 
     if (
       shouldTransformDynamicImport &&
       shouldTransformESM &&
-      moduleTransformation !== "transform-modules-umd"
+      modules !== "umd"
     ) {
       modulesPluginNames.push("proposal-dynamic-import");
     } else {
@@ -217,7 +217,8 @@ export default declare((api, opts) => {
   const transformTargets = forceAllTransforms || hasUglifyTarget ? {} : targets;
 
   const modulesPluginNames = getModulesPluginNames({
-    moduleTransformation: moduleTransformations[modules.toString()] || null,
+    modules,
+    transformations: moduleTransformations,
     // TODO: Remove the 'api.caller' check eventually. Just here to prevent
     // unnecessary breakage in the short term for users on older betas/RCs.
     shouldTransformESM:

--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -132,9 +132,13 @@ export default declare((api, opts) => {
     // TODO: Remove the 'api.caller' check eventually. Just here to prevent
     // unnecessary breakage in the short term for users on older betas/RCs.
     const shouldTransformESM =
-      modules !== "auto" || !api.caller || !api.caller(supportsStaticESM);
+      (modules !== "auto" || !api.caller || !api.caller(supportsStaticESM)) &&
+      !exclude.plugins.has(moduleTransformations[modules]);
     const shouldTransformDynamicImport =
-      modules !== "auto" || !api.caller || !api.caller(supportsDynamicImport);
+      (modules !== "auto" ||
+        !api.caller ||
+        !api.caller(supportsDynamicImport)) &&
+      !exclude.plugins.has("proposal-dynamic-import");
 
     if (shouldTransformESM) {
       // NOTE: not giving spec here yet to avoid compatibility issues when

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -32,7 +32,7 @@ const validateTopLevelOptions = (options: Options) => {
   }
 };
 
-const allPluginsList = [...Object.keys(pluginsList)];
+const allPluginsList = Object.keys(pluginsList);
 
 // NOTE: Since module plugins are handled seperatly compared to other plugins (via the "modules" option) it
 // should only be possible to exclude and not include module plugins, otherwise it's possible that preset-env

--- a/packages/babel-preset-env/test/debug-fixtures/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/corejs-without-usebuiltins/stdout.txt
@@ -40,6 +40,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
 Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-android/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-optional-catch-binding { "android":"4" }
   transform-named-capturing-groups-regex { "android":"4" }
   transform-reserved-words { "android":"4" }
+  transform-modules-commonjs { "android":"4" }
+  proposal-dynamic-import { "android":"4" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-electron/stdout.txt
@@ -34,6 +34,8 @@ Using plugins:
   transform-named-capturing-groups-regex { "electron":"0.36" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
+  transform-modules-commonjs { "electron":"0.36" }
+  proposal-dynamic-import { "electron":"0.36" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-force-all-transforms/stdout.txt
@@ -40,6 +40,7 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  syntax-dynamic-import { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-no-import/stdout.txt
@@ -20,6 +20,8 @@ Using plugins:
   proposal-json-strings { "node":"6" }
   proposal-optional-catch-binding { "node":"6" }
   transform-named-capturing-groups-regex { "node":"6" }
+  transform-modules-commonjs { "node":"6" }
+  proposal-dynamic-import { "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-proposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-shippedProposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-specific-targets/stdout.txt
@@ -42,6 +42,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-versions-decimals/stdout.txt
@@ -50,6 +50,8 @@ Using plugins:
   transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
+  transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2-versions-strings/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs2/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-all-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-all/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-android/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-optional-catch-binding { "android":"4" }
   transform-named-capturing-groups-regex { "android":"4" }
   transform-reserved-words { "android":"4" }
+  transform-modules-commonjs { "android":"4" }
+  proposal-dynamic-import { "android":"4" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-babel-polyfill/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-electron/stdout.txt
@@ -34,6 +34,8 @@ Using plugins:
   transform-named-capturing-groups-regex { "electron":"0.36" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
+  transform-modules-commonjs { "electron":"0.36" }
+  proposal-dynamic-import { "electron":"0.36" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es-proposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-es/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-force-all-transforms/stdout.txt
@@ -40,6 +40,7 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  syntax-dynamic-import { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-no-import/stdout.txt
@@ -20,6 +20,8 @@ Using plugins:
   proposal-json-strings { "node":"6" }
   proposal-optional-catch-binding { "node":"6" }
   transform-named-capturing-groups-regex { "node":"6" }
+  transform-modules-commonjs { "node":"6" }
+  proposal-dynamic-import { "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-proposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-runtime-only/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-specific-entries/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-specific-targets/stdout.txt
@@ -42,6 +42,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stable-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -14,6 +14,8 @@ Using plugins:
   proposal-json-strings { "samsung":"8.2" }
   proposal-optional-catch-binding { "samsung":"8.2" }
   transform-named-capturing-groups-regex { "samsung":"8.2" }
+  transform-modules-commonjs { "samsung":"8.2" }
+  proposal-dynamic-import { "samsung":"8.2" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stable/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stage-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-stage/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-decimals/stdout.txt
@@ -50,6 +50,8 @@ Using plugins:
   transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
+  transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-versions-strings/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-web-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3-web/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-corejs3/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs-no-import/stdout.txt
@@ -20,6 +20,8 @@ Using plugins:
   proposal-json-strings { "node":"6" }
   proposal-optional-catch-binding { "node":"6" }
   transform-named-capturing-groups-regex { "node":"6" }
+  transform-modules-commonjs { "node":"6" }
+  proposal-dynamic-import { "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs-shippedProposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  transform-modules-commonjs {}
+  proposal-dynamic-import {}
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs-uglify/stdout.txt
@@ -43,6 +43,7 @@ Using plugins:
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
+  syntax-dynamic-import { "chrome":"55" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/entry-no-corejs/stdout.txt
@@ -39,6 +39,8 @@ Using plugins:
   proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
   proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
   transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
 
 Using polyfills with `entry` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/plugins-only/stdout.txt
@@ -27,6 +27,8 @@ Using plugins:
   proposal-json-strings { "firefox":"52", "node":"7.4" }
   proposal-optional-catch-binding { "firefox":"52", "node":"7.4" }
   transform-named-capturing-groups-regex { "firefox":"52", "node":"7.4" }
+  transform-modules-commonjs { "firefox":"52", "node":"7.4" }
+  proposal-dynamic-import { "firefox":"52", "node":"7.4" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
 Successfully compiled 1 file with Babel.

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-none/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-proposals-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-proposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-shippedProposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2-with-import/stdout.txt
@@ -15,6 +15,8 @@ Using plugins:
   proposal-json-strings { "chrome":"55" }
   proposal-optional-catch-binding { "chrome":"55" }
   transform-named-capturing-groups-regex { "chrome":"55" }
+  transform-modules-commonjs { "chrome":"55" }
+  proposal-dynamic-import { "chrome":"55" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs2/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-none/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-proposals-chrome-71/stdout.txt
@@ -12,6 +12,8 @@ Using plugins:
   syntax-object-rest-spread { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
+  transform-modules-commonjs { "chrome":"71" }
+  proposal-dynamic-import { "chrome":"71" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-proposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-shippedProposals/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3-with-import/stdout.txt
@@ -15,6 +15,8 @@ Using plugins:
   proposal-json-strings { "chrome":"55" }
   proposal-optional-catch-binding { "chrome":"55" }
   transform-named-capturing-groups-regex { "chrome":"55" }
+  transform-modules-commonjs { "chrome":"55" }
+  proposal-dynamic-import { "chrome":"55" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-corejs3/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-no-corejs-none/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-no-corejs-none/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/debug-fixtures/usage-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/debug-fixtures/usage-no-corejs/stdout.txt
@@ -38,6 +38,8 @@ Using plugins:
   proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -26,6 +26,7 @@ Using plugins:
   proposal-json-strings { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
   proposal-optional-catch-binding { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
   transform-named-capturing-groups-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  syntax-dynamic-import { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -26,6 +26,7 @@ Using plugins:
   proposal-json-strings { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
   proposal-optional-catch-binding { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
   transform-named-capturing-groups-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  syntax-dynamic-import { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
 
 Using polyfills with `usage` option:
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -20,5 +20,7 @@ Using plugins:
   proposal-json-strings { "safari":"10" }
   proposal-optional-catch-binding { "safari":"10" }
   transform-named-capturing-groups-regex { "safari":"10" }
+  transform-modules-commonjs { "safari":"10" }
+  proposal-dynamic-import { "safari":"10" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/index.spec.js
+++ b/packages/babel-preset-env/test/index.spec.js
@@ -1,6 +1,18 @@
 "use strict";
 
 const babelPresetEnv = require("../lib/index");
+const addCoreJS2UsagePlugin = require("../lib/polyfills/corejs2/usage-plugin")
+  .default;
+const addCoreJS3UsagePlugin = require("../lib/polyfills/corejs3/usage-plugin")
+  .default;
+const addRegeneratorUsagePlugin = require("../lib/polyfills/regenerator/usage-plugin")
+  .default;
+const replaceCoreJS2EntryPlugin = require("../lib/polyfills/corejs2/entry-plugin")
+  .default;
+const replaceCoreJS3EntryPlugin = require("../lib/polyfills/corejs3/entry-plugin")
+  .default;
+const removeRegeneratorEntryPlugin = require("../lib/polyfills/regenerator/entry-plugin")
+  .default;
 
 describe("babel-preset-env", () => {
   describe("transformIncludesAndExcludes", () => {
@@ -21,6 +33,212 @@ describe("babel-preset-env", () => {
         all: ["es.map"],
         plugins: new Set(),
         builtIns: new Set(["es.map"]),
+      });
+    });
+  });
+  describe("getModulesPluginNames", () => {
+    describe("no moduleTransformation is specified", () => {
+      it("returns only syntax-dynamic-import", () => {
+        expect(
+          babelPresetEnv.getModulesPluginNames({
+            moduleTransformation: null,
+            shouldTransformESM: false,
+            shouldTransformDynamicImport: false,
+          }),
+        ).toEqual(["syntax-dynamic-import"]);
+      });
+    });
+    describe("a moduleTransformation is specified", () => {
+      describe("ESMs should not be transformed", () => {
+        it("returns syntax-dynamic-import", () => {
+          expect(
+            babelPresetEnv.getModulesPluginNames({
+              moduleTransformation: "transform-modules-commonjs",
+              shouldTransformESM: false,
+              shouldTransformDynamicImport: false,
+            }),
+          ).toEqual(["syntax-dynamic-import"]);
+        });
+      });
+      describe("ESMs should be transformed", () => {
+        describe("dynamic imports should not be transformed", () => {
+          it("returns moduleTransformation and syntax-dynamic-import", () => {
+            const moduleTransformation = "transform-modules-commonjs";
+            expect(
+              babelPresetEnv.getModulesPluginNames({
+                moduleTransformation: moduleTransformation,
+                shouldTransformESM: true,
+                shouldTransformDynamicImport: false,
+              }),
+            ).toEqual([moduleTransformation, "syntax-dynamic-import"]);
+          });
+        });
+        describe("dynamic imports should be transformed", () => {
+          it("returns moduleTransformation and proposal-dynamic-import", () => {
+            const moduleTransformation = "transform-modules-commonjs";
+            expect(
+              babelPresetEnv.getModulesPluginNames({
+                moduleTransformation: moduleTransformation,
+                shouldTransformESM: true,
+                shouldTransformDynamicImport: true,
+              }),
+            ).toEqual([moduleTransformation, "proposal-dynamic-import"]);
+          });
+        });
+      });
+    });
+  });
+  describe("getPolyfillPlugins", () => {
+    const staticProps = {
+      polyfillTargets: [],
+      include: new Set(),
+      exclude: new Set(),
+      proposals: false,
+      shippedProposals: false,
+      debug: false,
+    };
+    describe("useBuiltIns is false", () => {
+      it("returns no polyfill plugins", () => {
+        expect(
+          babelPresetEnv.getPolyfillPlugins(
+            Object.assign(
+              {
+                useBuiltIns: false,
+                corejs: false,
+                regenerator: false,
+              },
+              staticProps,
+            ),
+          ),
+        ).toEqual([]);
+      });
+    });
+    describe("useBuiltIns is not false", () => {
+      describe("corejs is not given", () => {
+        it("returns no polyfill plugins", () => {
+          expect(
+            babelPresetEnv.getPolyfillPlugins(
+              Object.assign(
+                {
+                  useBuiltIns: "usage",
+                  corejs: false,
+                  regenerator: false,
+                },
+                staticProps,
+              ),
+            ),
+          ).toEqual([]);
+        });
+      });
+      describe("useBuiltIns is set to usage", () => {
+        describe("using corejs 2", () => {
+          it("returns an array with core js 2 usage plugin", () => {
+            const polyfillPlugins = babelPresetEnv.getPolyfillPlugins(
+              Object.assign(
+                {
+                  useBuiltIns: "usage",
+                  corejs: { major: 2 },
+                  regenerator: false,
+                },
+                staticProps,
+              ),
+            );
+            expect(polyfillPlugins.length).toBe(1);
+            expect(polyfillPlugins[0][0]).toEqual(addCoreJS2UsagePlugin);
+          });
+        });
+        describe("using corejs 3", () => {
+          describe("regenerator is set to false", () => {
+            it("returns an array with core js 3 usage plugin", () => {
+              const polyfillPlugins = babelPresetEnv.getPolyfillPlugins(
+                Object.assign(
+                  {
+                    useBuiltIns: "usage",
+                    corejs: { major: 3 },
+                    regenerator: false,
+                  },
+                  staticProps,
+                ),
+              );
+              expect(polyfillPlugins.length).toBe(1);
+              expect(polyfillPlugins[0][0]).toEqual(addCoreJS3UsagePlugin);
+            });
+          });
+
+          describe("regenerator is set to true", () => {
+            it("returns an array with core js 3 usage plugin and add regenerator usage plugin", () => {
+              const polyfillPlugins = babelPresetEnv.getPolyfillPlugins(
+                Object.assign(
+                  {
+                    useBuiltIns: "usage",
+                    corejs: { major: 3 },
+                    regenerator: true,
+                  },
+                  staticProps,
+                ),
+              );
+              expect(polyfillPlugins.length).toBe(2);
+              expect(polyfillPlugins[0][0]).toEqual(addCoreJS3UsagePlugin);
+              expect(polyfillPlugins[1][0]).toEqual(addRegeneratorUsagePlugin);
+            });
+          });
+        });
+      });
+      describe("useBuiltIns is set to entry", () => {
+        describe("using corejs 2", () => {
+          it("returns an array with core js 2 entry plugin", () => {
+            const polyfillPlugins = babelPresetEnv.getPolyfillPlugins(
+              Object.assign(
+                {
+                  useBuiltIns: "entry",
+                  corejs: { major: 2 },
+                  regenerator: true,
+                },
+                staticProps,
+              ),
+            );
+            expect(polyfillPlugins.length).toBe(1);
+            expect(polyfillPlugins[0][0]).toEqual(replaceCoreJS2EntryPlugin);
+          });
+        });
+        describe("using corejs 3", () => {
+          describe("regenerator is set to true", () => {
+            it("returns an array with core js 3 entry plugin", () => {
+              const polyfillPlugins = babelPresetEnv.getPolyfillPlugins(
+                Object.assign(
+                  {
+                    useBuiltIns: "entry",
+                    corejs: { major: 3 },
+                    regenerator: true,
+                  },
+                  staticProps,
+                ),
+              );
+              expect(polyfillPlugins.length).toBe(1);
+              expect(polyfillPlugins[0][0]).toEqual(replaceCoreJS3EntryPlugin);
+            });
+          });
+
+          describe("regenerator is set to false", () => {
+            it("returns an array with core js 3 entry plugin and remove regenerator entry plugin", () => {
+              const polyfillPlugins = babelPresetEnv.getPolyfillPlugins(
+                Object.assign(
+                  {
+                    useBuiltIns: "entry",
+                    corejs: { major: 3 },
+                    regenerator: false,
+                  },
+                  staticProps,
+                ),
+              );
+              expect(polyfillPlugins.length).toBe(2);
+              expect(polyfillPlugins[0][0]).toEqual(replaceCoreJS3EntryPlugin);
+              expect(polyfillPlugins[1][0]).toEqual(
+                removeRegeneratorEntryPlugin,
+              );
+            });
+          });
+        });
       });
     });
   });

--- a/packages/babel-preset-env/test/index.spec.js
+++ b/packages/babel-preset-env/test/index.spec.js
@@ -13,6 +13,7 @@ const replaceCoreJS3EntryPlugin = require("../lib/polyfills/corejs3/entry-plugin
   .default;
 const removeRegeneratorEntryPlugin = require("../lib/polyfills/regenerator/entry-plugin")
   .default;
+const transformations = require("../lib/module-transformations").default;
 
 describe("babel-preset-env", () => {
   describe("transformIncludesAndExcludes", () => {
@@ -37,23 +38,25 @@ describe("babel-preset-env", () => {
     });
   });
   describe("getModulesPluginNames", () => {
-    describe("no moduleTransformation is specified", () => {
+    describe("modules is set to false", () => {
       it("returns only syntax-dynamic-import", () => {
         expect(
           babelPresetEnv.getModulesPluginNames({
-            moduleTransformation: null,
+            modules: false,
+            transformations,
             shouldTransformESM: false,
             shouldTransformDynamicImport: false,
           }),
         ).toEqual(["syntax-dynamic-import"]);
       });
     });
-    describe("a moduleTransformation is specified", () => {
+    describe("modules is not set to false", () => {
       describe("ESMs should not be transformed", () => {
         it("returns syntax-dynamic-import", () => {
           expect(
             babelPresetEnv.getModulesPluginNames({
-              moduleTransformation: "transform-modules-commonjs",
+              modules: "commonjs",
+              transformations,
               shouldTransformESM: false,
               shouldTransformDynamicImport: false,
             }),
@@ -62,27 +65,30 @@ describe("babel-preset-env", () => {
       });
       describe("ESMs should be transformed", () => {
         describe("dynamic imports should not be transformed", () => {
-          it("returns moduleTransformation and syntax-dynamic-import", () => {
-            const moduleTransformation = "transform-modules-commonjs";
+          it("returns specified modules transform and syntax-dynamic-import", () => {
             expect(
               babelPresetEnv.getModulesPluginNames({
-                moduleTransformation: moduleTransformation,
+                modules: "commonjs",
+                transformations,
                 shouldTransformESM: true,
                 shouldTransformDynamicImport: false,
               }),
-            ).toEqual([moduleTransformation, "syntax-dynamic-import"]);
+            ).toEqual(["transform-modules-commonjs", "syntax-dynamic-import"]);
           });
         });
         describe("dynamic imports should be transformed", () => {
-          it("returns moduleTransformation and proposal-dynamic-import", () => {
-            const moduleTransformation = "transform-modules-commonjs";
+          it("returns specified modules transform and proposal-dynamic-import", () => {
             expect(
               babelPresetEnv.getModulesPluginNames({
-                moduleTransformation: moduleTransformation,
+                modules: "systemjs",
+                transformations,
                 shouldTransformESM: true,
                 shouldTransformDynamicImport: true,
               }),
-            ).toEqual([moduleTransformation, "proposal-dynamic-import"]);
+            ).toEqual([
+              "transform-modules-systemjs",
+              "proposal-dynamic-import",
+            ]);
           });
         });
       });

--- a/packages/babel-preset-env/test/normalize-options.spec.js
+++ b/packages/babel-preset-env/test/normalize-options.spec.js
@@ -84,6 +84,24 @@ describe("normalize-options", () => {
         });
       });
     });
+
+    it("throws when including module plugins", () => {
+      expect(() =>
+        normalizeOptions.default({ include: ["proposal-dynamic-import"] }),
+      ).toThrow();
+      expect(() =>
+        normalizeOptions.default({ include: ["transform-modules-amd"] }),
+      ).toThrow();
+    });
+
+    it("allows exclusion of module plugins ", () => {
+      expect(() =>
+        normalizeOptions.default({ exclude: ["proposal-dynamic-import"] }),
+      ).not.toThrow();
+      expect(() =>
+        normalizeOptions.default({ exclude: ["transform-modules-commonjs"] }),
+      ).not.toThrow();
+    });
   });
 
   describe("Config format validation", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10194 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes how includes and excludes of module plugins (proposal-dynamic-import, transform-modules-commonjs, transform-modules-amd, transform-modules-commonjs, transform-modules-systemjs, transform-modules-umd) works. After this PR it is possible to exclude module plugins, but not include them.

Before this PR it wasn't possible to exclude any of the plugins listed above. This caused issues when you wanted to  transform ES modules, but not dynamic imports (see [this](https://github.com/babel/babel/issues/10194) issue). 

Another case that this PR is fixing is that it was possible to include a module plugin. However, that could potentially cause issues where a plugin was added twice, eg. with the following config: 
```
{
    presets: [
      [
        '@babel/preset-env',
        {
          modules: 'cjs',
          include: ['@babel/plugin-transform-modules-commonjs'],
        },
      ],
    ],
  }
```

Adding this PR will make it possible to set `modules: 'cjs'` and `exclude: ['transform-modules-commonjs']`, which will resolve in that modules are not transformed to commonjs. A warning or an error might be preferable here, but I think that this behaviour is better then it was before (before it just transformed modules to commonjs). Furthermore, unless someones babel config is ambiguous (see cases above), this change should not break anyones' builds.