### PR TITLE
Add static to class property builder

### DIFF
--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -403,8 +403,8 @@ export const classMethodOrPropertyCommon = {
     optional: true,
   },
   static: {
+    default: false,
     validate: assertValueType("boolean"),
-    optional: true,
   },
   computed: {
     default: false,

--- a/packages/babel-types/src/definitions/experimental.js
+++ b/packages/babel-types/src/definitions/experimental.js
@@ -33,7 +33,14 @@ defineType("BindExpression", {
 
 defineType("ClassProperty", {
   visitor: ["key", "value", "typeAnnotation", "decorators"],
-  builder: ["key", "value", "typeAnnotation", "decorators", "computed"],
+  builder: [
+    "key",
+    "value",
+    "typeAnnotation",
+    "decorators",
+    "computed",
+    "static",
+  ],
   aliases: ["Property"],
   fields: {
     ...classMethodOrPropertyCommon,

--- a/packages/babel-types/test/builders/experimental/__snapshots__/classProperty.js.snap
+++ b/packages/babel-types/test/builders/experimental/__snapshots__/classProperty.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builders experimental classProperty should validate 1`] = `
+Object {
+  "computed": false,
+  "decorators": null,
+  "key": Object {
+    "type": "StringLiteral",
+    "value": "test",
+  },
+  "static": false,
+  "type": "ClassProperty",
+  "typeAnnotation": null,
+  "value": Object {
+    "type": "NumericLiteral",
+    "value": 1,
+  },
+}
+`;
+
+exports[`builders experimental classProperty should validate 2`] = `
+Object {
+  "computed": false,
+  "decorators": null,
+  "key": Object {
+    "type": "StringLiteral",
+    "value": "test",
+  },
+  "static": true,
+  "type": "ClassProperty",
+  "typeAnnotation": null,
+  "value": Object {
+    "type": "NumericLiteral",
+    "value": 1,
+  },
+}
+`;

--- a/packages/babel-types/test/builders/experimental/classProperty.js
+++ b/packages/babel-types/test/builders/experimental/classProperty.js
@@ -1,0 +1,24 @@
+import * as t from "../../..";
+
+describe("builders", function() {
+  describe("experimental", function() {
+    describe("classProperty", function() {
+      it("should validate", function() {
+        expect(
+          t.classProperty(t.stringLiteral("test"), t.numericLiteral(1)),
+        ).toMatchSnapshot();
+
+        expect(
+          t.classProperty(
+            t.stringLiteral("test"),
+            t.numericLiteral(1),
+            null,
+            null,
+            false,
+            true,
+          ),
+        ).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10247
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2071
| Any Dependency Changes?  | No
| License                  | MIT

Add static parameter to `t.classsProperty` builder
```js
t.classProperty(key, value, typeAnnotation, decorators, computed, static);
```
