### PR TITLE
Add `cloneInputAst` option to `babel.transformFromAst`

### DIFF
--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -81,6 +81,7 @@ export default function* loadPrivatePartialConfig(
     root: rootDir = ".",
     rootMode = "root",
     caller,
+    cloneInputAst = true,
   } = args;
   const absoluteCwd = path.resolve(cwd);
   const absoluteRootDir = yield* resolveRootMode(
@@ -110,6 +111,7 @@ export default function* loadPrivatePartialConfig(
   // Tack the passes onto the object itself so that, if this object is
   // passed back to Babel a second time, it will be in the right structure
   // to not change behavior.
+  options.cloneInputAst = cloneInputAst;
   options.babelrc = false;
   options.configFile = false;
   options.passPerPreset = false;

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -51,6 +51,10 @@ const ROOT_VALIDATORS: ValidatorSet = {
   code: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "code">>),
   ast: (assertBoolean: Validator<$PropertyType<ValidatedOptions, "ast">>),
 
+  cloneInputAst: (assertBoolean: Validator<
+    $PropertyType<ValidatedOptions, "cloneInputAst">,
+  >),
+
   envName: (assertString: Validator<
     $PropertyType<ValidatedOptions, "envName">,
   >),
@@ -184,6 +188,7 @@ export type ValidatedOptions = {
   rootMode?: RootMode,
   code?: boolean,
   ast?: boolean,
+  cloneInputAst?: boolean,
   inputSourceMap?: RootInputSourceMapOption,
   envName?: string,
   caller?: CallerMetadata,

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -34,7 +34,11 @@ export default function* normalizeFile(
     } else if (ast.type !== "File") {
       throw new Error("AST root must be a Program or File node");
     }
-    ast = cloneDeep(ast);
+
+    const { cloneInputAst } = options;
+    if (cloneInputAst) {
+      ast = cloneDeep(ast);
+    }
   } else {
     ast = yield* parser(pluginPasses, options, code);
   }

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -214,6 +214,31 @@ describe("api", function () {
     );
   });
 
+  it("transformFromAst should mutate the AST when cloneInputAst is false", function () {
+    const program = "const identifier = 1";
+    const node = parse(program);
+    const { code } = transformFromAst(node, program, {
+      cloneInputAst: false,
+      plugins: [
+        function () {
+          return {
+            visitor: {
+              Identifier: function (path) {
+                path.node.name = "replaced";
+              },
+            },
+          };
+        },
+      ],
+    });
+
+    expect(code).toBe("const replaced = 1;");
+    expect(node.program.body[0].declarations[0].id.name).toBe(
+      "replaced",
+      "original ast should have been mutated",
+    );
+  });
+
   it("options throw on falsy true", function () {
     return expect(function () {
       transform("", {

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -984,6 +984,7 @@ describe("buildConfigChain", function () {
       passPerPreset: false,
       plugins: [],
       presets: [],
+      cloneInputAst: true,
     });
     const realEnv = process.env.NODE_ENV;
     const realBabelEnv = process.env.BABEL_ENV;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10231, fixes #11206 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Added new flag `cloneInputAst`
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2306
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


<a href="https://gitpod.io/#https://github.com/babel/babel/pull/10241"><img src="https://gitpod.io/api/apps/github/pbs/github.com/coderaiser/babel.git/8983fe765a2514ca0f11d9f27eaf463f445dfeee.svg" /></a>

