### PR TITLE
Implements relativeRuntime

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -27,6 +27,11 @@ function resolveAbsoluteRuntime(moduleName: string, dirname: string) {
   }
 }
 
+function resolveRelativeRuntime(moduleName: string, dirname: string) {
+  const absoluteRuntime = resolveAbsoluteRuntime(moduleName, dirname);
+  return path.relative(dirname, absoluteRuntime);
+}
+
 function supportsStaticESM(caller) {
   return !!(caller && caller.supportsStaticESM);
 }
@@ -41,6 +46,7 @@ export default declare((api, options, dirname) => {
     useESModules = false,
     version: runtimeVersion = "7.0.0-beta.0",
     absoluteRuntime = false,
+    relativeRuntime = false,
   } = options;
 
   let proposals = false;
@@ -91,6 +97,22 @@ export default declare((api, options, dirname) => {
   ) {
     throw new Error(
       "The 'absoluteRuntime' option must be undefined, a boolean, or a string.",
+    );
+  }
+  if (
+    typeof relativeRuntime !== "boolean" &&
+    typeof relativeRuntime !== "string"
+  ) {
+    throw new Error(
+      "The 'relativeRuntime' option must be undefined, a boolean, or a string.",
+    );
+  }
+  if (
+    absoluteRuntime !== false &&
+    relativeRuntime !== false
+  ) {
+    throw new Error(
+      "The 'absoluteRuntime' and 'relativeRuntime' settings cannot be enabled at the same time",
     );
   }
 
@@ -186,6 +208,11 @@ export default declare((api, options, dirname) => {
     modulePath = resolveAbsoluteRuntime(
       moduleName,
       path.resolve(dirname, absoluteRuntime === true ? "." : absoluteRuntime),
+    );
+  } else if (relativeRuntime !== false) {
+    modulePath = resolveRelativeRuntime(
+      moduleName,
+      path.resolve(dirname, relativeRuntime === true ? "." : relativeRuntime),
     );
   }
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/relative/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/relative/input.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/relative/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/relative/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-classes",
+    ["transform-runtime", { "absoluteRuntime": "./subfolder" }]
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/relative/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/relative/output.js
@@ -1,0 +1,7 @@
+var _classCallCheck = require("../../../../node_modules/@babel/runtime/helpers/classCallCheck");
+
+let Foo = function Foo() {
+  "use strict";
+
+  _classCallCheck(this, Foo);
+};

--- a/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/true/input.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/true/input.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/true/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/true/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-classes",
+    ["transform-runtime", { "absoluteRuntime": true }]
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/true/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/relativeRuntime/true/output.js
@@ -1,0 +1,7 @@
+var _classCallCheck = require("../../../../node_modules/@babel/runtime/helpers/classCallCheck");
+
+let Foo = function Foo() {
+  "use strict";
+
+  _classCallCheck(this, Foo);
+};


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/10355
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

This PR adds a counterpart to `absoluteRuntime` named `relativeRuntime` which, when used, will hardcode the relative path between the transpiled file and the runtime within its `import` tag. This will help with setups where the runtime comes from a package deep within the dependency tree (think Next.js or CRA) and you want the build artifacts to work the same way across various machines (where absolute paths would break).