### PR TITLE
Refactor trailing comment adjustment

### DIFF
--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -132,6 +132,7 @@ export default class CommentsParser extends BaseParser {
     if (firstChild) {
       switch (node.type) {
         case "ObjectExpression":
+        case "ObjectPattern":
           this.adjustCommentsAfterTrailingComma(node, node.properties);
           break;
         case "CallExpression":

--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -38,7 +38,7 @@ export default class CommentsParser extends BaseParser {
     this.state.leadingComments.push(comment);
   }
 
-  adjustCommentsAfterTrailingComma_(node: Node, elements: Node[]) {
+  adjustCommentsAfterTrailingComma(node: Node, elements: Node[]) {
     if (elements.length === 0) {
       return;
     }
@@ -132,13 +132,13 @@ export default class CommentsParser extends BaseParser {
     if (firstChild) {
       switch (node.type) {
         case "ObjectExpression":
-          this.adjustCommentsAfterTrailingComma_(node, node.properties);
+          this.adjustCommentsAfterTrailingComma(node, node.properties);
           break;
         case "CallExpression":
-          this.adjustCommentsAfterTrailingComma_(node, node.arguments);
+          this.adjustCommentsAfterTrailingComma(node, node.arguments);
           break;
         case "ArrayExpression":
-          this.adjustCommentsAfterTrailingComma_(node, node.elements);
+          this.adjustCommentsAfterTrailingComma(node, node.elements);
           break;
       }
     }

--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -45,9 +45,6 @@ export default class CommentsParser extends BaseParser {
     if (this.state.leadingComments.length === 0) {
       return;
     }
-    if (!this.state.commentPreviousNode) {
-      return;
-    }
 
     const lastElement = last(elements);
 

--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -60,17 +60,23 @@ export default class CommentsParser extends BaseParser {
       }
     }
 
-    lastElement.trailingComments = [];
+    const newTrailingComments = [];
     while (this.state.leadingComments.length) {
       const leadingComment = this.state.leadingComments.shift();
       if (leadingComment.end < node.end) {
-        lastElement.trailingComments.push(leadingComment);
+        newTrailingComments.push(leadingComment);
       } else {
         if (node.trailingComments === undefined) {
           node.trailingComments = [];
         }
         node.trailingComments.push(leadingComment);
       }
+    }
+
+    if (newTrailingComments.length > 0) {
+      lastElement.trailingComments = newTrailingComments;
+    } else if (lastElement.trailingComments !== undefined) {
+      lastElement.trailingComments = [];
     }
   }
 

--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -138,6 +138,7 @@ export default class CommentsParser extends BaseParser {
           this.adjustCommentsAfterTrailingComma(node, node.arguments);
           break;
         case "ArrayExpression":
+        case "ArrayPattern":
           this.adjustCommentsAfterTrailingComma(node, node.elements);
           break;
       }

--- a/packages/babel-parser/src/parser/comments.js
+++ b/packages/babel-parser/src/parser/comments.js
@@ -143,6 +143,16 @@ export default class CommentsParser extends BaseParser {
           this.adjustCommentsAfterTrailingComma(node, node.elements);
           break;
       }
+    } else if (
+      this.state.commentPreviousNode &&
+      ((this.state.commentPreviousNode.type === "ImportSpecifier" &&
+        node.type !== "ImportSpecifier") ||
+        (this.state.commentPreviousNode.type === "ExportSpecifier" &&
+          node.type !== "ExportSpecifier"))
+    ) {
+      this.adjustCommentsAfterTrailingComma(node, [
+        this.state.commentPreviousNode,
+      ]);
     }
 
     if (lastChild) {

--- a/packages/babel-parser/test/fixtures/comments/basic/array-pattern-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/comments/basic/array-pattern-trailing-comma/input.js
@@ -1,0 +1,6 @@
+const [
+  /* One */
+  x
+  /* Two */,
+  /* Three */
+] /* Four */ = [];

--- a/packages/babel-parser/test/fixtures/comments/basic/array-pattern-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/array-pattern-trailing-comma/output.json
@@ -1,0 +1,254 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 69,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 18
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 69,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 18
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 69,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 18
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 68,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 6,
+                "column": 17
+              }
+            },
+            "id": {
+              "type": "ArrayPattern",
+              "start": 6,
+              "end": 52,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 6,
+                  "column": 1
+                }
+              },
+              "elements": [
+                {
+                  "type": "Identifier",
+                  "start": 22,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 3
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x",
+                  "leadingComments": [
+                    {
+                      "type": "CommentBlock",
+                      "value": " One ",
+                      "start": 10,
+                      "end": 19,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 11
+                        }
+                      }
+                    }
+                  ],
+                  "trailingComments": [
+                    {
+                      "type": "CommentBlock",
+                      "value": " Two ",
+                      "start": 26,
+                      "end": 35,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 11
+                        }
+                      }
+                    },
+                    {
+                      "type": "CommentBlock",
+                      "value": " Three ",
+                      "start": 39,
+                      "end": 50,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 13
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trailingComments": [
+                {
+                  "type": "CommentBlock",
+                  "value": " Four ",
+                  "start": 53,
+                  "end": 63,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 12
+                    }
+                  }
+                }
+              ]
+            },
+            "init": {
+              "type": "ArrayExpression",
+              "start": 66,
+              "end": 68,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 15
+                },
+                "end": {
+                  "line": 6,
+                  "column": 17
+                }
+              },
+              "elements": []
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentBlock",
+      "value": " One ",
+      "start": 10,
+      "end": 19,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Two ",
+      "start": 26,
+      "end": 35,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Three ",
+      "start": 39,
+      "end": 50,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Four ",
+      "start": 53,
+      "end": 63,
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 12
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma-shorthand/input.js
+++ b/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma-shorthand/input.js
@@ -1,1 +1,1 @@
-fn(a, { b }, /* comment */);
+fn(a, { b }, /* comment 1 */) /* comment 2 */;

