### PR TITLE
chore: remove tryResolve dependency

### DIFF
--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -11,7 +11,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "lodash": "^4.17.13",
-    "semver": "^5.3.0",
-    "try-resolve": "^1.0.0"
+    "semver": "^5.3.0"
   }
 }

--- a/packages/babel-helper-fixtures/src/index.js
+++ b/packages/babel-helper-fixtures/src/index.js
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import resolve from "try-resolve";
 import clone from "lodash/clone";
 import extend from "lodash/extend";
 import semver from "semver";
@@ -35,6 +34,13 @@ type Suite = {
   filename: string,
 };
 
+function tryResolve(module) {
+  try {
+    return require.resolve(module);
+  } catch (e) {
+    return null;
+  }
+}
 function assertDirectory(loc) {
   if (!fs.statSync(loc).isDirectory()) {
     throw new Error(`Expected ${loc} to be a directory.`);
@@ -76,7 +82,7 @@ export default function get(entryLoc): Array<Suite> {
   const suites = [];
 
   let rootOpts = {};
-  const rootOptsLoc = resolve(entryLoc + "/options");
+  const rootOptsLoc = tryResolve(entryLoc + "/options");
   if (rootOptsLoc) rootOpts = require(rootOptsLoc);
 
   for (const suiteName of fs.readdirSync(entryLoc)) {
@@ -92,7 +98,7 @@ export default function get(entryLoc): Array<Suite> {
     assertDirectory(suite.filename);
     suites.push(suite);
 
-    const suiteOptsLoc = resolve(suite.filename + "/options");
+    const suiteOptsLoc = tryResolve(suite.filename + "/options");
     if (suiteOptsLoc) suite.options = require(suiteOptsLoc);
 
     for (const taskName of fs.readdirSync(suite.filename)) {
@@ -139,7 +145,7 @@ export default function get(entryLoc): Array<Suite> {
 
       const taskOpts = cloneDeep(suite.options);
 
-      const taskOptsLoc = resolve(taskDir + "/options");
+      const taskOptsLoc = tryResolve(taskDir + "/options");
       if (taskOptsLoc) extend(taskOpts, require(taskOptsLoc));
 
       const test = {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | remove `try-resolve` dependency from fixtures-runner.
| License                  | MIT

I couldn't even find the repository of `try-resolve` but looking to https://unpkg.com/browse/try-resolve@1.0.1/index.js it is straightforward and we don't need the extra `resolve.relative` method.