### PR TITLE
Add parser support for static decorators

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2021,11 +2021,15 @@ export default class ExpressionParser extends LValParser {
     return this.createIdentifier(node, name);
   }
 
-  createIdentifier(node: N.Identifier, name: string): N.Identifier {
+  createIdentifier<T: N.Identifier | N.DecoratorIdentifier>(
+    node: T,
+    name: string,
+    type: $PropertyType<T, "name"> = "Identifier",
+  ): T {
     node.name = name;
     node.loc.identifierName = name;
 
-    return this.finishNode(node, "Identifier");
+    return this.finishNode(node, type);
   }
 
   parseIdentifierName(pos: number, liberal?: boolean): string {

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -369,6 +369,9 @@ export default class LValParser extends NodeUtils {
             "'let' is not allowed to be used as a name in 'let' or 'const' declarations.",
           );
         }
+      /* falls through */
+
+      case "DecoratorIdentifier":
         if (!(bindingType & BIND_NONE)) {
           this.scope.declareName(expr.name, bindingType, expr.start);
         }

--- a/packages/babel-parser/src/plugin-utils.js
+++ b/packages/babel-parser/src/plugin-utils.js
@@ -41,6 +41,19 @@ export function getPluginOption(
 const PIPELINE_PROPOSALS = ["minimal", "smart", "fsharp"];
 
 export function validatePlugins(plugins: PluginList) {
+  if (hasPlugin(plugins, "staticDecorators")) {
+    if (hasPlugin(plugins, "decorators")) {
+      throw new Error(
+        "Cannot use the decorators and staticDecorators plugins together",
+      );
+    }
+    if (hasPlugin(plugins, "decorators-legacy")) {
+      throw new Error(
+        "Cannot use the decorators-legacy and staticDecorators plugins together",
+      );
+    }
+  }
+
   if (hasPlugin(plugins, "decorators")) {
     if (hasPlugin(plugins, "decorators-legacy")) {
       throw new Error(

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1323,6 +1323,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         case "declare": {
           const declaration = this.tsTryParseDeclare(node);
           if (declaration) {
+            if (declaration.type === "DecoratorDeclaration") {
+              throw this.raise(
+                declaration.start,
+                `TypeScript's "declare" doesn't support decorator declarations`,
+              );
+            }
             declaration.declare = true;
             return declaration;
           }
@@ -1976,6 +1982,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (declaration && isDeclare) {
         // Reset location to include `declare` in range
         this.resetStartLocation(declaration, startPos, startLoc);
+
+        if (declaration.type === "DecoratorDeclaration") {
+          throw this.raise(
+            declaration.start,
+            `TypeScript's "declare" doesn't support decorator declarations`,
+          );
+        }
 
         declaration.declare = true;
       }

--- a/packages/babel-parser/src/plugins/typescript/scope.js
+++ b/packages/babel-parser/src/plugins/typescript/scope.js
@@ -94,10 +94,11 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
     return super.isRedeclaredInScope(...arguments);
   }
 
-  checkLocalExport(id: N.Identifier) {
+  checkLocalExport(id: N.Identifier | N.DecoratorIdentifier) {
     if (
-      this.scopeStack[0].types.indexOf(id.name) === -1 &&
-      this.scopeStack[0].exportOnlyBindings.indexOf(id.name) === -1
+      id.type !== "Identifier" ||
+      (this.scopeStack[0].types.indexOf(id.name) === -1 &&
+        this.scopeStack[0].exportOnlyBindings.indexOf(id.name) === -1)
     ) {
       super.checkLocalExport(id);
     }

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -13,6 +13,7 @@ import {
   lineBreakG,
   isNewLine,
   isWhitespace,
+  skipWhiteSpace,
 } from "../util/whitespace";
 import State from "./state";
 
@@ -166,6 +167,21 @@ export default class Tokenizer extends LocationParser {
     const curr = this.state;
     this.state = old;
     return curr;
+  }
+
+  // Get the next non-whitespace character position
+  lookaheadChPos(noNewLine?: boolean): number {
+    skipWhiteSpace.lastIndex = this.state.pos;
+    // $FlowIgnore
+    const [skip] = skipWhiteSpace.exec(this.input);
+
+    if (noNewLine && lineBreak.test(skip)) return -1;
+    return this.state.pos + skip.length;
+  }
+
+  lookaheadCh(noNewLine?: boolean): number {
+    const pos = this.lookaheadChPos(noNewLine);
+    return pos === -1 ? -1 : this.input.charCodeAt(pos);
   }
 
   // Toggle strict mode. Re-reads the next number or string to please

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -51,6 +51,7 @@ export type Declaration =
   | VariableDeclaration
   | ClassDeclaration
   | FunctionDeclaration
+  | DecoratorDeclaration
   | TsInterfaceDeclaration
   | TsTypeAliasDeclaration
   | TsEnumDeclaration
@@ -346,10 +347,30 @@ export type VariableDeclarator = NodeBase & {
 
 export type ArgumentPlaceholder = NodeBase & { type: "ArgumentPlaceholder" };
 
+export type DecoratorDeclaration = NodeBase & {
+  type: "DecoratorDeclaration",
+  id: DecoratorIdentifier,
+  params: $ReadOnlyArray<Pattern>,
+  body: $ReadOnlyArray<Decorator>,
+};
+
 export type Decorator = NodeBase & {
   type: "Decorator",
+
+  // NOTE: expression is used for "decorators" and "legacy-decorators",
+  //       name is used for "staticDecorators"
+
   expression: Expression,
+  id: DecoratorIdentifier,
+
   arguments?: Array<Expression | SpreadElement>,
+};
+
+export type DecoratorIdentifier = NodeBase & {
+  type: "DecoratorIdentifier",
+  name: string,
+
+  __clone(): DecoratorIdentifier,
 };
 
 export type Directive = NodeBase & {
@@ -800,7 +821,7 @@ export type AnyExport =
   | TsNamespaceExportDeclaration;
 
 export type ModuleSpecifier = NodeBase & {
-  local: Identifier,
+  local: Identifier | DecoratorIdentifier,
 };
 
 // Imports
@@ -818,7 +839,7 @@ export type ImportDeclaration = NodeBase & {
 
 export type ImportSpecifier = ModuleSpecifier & {
   type: "ImportSpecifier",
-  imported: Identifier,
+  imported: Identifier | DecoratorIdentifier,
 };
 
 export type ImportDefaultSpecifier = ModuleSpecifier & {
@@ -842,13 +863,13 @@ export type ExportNamedDeclaration = NodeBase & {
 
 export type ExportSpecifier = NodeBase & {
   type: "ExportSpecifier",
-  exported: Identifier,
-  local: Identifier,
+  exported: Identifier | DecoratorIdentifier,
+  local: Identifier | DecoratorIdentifier,
 };
 
 export type ExportDefaultSpecifier = NodeBase & {
   type: "ExportDefaultSpecifier",
-  exported: Identifier,
+  exported: Identifier | DecoratorIdentifier,
 };
 
 export type ExportDefaultDeclaration = NodeBase & {
@@ -857,6 +878,7 @@ export type ExportDefaultDeclaration = NodeBase & {
     | OptFunctionDeclaration
     | OptTSDeclareFunction
     | OptClassDeclaration
+    | DecoratorDeclaration
     | Expression,
 };
 

--- a/packages/babel-parser/src/util/scopeflags.js
+++ b/packages/babel-parser/src/util/scopeflags.js
@@ -37,20 +37,21 @@ export function functionFlags(isAsync: boolean, isGenerator: boolean) {
 
 // These flags are meant to be _only_ used inside the Scope class (or subclasses).
 // prettier-ignore
-export const BIND_KIND_VALUE           = 0b00000_0000_01,
-             BIND_KIND_TYPE            = 0b00000_0000_10,
+export const BIND_KIND_VALUE           = 0b00000_0000_001,
+             BIND_KIND_TYPE            = 0b00000_0000_010,
+             BIND_KIND_DECORATOR       = 0b00000_0000_100,
              // Used in checkLVal and declareName to determine the type of a binding
-             BIND_SCOPE_VAR            = 0b00000_0001_00, // Var-style binding
-             BIND_SCOPE_LEXICAL        = 0b00000_0010_00, // Let- or const-style binding
-             BIND_SCOPE_FUNCTION       = 0b00000_0100_00, // Function declaration
-             BIND_SCOPE_OUTSIDE        = 0b00000_1000_00, // Special case for function names as
+             BIND_SCOPE_VAR            = 0b00000_0001_000, // Var-style binding
+             BIND_SCOPE_LEXICAL        = 0b00000_0010_000, // Let- or const-style binding
+             BIND_SCOPE_FUNCTION       = 0b00000_0100_000, // Function declaration
+             BIND_SCOPE_OUTSIDE        = 0b00000_1000_000, // Special case for function names as
                                                    // bound inside the function
              // Misc flags
-             BIND_FLAGS_NONE           = 0b00001_0000_00,
-             BIND_FLAGS_CLASS          = 0b00010_0000_00,
-             BIND_FLAGS_TS_ENUM        = 0b00100_0000_00,
-             BIND_FLAGS_TS_CONST_ENUM  = 0b01000_0000_00,
-             BIND_FLAGS_TS_EXPORT_ONLY = 0b10000_0000_00;
+             BIND_FLAGS_NONE           = 0b00001_0000_000,
+             BIND_FLAGS_CLASS          = 0b00010_0000_000,
+             BIND_FLAGS_TS_ENUM        = 0b00100_0000_000,
+             BIND_FLAGS_TS_CONST_ENUM  = 0b01000_0000_000,
+             BIND_FLAGS_TS_EXPORT_ONLY = 0b10000_0000_000;
 
 // These flags are meant to be _only_ used by Scope consumers
 // prettier-ignore
@@ -59,6 +60,7 @@ export const BIND_CLASS         = BIND_KIND_VALUE | BIND_KIND_TYPE | BIND_SCOPE_
              BIND_LEXICAL       = BIND_KIND_VALUE | 0              | BIND_SCOPE_LEXICAL  | 0                 ,
              BIND_VAR           = BIND_KIND_VALUE | 0              | BIND_SCOPE_VAR      | 0                 ,
              BIND_FUNCTION      = BIND_KIND_VALUE | 0              | BIND_SCOPE_FUNCTION | 0                 ,
+             BIND_DECORATOR     = BIND_KIND_DECORATOR              | BIND_SCOPE_LEXICAL  | 0                 ,
              BIND_TS_INTERFACE  = 0               | BIND_KIND_TYPE | 0                   | BIND_FLAGS_CLASS  ,
              BIND_TS_TYPE       = 0               | BIND_KIND_TYPE | 0                   | 0                 ,
              BIND_TS_ENUM       = BIND_KIND_VALUE | BIND_KIND_TYPE | BIND_SCOPE_LEXICAL  | BIND_FLAGS_TS_ENUM,
@@ -78,6 +80,7 @@ export type BindingTypes =
   | typeof BIND_LEXICAL
   | typeof BIND_CLASS
   | typeof BIND_FUNCTION
+  | typeof BIND_DECORATOR
   | typeof BIND_TS_INTERFACE
   | typeof BIND_TS_TYPE
   | typeof BIND_TS_ENUM

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/84/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/84/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "Unexpected token (1:8)"
+  "throws": "Unexpected token, expected \"from\" (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-batch-missing-from-clause/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-batch-missing-from-clause/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:8)"
+  "throws": "Unexpected token, expected \"from\" (1:8)"
 }

--- a/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-batch-token/options.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-export-declaration/invalid-export-batch-token/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:9)"
+  "throws": "Unexpected token, expected \"from\" (1:9)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/decorators/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/decorators/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators' (1:0)",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators, staticDecorators' (1:0)",
   "plugins": []
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-2/export-decorated-class-without-plugin/options.json
@@ -1,5 +1,5 @@
 {
   "sourceType": "module",
-  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators, decorators-legacy' (1:7)",
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators, decorators-legacy, staticDecorators' (1:7)",
   "plugins": null
 }

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-declaration/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-declaration/input.js
@@ -1,0 +1,2 @@
+decorator @foo {}
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-declaration/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "staticDecorators"
+  ],
+  "throws": "Identifier '@foo' has already been declared (2:10)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-import/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-import/input.js
@@ -1,0 +1,2 @@
+decorator @foo {}
+import { @foo } from "x";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-import/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-declaration-import/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["staticDecorators"],
+  "throws": "Identifier '@foo' has already been declared (2:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-declaration/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-declaration/input.js
@@ -1,0 +1,2 @@
+import { @foo } from "x";
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-declaration/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["staticDecorators"],
+  "throws": "Identifier '@foo' has already been declared (2:10)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-import/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-import/input.js
@@ -1,0 +1,2 @@
+import { @foo } from "x";
+import { @foo } from "x";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-import/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-duplicated-import-import/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["staticDecorators"],
+  "throws": "Identifier '@foo' has already been declared (2:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-after/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-after/input.js
@@ -1,0 +1,2 @@
+decorator @foo {}
+export { @foo };

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-after/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-after/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-after/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-after/output.json
@@ -1,0 +1,136 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 16
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 16
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 18,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 16
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 27,
+            "end": 31,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 27,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "exported": {
+              "type": "DecoratorIdentifier",
+              "start": 27,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-before/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-before/input.js
@@ -1,0 +1,2 @@
+export { @foo };
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-before/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-before/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-before/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-before/output.json
@@ -1,0 +1,136 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 17
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 17
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 16,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 16
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 9,
+            "end": 13,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "exported": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null
+      },
+      {
+        "type": "DecoratorDeclaration",
+        "start": 17,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 27,
+          "end": 31,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-after-lexical/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-after-lexical/input.js
@@ -1,0 +1,2 @@
+let foo;
+export { @foo };

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-after-lexical/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-after-lexical/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "Export '@foo' is not defined (2:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-before-lexical/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-before-lexical/input.js
@@ -1,0 +1,2 @@
+export { @foo };
+let foo;

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-before-lexical/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-decorator-before-lexical/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "Export '@foo' is not defined (1:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-after-decorator/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-after-decorator/input.js
@@ -1,0 +1,2 @@
+decorator @foo {}
+export { foo };

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-after-decorator/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-after-decorator/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "Export 'foo' is not defined (2:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-before-decorator/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-before-decorator/input.js
@@ -1,0 +1,2 @@
+export { foo };
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-before-decorator/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-export-lexical-before-decorator/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "Export 'foo' is not defined (1:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-1/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-1/input.js
@@ -1,0 +1,2 @@
+let foo;
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-1/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-1/output.json
@@ -1,0 +1,119 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 26,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 17
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 26,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 17
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 8,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "DecoratorDeclaration",
+        "start": 9,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 19,
+          "end": 23,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-2/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-2/input.js
@@ -1,0 +1,2 @@
+decorator @foo {}
+let foo;

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-2/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-same-name-lexical-2/output.json
@@ -1,0 +1,119 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 26,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 8
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 26,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 8
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 18,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 8
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 22,
+            "end": 25,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 7
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 22,
+              "end": 25,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 7
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-1/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-1/input.js
@@ -1,0 +1,4 @@
+decorator @foo {}
+{
+  decorator @foo {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-1/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-1/output.json
@@ -1,0 +1,119 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      },
+      {
+        "type": "BlockStatement",
+        "start": 18,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "body": [
+          {
+            "type": "DecoratorDeclaration",
+            "start": 22,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 2
+              },
+              "end": {
+                "line": 3,
+                "column": 19
+              }
+            },
+            "id": {
+              "type": "DecoratorIdentifier",
+              "start": 32,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 12
+                },
+                "end": {
+                  "line": 3,
+                  "column": 16
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "body": []
+          }
+        ],
+        "directives": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-2/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-2/input.js
@@ -1,0 +1,4 @@
+{
+  decorator @foo {}
+}
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-2/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/binding-shadowed-2/output.json
@@ -1,0 +1,119 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 17
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 17
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "BlockStatement",
+        "start": 0,
+        "end": 23,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "body": [
+          {
+            "type": "DecoratorDeclaration",
+            "start": 4,
+            "end": 21,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 19
+              }
+            },
+            "id": {
+              "type": "DecoratorIdentifier",
+              "start": 14,
+              "end": 18,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 16
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "body": []
+          }
+        ],
+        "directives": []
+      },
+      {
+        "type": "DecoratorDeclaration",
+        "start": 24,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 34,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 10
+            },
+            "end": {
+              "line": 4,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-newline/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-newline/input.js
@@ -1,0 +1,2 @@
+decorator
+@foo() {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-newline/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-newline/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Leading decorators must be attached to a class declaration (2:7)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-space/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-space/input.js
@@ -1,0 +1,1 @@
+decorator @ foo () {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-space/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-no-space/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected space in decorator name (1:11)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-default/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-default/input.js
@@ -1,0 +1,1 @@
+decorator @foo(a = 2) {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-default/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-default/output.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 24,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 24,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 24,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "params": [
+          {
+            "type": "AssignmentPattern",
+            "start": 15,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 20
+              }
+            },
+            "left": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 16,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 15
+                },
+                "end": {
+                  "line": 1,
+                  "column": 16
+                },
+                "identifierName": "a"
+              },
+              "name": "a"
+            },
+            "right": {
+              "type": "NumericLiteral",
+              "start": 19,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                }
+              },
+              "extra": {
+                "rawValue": 2,
+                "raw": "2"
+              },
+              "value": 2
+            }
+          }
+        ],
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-destructuring/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-destructuring/input.js
@@ -1,0 +1,1 @@
+decorator @foo({ bar }, [ baz ]) {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-destructuring/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-destructuring/output.json
@@ -1,0 +1,176 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 35,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 35
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 35,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 35
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "params": [
+          {
+            "type": "ObjectPattern",
+            "start": 15,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "properties": [
+              {
+                "type": "ObjectProperty",
+                "start": 17,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                },
+                "method": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 17,
+                  "end": 20,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 20
+                    },
+                    "identifierName": "bar"
+                  },
+                  "name": "bar"
+                },
+                "computed": false,
+                "shorthand": true,
+                "value": {
+                  "type": "Identifier",
+                  "start": 17,
+                  "end": 20,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 20
+                    },
+                    "identifierName": "bar"
+                  },
+                  "name": "bar"
+                },
+                "extra": {
+                  "shorthand": true
+                }
+              }
+            ]
+          },
+          {
+            "type": "ArrayPattern",
+            "start": 24,
+            "end": 31,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 31
+              }
+            },
+            "elements": [
+              {
+                "type": "Identifier",
+                "start": 26,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 29
+                  },
+                  "identifierName": "baz"
+                },
+                "name": "baz"
+              }
+            ]
+          }
+        ],
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-empty/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-empty/input.js
@@ -1,0 +1,1 @@
+decorator @foo() {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-empty/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-empty/output.json
@@ -1,0 +1,69 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 19,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 19
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 19,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 19
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 19,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 19
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "params": [],
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-no-any-expression/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-no-any-expression/input.js
@@ -1,0 +1,1 @@
+decorator @foo(a.b) {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-no-any-expression/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-no-any-expression/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["staticDecorators"],
+  "throws": "Unexpected token, expected \",\" (1:16)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-omitted/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-omitted/input.js
@@ -1,0 +1,1 @@
+decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-omitted/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-omitted/output.json
@@ -1,0 +1,68 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 17,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 17
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 17,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 17
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-rest/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-rest/input.js
@@ -1,0 +1,1 @@
+decorator @foo(a, b, ...c) {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-rest/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-rest/output.json
@@ -1,0 +1,136 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 29,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 29
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 29
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 29
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "start": 15,
+            "end": 16,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 16
+              },
+              "identifierName": "a"
+            },
+            "name": "a"
+          },
+          {
+            "type": "Identifier",
+            "start": 18,
+            "end": 19,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 18
+              },
+              "end": {
+                "line": 1,
+                "column": 19
+              },
+              "identifierName": "b"
+            },
+            "name": "b"
+          },
+          {
+            "type": "RestElement",
+            "start": 21,
+            "end": 25,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 21
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              }
+            },
+            "argument": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 25,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                },
+                "identifierName": "c"
+              },
+              "name": "c"
+            }
+          }
+        ],
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-trailing-comma/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-trailing-comma/input.js
@@ -1,0 +1,1 @@
+decorator @foo(a,) {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-params-trailing-comma/output.json
@@ -1,0 +1,87 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 21,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 21
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 21,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 21
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 21,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 21
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "start": 15,
+            "end": 16,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 16
+              },
+              "identifierName": "a"
+            },
+            "name": "a"
+          }
+        ],
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-valid-newline/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-valid-newline/input.js
@@ -1,0 +1,6 @@
+decorator @foo
+()
+{}
+
+decorator @bar
+{}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-valid-newline/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/declaration-valid-newline/output.json
@@ -1,0 +1,102 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 2
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 20,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "params": [],
+        "body": []
+      },
+      {
+        "type": "DecoratorDeclaration",
+        "start": 22,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 32,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 10
+            },
+            "end": {
+              "line": 5,
+              "column": 14
+            },
+            "identifierName": "bar"
+          },
+          "name": "bar"
+        },
+        "body": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-alias/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-alias/input.js
@@ -1,0 +1,2 @@
+decorator @dec {}
+export { @dec as @foo };

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-alias/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-alias/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-alias/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-alias/output.json
@@ -1,0 +1,136 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 42,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 42,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 24
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "dec"
+          },
+          "name": "dec"
+        },
+        "body": []
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 18,
+        "end": 42,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 24
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 27,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 27,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                },
+                "identifierName": "dec"
+              },
+              "name": "dec"
+            },
+            "exported": {
+              "type": "DecoratorIdentifier",
+              "start": 35,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 17
+                },
+                "end": {
+                  "line": 2,
+                  "column": 21
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-declaration/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-declaration/input.js
@@ -1,0 +1,1 @@
+export decorator @foo {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-declaration/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "Decorator declarations are only allowed as named exports. (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-alias/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-alias/input.js
@@ -1,0 +1,1 @@
+export { @foo as @bar } from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-alias/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-alias/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-alias/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-alias/output.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 35,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 35
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 35,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 35
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 9,
+            "end": 21,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 21
+              }
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "exported": {
+              "type": "DecoratorIdentifier",
+              "start": 17,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 29,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 29
+            },
+            "end": {
+              "line": 1,
+              "column": 34
+            }
+          },
+          "extra": {
+            "rawValue": "mod",
+            "raw": "\"mod\""
+          },
+          "value": "mod"
+        },
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-default/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-default/input.js
@@ -1,0 +1,1 @@
+export @dec from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-default/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-default/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["staticDecorators", "exportDefaultFrom"],
+  "throws": "Leading decorators must be attached to a class declaration (1:12)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-named/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-named/input.js
@@ -1,0 +1,1 @@
+export { @foo } from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-named/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-named/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-named/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-from-named/output.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 27
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 27,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 27
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 9,
+            "end": 13,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "exported": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 21,
+          "end": 26,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 1,
+              "column": 26
+            }
+          },
+          "extra": {
+            "rawValue": "mod",
+            "raw": "\"mod\""
+          },
+          "value": "mod"
+        },
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-named/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-named/input.js
@@ -1,0 +1,2 @@
+decorator @dec {}
+export { @dec };

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-named/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-named/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/export-named/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/export-named/output.json
@@ -1,0 +1,136 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 16
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 16
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "DecoratorDeclaration",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "DecoratorIdentifier",
+          "start": 10,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            },
+            "identifierName": "dec"
+          },
+          "name": "dec"
+        },
+        "body": []
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 18,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 16
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 27,
+            "end": 31,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 27,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                },
+                "identifierName": "dec"
+              },
+              "name": "dec"
+            },
+            "exported": {
+              "type": "DecoratorIdentifier",
+              "start": 27,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                },
+                "identifierName": "dec"
+              },
+              "name": "dec"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-alias/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-alias/input.js
@@ -1,0 +1,1 @@
+import { @foo as @bar } from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-alias/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-alias/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-alias/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-alias/output.json
@@ -1,0 +1,121 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 35,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 35
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 35,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 35
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 9,
+            "end": 21,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 21
+              }
+            },
+            "imported": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 17,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 29,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 29
+            },
+            "end": {
+              "line": 1,
+              "column": 34
+            }
+          },
+          "extra": {
+            "rawValue": "mod",
+            "raw": "\"mod\""
+          },
+          "value": "mod"
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-default/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-default/input.js
@@ -1,0 +1,1 @@
+import @dec from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-default/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-default/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "throws": "Invalid decorator in default import specifier (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-named/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-named/input.js
@@ -1,0 +1,1 @@
+import { @foo } from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-named/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-named/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/import-named/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/import-named/output.json
@@ -1,0 +1,121 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 27
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 27,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 27
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 9,
+            "end": 13,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "imported": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "local": {
+              "type": "DecoratorIdentifier",
+              "start": 9,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 9
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 21,
+          "end": 26,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 1,
+              "column": 26
+            }
+          },
+          "extra": {
+            "rawValue": "mod",
+            "raw": "\"mod\""
+          },
+          "value": "mod"
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-declaration/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-declaration/input.js
@@ -1,0 +1,1 @@
+decorator @dec {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-declaration/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling the parser plugin: 'staticDecorators' (1:0)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-default/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-default/input.js
@@ -1,0 +1,1 @@
+import @dec from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-default/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-default/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling the parser plugin: 'staticDecorators' (1:7)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-named/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-named/input.js
@@ -1,0 +1,1 @@
+import { @dec } from "mod";

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-named/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-import-named/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling the parser plugin: 'staticDecorators' (1:9)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-usage/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-usage/input.js
@@ -1,0 +1,3 @@
+class A {
+  @dec foo() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-usage/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/no-plugin-usage/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [],
+  "throws": "This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators, staticDecorators' (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["staticDecorators"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-multiple/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-multiple/input.js
@@ -1,0 +1,4 @@
+@a @b
+class Foo {
+  @c @d bar() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-multiple/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-multiple/output.json
@@ -1,0 +1,273 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 36,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 36,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 36,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "decorators": [
+          {
+            "type": "Decorator",
+            "start": 0,
+            "end": 2,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 2
+              }
+            },
+            "id": {
+              "type": "DecoratorIdentifier",
+              "start": 0,
+              "end": 2,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 2
+                },
+                "identifierName": "a"
+              },
+              "name": "a"
+            }
+          },
+          {
+            "type": "Decorator",
+            "start": 3,
+            "end": 5,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 3
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "id": {
+              "type": "DecoratorIdentifier",
+              "start": 3,
+              "end": 5,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 3
+                },
+                "end": {
+                  "line": 1,
+                  "column": 5
+                },
+                "identifierName": "b"
+              },
+              "name": "b"
+            }
+          }
+        ],
+        "id": {
+          "type": "Identifier",
+          "start": 12,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 9
+            },
+            "identifierName": "Foo"
+          },
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 16,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 20,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 16
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 20,
+                  "end": 22,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 4
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 20,
+                    "end": 22,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 4
+                      },
+                      "identifierName": "c"
+                    },
+                    "name": "c"
+                  }
+                },
+                {
+                  "type": "Decorator",
+                  "start": 23,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 7
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 23,
+                    "end": 25,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 7
+                      },
+                      "identifierName": "d"
+                    },
+                    "name": "d"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 26,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "identifierName": "bar"
+                },
+                "name": "bar"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 32,
+                "end": 34,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 16
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-nested/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-nested/input.js
@@ -1,0 +1,6 @@
+class A {
+  @dec(class B {
+    @dec b() {}
+  })
+  a() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-nested/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-nested/output.json
@@ -1,0 +1,317 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 58,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 58,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 58,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 58,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 12,
+              "end": 56,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 8
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 47,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 4
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  },
+                  "arguments": [
+                    {
+                      "type": "ClassExpression",
+                      "start": 17,
+                      "end": 46,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 3
+                        }
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 23,
+                        "end": 24,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 14
+                          },
+                          "identifierName": "B"
+                        },
+                        "name": "B"
+                      },
+                      "superClass": null,
+                      "body": {
+                        "type": "ClassBody",
+                        "start": 25,
+                        "end": 46,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 15
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 3
+                          }
+                        },
+                        "body": [
+                          {
+                            "type": "ClassMethod",
+                            "start": 31,
+                            "end": 42,
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 4
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 15
+                              }
+                            },
+                            "decorators": [
+                              {
+                                "type": "Decorator",
+                                "start": 31,
+                                "end": 35,
+                                "loc": {
+                                  "start": {
+                                    "line": 3,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 8
+                                  }
+                                },
+                                "id": {
+                                  "type": "DecoratorIdentifier",
+                                  "start": 31,
+                                  "end": 35,
+                                  "loc": {
+                                    "start": {
+                                      "line": 3,
+                                      "column": 4
+                                    },
+                                    "end": {
+                                      "line": 3,
+                                      "column": 8
+                                    },
+                                    "identifierName": "dec"
+                                  },
+                                  "name": "dec"
+                                }
+                              }
+                            ],
+                            "static": false,
+                            "key": {
+                              "type": "Identifier",
+                              "start": 36,
+                              "end": 37,
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 10
+                                },
+                                "identifierName": "b"
+                              },
+                              "name": "b"
+                            },
+                            "computed": false,
+                            "kind": "method",
+                            "id": null,
+                            "generator": false,
+                            "async": false,
+                            "params": [],
+                            "body": {
+                              "type": "BlockStatement",
+                              "start": 40,
+                              "end": 42,
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 13
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 15
+                                }
+                              },
+                              "body": [],
+                              "directives": []
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 50,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 54,
+                "end": 56,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 8
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-params/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-params/input.js
@@ -1,0 +1,4 @@
+class A {
+  @dec
+  foo() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-params/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-params/output.json
@@ -1,0 +1,175 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 29,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 29,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 12,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 10
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 16,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 19,
+                "end": 22,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 25,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 10
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-space/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-space/input.js
@@ -1,0 +1,4 @@
+class A {
+  @ dec
+  foo() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-space/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-no-space/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "staticDecorators"
+  ],
+  "throws": "Unexpected space in decorator name (2:3)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-class/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-class/input.js
@@ -1,0 +1,2 @@
+@dec
+class A {}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-class/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-class/output.json
@@ -1,0 +1,118 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 15,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 10
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 15,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 10
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 15,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 10
+          }
+        },
+        "decorators": [
+          {
+            "type": "Decorator",
+            "start": 0,
+            "end": 4,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            },
+            "id": {
+              "type": "DecoratorIdentifier",
+              "start": 0,
+              "end": 4,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 4
+                },
+                "identifierName": "dec"
+              },
+              "name": "dec"
+            }
+          }
+        ],
+        "id": {
+          "type": "Identifier",
+          "start": 11,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 13,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 8
+            },
+            "end": {
+              "line": 2,
+              "column": 10
+            }
+          },
+          "body": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-computed/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-computed/input.js
@@ -1,0 +1,3 @@
+class A {
+  @dec [foo]() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-computed/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-computed/output.json
@@ -1,0 +1,175 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 29,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 29,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 12,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 16,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  }
+                }
+              ],
+              "static": false,
+              "computed": true,
+              "key": {
+                "type": "Identifier",
+                "start": 18,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 25,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 17
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-field/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-field/input.js
@@ -1,0 +1,3 @@
+class A {
+  @dec foo;
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-field/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-field/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["staticDecorators", "classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-field/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-field/output.json
@@ -1,0 +1,154 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 23,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 23,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 23,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 23,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 11
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 16,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 17,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-generator/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-generator/input.js
@@ -1,0 +1,3 @@
+class A {
+  @dec *gen() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-generator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-generator/output.json
@@ -1,0 +1,175 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 28,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 28,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 12,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 16
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 16,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  }
+                }
+              ],
+              "static": false,
+              "kind": "method",
+              "key": {
+                "type": "Identifier",
+                "start": 18,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "identifierName": "gen"
+                },
+                "name": "gen"
+              },
+              "computed": false,
+              "id": null,
+              "generator": true,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 24,
+                "end": 26,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-private/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-private/input.js
@@ -1,0 +1,3 @@
+class A {
+  @dec #foo() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-private/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-private/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["staticDecorators", "classPrivateMethods"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-private/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-on-private/output.json
@@ -1,0 +1,189 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 28,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 28,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassPrivateMethod",
+              "start": 12,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 16
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 16,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  }
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 17,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 18,
+                  "end": 21,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11
+                    },
+                    "identifierName": "foo"
+                  },
+                  "name": "foo"
+                }
+              },
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 24,
+                "end": 26,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-any-expression/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-any-expression/input.js
@@ -1,0 +1,4 @@
+class A {
+  @dec(a + b[c])
+  foo() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-any-expression/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-any-expression/output.json
@@ -1,0 +1,260 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 12,
+              "end": 37,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 10
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 26,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 16
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  },
+                  "arguments": [
+                    {
+                      "type": "BinaryExpression",
+                      "start": 17,
+                      "end": 25,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 15
+                        }
+                      },
+                      "left": {
+                        "type": "Identifier",
+                        "start": 17,
+                        "end": 18,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 7
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 8
+                          },
+                          "identifierName": "a"
+                        },
+                        "name": "a"
+                      },
+                      "operator": "+",
+                      "right": {
+                        "type": "MemberExpression",
+                        "start": 21,
+                        "end": 25,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 11
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 15
+                          }
+                        },
+                        "object": {
+                          "type": "Identifier",
+                          "start": 21,
+                          "end": 22,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 11
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 12
+                            },
+                            "identifierName": "b"
+                          },
+                          "name": "b"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 23,
+                          "end": 24,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 13
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 14
+                            },
+                            "identifierName": "c"
+                          },
+                          "name": "c"
+                        },
+                        "computed": true
+                      }
+                    }
+                  ]
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 29,
+                "end": 32,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 35,
+                "end": 37,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 10
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-empty/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-empty/input.js
@@ -1,0 +1,4 @@
+class A {
+  @dec()
+  foo() {}
+}

