### PR TITLE
Allow setting 'allowNamespaces' in typescript preset

### DIFF
--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -4,12 +4,7 @@ import transformTypeScript from "@babel/plugin-transform-typescript";
 export default declare(
   (
     api,
-    {
-      jsxPragma,
-      allExtensions = false,
-      isTSX = false,
-      allowNamespaces = false,
-    },
+    { jsxPragma, allExtensions = false, isTSX = false, allowNamespaces },
   ) => {
     api.assertVersion(7);
 

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -2,7 +2,15 @@ import { declare } from "@babel/helper-plugin-utils";
 import transformTypeScript from "@babel/plugin-transform-typescript";
 
 export default declare(
-  (api, { jsxPragma, allExtensions = false, isTSX = false }) => {
+  (
+    api,
+    {
+      jsxPragma,
+      allExtensions = false,
+      isTSX = false,
+      allowNamespaces = false,
+    },
+  ) => {
     api.assertVersion(7);
 
     if (typeof allExtensions !== "boolean") {
@@ -20,7 +28,9 @@ export default declare(
       overrides: allExtensions
         ? [
             {
-              plugins: [[transformTypeScript, { jsxPragma, isTSX }]],
+              plugins: [
+                [transformTypeScript, { jsxPragma, isTSX, allowNamespaces }],
+              ],
             },
           ]
         : [
@@ -28,13 +38,18 @@ export default declare(
               // Only set 'test' if explicitly requested, since it requires that
               // Babel is being called`
               test: /\.ts$/,
-              plugins: [[transformTypeScript, { jsxPragma }]],
+              plugins: [[transformTypeScript, { jsxPragma, allowNamespaces }]],
             },
             {
               // Only set 'test' if explicitly requested, since it requires that
               // Babel is being called`
               test: /\.tsx$/,
-              plugins: [[transformTypeScript, { jsxPragma, isTSX: true }]],
+              plugins: [
+                [
+                  transformTypeScript,
+                  { jsxPragma, isTSX: true, allowNamespaces },
+                ],
+              ],
             },
           ],
     };


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10383
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Pass: yes, added: no (no existing tests for this preset)
| Documentation PR Link    | https://github.com/babel/website/pull/2092
| Any Dependency Changes?  | No
| License                  | MIT

In order to enable babel to be adopted on typescript projects, namespaces support was added in https://github.com/babel/babel/pull/9785. Enabling this is suggested when encountering a namespace during compilation. However, this can currently only be enabled at the level of `babel-plugin-transform-typescript`, and so this error is not actionable when using `babel-preset-typescript`, which is likely the most common way of using typescript with babel.

Using `babel-plugin-transform-typescript` in order to enable this on projects also requires re-implementing the TSX-handling logic that is in `babel-preset-typescript`. This change will make it easier to adopt babel for existing typescript projects that use namespaces.
