### PR TITLE
[parser] Add support for private fields in TypeScript

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -2021,12 +2021,15 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     parseClassPrivateProperty(
       node: N.ClassPrivateProperty,
     ): N.ClassPrivateProperty {
+      // $FlowIgnore
       if (node.abstract) {
         this.raise(
           node.start,
           "Private elements cannot have the 'abstract' modifier.",
         );
       }
+
+      // $FlowIgnore
       if (node.accessibility) {
         this.raise(
           node.start,

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -762,7 +762,14 @@ export type ClassPrivateProperty = NodeBase & {
   value: ?Expression, // TODO: Not in spec that this is nullable.
   static: boolean,
   computed: false,
-  typeAnnotation?: ?TypeAnnotation, // TODO: Not in spec
+
+  // Flow and Typescript
+  typeAnnotation?: ?TypeAnnotationBase,
+
+  // TypeScript only
+  optional?: true,
+  definite?: true,
+  readonly?: true,
 };
 
 export type OptClassDeclaration = ClassBase &

--- a/packages/babel-parser/test/fixtures/typescript/class/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "plugins": ["typescript", "classProperties"]
+  "plugins": ["typescript", "classProperties", "classPrivateProperties"]
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-abstract/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-abstract/input.ts
@@ -1,0 +1,3 @@
+abstract class A {
+  abstract #a;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-abstract/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-abstract/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Private elements cannot have the 'abstract' modifier. (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-private/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-private/input.ts
@@ -1,0 +1,3 @@
+class A {
+  private #a;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-private/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-private/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Private elements cannot have an accessibility modifier ('private') (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-protected/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-protected/input.ts
@@ -1,0 +1,3 @@
+class A {
+  protected #a;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-protected/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-protected/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Private elements cannot have an accessibility modifier ('protected') (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-public/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-public/input.ts
@@ -1,0 +1,3 @@
+class A {
+  public #a;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-public/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-public/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Private elements cannot have an accessibility modifier ('public') (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-readonly/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-readonly/input.ts
@@ -1,0 +1,4 @@
+class A {
+  readonly #a;
+  readonly #b: string;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-readonly/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-readonly/output.json
@@ -1,0 +1,215 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 49,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 49,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 49,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 49,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 14
+                }
+              },
+              "readonly": true,
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 21,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 13
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 22,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 13
+                    },
+                    "identifierName": "a"
+                  },
+                  "name": "a"
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 27,
+              "end": 47,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 22
+                }
+              },
+              "readonly": true,
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 36,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 13
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 37,
+                  "end": 38,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 13
+                    },
+                    "identifierName": "b"
+                  },
+                  "name": "b"
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 38,
+                "end": 46,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 40,
+                  "end": 46,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 21
+                    }
+                  }
+                }
+              },
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-static/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-static/input.ts
@@ -1,0 +1,4 @@
+class A {
+  static #x;
+  static #y: string;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields-static/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields-static/output.json
@@ -1,0 +1,213 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 45,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 45,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 45,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 45,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassPrivateProperty",
+              "start": 12,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 12
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "PrivateName",
+                "start": 19,
+                "end": 21,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 20,
+                  "end": 21,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start": 25,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 20
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "PrivateName",
+                "start": 32,
+                "end": 34,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 11
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 33,
+                  "end": 34,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 11
+                    },
+                    "identifierName": "y"
+                  },
+                  "name": "y"
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 34,
+                "end": 42,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 36,
+                  "end": 42,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts
@@ -1,0 +1,7 @@
+class A {
+  #a: string;
+  #b?;
+  #c?: number;
+  #d!;
+  #e!: boolean;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/private-fields/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/private-fields/output.json
@@ -1,0 +1,424 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 70,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 70,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 70,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 70,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 7,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassPrivateProperty",
+              "start": 12,
+              "end": 23,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 13
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 12,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 4
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 13,
+                  "end": 14,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 4
+                    },
+                    "identifierName": "a"
+                  },
+                  "name": "a"
+                }
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 14,
+                "end": 22,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 16,
+                  "end": 22,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 6
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 12
+                    }
+                  }
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start": 26,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 6
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 26,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 4
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 27,
+                  "end": 28,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 4
+                    },
+                    "identifierName": "b"
+                  },
+                  "name": "b"
+                }
+              },
+              "optional": true,
+              "value": null
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start": 33,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 14
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 33,
+                "end": 35,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 4
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 34,
+                  "end": 35,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 4
+                    },
+                    "identifierName": "c"
+                  },
+                  "name": "c"
+                }
+              },
+              "optional": true,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 36,
+                "end": 44,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 13
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSNumberKeyword",
+                  "start": 38,
+                  "end": 44,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 13
+                    }
+                  }
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start": 48,
+              "end": 52,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 6
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 48,
+                "end": 50,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 4
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 49,
+                  "end": 50,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "identifierName": "d"
+                  },
+                  "name": "d"
+                }
+              },
+              "definite": true,
+              "value": null
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start": 55,
+              "end": 68,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 2
+                },
+                "end": {
+                  "line": 6,
+                  "column": 15
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 55,
+                "end": 57,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 4
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 56,
+                  "end": 57,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 4
+                    },
+                    "identifierName": "e"
+                  },
+                  "name": "e"
+                }
+              },
+              "definite": true,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 58,
+                "end": 67,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 14
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSBooleanKeyword",
+                  "start": 60,
+                  "end": 67,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 14
+                    }
+                  }
+                }
+              },
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This implements https://github.com/microsoft/TypeScript/pull/30829 / https://github.com/microsoft/TypeScript/pull/33509. This PR also supports parsing static fields, which is not suppoerted by the TypeScript PR yet.

cc @babel/typescript 