--- a/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma-shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma-shorthand/output.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 28,
+  "end": 46,
   "loc": {
     "start": {
       "line": 1,
@@ -9,13 +9,13 @@
     },
     "end": {
       "line": 1,
-      "column": 28
+      "column": 46
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 28,
+    "end": 46,
     "loc": {
       "start": {
         "line": 1,
@@ -23,7 +23,7 @@
       },
       "end": {
         "line": 1,
-        "column": 28
+        "column": 46
       }
     },
     "sourceType": "script",
@@ -32,7 +32,7 @@
       {
         "type": "ExpressionStatement",
         "start": 0,
-        "end": 28,
+        "end": 46,
         "loc": {
           "start": {
             "line": 1,
@@ -40,13 +40,13 @@
           },
           "end": {
             "line": 1,
-            "column": 28
+            "column": 46
           }
         },
         "expression": {
           "type": "CallExpression",
           "start": 0,
-          "end": 27,
+          "end": 29,
           "loc": {
             "start": {
               "line": 1,
@@ -54,7 +54,7 @@
             },
             "end": {
               "line": 1,
-              "column": 27
+              "column": 29
             }
           },
           "callee": {
@@ -166,9 +166,9 @@
               "trailingComments": [
                 {
                   "type": "CommentBlock",
-                  "value": " comment ",
+                  "value": " comment 1 ",
                   "start": 13,
-                  "end": 26,
+                  "end": 28,
                   "loc": {
                     "start": {
                       "line": 1,
@@ -176,11 +176,29 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 26
+                      "column": 28
                     }
                   }
                 }
               ]
+            }
+          ],
+          "trailingComments": [
+            {
+              "type": "CommentBlock",
+              "value": " comment 2 ",
+              "start": 30,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 30
+                },
+                "end": {
+                  "line": 1,
+                  "column": 45
+                }
+              }
             }
           ]
         }
@@ -191,9 +209,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": " comment ",
+      "value": " comment 1 ",
       "start": 13,
