### PR TITLE
Ensure the corejs-plugin injected imports is handled by module transforms

### DIFF
--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -203,22 +203,22 @@ export default declare((api, opts) => {
 
     if (corejs) {
       if (useBuiltIns === "usage") {
-        if (corejs.major === 2) {
-          plugins.push([addCoreJS2UsagePlugin, pluginOptions]);
-        } else {
-          plugins.push([addCoreJS3UsagePlugin, pluginOptions]);
-        }
         if (regenerator) {
-          plugins.push([addRegeneratorUsagePlugin, pluginOptions]);
+          plugins.unshift([addRegeneratorUsagePlugin, pluginOptions]);
+        }
+        if (corejs.major === 2) {
+          plugins.unshift([addCoreJS2UsagePlugin, pluginOptions]);
+        } else {
+          plugins.unshift([addCoreJS3UsagePlugin, pluginOptions]);
         }
       } else {
+        if (!regenerator) {
+          plugins.unshift([removeRegeneratorEntryPlugin, pluginOptions]);
+        }
         if (corejs.major === 2) {
-          plugins.push([replaceCoreJS2EntryPlugin, pluginOptions]);
+          plugins.unshift([replaceCoreJS2EntryPlugin, pluginOptions]);
         } else {
-          plugins.push([replaceCoreJS3EntryPlugin, pluginOptions]);
-          if (!regenerator) {
-            plugins.push([removeRegeneratorEntryPlugin, pluginOptions]);
-          }
+          plugins.unshift([replaceCoreJS3EntryPlugin, pluginOptions]);
         }
       }
     }

--- a/packages/babel-preset-env/src/polyfills/corejs2/entry-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/entry-plugin.js
@@ -33,14 +33,12 @@ export default function(
   );
 
   const isPolyfillImport = {
-    ImportDeclaration(path: NodePath) {
-      if (isPolyfillSource(getImportSource(path))) {
-        this.replaceBySeparateModulesImport(path);
-      }
-    },
     Program(path: NodePath) {
       path.get("body").forEach(bodyPath => {
-        if (isPolyfillSource(getRequireSource(bodyPath))) {
+        const source = bodyPath.isImportDeclaration()
+          ? getImportSource(bodyPath)
+          : getRequireSource(bodyPath);
+        if (isPolyfillSource(source)) {
           this.replaceBySeparateModulesImport(bodyPath);
         }
       });

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async-modules-amd/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async-modules-amd/input.mjs
@@ -1,0 +1,1 @@
+async function a(){}

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async-modules-amd/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async-modules-amd/options.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 2,
+        "modules": "amd"
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async-modules-amd/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async-modules-amd/output.js
@@ -1,0 +1,28 @@
+define(["core-js/modules/es6.promise", "core-js/modules/es6.object.to-string", "regenerator-runtime/runtime"], function (_es, _es6Object, _runtime) {
+  "use strict";
+
+  function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+  function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+  function a() {
+    return _a.apply(this, arguments);
+  }
+
+  function _a() {
+    _a = _asyncToGenerator(
+    /*#__PURE__*/
+    regeneratorRuntime.mark(function _callee() {
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+    return _a.apply(this, arguments);
+  }
+});

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-regenerator-used-async/output.mjs
@@ -1,6 +1,6 @@
-import "regenerator-runtime/runtime";
 import "core-js/modules/es6.promise";
 import "core-js/modules/es6.object.to-string";
+import "regenerator-runtime/runtime";
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async-modules-amd/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async-modules-amd/input.mjs
@@ -1,0 +1,1 @@
+async function a(){}

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async-modules-amd/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async-modules-amd/options.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3,
+        "modules": "amd"
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async-modules-amd/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-regenerator-used-async-modules-amd/output.js
@@ -1,0 +1,28 @@
+define(["core-js/modules/es.object.to-string", "core-js/modules/es.promise", "regenerator-runtime/runtime"], function (_esObject, _es, _runtime) {
+  "use strict";
+
+  function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+  function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+  function a() {
+    return _a.apply(this, arguments);
+  }
+
+  function _a() {
+    _a = _asyncToGenerator(
+    /*#__PURE__*/
+    regeneratorRuntime.mark(function _callee() {
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+    return _a.apply(this, arguments);
+  }
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10333 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The current sequences of corejs-plugin and module-transforms plugin is
```
// traverse begins
[Program.exit]: module-transforms
// traverse ends
[post]: corejs-plugin addImport
```
However, if user specifies `module: "amd"`, the injected corejs imports will not be transpiled.

This PR changes the sequences above into
```
// traverse begins
[Program.exit]: corejs-plugin addImport
[Program.exit]: module-transforms
// traverse ends
```
Hence I don't adjust the timing of module-transforms since they are public available and doing so may introduce breaking changes. However, the `corejsPlugin` is private so it should be good.

Therefore, this PR can be split into two parts:
1. adjust timing of `addImport` inside `corejs-plugin`
2. move `corejs-plugin` before `module-transforms` plugin.

/cc @zloirock 