### PR TITLE
Add a builder definition including name for tsTypeParameter

### DIFF
--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -494,6 +494,7 @@ defineType("TSTypeParameterDeclaration", {
 });
 
 defineType("TSTypeParameter", {
+  builder: ["constraint", "default", "name"],
   visitor: ["constraint", "default"],
   fields: {
     name: {

--- a/packages/babel-types/test/builders/typescript/__snapshots__/tsTypeParameter.js.snap
+++ b/packages/babel-types/test/builders/typescript/__snapshots__/tsTypeParameter.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builders typescript tsTypeParameter accept name as argument for tsTypeParameter 1`] = `
+Object {
+  "constraint": Object {
+    "type": "TSTypeReference",
+    "typeName": Object {
+      "name": "bar",
+      "type": "Identifier",
+    },
+    "typeParameters": null,
+  },
+  "default": Object {
+    "type": "TSTypeReference",
+    "typeName": Object {
+      "name": "baz",
+      "type": "Identifier",
+    },
+    "typeParameters": null,
+  },
+  "name": "foo",
+  "type": "TSTypeParameter",
+}
+`;

--- a/packages/babel-types/test/builders/typescript/tsTypeParameter.js
+++ b/packages/babel-types/test/builders/typescript/tsTypeParameter.js
@@ -1,0 +1,24 @@
+import * as t from "../../..";
+
+describe("builders", function() {
+  describe("typescript", function() {
+    describe("tsTypeParameter", function() {
+      it("accept name as argument for tsTypeParameter", function() {
+        const tsTypeParameter = t.tsTypeParameter(
+          t.tsTypeReference(t.identifier("bar")),
+          t.tsTypeReference(t.identifier("baz")),
+          "foo",
+        );
+        expect(tsTypeParameter).toMatchSnapshot();
+      });
+      it("throws when name is missing", function() {
+        expect(() => {
+          t.tsTypeParameter(
+            t.tsTypeReference(t.identifier("bar")),
+            t.tsTypeReference(t.identifier("baz")),
+          );
+        }).toThrow("Property name expected type of string but got null");
+      });
+    });
+  });
+});


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10317 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2080
| Any Dependency Changes?  | No
| License                  | MIT

Adds `name` to the visitor field for `TSTypeParameter`, this is a required field but since it is not listed here the assert fails rendering the function useless, since it cannot be called with either 2 or 3 arguments. 

Documentation: I found this when trying to run all the t.* [builder functions](https://babeljs.io/docs/en/babel-types.html), but my generation "fails" here because it doesn't look like [these arguments are required](https://deploy-preview-2080--babel.netlify.com/docs/en/babel-types#tstypeparameter), they are (which has been corrected in the current master). So I will need to re-run that generation once that fix is available. 