### PR TITLE
perf: always return `void 0` as undefined node

### DIFF
--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -490,12 +490,7 @@ export default class Scope {
   }
 
   buildUndefinedNode() {
-    if (this.hasBinding("undefined")) {
-      return t.unaryExpression("void", t.numericLiteral(0), true);
-    } else {
-      // eslint-disable-next-line @babel/development/no-undefined-identifier
-      return t.identifier("undefined");
-    }
+    return t.unaryExpression("void", t.numericLiteral(0), true);
   }
 
   registerConstantViolation(path: NodePath) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Performance tweak
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Effectively, `this.hasBinding("undefined")` will always returns true since `undefined` is a global property. As `void 0` is safer than `undefined`, here we remove the `if` conditional check. `buildUndefinedNode` will be a bit faster as it doesn't have to look through the nested scopes.

I would also suggest that we move `buildUndefinedNode` to babel-types and clearly state that it is not relevant to the Scope class.