### PR TITLE
Don't allow instance properties transformation on namespace

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -113,7 +113,14 @@ export default declare((api, options, dirname) => {
     );
   }
 
+  function isNamespaced(path) {
+    const binding = path.scope.getBinding(path.node.name);
+    if (!binding) return false;
+    return binding.path.isImportNamespaceSpecifier();
+  }
+
   function maybeNeedsPolyfill(path, methods, name) {
+    if (isNamespaced(path.get("object"))) return false;
     if (!methods[name].types) return true;
 
     const typeAnnotation = path.get("object").getTypeAnnotation();

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-namespaced/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-namespaced/input.mjs
@@ -1,0 +1,2 @@
+import * as bar from "bar";
+bar.map();

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-namespaced/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-namespaced/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-runtime", { "corejs": 3 }]]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-namespaced/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-namespaced/output.mjs
@@ -1,0 +1,2 @@
+import * as bar from "bar";
+bar.map();

--- a/packages/babel-preset-env/src/polyfills/corejs2/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs2/usage-plugin.js
@@ -15,6 +15,7 @@ import {
   isPolyfillSource,
   getImportSource,
   getRequireSource,
+  isNamespaced,
 } from "../../utils";
 import { logUsagePolyfills } from "../../debug";
 
@@ -101,6 +102,9 @@ export default function(
       enter(path: NodePath) {
         const { node } = path;
         const { object, property } = node;
+
+        // ignore namespace
+        if (isNamespaced(path.get("object"))) return;
 
         let evaluatedPropType = object.name;
         let propertyName = property.name;

--- a/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js
@@ -21,6 +21,7 @@ import {
   isPolyfillSource,
   getImportSource,
   getRequireSource,
+  isNamespaced,
 } from "../../utils";
 import { logUsagePolyfills } from "../../debug";
 
@@ -98,7 +99,7 @@ export default function(
         }
       }
     }
-    return { builtIn, instanceType };
+    return { builtIn, instanceType, isNamespaced: isNamespaced(path) };
   }
 
   const addAndRemovePolyfillImports = {
@@ -230,7 +231,8 @@ export default function(
       };
 
       this.addPropertyDependencies = function(source = {}, key) {
-        const { builtIn, instanceType } = source;
+        const { builtIn, instanceType, isNamespaced } = source;
+        if (isNamespaced) return;
         if (PossibleGlobalObjects.has(builtIn)) {
           this.addBuiltInDependencies(key);
         } else if (has(StaticProperties, builtIn)) {

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -162,3 +162,10 @@ export function getModulePath(mod: string): string {
 export function createImport(path: NodePath, mod: string) {
   return addSideEffect(path, getModulePath(mod));
 }
+
+export function isNamespaced(path: NodePath) {
+  if (!path.node) return false;
+  const binding = path.scope.getBinding(path.node.name);
+  if (!binding) return false;
+  return binding.path.isImportNamespaceSpecifier();
+}

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-modules-namespaced/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-modules-namespaced/input.mjs
@@ -1,0 +1,2 @@
+import * as ns from "ns";
+ns.map;

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-modules-namespaced/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-modules-namespaced/options.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "modules": false,
+        "useBuiltIns": "usage",
+        "corejs": 2
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-modules-namespaced/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-modules-namespaced/output.mjs
@@ -1,0 +1,3 @@
+import * as ns from "ns";
+ns.map;
+

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-modules-namespaced/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-modules-namespaced/input.mjs
@@ -1,0 +1,2 @@
+import * as ns from "ns";
+ns.map;

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-modules-namespaced/options.json
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-modules-namespaced/options.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "modules": false,
+        "useBuiltIns": "usage",
+        "corejs": 3
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-modules-namespaced/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-modules-namespaced/output.mjs
@@ -1,0 +1,2 @@
+import * as ns from "ns";
+ns.map;


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

Properties transformation on namespace is unnecessary and will break webpack's [Tree-Shaking](https://webpack.js.org/guides/tree-shaking/).

Input:
```js
import * as op from 'rxjs/operators';
op.map(fn);
```

Before output:
```js
import _mapInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/map";
import * as op from 'rxjs/operators';

_mapInstanceProperty(op).call(op, fn);
```

After output:
```js
import * as op from 'rxjs/operators';
op.map(fn);
```