--- a/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-empty/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/static-decorators/usage-params-empty/output.json
@@ -1,0 +1,176 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 31,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 31,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 31,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 31,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 12,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 10
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 12,
+                  "end": 18,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 8
+                    }
+                  },
+                  "id": {
+                    "type": "DecoratorIdentifier",
+                    "start": 12,
+                    "end": 16,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  },
+                  "arguments": []
+                }
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 21,
+                "end": 24,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 27,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 10
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -8,137 +8,144 @@
 /**
  * Parse the provided code as an entire ECMAScript program.
  */
-export function parse(input: string, options?: ParserOptions): import('@babel/types').File;
+export function parse(
+  input: string,
+  options?: ParserOptions
+): import("@babel/types").File;
 
 /**
  * Parse the provided code as a single expression.
  */
-export function parseExpression(input: string, options?: ParserOptions): import('@babel/types').Expression;
+export function parseExpression(
+  input: string,
+  options?: ParserOptions
+): import("@babel/types").Expression;
 
 export interface ParserOptions {
-    /**
-     * By default, import and export declarations can only appear at a program's top level.
-     * Setting this option to true allows them anywhere where a statement is allowed.
-     */
-    allowImportExportEverywhere?: boolean;
+  /**
+   * By default, import and export declarations can only appear at a program's top level.
+   * Setting this option to true allows them anywhere where a statement is allowed.
+   */
+  allowImportExportEverywhere?: boolean;
 
-    /**
-     * By default, await use is not allowed outside of an async function.
-     * Set this to true to accept such code.
-     */
-    allowAwaitOutsideFunction?: boolean;
+  /**
+   * By default, await use is not allowed outside of an async function.
+   * Set this to true to accept such code.
+   */
+  allowAwaitOutsideFunction?: boolean;
 
-    /**
-     * By default, a return statement at the top level raises an error.
-     * Set this to true to accept such code.
-     */
-    allowReturnOutsideFunction?: boolean;
+  /**
+   * By default, a return statement at the top level raises an error.
+   * Set this to true to accept such code.
+   */
+  allowReturnOutsideFunction?: boolean;
 
-    allowSuperOutsideMethod?: boolean;
+  allowSuperOutsideMethod?: boolean;
 
-    /**
-     * By default, exported identifiers must refer to a declared variable.
-     * Set this to true to allow export statements to reference undeclared variables.
-     */
-    allowUndeclaredExports?: boolean;
+  /**
+   * By default, exported identifiers must refer to a declared variable.
+   * Set this to true to allow export statements to reference undeclared variables.
+   */
+  allowUndeclaredExports?: boolean;
 
-    /**
-     * Indicate the mode the code should be parsed in.
-     * Can be one of "script", "module", or "unambiguous". Defaults to "script".
-     * "unambiguous" will make @babel/parser attempt to guess, based on the presence
-     * of ES6 import or export statements.
-     * Files with ES6 imports and exports are considered "module" and are otherwise "script".
-     */
-    sourceType?: 'script' | 'module' | 'unambiguous';
+  /**
+   * Indicate the mode the code should be parsed in.
+   * Can be one of "script", "module", or "unambiguous". Defaults to "script".
+   * "unambiguous" will make @babel/parser attempt to guess, based on the presence
+   * of ES6 import or export statements.
+   * Files with ES6 imports and exports are considered "module" and are otherwise "script".
+   */
+  sourceType?: "script" | "module" | "unambiguous";
 
-    /**
-     * Correlate output AST nodes with their source filename.
-     * Useful when generating code and source maps from the ASTs of multiple input files.
-     */
-    sourceFilename?: string;
+  /**
+   * Correlate output AST nodes with their source filename.
+   * Useful when generating code and source maps from the ASTs of multiple input files.
+   */
+  sourceFilename?: string;
 
-    /**
-     * By default, the first line of code parsed is treated as line 1.
-     * You can provide a line number to alternatively start with.
-     * Useful for integration with other source tools.
-     */
-    startLine?: number;
+  /**
+   * By default, the first line of code parsed is treated as line 1.
+   * You can provide a line number to alternatively start with.
+   * Useful for integration with other source tools.
+   */
+  startLine?: number;
 
-    /**
-     * Array containing the plugins that you want to enable.
-     */
-    plugins?: ParserPlugin[];
+  /**
+   * Array containing the plugins that you want to enable.
+   */
+  plugins?: ParserPlugin[];
 
-    /**
-     * Should the parser work in strict mode.
-     * Defaults to true if sourceType === 'module'. Otherwise, false.
-     */
-    strictMode?: boolean;
+  /**
+   * Should the parser work in strict mode.
+   * Defaults to true if sourceType === 'module'. Otherwise, false.
+   */
+  strictMode?: boolean;
 
-    /**
-     * Adds a ranges property to each node: [node.start, node.end]
-     */
-    ranges?: boolean;
+  /**
+   * Adds a ranges property to each node: [node.start, node.end]
+   */
+  ranges?: boolean;
 
-    /**
-     * Adds all parsed tokens to a tokens property on the File node.
-     */
-    tokens?: boolean;
+  /**
+   * Adds all parsed tokens to a tokens property on the File node.
+   */
+  tokens?: boolean;
 
-    /**
-     * By default, the parser adds information about parentheses by setting
-     * `extra.parenthesized` to `true` as needed.
-     * When this option is `true` the parser creates `ParenthesizedExpression`
-     * AST nodes instead of using the `extra` property.
-     */
-    createParenthesizedExpressions?: boolean;
+  /**
+   * By default, the parser adds information about parentheses by setting
+   * `extra.parenthesized` to `true` as needed.
+   * When this option is `true` the parser creates `ParenthesizedExpression`
+   * AST nodes instead of using the `extra` property.
+   */
+  createParenthesizedExpressions?: boolean;
 }
 
 export type ParserPlugin =
