### PR TITLE
chore: Upgrade source-map to 0.6.1

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^0.5.1",
     "output-file-sync": "^2.0.0",
     "slash": "^2.0.0",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   },
   "optionalDependencies": {
     "chokidar": "^2.1.8"

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.13",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "^7.6.0"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -17,7 +17,7 @@
     "@babel/types": "^7.6.0",
     "jsesc": "^2.5.1",
     "lodash": "^4.17.13",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   },
   "devDependencies": {
     "@babel/helper-fixtures": "^7.6.0",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -20,6 +20,6 @@
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.13",
     "resolve": "^1.3.2",
-    "source-map": "^0.5.0"
+    "source-map": "^0.6.1"
   }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    |
| Any Dependency Changes?  | 👍
| License                  | MIT

Update source-map to `^0.6.1`.  This is the latest version to support node.js 6, also the latest version to support a fully synchronous API.