### PR TITLE
fix: allow the process to exit naturally

### DIFF
--- a/packages/babel-cli/src/babel/index.js
+++ b/packages/babel-cli/src/babel/index.js
@@ -6,8 +6,12 @@ import fileCommand from "./file";
 
 const opts = parseArgv(process.argv);
 
-const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
-fn(opts).catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+if (opts) {
+  const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
+  fn(opts).catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+} else {
+  process.exitCode = 2;
+}

--- a/packages/babel-cli/src/babel/options.js
+++ b/packages/babel-cli/src/babel/options.js
@@ -158,7 +158,7 @@ export type CmdOptions = {
   cliOptions: Object,
 };
 
-export default function parseArgv(args: Array<string>): CmdOptions {
+export default function parseArgv(args: Array<string>): CmdOptions | null {
   //
   commander.parse(args);
 
@@ -223,7 +223,7 @@ export default function parseArgv(args: Array<string>): CmdOptions {
     errors.forEach(function(e) {
       console.error("  " + e);
     });
-    process.exit(2);
+    return null;
   }
 
   const opts = commander.opts();

--- a/packages/babel-cli/src/babel/util.js
+++ b/packages/babel-cli/src/babel/util.js
@@ -112,7 +112,7 @@ export function deleteDir(path: string): void {
 
 process.on("uncaughtException", function(err) {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });
 
 export function requireChokidar(): Object {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Error log could get truncated under certain circumstances
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

`process.exit()` would terminate the process as soon as possible even when there are pending asynchronous I/O operations. It could lead to truncated error logs when I/O device is slow or the error log is big.

In this PR we replace `process.exit()` by setting `process.exitCode`. Doing so and avoiding scheduling more tasks to event loop will allow the process to exit naturally.
