### PR TITLE
fix: normalize sourcemap sources when generating from file name

### DIFF
--- a/packages/babel-generator/src/source-map.js
+++ b/packages/babel-generator/src/source-map.js
@@ -7,8 +7,9 @@ import sourceMap from "source-map";
 export default class SourceMap {
   constructor(opts, code) {
     this._cachedMap = null;
-    this._code = code;
-    this._opts = opts;
+    const { _opts, _code } = normalizeSourceFileName(opts, code);
+    this._code = _code;
+    this._opts = _opts;
     this._rawMappings = [];
   }
 
@@ -73,6 +74,9 @@ export default class SourceMap {
     this._lastGenLine = generatedLine;
     this._lastSourceLine = line;
     this._lastSourceColumn = column;
+    if (filename) {
+      filename = filename.replace(/\\/g, "/");
+    }
 
     // We are deliberately not using the `source-map` library here to allow
     // callers to use these mappings without any overhead
@@ -93,4 +97,20 @@ export default class SourceMap {
             },
     });
   }
+}
+
+function normalizeSourceFileName(opts, code) {
+  let _opts = opts;
+  const _code = code;
+  if (typeof code === "string") {
+    _opts = {
+      ...opts,
+      sourceFileName: _opts.sourceFileName.replace(/\\/g, "/"),
+    };
+  } else if (typeof code === "object") {
+    Object.keys(code).forEach(sourceFileName => {
+      _code[sourceFileName.replace(/\\/g, "/")] = code[sourceFileName];
+    });
+  }
+  return { _opts, _code };
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10254 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Test passes on my local Windows build
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Replace in sourceFileName from `\` to `/` when generating source maps.