### PR TITLE
chore: bump regexpu-core to version 4.6.0

### DIFF
--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/helper-regex": "^7.4.4",
-    "regexpu-core": "^4.5.4"
+    "regexpu-core": "^4.6.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/helper-regex": "^7.4.4",
-    "regexpu-core": "^4.5.4"
+    "regexpu-core": "^4.6.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-plugin-transform-dotall-regex/test/fixtures/dotall-regex/simple/output.js
+++ b/packages/babel-plugin-transform-dotall-regex/test/fixtures/dotall-regex/simple/output.js
@@ -1,2 +1,2 @@
 var a = /./;
-var b = /[\0-\uFFFF]/;
+var b = /[\s\S]/;

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/helper-regex": "^7.4.4",
-    "regexpu-core": "^4.5.4"
+    "regexpu-core": "^4.6.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-preset-env/test/fixtures/sanity/regex-dot-all/output.js
+++ b/packages/babel-preset-env/test/fixtures/sanity/regex-dot-all/output.js
@@ -1,2 +1,2 @@
-/[\0-\uFFFF]/;
+/[\s\S]/;
 /(?:[\0-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9133,9 +9133,9 @@ regexpp@^2.0.1:
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^4.5.4:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.5.tgz#aaffe61c2af58269b3e516b61a73790376326411"
-  integrity sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
+  integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^8.1.0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixe master branch build failure due to regexpu-core update
| Tests Added + Pass?      | Yes
| License                  | MIT

A recent [update](https://github.com/mathiasbynens/regexpu-core/pull/29) of `regexpu-core` changes the transformation of `/./` when `dotAll` flag is open.