-      "end": 26,
+      "end": 28,
       "loc": {
         "start": {
           "line": 1,
@@ -201,7 +219,23 @@
         },
         "end": {
           "line": 1,
-          "column": 26
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " comment 2 ",
+      "start": 30,
+      "end": 45,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 30
+        },
+        "end": {
+          "line": 1,
+          "column": 45
         }
       }
     }

--- a/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma/input.js
@@ -1,1 +1,1 @@
-fn(a, b, /* comment */);
+fn(a, b, /* comment 1 */) /* comment 2*/;

--- a/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/function-trailing-comma/output.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 24,
+  "end": 41,
   "loc": {
     "start": {
       "line": 1,
@@ -9,13 +9,13 @@
     },
     "end": {
       "line": 1,
-      "column": 24
+      "column": 41
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 24,
+    "end": 41,
     "loc": {
       "start": {
         "line": 1,
@@ -23,7 +23,7 @@
       },
       "end": {
         "line": 1,
-        "column": 24
+        "column": 41
       }
     },
     "sourceType": "script",
@@ -32,7 +32,7 @@
       {
         "type": "ExpressionStatement",
         "start": 0,
-        "end": 24,
+        "end": 41,
         "loc": {
           "start": {
             "line": 1,
@@ -40,13 +40,13 @@
           },
           "end": {
             "line": 1,
-            "column": 24
+            "column": 41
           }
         },
         "expression": {
           "type": "CallExpression",
           "start": 0,
-          "end": 23,
+          "end": 25,
           "loc": {
             "start": {
               "line": 1,
@@ -54,7 +54,7 @@
             },
             "end": {
               "line": 1,
-              "column": 23
+              "column": 25
             }
           },
           "callee": {
@@ -111,9 +111,9 @@
               "trailingComments": [
                 {
                   "type": "CommentBlock",
-                  "value": " comment ",
+                  "value": " comment 1 ",
                   "start": 9,
-                  "end": 22,
+                  "end": 24,
                   "loc": {
                     "start": {
                       "line": 1,
@@ -121,11 +121,29 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 22
+                      "column": 24
                     }
                   }
                 }
               ]
+            }
+          ],
+          "trailingComments": [
+            {
+              "type": "CommentBlock",
+              "value": " comment 2",
+              "start": 26,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 26
+                },
+                "end": {
+                  "line": 1,
+                  "column": 40
+                }
+              }
             }
           ]
         }
@@ -136,9 +154,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": " comment ",
+      "value": " comment 1 ",
       "start": 9,
-      "end": 22,
+      "end": 24,
       "loc": {
         "start": {
           "line": 1,
@@ -146,7 +164,23 @@
         },
         "end": {
           "line": 1,
-          "column": 22
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " comment 2",
+      "start": 26,
+      "end": 40,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 26
+        },
+        "end": {
+          "line": 1,
+          "column": 40
         }
       }
     }

--- a/packages/babel-parser/test/fixtures/comments/basic/object-expression-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/comments/basic/object-expression-trailing-comma/input.js
@@ -1,0 +1,6 @@
+const {
+  /* One */
+  x
+  /* Two */,
+  /* Three */
+} /* Four */ = {};

