### PR TITLE
Traverse performance

### DIFF
--- a/packages/babel-traverse/src/index.js
+++ b/packages/babel-traverse/src/index.js
@@ -31,6 +31,10 @@ export default function traverse(
     }
   }
 
+  if (!t.VISITOR_KEYS[parent.type]) {
+    return;
+  }
+
   visitors.explode(opts);
 
   traverse.node(parent, opts, scope, state, parentPath);

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -44,6 +44,7 @@ export function _call(fns?: Array<Function>): boolean {
     // node has been replaced, it will have been requeued
     if (this.node !== node) return true;
 
+    // this.shouldSkip || this.shouldStop || this.removed
     if (this._traverseFlags > 0) return true;
   }
 
@@ -100,6 +101,7 @@ export function skipKey(key) {
 }
 
 export function stop() {
+  // this.shouldSkip = true; this.shouldStop = true;
   this._traverseFlags |= SHOULD_SKIP | SHOULD_STOP;
 }
 
@@ -123,6 +125,7 @@ export function setContext(context) {
   if (this.skipKeys != null) {
     this.skipKeys = {};
   }
+  // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
   this._traverseFlags = 0;
 
   if (context) {

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -216,7 +216,6 @@ export function pushContext(context) {
 
 export function setup(parentPath, container, listKey, key) {
   this.listKey = listKey;
-  this.parentKey = listKey || key;
   this.container = container;
 
   this.parentPath = parentPath || this.parentPath;

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -93,6 +93,9 @@ export function skip() {
 }
 
 export function skipKey(key) {
+  if (this.skipKeys == null) {
+    this.skipKeys = {};
+  }
   this.skipKeys[key] = true;
 }
 
@@ -117,7 +120,9 @@ export function setScope() {
 }
 
 export function setContext(context) {
-  this.skipKeys = {};
+  if (this.skipKeys != null) {
+    this.skipKeys = {};
+  }
   this._traverseFlags = 0;
 
   if (context) {

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -1,6 +1,7 @@
 // This file contains methods responsible for maintaining a TraversalContext.
 
 import traverse from "../index";
+import { SHOULD_SKIP, SHOULD_STOP } from "./index";
 
 export function call(key): boolean {
   const opts = this.opts;
@@ -43,7 +44,7 @@ export function _call(fns?: Array<Function>): boolean {
     // node has been replaced, it will have been requeued
     if (this.node !== node) return true;
 
-    if (this.shouldStop || this.shouldSkip || this.removed) return true;
+    if (this._traverseFlags > 0) return true;
   }
 
   return false;
@@ -96,8 +97,7 @@ export function skipKey(key) {
 }
 
 export function stop() {
-  this.shouldStop = true;
-  this.shouldSkip = true;
+  this._traverseFlags |= SHOULD_SKIP | SHOULD_STOP;
 }
 
 export function setScope() {
@@ -117,10 +117,8 @@ export function setScope() {
 }
 
 export function setContext(context) {
-  this.shouldSkip = false;
-  this.shouldStop = false;
-  this.removed = false;
   this.skipKeys = {};
+  this._traverseFlags = 0;
 
   if (context) {
     this.context = context;

--- a/packages/babel-traverse/src/path/context.js
+++ b/packages/babel-traverse/src/path/context.js
@@ -215,7 +215,6 @@ export function pushContext(context) {
 }
 
 export function setup(parentPath, container, listKey, key) {
-  this.inList = !!listKey;
   this.listKey = listKey;
   this.parentKey = listKey || key;
   this.container = container;

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -33,7 +33,7 @@ export default class NodePath {
     this.hub = hub;
     this.contexts = [];
     this.data = null;
-    // shouldSkip = false && shouldStop = false && removed = false
+    // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
     this._traverseFlags = 0;
     this.state = null;
     this.opts = null;

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -23,15 +23,18 @@ import * as NodePath_comments from "./comments";
 
 const debug = buildDebug("babel");
 
+export const REMOVED = 1 << 0;
+export const SHOULD_STOP = 1 << 1;
+export const SHOULD_SKIP = 1 << 2;
+
 export default class NodePath {
   constructor(hub: HubInterface, parent: Object) {
     this.parent = parent;
     this.hub = hub;
     this.contexts = [];
     this.data = Object.create(null);
-    this.shouldSkip = false;
-    this.shouldStop = false;
-    this.removed = false;
+    // shouldSkip = false && shouldStop = false && removed = false
+    this._traverseFlags = 0;
     this.state = null;
     this.opts = null;
     this.skipKeys = null;
@@ -55,6 +58,7 @@ export default class NodePath {
   removed: boolean;
   state: any;
   opts: ?Object;
+  _traverseFlags: number;
   skipKeys: ?Object;
   parentPath: ?NodePath;
   context: TraversalContext;
@@ -155,6 +159,41 @@ export default class NodePath {
 
   get parentKey() {
     return this.listKey || this.key;
+  }
+
+  get shouldSkip() {
+    return !!(this._traverseFlags & SHOULD_SKIP);
+  }
+
+  set shouldSkip(v) {
+    if (v) {
+      this._traverseFlags |= SHOULD_SKIP;
+    } else {
+      this._traverseFlags &= ~SHOULD_SKIP;
+    }
+  }
+
+  get shouldStop() {
+    return !!(this._traverseFlags & SHOULD_STOP);
+  }
+
+  set shouldStop(v) {
+    if (v) {
+      this._traverseFlags |= SHOULD_STOP;
+    } else {
+      this._traverseFlags &= ~SHOULD_STOP;
+    }
+  }
+
+  get removed() {
+    return !!(this._traverseFlags & REMOVED);
+  }
+  set removed(v) {
+    if (v) {
+      this._traverseFlags |= REMOVED;
+    } else {
+      this._traverseFlags &= ~REMOVED;
+    }
   }
 }
 

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -46,7 +46,6 @@ export default class NodePath {
     this.node = null;
     this.scope = null;
     this.type = null;
-    this.typeAnnotation = null;
   }
 
   parent: Object;
@@ -68,7 +67,6 @@ export default class NodePath {
   node: ?Object;
   scope: Scope;
   type: ?string;
-  typeAnnotation: ?Object;
 
   static get({ hub, parentPath, parent, container, listKey, key }): NodePath {
     if (!hub && parentPath) {

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -39,7 +39,6 @@ export default class NodePath {
     this.context = null;
     this.container = null;
     this.listKey = null;
-    this.parentKey = null;
     this.key = null;
     this.node = null;
     this.scope = null;
@@ -61,7 +60,6 @@ export default class NodePath {
   context: TraversalContext;
   container: ?Object | Array<Object>;
   listKey: ?string;
-  parentKey: ?string;
   key: ?string;
   node: ?Object;
   scope: Scope;
@@ -153,6 +151,10 @@ export default class NodePath {
 
   get inList() {
     return !!this.listKey;
+  }
+
+  get parentKey() {
+    return this.listKey || this.key;
   }
 }
 

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -32,7 +32,7 @@ export default class NodePath {
     this.parent = parent;
     this.hub = hub;
     this.contexts = [];
-    this.data = Object.create(null);
+    this.data = null;
     // shouldSkip = false && shouldStop = false && removed = false
     this._traverseFlags = 0;
     this.state = null;
@@ -111,10 +111,16 @@ export default class NodePath {
   }
 
   setData(key: string, val: any): any {
+    if (this.data == null) {
+      this.data = Object.create(null);
+    }
     return (this.data[key] = val);
   }
 
   getData(key: string, def?: any): any {
+    if (this.data == null) {
+      this.data = Object.create(null);
+    }
     let val = this.data[key];
     if (val === undefined && def !== undefined) val = this.data[key] = def;
     return val;

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -39,7 +39,6 @@ export default class NodePath {
     this.context = null;
     this.container = null;
     this.listKey = null;
-    this.inList = false;
     this.parentKey = null;
     this.key = null;
     this.node = null;
@@ -62,7 +61,6 @@ export default class NodePath {
   context: TraversalContext;
   container: ?Object | Array<Object>;
   listKey: ?string;
-  inList: boolean;
   parentKey: ?string;
   key: ?string;
   node: ?Object;
@@ -151,6 +149,10 @@ export default class NodePath {
 
   toString() {
     return generator(this.node).code;
+  }
+
+  get inList() {
+    return !!this.listKey;
   }
 }
 

--- a/packages/babel-traverse/src/path/removal.js
+++ b/packages/babel-traverse/src/path/removal.js
@@ -1,6 +1,7 @@
 // This file contains methods responsible for removing a node.
 
 import { hooks } from "./lib/removal-hooks";
+import { REMOVED, SHOULD_SKIP } from "./index";
 
 export function remove() {
   this._assertUnremoved();
@@ -39,8 +40,7 @@ export function _remove() {
 }
 
 export function _markRemoved() {
-  this.shouldSkip = true;
-  this.removed = true;
+  this._traverseFlags |= SHOULD_SKIP | REMOVED;
   this.node = null;
 }
 

--- a/packages/babel-traverse/src/path/removal.js
+++ b/packages/babel-traverse/src/path/removal.js
@@ -40,6 +40,7 @@ export function _remove() {
 }
 
 export function _markRemoved() {
+  // this.shouldSkip = true; this.removed = true;
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
   this.node = null;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Minor: Bug Fix? | 👍
| Major: Breaking Change?  | No if one is using public API.
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In this PR we improve the performance of babel-traverse by revising the memory layout of `NodePath`. It results to 10% performance gain compared to the control branch on the following test cases.

```js
const babel = require("/path/to/local/babel-core");
const code = require("fs").readFileSync("./fixtures/es5/babylon-dist.js");
babel.transform(code, { preset: ["@babel/env"] });
```

I can observe this branch outperforms control branch consistently.
```
┌─────────────────────┬──────────────────────────────┐
│ fixture             │ devTransform                 │
├─────────────────────┼──────────────────────────────┤
│ es5/babylon-dist.js │ 1.02 ops/sec ±31.84% (978ms) │
└─────────────────────┴──────────────────────────────┘
┌─────────────────────┬───────────────────────────────┐
│ fixture             │ baseTransform                 │
├─────────────────────┼───────────────────────────────┤
│ es5/babylon-dist.js │ 0.86 ops/sec ±20.52% (1167ms) │
└─────────────────────┴───────────────────────────────┘

```

And the memory usage improvements due to compressing traverse flags and adding accessor methods for `inList` and `parentPath`.
```
┌─────────────────────┬──────────────────┐
│ fixture             │ devTransform x5  │
├─────────────────────┼──────────────────┤
│ es5/babylon-dist.js │ heap: 239.37 MiB │
└─────────────────────┴──────────────────┘
┌─────────────────────┬──────────────────┐
│ fixture             │ baseTransform x5 │
├─────────────────────┼──────────────────┤
│ es5/babylon-dist.js │ heap: 305.47 MiB │
└─────────────────────┴──────────────────┘
```

The following changes are implemented:
- Removed `NodePath.inList` data property, a get accessor is provided for backward compatibility (partially). 
- Removed `NodePath.parentKey` data property, a get accessor is provided for backward compatibility (partially). 
- Removed `NodePath.typeAnnotation` data property, it is introduced in #1752 but since then it is not used by any routines. I believe it is a mistype of `Node.typeAnnotation`.
- Compressed `NodePath.shouldSkip/shouldStop/removed` into `_traverseFlags` bit array, both get accessor and set accessor is provided for backward compatibility.
- Lazily assign `this.skipKeys` in `setContext`.
- Lazily initialize `this.data` in `NodePath.constructor`.

In practice `inList` and `parentKey` should be treated as read-only since these two properties are rewritten in `setContext`. The current behavior accepts one assigning these two properties.

The `shouldSkip/shouldStop/removed` traverse flags are handy and turbofan would inline these simple accessors we don't introduce performance overhead here. By compressing these states into bit array we optimize the performance of `setContext`.