### PR TITLE
Updates documentation of the `findParent` and `find` methods

### DIFF
--- a/packages/babel-traverse/src/path/ancestry.js
+++ b/packages/babel-traverse/src/path/ancestry.js
@@ -4,8 +4,10 @@ import * as t from "@babel/types";
 import NodePath from "./index";
 
 /**
- * Call the provided `callback` with the `NodePath`s of all the parents.
- * When the `callback` returns a truthy value, we return that node path.
+ * Starting at the parent path of the current `NodePath` and going up the
+ * tree, return the first `NodePath` that causes the provided `callback`
+ * to return a truthy value, or `null` if the `callback` never returns a
+ * truthy value.
  */
 
 export function findParent(callback): ?NodePath {
@@ -18,7 +20,8 @@ export function findParent(callback): ?NodePath {
 
 /**
  * Starting at current `NodePath` and going up the tree, return the first
- * `NodePath` that causes the provided `callback` to return a truthy value.
+ * `NodePath` that causes the provided `callback` to return a truthy value,
+ * or `null` if the `callback` never returns a truthy value.
  */
 
 export function find(callback): ?NodePath {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No new tests
| Documentation PR Link    |
| Any Dependency Changes?  | No
| License                  | MIT

Updates the documentation of the `findParent` and `find` methods so that they are consistent with each other and so that they mention when they return `null`.