### PR TITLE
`babel --watch` should have equivalent file selection logic with `babel`

### DIFF
--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -216,6 +216,7 @@ export default async function({
       const chokidar = util.requireChokidar();
       chokidar
         .watch(filenames, {
+          disableGlobbing: true,
           persistent: true,
           ignoreInitial: true,
           awaitWriteFinish: {

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -224,7 +224,10 @@ export default async function({
           },
         })
         .on("all", function(type: string, filename: string): void {
-          if (!util.isCompilableExtension(filename, cliOptions.extensions)) {
+          if (
+            !util.isCompilableExtension(filename, cliOptions.extensions) &&
+            !filenames.includes(filename)
+          ) {
             return;
           }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10270 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Nope
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

In this PR, we align file selection logic of `--watch` to one time building. In
https://github.com/babel/babel/blob/f08062b1deaf34d28726d0ef825821d060cb8554/packages/babel-cli/src/babel/file.js#L144-L163
The cli options `--extensions` is used to filter compilable files if the `filename` argument is a directory. However the watch logic excludes all non-compilable files even if it is specified in `filename` argument.

We also introduce minor performance tweak by passing `disableGlobbing: true` into chokidar as `@babel/cli` does not support globbing.

Fixture-based unit test does not work here since we need separate process to trigger a file change.