### PR TITLE
Allow running tests in watch mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,12 @@ Substitute spaces for hyphens and forward slashes when targeting specific test n
 $ TEST_GREP="arrow functions destructuring parameters" make test
 ```
 
+Use the `TEST_WATCH` flag to run tests in watch mode:
+
+```sh
+TEST_GREP=transformation TEST_WATCH=1 make test
+```
+
 To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment variable:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ $ TEST_GREP="arrow functions destructuring parameters" make test
 Use the `TEST_WATCH` flag to run tests in watch mode:
 
 ```sh
-TEST_GREP=transformation TEST_WATCH=1 make test
+$ TEST_GREP=transformation TEST_WATCH=1 make test
 ```
 
 To enable the Node.js debugger added in v6.3.0, set the `TEST_DEBUG` environment variable:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,4 +23,8 @@ if [ -n "$TEST_ONLY" ]; then
   jestArgs+=("(packages|codemods)/.*$TEST_ONLY.*/test")
 fi
 
+if [ ! -z "$TEST_WATCH" ]; then
+  jestArgs+=("--watch")
+fi
+
 $node node_modules/jest/bin/jest.js "${jestArgs[@]}"


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

This adds an environment variable, `TEST_WATCH` to allow running tests in Jest's watch mode. I found it useful for iterating over test fixes and thought others might benefit from it too.