### PR TITLE
chore: remove trim-right dependency

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -17,8 +17,7 @@
     "@babel/types": "^7.6.0",
     "jsesc": "^2.5.1",
     "lodash": "^4.17.13",
-    "source-map": "^0.5.0",
-    "trim-right": "^1.0.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "@babel/helper-fixtures": "^7.6.0",

--- a/packages/babel-generator/src/buffer.js
+++ b/packages/babel-generator/src/buffer.js
@@ -1,5 +1,4 @@
 import type SourceMap from "./source-map";
-import trimRight from "trim-right";
 
 const SPACES_RE = /^[ \t]+$/;
 
@@ -43,7 +42,7 @@ export default class Buffer {
     const result = {
       // Whatever trim is used here should not execute a regex against the
       // source string since it may be arbitrarily large after all transformations
-      code: trimRight(this._buf.join("")),
+      code: this._buf.join("").trimRight(),
       map: null,
       rawMappings: map && map.getRawMappings(),
     };

--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import trimEnd from "lodash/trimEnd";
 import resolve from "try-resolve";
 import clone from "lodash/clone";
 import extend from "lodash/extend";
@@ -275,7 +274,7 @@ export function multiple(entryLoc, ignore?: Array<string>) {
 
 export function readFile(filename) {
   if (fs.existsSync(filename)) {
-    let file = trimEnd(fs.readFileSync(filename, "utf8"));
+    let file = fs.readFileSync(filename, "utf8").trimRight();
     file = file.replace(/\r\n/g, "\n");
     return file;
   } else {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | remove `trim-right` and `lodash/trimEnd` dependencies
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | remove `trim-right` and `lodash/trimEnd` dependencies
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`String.prototype.trimRight` is supported on `node >= 6.5`: http://kangax.github.io/compat-table/es2016plus/