### PR TITLE
Filter "dot directories" in addition to "dot files" when `includeDotFiles` is falsy.

### DIFF
--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -20,10 +20,8 @@ export function readdir(
   return readdirRecursive(dirname, (filename, _index, currentDirectory) => {
     const stat = fs.statSync(path.join(currentDirectory, filename));
 
-    if (stat.isDirectory()) return true;
-
     return (
-      (includeDotfiles || filename[0] !== ".") && (!filter || filter(filename))
+      (includeDotfiles || filename[0] !== ".") && (stat.isDirectory() || !filter || filter(filename))
     );
   });
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

Fixes #10037
