### PR TITLE
babel-preset-env: bump esmodule browserlist to Safari 11

### DIFF
--- a/packages/babel-preset-env/data/built-in-modules.json
+++ b/packages/babel-preset-env/data/built-in-modules.json
@@ -3,9 +3,9 @@
     "edge": "16",
     "firefox": "60",
     "chrome": "61",
-    "safari": "10.1",
+    "safari": "11",
     "opera": "48",
-    "ios_saf": "10.3",
+    "ios_saf": "11",
     "and_chr": "71",
     "and_ff": "64"
   }

--- a/packages/babel-preset-env/data/built-in-modules.json
+++ b/packages/babel-preset-env/data/built-in-modules.json
@@ -5,8 +5,8 @@
     "chrome": "61",
     "safari": "11",
     "opera": "48",
-    "ios_saf": "11",
-    "and_chr": "71",
-    "and_ff": "64"
+    "ios_saf": "11.0",
+    "and_chr": "74",
+    "and_ff": "66"
   }
 }

--- a/packages/babel-preset-env/scripts/build-modules-support.js
+++ b/packages/babel-preset-env/scripts/build-modules-support.js
@@ -4,7 +4,6 @@ const fs = require("fs");
 const moduleSupport = require("caniuse-db/features-json/es6-module.json");
 
 const skipList = new Set(["android", "samsung"]);
-const acceptedWithCaveats = new Set(["safari", "ios_saf"]);
 
 const { stats } = moduleSupport;
 
@@ -16,9 +15,7 @@ Object.keys(stats).forEach(browser => {
     const allowedVersions = Object.keys(browserVersions)
       .filter(value => {
         // Edge 16/17 are marked as "y #6"
-        return acceptedWithCaveats.has(browser)
-          ? browserVersions[value][0] === "a"
-          : browserVersions[value].startsWith("y");
+        return browserVersions[value].startsWith("y");
       })
       .sort((a, b) => a - b);
 


### PR DESCRIPTION
[ios_saf 10.3](https://github.com/Fyrd/caniuse/blob/bed4faadcea2ec7719c5f43167c0e2dace892be7/features-json/es6-module.json#L318) and [safari 10.1](https://github.com/Fyrd/caniuse/blob/master/features-json/es6-module.json#L239) do not support the `nomodule` attribute, so they should not be the minimum constraints when `esmodules: true`.

It is common to use `esmodules: true` to split a build into two bundles (one containing fewer polyfills and transformed code - intended for newer browsers - and the other including more code to make old browsers happy), and `nomodule` is critical for that. I suggest bumping these browserlist constraints to Safari 11, which does support `nomodule`.

To support these older Safari versions, a few big-cost transforms must be added (list comes from my repro here: https://github.com/connorjclark/babel-esmodule-preset/tree/826e1c83faaa8a62f473179a08f467e575825c3e/src-esmodule). Bumping to 11 will remove all of these:

```
transform-template-literals { "ios":"10.3", "safari":"10.1" }
transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
transform-block-scoping { "ios":"10.3", "safari":"10.1" }
transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
```

The `async-to-generator` transform is especially bad - adds lots of code that is slower than native async/await, even though all browsers that properly support es6 modules also support async/await.

Note @wardpeet [originally pointed](https://github.com/GoogleChrome/web.dev/issues/965) out that this "build for modern browsers only" pattern doesn't really [cut](https://responsivenews.co.uk/post/18948466399/cutting-the-mustard) [the](https://snugug.com/musings/modern-cutting-the-mustard/) [mustard](https://fettblog.eu/cutting-the-mustard-2018/) anymore - there are browsers 3 years old that support modules. However, these changes will at least cut some cruft for those still using this pattern.