--- a/packages/babel-parser/test/fixtures/comments/basic/object-expression-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/object-expression-trailing-comma/output.json
@@ -1,0 +1,292 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 69,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 18
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 69,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 18
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 69,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 18
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 68,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 6,
+                "column": 17
+              }
+            },
+            "id": {
+              "type": "ObjectPattern",
+              "start": 6,
+              "end": 52,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 6,
+                  "column": 1
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 22,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 3
+                    }
+                  },
+                  "method": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 22,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 3
+                      },
+                      "identifierName": "x"
+                    },
+                    "name": "x"
+                  },
+                  "computed": false,
+                  "shorthand": true,
+                  "value": {
+                    "type": "Identifier",
+                    "start": 22,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 3
+                      },
+                      "identifierName": "x"
+                    },
+                    "name": "x"
+                  },
+                  "leadingComments": [
+                    {
+                      "type": "CommentBlock",
+                      "value": " One ",
+                      "start": 10,
+                      "end": 19,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 11
+                        }
+                      }
+                    }
+                  ],
+                  "trailingComments": [
+                    {
+                      "type": "CommentBlock",
+                      "value": " Two ",
+                      "start": 26,
+                      "end": 35,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 11
+                        }
+                      }
+                    },
+                    {
+                      "type": "CommentBlock",
+                      "value": " Three ",
+                      "start": 39,
+                      "end": 50,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 13
+                        }
+                      }
+                    }
+                  ],
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ],
+              "trailingComments": [
+                {
+                  "type": "CommentBlock",
+                  "value": " Four ",
+                  "start": 53,
+                  "end": 63,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 12
+                    }
+                  }
+                }
+              ]
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start": 66,
+              "end": 68,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 15
+                },
+                "end": {
+                  "line": 6,
+                  "column": 17
+                }
+              },
+              "properties": []
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentBlock",
+      "value": " One ",
+      "start": 10,
+      "end": 19,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Two ",
+      "start": 26,
+      "end": 35,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Three ",
+      "start": 39,
+      "end": 50,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Four ",
+      "start": 53,
+      "end": 63,
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 12
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/comments/basic/object-property-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/comments/basic/object-property-trailing-comma/input.js
@@ -2,4 +2,4 @@ var obj = {
   a: '1', // comment 1
   b: '2', // comment 2
   c: '3', // comment 3
-};
+}; // comment 4

--- a/packages/babel-parser/test/fixtures/comments/basic/object-property-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/object-property-trailing-comma/output.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 83,
+  "end": 96,
   "loc": {
     "start": {
       "line": 1,
@@ -9,13 +9,13 @@
     },
     "end": {
       "line": 5,
-      "column": 2
+      "column": 15
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 83,
+    "end": 96,
     "loc": {
       "start": {
         "line": 1,
@@ -23,7 +23,7 @@
       },
       "end": {
         "line": 5,
-        "column": 2
+        "column": 15
       }
     },
     "sourceType": "script",
@@ -313,7 +313,25 @@
             }
           }
         ],
-        "kind": "var"
+        "kind": "var",
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " comment 4",
+            "start": 84,
+            "end": 96,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 15
+              }
+            }
+          }
+        ]
       }
     ],
     "directives": []
@@ -364,6 +382,22 @@
         "end": {
           "line": 4,
           "column": 22
+        }
+      }
+    },
+    {
+      "type": "CommentLine",
+      "value": " comment 4",
+      "start": 84,
+      "end": 96,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 3
+        },
+        "end": {
+          "line": 5,
+          "column": 15
         }
       }
     }

--- a/packages/babel-parser/test/fixtures/comments/basic/switch-function-call-no-semicolon/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/switch-function-call-no-semicolon/output.json
@@ -250,25 +250,7 @@
                 "label": null
               }
             ],
-            "test": null,
-            "leadingComments": [
-              {
-                "type": "CommentLine",
-                "value": " comment",
-                "start": 47,
-                "end": 57,
-                "loc": {
-                  "start": {
-                    "line": 4,
-                    "column": 4
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 14
-                  }
-                }
-              }
-            ]
+            "test": null
           }
         ]
       }

--- a/packages/babel-parser/test/fixtures/comments/regression/10230/output.json
+++ b/packages/babel-parser/test/fixtures/comments/regression/10230/output.json
@@ -143,11 +143,47 @@
                     "raw": "42"
                   },
                   "value": 42
-                }
+                },
+                "trailingComments": [
+                  {
+                    "type": "CommentLine",
+                    "value": " One",
+                    "start": 17,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 8
+                      }
+                    }
+                  }
+                ]
               }
             ]
           }
-        }
+        },
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": " Two",
+            "start": 27,
+            "end": 33,
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 0
+              },
+              "end": {
+                "line": 6,
+                "column": 6
+              }
+            }
+          }
+        ]
       },
       {
         "type": "ExpressionStatement",
@@ -179,25 +215,7 @@
             "identifierName": "B"
           },
           "name": "B"
