### PR TITLE
assertNoDuplicates throw with more context

### DIFF
--- a/packages/babel-core/src/config/config-descriptors.js
+++ b/packages/babel-core/src/config/config-descriptors.js
@@ -345,6 +345,7 @@ function assertNoDuplicates(items: Array<UnloadedDescriptor>): void {
     }
 
     if (nameMap.has(item.name)) {
+      const conflicts = items.filter(i => i.value === item.value);
       throw new Error(
         [
           `Duplicate plugin/preset detected.`,
@@ -355,6 +356,9 @@ function assertNoDuplicates(items: Array<UnloadedDescriptor>): void {
           `    ['some-plugin', {}],`,
           `    ['some-plugin', {}, 'some unique name'],`,
           `  ]`,
+          ``,
+          `Duplicates detected are:`,
+          `${JSON.stringify(conflicts, null, 2)}`,
         ].join("\n"),
       );
     }

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -27,14 +27,19 @@ describe("option-manager", () => {
       return { plugin, calls };
     }
 
-    it("should throw if a plugin is repeated", () => {
-      const { calls, plugin } = makePlugin();
+    it("should throw if a plugin is repeated, with information about the repeated plugin", () => {
+      const { calls, plugin } = makePlugin("my-plugin");
 
       expect(() => {
         loadOptions({
-          plugins: [plugin, plugin],
+          plugins: [
+            [plugin, undefined, "my-plugin"],
+            [plugin, undefined, "my-plugin"],
+          ],
         });
-      }).toThrow(/Duplicate plugin\/preset detected/);
+      }).toThrow(
+        /Duplicate plugin\/preset detected.*Duplicates detected are.*my-plugin.*my-plugin/ms,
+      );
       expect(calls).toEqual([]);
     });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9778 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->



When users see errors like

```
Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]
```

It can be difficult to determine the source of the conflict, especially
in a larger build system.

This commit outputs what is known about the plugins that actually
conflict, which can be helpful for users to determine the root cause of
the conflict.

New example output on conflict:
```
Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]

Duplicates detected are:
[
      "root": "/Users/dhamilto/src/linkedin/ember-cli-pemberly-m3",
      "name": "ember-m3"
    },
    "dirname": "/Users/dhamilto/src/linkedin/ember-cli-pemberly-m3",
    "ownPass": false,
    "file": {
      "request": "/Users/dhamilto/src/linkedin/ember-cli-pemberly-m3/node_modules/ember-compatibilit
y-helpers/comparision-plugin.js",
      "resolved": "/Users/dhamilto/src/linkedin/ember-cli-pemberly-m3/node_modules/ember-compatibili
ty-helpers/comparision-plugin.js"
    }
  },
  {
    "alias": "/Users/dhamilto/src/linkedin/ember-cli-pemberly-m3/node_modules/ember-compatibility-he
y-helpers/comparision-plugin.js",
      "resolved": "/Users/dhamilto/src/linkedin/ember-cli-pemberly-m3/node_modules/ember-compatibili
ty-helpers/comparision-plugin.js"
    }
  }
]
```

Partially addresses #9778