### PR TITLE
chore: add lint-ts rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,13 @@ watch: clean clean-lib
 flow:
 	./node_modules/.bin/flow check --strip-root
 
-lint:
+lint: lint-js lint-ts
+
+lint-js:
 	./node_modules/.bin/eslint scripts $(SOURCES) '*.js' --format=codeframe
+
+lint-ts:
+	./scripts/tests/typescript/lint.sh
 
 fix: fix-json
 	./node_modules/.bin/eslint scripts $(SOURCES) '*.js' --format=codeframe --fix

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "test262-stream": "^1.2.0",
     "through2": "^2.0.0",
+    "typescript": "^3.6.3",
     "warnings-to-errors-webpack-plugin": "^2.0.0",
     "webpack": "^3.4.1",
     "webpack-dependency-suite": "^2.4.4",

--- a/scripts/tests/typescript/lint.sh
+++ b/scripts/tests/typescript/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+node="node"
+tsFlags="--strict"
+
+$node ./node_modules/typescript/bin/tsc $tsFlags ./packages/babel-types/lib/index.d.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -10438,6 +10438,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
 uglify-js@3.4.x:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

Add `lint-ts` to `lint` rule. Basically it runs typescript compiler on generated babel types `index.d.ts` and reports any errors. This should prevent #10403 happens again.
