### PR TITLE
feat: if code frame error is on a single line, highlight the whole path

### DIFF
--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -19,6 +19,17 @@ const errorVisitor = {
   },
 };
 
+export type NodeLocation = {
+  loc?: {
+    end?: { line: number, column: number },
+    start: { line: number, column: number },
+  },
+  _loc?: {
+    end?: { line: number, column: number },
+    start: { line: number, column: number },
+  },
+};
+
 export default class File {
   _map: Map<any, any> = new Map();
   opts: Object;
@@ -250,10 +261,7 @@ export default class File {
   }
 
   buildCodeFrameError(
-    node: ?{
-      loc?: { start: { line: number, column: number } },
-      _loc?: { start: { line: number, column: number } },
-    },
+    node: ?NodeLocation,
     msg: string,
     Error: typeof Error = SyntaxError,
   ): Error {
@@ -288,7 +296,7 @@ export default class File {
               column: loc.start.column + 1,
             },
             end:
-              loc.start.line === loc.end.line
+              loc.end && loc.start.line === loc.end.line
                 ? {
                     line: loc.end.line,
                     column: loc.end.column + 1,

--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -287,6 +287,13 @@ export default class File {
               line: loc.start.line,
               column: loc.start.column + 1,
             },
+            end:
+              loc.start.line === loc.end.line
+                ? {
+                    line: loc.end.line,
+                    column: loc.end.column + 1,
+                  }
+                : undefined,
           },
           { highlightCode },
         );

--- a/packages/babel-core/src/transformation/plugin-pass.js
+++ b/packages/babel-core/src/transformation/plugin-pass.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type File from "./file/file";
+import type NodeLocation from "./file/file";
 
 export default class PluginPass {
   _map: Map<mixed, mixed> = new Map();
@@ -47,14 +48,7 @@ export default class PluginPass {
     return this.file.getModuleName();
   }
 
-  buildCodeFrameError(
-    node: ?{
-      loc?: { start: { line: number, column: number } },
-      _loc?: { start: { line: number, column: number } },
-    },
-    msg: string,
-    Error?: typeof Error,
-  ) {
+  buildCodeFrameError(node: ?NodeLocation, msg: string, Error?: typeof Error) {
     return this.file.buildCodeFrameError(node, msg, Error);
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | 👍 
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Before:
![image](https://user-images.githubusercontent.com/1404810/63515359-f7c84780-c4ea-11e9-8f93-d3b595df8085.png)

After: 
![image](https://user-images.githubusercontent.com/1404810/63515323-e121f080-c4ea-11e9-86ca-2f510c2bf2f2.png)

`buildCodeFrameError` doesn't seem to have any tests, at least not any I could find. Thoughts on where I can add one (if you want this)

This _might_ make sense as an option passed to `path.buildCodeFrameError` rather than `buildCodeFrameError` forcing it on consumers?