### PR TITLE
Adds note about two approval policy to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 Before making a PR, please read our contributing guidelines
 https://github.com/babel/babel/blob/master/CONTRIBUTING.md
 
+Please note that the Babel Team requires two approvals before merging PRs.
+
 For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)
 
 If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 Before making a PR, please read our contributing guidelines
 https://github.com/babel/babel/blob/master/CONTRIBUTING.md
 
-Please note that the Babel Team requires two approvals before merging PRs.
+Please note that the Babel Team requires two approvals before merging most PRs.
 
 For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | N/A
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

I've sometimes noticed some folks getting confused about Babel's two approval policy. From the Contributor point of view, the PR seems stale after getting the first approval.

This adds a comment to the PR template with the goal of surfacing the policy and avoiding confusion.
