### PR TITLE
Updating regenerator/missing package version bump

### DIFF
--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill",
-  "version": "6.26.0",
+  "version": "6.26.1",
   "description": "Provides polyfills necessary for a full ES2015+ environment",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
@@ -10,6 +10,6 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "core-js": "^2.5.7",
-    "regenerator-runtime": "^0.12.0"
+    "regenerator-runtime": "^0.11.0"
   }
 }


### PR DESCRIPTION
This causes tree-shaking problems:

Requesting it to go to v0.11.0 so there's consistency across your own usage

```
regenerator-runtime (Found 2 resolved, 2 installed, 3 depended. Latest 0.11.0.)
  0.10.5 ~/babel-polyfill/~/regenerator-runtime
    ecom-web-app@1.0.0 -> babel-polyfill@^6.26.0 -> regenerator-runtime@^0.10.5
  0.11.0 ~/babel-runtime/~/regenerator-runtime
    ecom-web-app@1.0.0 -> babel-polyfill@^6.26.0 -> babel-runtime@^6.26.0 -> regenerator-runtime@^0.11.0
    ecom-web-app@1.0.0 -> babel-runtime@^6.26.0 -> regenerator-runtime@^0.11.0
```

When i look in the repo on branch 6:

```{
  "name": "babel-polyfill",
  "version": "6.26.0",
  "description": "Provides polyfills necessary for a full ES2015+ environment",
  "author": "Sebastian McKenzie <sebmck@gmail.com>",
  "homepage": "https://babeljs.io/",
  "license": "MIT",
  "repository": "https://github.com/babel/babel/tree/master/packages/babel-polyfill",
  "main": "lib/index.js",
  "dependencies": {
    "babel-runtime": "^6.26.0",
    "core-js": "^2.5.7",
    "regenerator-runtime": "^0.12.0"
  }
}
```


When i loook in my node modules:

```{
  "name": "babel-polyfill",
  "version": "6.26.0",
  "description": "Provides polyfills necessary for a full ES2015+ environment",
  "author": "Sebastian McKenzie <sebmck@gmail.com>",
  "homepage": "https://babeljs.io/",
  "license": "MIT",
  "repository": "https://github.com/babel/babel/tree/master/packages/babel-polyfill",
  "main": "lib/index.js",
  "dependencies": {
    "babel-runtime": "^6.26.0",
    "core-js": "^2.5.0",
    "regenerator-runtime": "^0.10.5"
  }
}
```