-    'asyncGenerators' |
-    'bigInt' |
-    'classPrivateMethods' |
-    'classPrivateProperties' |
-    'classProperties' |
-    'decorators' |
-    'decorators-legacy' |
-    'doExpressions' |
-    'dynamicImport' |
-    'estree' |
-    'exportDefaultFrom' |
-    'exportNamespaceFrom' |
-    'flow' |
-    'flowComments' |
-    'functionBind' |
-    'functionSent' |
-    'importMeta' |
-    'jsx' |
-    'logicalAssignment' |
-    'nullishCoalescingOperator' |
-    'numericSeparator' |
-    'objectRestSpread' |
-    'optionalCatchBinding' |
-    'optionalChaining' |
-    'partialApplication' |
-    'pipelineOperator' |
-    'placeholders' |
-    'throwExpressions' |
-    'typescript' |
-    ParserPluginWithOptions;
+  | "asyncGenerators"
+  | "bigInt"
+  | "classPrivateMethods"
+  | "classPrivateProperties"
+  | "classProperties"
+  | "decorators"
+  | "decorators-legacy"
+  | "doExpressions"
+  | "dynamicImport"
+  | "estree"
+  | "exportDefaultFrom"
+  | "exportNamespaceFrom"
+  | "flow"
+  | "flowComments"
+  | "functionBind"
+  | "functionSent"
+  | "importMeta"
+  | "jsx"
+  | "logicalAssignment"
+  | "nullishCoalescingOperator"
+  | "numericSeparator"
+  | "objectRestSpread"
+  | "optionalCatchBinding"
+  | "optionalChaining"
+  | "partialApplication"
+  | "pipelineOperator"
+  | "placeholders"
+  | "staticDecorators"
+  | "throwExpressions"
+  | "typescript"
+  | ParserPluginWithOptions;
 
 export type ParserPluginWithOptions =
