### PR TITLE
Include test for optional chaining with template strings

### DIFF
--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/8354/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/8354/exec.js
@@ -1,0 +1,5 @@
+const foo = undefined;
+const bar = 'bar';
+const foobar = foo?.replace(`foo${bar}`, '');
+
+expect(foobar).toBe(undefined);

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/8354/options.json
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/regression/8354/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-optional-chaining", "transform-template-literals"]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8354
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

Issue #8354 reports an incompatibility between the optional chaining and template literal plugins. Something fixed the problem since then, though.

This only adds a test to keep it from regressing in the future. The test code fails on `v7.0.0-beta.47` with the same message reported on the original issue and passes on current master.
