### PR TITLE
fix: normalize moduleName of absolute runtime

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -10,9 +10,9 @@ import { typeAnnotationToString } from "./helpers";
 
 function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
   try {
-    return path.dirname(
-      resolve.sync(`${moduleName}/package.json`, { basedir: dirname }),
-    );
+    return path
+      .dirname(resolve.sync(`${moduleName}/package.json`, { basedir: dirname }))
+      .replace(/\\/g, "/");
   } catch (err) {
     if (err.code !== "MODULE_NOT_FOUND") throw err;
 

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -10,9 +10,9 @@ import { typeAnnotationToString } from "./helpers";
 
 function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
   try {
-    return path
-      .dirname(resolve.sync(`${moduleName}/package.json`, { basedir: dirname }))
-      .replace(/\\/g, "/");
+    return path.posix.dirname(
+      resolve.sync(`${moduleName}/package.json`, { basedir: dirname }),
+    );
   } catch (err) {
     if (err.code !== "MODULE_NOT_FOUND") throw err;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10209
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Nope 😢
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The moduleName of resolved absolute runtime should be normalized, otherwise it will return
`PATH\\TO\\MODULE` on Windows 7, which is apparently incorrect.

I don't know how to add a unit test given that CI runs on Linux only.