### PR TITLE
fix: ensure `@babel/parser` can reference `@babel/types`

### DIFF
--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -35,5 +35,8 @@
   },
   "bin": {
     "parser": "./bin/babel-parser.js"
+  },
+  "dependencies": {
+    "@babel/types": "^7.5.5"
   }
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

The type declarations for `@babel/parser` reference `@babel/types` but previously there was no explicit dependency on `@babel/parser`. This meant that TypeScript is unable to process `@babel/parser` unless `@babel/types` also happens to be installed. Furthermore, if installing using a stricter `node_modules` layout (like the one favored by `pnpm`), even if `@babel/types` is installed by another package `@babel/parser` will be unable to see it. With an explicit dependency this problem goes away.

See [discussion on Slack](https://babeljs.slack.com/archives/C062RC35M/p1565380370022200).