### PR TITLE
perf: replace lookahead by lookaheadCharCode

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -590,7 +590,7 @@ export default class ExpressionParser extends LValParser {
     } else if (this.match(tt.questionDot)) {
       this.expectPlugin("optionalChaining");
       state.optionalChainMember = true;
-      if (noCalls && this.lookahead().type === tt.parenL) {
+      if (noCalls && this.lookaheadCharCode() === charCodes.leftParenthesis) {
         state.stop = true;
         return base;
       }

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -170,7 +170,7 @@ export default class StatementParser extends ExpressionParser {
       case tt._for:
         return this.parseForStatement(node);
       case tt._function:
-        if (this.lookahead().type === tt.dot) break;
+        if (this.lookaheadCharCode() === charCodes.dot) break;
         if (context) {
           if (this.state.strict) {
             this.raise(
@@ -223,8 +223,11 @@ export default class StatementParser extends ExpressionParser {
         return this.parseEmptyStatement(node);
       case tt._export:
       case tt._import: {
-        const nextToken = this.lookahead();
-        if (nextToken.type === tt.parenL || nextToken.type === tt.dot) {
+        const nextTokenCharCode = this.lookaheadCharCode();
+        if (
+          nextTokenCharCode === charCodes.leftParenthesis ||
+          nextTokenCharCode === charCodes.dot
+        ) {
           break;
         }
 

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -8,7 +8,7 @@ import {
   isIdentifierStart,
   keywordRelationalOperator,
 } from "../util/identifier";
-import { lineBreak, skipWhiteSpace } from "../util/whitespace";
+import { lineBreak } from "../util/whitespace";
 import * as charCodes from "charcodes";
 import {
   BIND_CLASS,
@@ -105,10 +105,7 @@ export default class StatementParser extends ExpressionParser {
     if (!this.isContextual("let")) {
       return false;
     }
-    skipWhiteSpace.lastIndex = this.state.pos;
-    const skip = skipWhiteSpace.exec(this.input);
-    // $FlowIgnore
-    const next = this.state.pos + skip[0].length;
+    const next = this.nextTokenStart();
     const nextCh = this.input.charCodeAt(next);
     // For ambiguous cases, determine if a LexicalDeclaration (or only a
     // Statement) is allowed here. If context is not empty then only a Statement
@@ -1760,18 +1757,9 @@ export default class StatementParser extends ExpressionParser {
 
   isAsyncFunction(): boolean {
     if (!this.isContextual("async")) return false;
-
-    const { pos } = this.state;
-
-    skipWhiteSpace.lastIndex = pos;
-    const skip = skipWhiteSpace.exec(this.input);
-
-    if (!skip || !skip.length) return false;
-
-    const next = pos + skip[0].length;
-
+    const next = this.nextTokenStart();
     return (
-      !lineBreak.test(this.input.slice(pos, next)) &&
+      !lineBreak.test(this.input.slice(this.state.pos, next)) &&
       this.input.slice(next, next + 8) === "function" &&
       (next + 8 === this.length ||
         !isIdentifierChar(this.input.charCodeAt(next + 8)))

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1738,11 +1738,11 @@ export default class StatementParser extends ExpressionParser {
   maybeParseExportDeclaration(node: N.Node): boolean {
     if (this.shouldParseExportDeclaration()) {
       if (this.isContextual("async")) {
-        const next = this.lookahead();
+        const next = this.nextTokenStart();
 
         // export async;
-        if (next.type !== tt._function) {
-          this.unexpected(next.start, `Unexpected token, expected "function"`);
+        if (!this.isUnparsedContextual(next, "function")) {
+          this.unexpected(next, `Unexpected token, expected "function"`);
         }
       }
 
@@ -1760,9 +1760,7 @@ export default class StatementParser extends ExpressionParser {
     const next = this.nextTokenStart();
     return (
       !lineBreak.test(this.input.slice(this.state.pos, next)) &&
-      this.input.slice(next, next + 8) === "function" &&
-      (next + 8 === this.length ||
-        !isIdentifierChar(this.input.charCodeAt(next + 8)))
+      this.isUnparsedContextual(next, "function")
     );
   }
 
@@ -1824,10 +1822,10 @@ export default class StatementParser extends ExpressionParser {
       return false;
     }
 
-    const lookahead = this.lookahead();
+    const next = this.nextTokenStart();
     return (
-      lookahead.type === tt.comma ||
-      (lookahead.type === tt.name && lookahead.value === "from")
+      this.input.charCodeAt(next) === charCodes.comma ||
+      this.isUnparsedContextual(next, "from")
     );
   }
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -19,6 +19,7 @@ import {
   BIND_CLASS,
 } from "../../util/scopeflags";
 import TypeScriptScopeHandler from "./scope";
+import * as charCodes from "charcodes";
 
 type TsModifier =
   | "readonly"
@@ -657,7 +658,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             : this.match(tt._null)
             ? "TSNullKeyword"
             : keywordTypeFromName(this.state.value);
-          if (type !== undefined && this.lookahead().type !== tt.dot) {
+          if (
+            type !== undefined &&
+            this.lookaheadCharCode() !== charCodes.dot
+          ) {
             const node: N.TsKeywordType = this.startNode();
             this.next();
             return this.finishNode(node, type);
@@ -1203,7 +1207,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     tsIsExternalModuleReference(): boolean {
       return (
-        this.isContextual("require") && this.lookahead().type === tt.parenL
+        this.isContextual("require") &&
+        this.lookaheadCharCode() === charCodes.leftParenthesis
       );
     }
 

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -13,11 +13,11 @@ import {
   lineBreakG,
   isNewLine,
   isWhitespace,
+  skipWhiteSpace,
 } from "../util/whitespace";
 import State from "./state";
 
 const VALID_REGEX_FLAGS = new Set(["g", "m", "s", "i", "y", "u"]);
-const skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
 
 // The following character codes are forbidden from being
 // an immediate sibling of NumericLiteralSeparator _
@@ -169,13 +169,16 @@ export default class Tokenizer extends LocationParser {
     return curr;
   }
 
-  lookaheadCharCode(): number {
+  nextTokenStart(): number {
     const thisTokEnd = this.state.pos;
     skipWhiteSpace.lastIndex = thisTokEnd;
     const skip = skipWhiteSpace.exec(this.input);
     // $FlowIgnore: The skipWhiteSpace ensures to match any string
-    const next = thisTokEnd + skip[0].length;
-    return this.input.charCodeAt(next);
+    return thisTokEnd + skip[0].length;
+  }
+
+  lookaheadCharCode(): number {
+    return this.input.charCodeAt(this.nextTokenStart());
   }
 
   // Toggle strict mode. Re-reads the next number or string to please

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -173,6 +173,7 @@ export default class Tokenizer extends LocationParser {
     const thisTokEnd = this.state.pos;
     skipWhiteSpace.lastIndex = thisTokEnd;
     const skip = skipWhiteSpace.exec(this.input);
+    // $FlowIgnore: The skipWhiteSpace ensures to match any string
     const next = thisTokEnd + skip[0].length;
     return this.input.charCodeAt(next);
   }

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -280,13 +280,7 @@ export default class Tokenizer extends LocationParser {
     const startLoc = this.state.curPosition();
     let ch = this.input.charCodeAt((this.state.pos += startSkip));
     if (this.state.pos < this.length) {
-      while (
-        ch !== charCodes.lineFeed &&
-        ch !== charCodes.carriageReturn &&
-        ch !== charCodes.lineSeparator &&
-        ch !== charCodes.paragraphSeparator &&
-        ++this.state.pos < this.length
-      ) {
+      while (!isNewLine(ch) && ++this.state.pos < this.length) {
         ch = this.input.charCodeAt(this.state.pos);
       }
     }
@@ -452,13 +446,7 @@ export default class Tokenizer extends LocationParser {
     let ch = this.input.charCodeAt(this.state.pos);
     if (ch !== charCodes.exclamationMark) return false;
 
-    while (
-      ch !== charCodes.lineFeed &&
-      ch !== charCodes.carriageReturn &&
-      ch !== charCodes.lineSeparator &&
-      ch !== charCodes.paragraphSeparator &&
-      ++this.state.pos < this.length
-    ) {
+    while (!isNewLine(ch) && ++this.state.pos < this.length) {
       ch = this.input.charCodeAt(this.state.pos);
     }
 

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -17,6 +17,7 @@ import {
 import State from "./state";
 
 const VALID_REGEX_FLAGS = new Set(["g", "m", "s", "i", "y", "u"]);
+const skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
 
 // The following character codes are forbidden from being
 // an immediate sibling of NumericLiteralSeparator _
@@ -166,6 +167,14 @@ export default class Tokenizer extends LocationParser {
     const curr = this.state;
     this.state = old;
     return curr;
+  }
+
+  lookaheadCharCode(): number {
+    const thisTokEnd = this.state.pos;
+    skipWhiteSpace.lastIndex = thisTokEnd;
+    const skip = skipWhiteSpace.exec(this.input);
+    const next = thisTokEnd + skip[0].length;
+    return this.input.charCodeAt(next);
   }
 
   // Toggle strict mode. Re-reads the next number or string to please


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Perf
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Introduced `tokenizer.lookaheadCharCode()` method, which simply skips the whitespaces and comments, until the next non-whitespace charcode. The idea is [borrowed from acorn](https://github.com/acornjs/acorn/blob/7e9817d17639d95cc6dbacfde734a0626b2a7dea/acorn/src/statement.js#L38-L40).

`tokenizer.lookahead()` is expensive in the way that it would cache the whole state and restore after `nextToken`. However, in most of times `tokenizer.lookahead` is used to compare the `type` of next token only, therefore we can replace `tokenizer.lookahead()` by `tokenizer.lookaheadCharCode()` which does _not_ interfere with the tokenizer state.

## Logic difference

The replacement is logically equivalent when the character maps to only one possible token type.

It is okay to replace `tt.parenL` with `charcode === 40`.

It will introduce logic difference when replacing `tt.dot` with `charcode === 46` since it may be part of `tt.ellipsis`. However `tt.ellipsis` should not immediately follow the `function` keyword and would bail in `parseExpression`. The same applies when following `import` and `null`.

## Benchmark report
Environment
CPU: Intel Core-i7 6820HQ
RAM: 16 GB 2133 MHz LPDDR3
Kernel: Darwin 18.7.0
Node.js: v12.9.0

Control group versions
acorn: v7.0.0
babel-parser: v7.5.5
```
┌──────────────────────────┬─────────────────────────────┬──────────────────────────────┬──────────────────────────────┬──────────────────────────────┬──────────────────────────────┐
│ fixture                  │ acorn                       │ babel                        │ babelDev                     │ esprima                      │ meriyah                      │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/angular.js           │ 30.26 ops/sec ±4.75% (33ms) │ 21.27 ops/sec ±4.57% (47ms)  │ 23.56 ops/sec ±3.79% (42ms)  │ 24.56 ops/sec ±7.19% (41ms)  │ 41.04 ops/sec ±2.64% (24ms)  │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/ember.debug.js       │ 11.48 ops/sec ±3.63% (87ms) │ 8.04 ops/sec ±3.97% (124ms)  │ 9.01 ops/sec ±3.5% (111ms)   │ 8.87 ops/sec ±14.86% (113ms) │ 17.27 ops/sec ±8.29% (58ms)  │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/babylon-dist.js      │ 54.39 ops/sec ±3.17% (18ms) │ 33.18 ops/sec ±5.38% (30ms)  │ 34.1 ops/sec ±5.29% (29ms)   │ 44.85 ops/sec ±1.74% (22ms)  │ 93.23 ops/sec ±1.13% (11ms)  │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/jquery.js            │ 65.05 ops/sec ±2.82% (15ms) │ 42.83 ops/sec ±5.56% (23ms)  │ 46.42 ops/sec ±4.71% (22ms)  │ 57.87 ops/sec ±1.11% (17ms)  │ 115 ops/sec ±2% (8.683ms)    │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/backbone.js          │ 270 ops/sec ±2.2% (3.707ms) │ 192 ops/sec ±2.09% (5.197ms) │ 203 ops/sec ±2.61% (4.915ms) │ 227 ops/sec ±2.78% (4.402ms) │ 465 ops/sec ±2.11% (2.148ms) │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es5/react-with-addons.js │ 32.19 ops/sec ±4.13% (31ms) │ 20.24 ops/sec ±4.75% (49ms)  │ 22.79 ops/sec ±3.07% (44ms)  │ 25.02 ops/sec ±4.86% (40ms)  │ 52.12 ops/sec ±1.53% (19ms)  │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es6/angular-compiler.js  │ 14.17 ops/sec ±5.99% (71ms) │ 10.35 ops/sec ±4.55% (97ms)  │ 11.39 ops/sec ±5.81% (88ms)  │ 14.55 ops/sec ±3.34% (69ms)  │ 26.89 ops/sec ±2.4% (37ms)   │
├──────────────────────────┼─────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ es6/material-ui-core.js  │ 21.06 ops/sec ±3.95% (47ms) │ 13.44 ops/sec ±3% (74ms)     │ 14.73 ops/sec ±2.93% (68ms)  │ 20.12 ops/sec ±3.46% (50ms)  │ 34.92 ops/sec ±2.13% (29ms)  │
└──────────────────────────┴─────────────────────────────┴──────────────────────────────┴──────────────────────────────┴──────────────────────────────┴──────────────────────────────┘
```

