### PR TITLE
Always use `sourceFileName` instead of `sourceFilename`.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,5 +1,5 @@
 type BabelParserOptions = {
-  sourceFilename?: string;
+  sourceFileName?: string;
   sourceType?: "module" | "script";
   plugins?: Array<Object>;
 };

--- a/packages/babel-cli/src/babel/file.js
+++ b/packages/babel-cli/src/babel/file.js
@@ -164,21 +164,21 @@ export default async function({
 
     const results = await Promise.all(
       _filenames.map(async function(filename: string): Promise<Object> {
-        let sourceFilename = filename;
+        let sourceFileName = filename;
         if (cliOptions.outFile) {
-          sourceFilename = path.relative(
+          sourceFileName = path.relative(
             path.dirname(cliOptions.outFile),
-            sourceFilename,
+            sourceFileName,
           );
         }
-        sourceFilename = slash(sourceFilename);
+        sourceFileName = slash(sourceFileName);
 
         try {
           return await util.compile(
             filename,
             defaults(
               {
-                sourceFileName: sourceFilename,
+                sourceFileName,
                 // Since we're compiling everything to be merged together,
                 // "inline" applies to the final output file, but not to the individual
                 // files being concatenated.

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -25,7 +25,7 @@ describe("generation", function() {
     };
     const parsed = Object.keys(sources).reduce(function(_parsed, filename) {
       _parsed[filename] = parse(sources[filename], {
-        sourceFilename: filename,
+        sourceFileName: filename,
       });
       return _parsed;
     }, {});

--- a/packages/babel-parser/src/options.js
+++ b/packages/babel-parser/src/options.js
@@ -9,7 +9,7 @@ export type SourceType = "script" | "module" | "unambiguous";
 
 export type Options = {
   sourceType: SourceType,
-  sourceFilename?: string,
+  sourceFileName?: string,
   startLine: number,
   allowAwaitOutsideFunction: boolean,
   allowReturnOutsideFunction: boolean,
@@ -27,7 +27,7 @@ export const defaultOptions: Options = {
   // Source type ("script" or "module") for different semantics
   sourceType: "script",
   // Source filename.
-  sourceFilename: undefined,
+  sourceFileName: undefined,
   // Line from which to start counting source. Useful for
   // integration with other tools.
   startLine: 1,

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -26,7 +26,7 @@ export default class Parser extends StatementParser {
     this.inModule = this.options.sourceType === "module";
     this.scope = new ScopeHandler(this.raise.bind(this), this.inModule);
     this.plugins = pluginsMap(this.options.plugins);
-    this.filename = options.sourceFilename;
+    this.filename = options.sourceFileName;
   }
 
   // This can be overwritten, for example, by the TypeScript plugin.

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -26,7 +26,7 @@ export default class Parser extends StatementParser {
     this.inModule = this.options.sourceType === "module";
     this.scope = new ScopeHandler(this.raise.bind(this), this.inModule);
     this.plugins = pluginsMap(this.options.plugins);
-    this.filename = options.sourceFileName;
+    this.filename = options.sourceFilename || options.sourceFileName;
   }
 
   // This can be overwritten, for example, by the TypeScript plugin.

--- a/packages/babel-parser/test/fixtures/core/categorized/filename-specified/options.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/filename-specified/options.json
@@ -1,3 +1,3 @@
 {
-  "sourceFilename": "path/to/input-file.js"
+  "sourceFileName": "path/to/input-file.js"
 }

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -55,7 +55,7 @@ export interface ParserOptions {
      * Correlate output AST nodes with their source filename.
      * Useful when generating code and source maps from the ASTs of multiple input files.
      */
-    sourceFilename?: string;
+    sourceFileName?: string;
 
     /**
      * By default, the first line of code parsed is treated as line 1.


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          |
| Major: Breaking Change?  | maybe
| Minor: New Feature?      |
| Tests Added + Pass?      | No, I'm not sure what changes are needed
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

There seems to be some confusion around which of these two is correct within the codebase. This consolidates all instances to be `sourceFileName` since that one had more instances.
