### PR TITLE
Do not remove let bindings even they are wrapped in closure

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -453,9 +453,7 @@ class BlockScoping {
       if (binding.kind === "let" || binding.kind === "const") {
         binding.kind = "var";
 
-        if (wrappedInClosure) {
-          scope.removeBinding(ref.name);
-        } else {
+        if (!wrappedInClosure) {
           scope.moveBindingTo(ref.name, parentScope);
         }
       }

--- a/packages/babel-plugin-transform-block-scoping/src/index.js
+++ b/packages/babel-plugin-transform-block-scoping/src/index.js
@@ -441,20 +441,25 @@ class BlockScoping {
   }
 
   updateScopeInfo(wrappedInClosure) {
-    const scope = this.scope;
+    const blockScope = this.blockPath.scope;
 
-    const parentScope = scope.getFunctionParent() || scope.getProgramParent();
+    const parentScope =
+      blockScope.getFunctionParent() || blockScope.getProgramParent();
     const letRefs = this.letReferences;
 
     for (const key of Object.keys(letRefs)) {
       const ref = letRefs[key];
-      const binding = scope.getBinding(ref.name);
+      const binding = blockScope.getBinding(ref.name);
       if (!binding) continue;
       if (binding.kind === "let" || binding.kind === "const") {
         binding.kind = "var";
 
-        if (!wrappedInClosure) {
-          scope.moveBindingTo(ref.name, parentScope);
+        if (wrappedInClosure) {
+          if (blockScope.hasOwnBinding(ref.name)) {
+            blockScope.removeBinding(ref.name);
+          }
+        } else {
+          blockScope.moveBindingTo(ref.name, parentScope);
         }
       }
     }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
@@ -8,27 +8,31 @@ const code = multiline([
   "}"
 ]);
 
+let programPath;
+let forOfPath;
+let functionPath;
+
 transform(code, {
   configFile: false,
   plugins: [
     "../../../../lib",
     {
       post({ path }) {
+        programPath = path;
         path.traverse({
-          Program(path) {
-            expect(Object.keys(path.scope.bindings)).toEqual(["foo", "bar"]);
-          },
-          ForOfStatement(path) {
-            // for declarations should be transformed to for bindings
-            expect(path.scope.bindings).toEqual({});
-            // The body should be wrapped into closure
-            expect(path.get("body").scope.bindings).toEqual({});
-          },
-          FunctionExpression(path) {
-            expect(Object.keys(path.scope.bindings)).toEqual(["foo", "bar", "qux", "quux"]);
-          }
-        })
+          ForOfStatement(path) { forOfPath = path },
+          FunctionExpression(path) { functionPath = path }
+        });
       }
     }
   ]
 });
+
+expect(Object.keys(programPath.scope.bindings)).toEqual(["foo", "bar"]);
+
+// for declarations should be transformed to for bindings
+expect(forOfPath.scope.bindings).toEqual({});
+// The body should be wrapped into closure
+expect(forOfPath.get("body").scope.bindings).toEqual({});
+
+expect(Object.keys(functionPath.scope.bindings)).toEqual(["foo", "bar", "qux", "quux"]);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/exec.js
@@ -1,0 +1,34 @@
+const code = multiline([
+  "for (const {foo, ...bar} of { bar: [] }) {",
+    "() => foo;",
+    "const [qux] = bar;",
+    "try {} catch (e) {",
+      "let quux = qux;",
+    "}",
+  "}"
+]);
+
+transform(code, {
+  configFile: false,
+  plugins: [
+    "../../../../lib",
+    {
+      post({ path }) {
+        path.traverse({
+          Program(path) {
+            expect(Object.keys(path.scope.bindings)).toEqual(["foo", "bar"]);
+          },
+          ForOfStatement(path) {
+            // for declarations should be transformed to for bindings
+            expect(path.scope.bindings).toEqual({});
+            // The body should be wrapped into closure
+            expect(path.get("body").scope.bindings).toEqual({});
+          },
+          FunctionExpression(path) {
+            expect(Object.keys(path.scope.bindings)).toEqual(["foo", "bar", "qux", "quux"]);
+          }
+        })
+      }
+    }
+  ]
+});

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/input.js
@@ -1,0 +1,4 @@
+for (const {foo, ...bar} of {}) {
+  () => foo;
+  bar;
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/input.js
@@ -1,4 +1,7 @@
 for (const {foo, ...bar} of {}) {
   () => foo;
-  bar;
+  const [qux] = bar;
+  try {} catch (e) {
+    const quux = qux;
+  }
 }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-block-scoping", ["proposal-object-rest-spread", { "loose": true }]]
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
@@ -3,7 +3,11 @@ function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) r
 var _loop = function (foo, bar) {
   () => foo;
 
-  bar;
+  var [qux] = bar;
+
+  try {} catch (e) {
+    var quux = qux;
+  }
 };
 
 for (var _ref of {}) {

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-10339/output.js
@@ -1,0 +1,16 @@
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
+var _loop = function (foo, bar) {
+  () => foo;
+
+  bar;
+};
+
+for (var _ref of {}) {
+  var {
+    foo
+  } = _ref,
+      bar = _objectWithoutPropertiesLoose(_ref, ["foo"]);
+
+  _loop(foo, bar);
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10339
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I would like to talk more details of #10339 than I did usually because it is an interesting bug: It is an issue that, on the surface, the `object-rest-spread` should be blamed but after digging you would find that it comes from `block-scoping` which seems completely unrelated.

I have simplified the OP's snippet a bit
```js
for (const {foo, ...bar} of {}) {
  () => foo;
  bar;
}
```

The minimum configuration to reproduce this bug is
```
{
  "plugins": ["transform-block-scoping", ["proposal-object-rest-spread", { "loose": true }]]
}
```
note that the plugin order matters here. Theoretically a loose approximation of this configuration would be a two-pass transformation: First transform with `transform-block-scoping` and then transform the intermediate result with `proposal-object-rest-spread`. The Babel REPL works good on two-pass transformation, which means there must be something wrong after the `block-scoping` transforms. Something that does not touch the syntax but the abstract metadata.

The error in #10339 comes from https://github.com/babel/babel/blob/eb3767d58b5e376fa4f4e95e1ba9dc86c667908d/packages/babel-plugin-proposal-object-rest-spread/src/index.js#L113-L116
in the `removeUnusedExcludeKeys` function that is invoked only in `loose` mode. This routine will lookup the binding informations of the ObjectPattern `{ foo, ...bar }` in the for-of statements. For unknown reasons the binding informations are corrupted so exception is thrown.

The block-scoping transform will try to wrap the loop body into a closure once a let reference is used inside a function expressions in the loop body. Which means
```js
for (const {foo, ...bar} of {}) {
  () => foo;
  bar;
}
```
will be transformed to
```js
var _loop = function (foo, bar) {
  () => foo;
  bar;
};

for (var { foo, ...bar } of qux) {
  _loop(foo, bar);
}
```
since `foo` is inside an arrow function expression. However, the `block-scoping` transform incorrectly removes the binding after the loop body is wrapped -- maybe because we tend to feel it is useless since the whole loop body is wrapped in a new scope.

This operation creates dichotomy between the actual code and the abstract syntax tree: The variable declarator is still in our code while its binding information is removed. This error has been hidden for a while until it is luckily detected by `object-rest-spread` loose mode, which tries to manipulate the code according to the binding information.

In the end, the fix is pretty straightforward: do not remove the binding information and always synchronize code with AST.