-    ['decorators', DecoratorsPluginOptions] |
-    ['pipelineOperator', PipelineOperatorPluginOptions] |
-    ['flow', FlowPluginOptions];
+  | ["decorators", DecoratorsPluginOptions]
+  | ["pipelineOperator", PipelineOperatorPluginOptions]
+  | ["flow", FlowPluginOptions];
 
 export interface DecoratorsPluginOptions {
-    decoratorsBeforeExport?: boolean;
+  decoratorsBeforeExport?: boolean;
 }
 
 export interface PipelineOperatorPluginOptions {
-    proposal: 'minimal' | 'smart';
+  proposal: "minimal" | "smart";
 }
 
 export interface FlowPluginOptions {
-    all?: boolean;
+  all?: boolean;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

After a long time since the proposal update, the PR is here :stuck_out_tongue: 
I'll close all the PRs for the older decorators versions. Note that they will still be maintianed with bug fixes and performance improvements if possible/needed.

---

**Open question**:
I created a new plugin (`staticDecorators`) because we had two different plugins for the other decorators flavors (`decorators` and `decorators-legacy`). If we can come up with a name for the proposal we had one year ago, I would prefer to use a single plugin live we did for the pipeline operator:
```
["decorators", { version: "static" | "legacy" | "?" }]
```
(and leave `decorators-legacy` for backward compatibility)

---

I'm cc-ing a few people which are/might be interested: @littledan @tomdale @kesne @tjcrowder @pabloalmunia