-        },
-        "leadingComments": [
-          {
-            "type": "CommentLine",
-            "value": " Two",
-            "start": 27,
-            "end": 33,
-            "loc": {
-              "start": {
-                "line": 6,
-                "column": 0
-              },
-              "end": {
-                "line": 6,
-                "column": 6
-              }
-            }
-          }
-        ]
+        }
       }
     ],
     "directives": []

--- a/packages/babel-parser/test/fixtures/es2015/modules/export-declaration-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/modules/export-declaration-trailing-comma/input.js
@@ -1,0 +1,5 @@
+export {
+  /* One */ Foo
+  /* Two */,
+  /* Three */
+} /* Four */ from "foo";

--- a/packages/babel-parser/test/fixtures/es2015/modules/export-declaration-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/export-declaration-trailing-comma/output.json
@@ -1,0 +1,256 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 76,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 76,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 24
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 76,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 24
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 21,
+            "end": 24,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 12
+              },
+              "end": {
+                "line": 2,
+                "column": 15
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 15
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 15
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            },
+            "leadingComments": [
+              {
+                "type": "CommentBlock",
+                "value": " One ",
+                "start": 11,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                }
+              }
+            ],
+            "trailingComments": [
+              {
+                "type": "CommentBlock",
+                "value": " Two ",
+                "start": 27,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 11
+                  }
+                }
+              },
+              {
+                "type": "CommentBlock",
+                "value": " Three ",
+                "start": 40,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 13
+                  }
+                }
+              },
+              {
+                "type": "CommentBlock",
+                "value": " Four ",
+                "start": 54,
+                "end": 64,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 12
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 70,
+          "end": 75,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 18
+            },
+            "end": {
+              "line": 5,
+              "column": 23
+            }
+          },
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        },
+        "declaration": null
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentBlock",
+      "value": " One ",
+      "start": 11,
+      "end": 20,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Two ",
+      "start": 27,
+      "end": 36,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Three ",
+      "start": 40,
+      "end": 51,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Four ",
+      "start": 54,
+      "end": 64,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 12
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/es2015/modules/import-declaration-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/modules/import-declaration-trailing-comma/input.js
@@ -1,0 +1,5 @@
+import {
+  /* One */ Foo
+  /* Two */,
+  /* Three */
+} /* Four */ from "foo";

--- a/packages/babel-parser/test/fixtures/es2015/modules/import-declaration-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/import-declaration-trailing-comma/output.json
@@ -1,0 +1,255 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 76,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 76,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 24
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 76,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 24
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 21,
+            "end": 24,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 12
+              },
+              "end": {
+                "line": 2,
+                "column": 15
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 15
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 15
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            },
+            "leadingComments": [
+              {
+                "type": "CommentBlock",
+                "value": " One ",
+                "start": 11,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                }
+              }
+            ],
+            "trailingComments": [
+              {
+                "type": "CommentBlock",
+                "value": " Two ",
+                "start": 27,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 11
+                  }
+                }
+              },
+              {
+                "type": "CommentBlock",
+                "value": " Three ",
+                "start": 40,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 13
+                  }
+                }
+              },
+              {
+                "type": "CommentBlock",
+                "value": " Four ",
+                "start": 54,
+                "end": 64,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 12
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 70,
+          "end": 75,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 18
+            },
+            "end": {
+              "line": 5,
+              "column": 23
+            }
+          },
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentBlock",
+      "value": " One ",
+      "start": 11,
+      "end": 20,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Two ",
+      "start": 27,
+      "end": 36,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Three ",
+      "start": 40,
+      "end": 51,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": " Four ",
+      "start": 54,
+      "end": 64,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 12
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes issues similar to 10368
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Following up from https://github.com/babel/babel/pull/10369

- Unify the logic for adjusting trailing comments into a separate function
- Use it for all three cases, which fixes a bug for ObjectExpressions and CallExpressions
- Update tests to check for the fixed bug