### PR TITLE
[parser] Add support for TS declare modifier on fields

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -127,12 +127,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return undefined;
     }
 
-    tsParseModifiers<T: TsModifier>(allowedModifiers: T[]): { [*]: true } {
-      const modifiers = {};
+    tsParseModifiers<T: TsModifier>(
+      allowedModifiers: T[],
+    ): { [key: TsModifier]: ?true, __proto__: null } {
+      const modifiers = Object.create(null);
 
       while (true) {
         const startPos = this.state.start;
-        const modifier = this.tsParseModifier(allowedModifiers);
+        const modifier: ?T = this.tsParseModifier(allowedModifiers);
 
         if (!modifier) break;
 

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -127,6 +127,11 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return undefined;
     }
 
+    /** Parses a list of modifiers, in any order.
+     *  If you need a specific order, you must call this function multiple times:
+     *    this.tsParseModifiers(["public"]);
+     *    this.tsParseModifiers(["abstract", "readonly"]);
+     */
     tsParseModifiers<T: TsModifier>(
       allowedModifiers: T[],
     ): { [key: TsModifier]: ?true, __proto__: null } {

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+/*:: declare var invariant; */
+
 import type { TokenType } from "../../tokenizer/types";
 import { types as tt } from "../../tokenizer/types";
 import { types as ct } from "../../tokenizer/context";
@@ -23,6 +25,7 @@ import TypeScriptScopeHandler from "./scope";
 type TsModifier =
   | "readonly"
   | "abstract"
+  | "declare"
   | "static"
   | "public"
   | "private"
@@ -122,6 +125,24 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         return modifier;
       }
       return undefined;
+    }
+
+    tsParseModifiers<T: TsModifier>(allowedModifiers: T[]): { [*]: true } {
+      const modifiers = {};
+
+      while (true) {
+        const startPos = this.state.start;
+        const modifier = this.tsParseModifier(allowedModifiers);
+
+        if (!modifier) break;
+
+        if (Object.hasOwnProperty.call(modifiers, modifier)) {
+          this.raise(startPos, `Duplicate modifier: '${modifier}'`);
+        }
+        modifiers[modifier] = true;
+      }
+
+      return modifiers;
     }
 
     tsIsListTerminator(kind: ParsingContext): boolean {
@@ -398,7 +419,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.eat(tt.name) && this.match(tt.colon);
     }
 
-    tsTryParseIndexSignature(node: N.TsIndexSignature): ?N.TsIndexSignature {
+    tsTryParseIndexSignature(node: N.Node): ?N.TsIndexSignature {
       if (
         !(
           this.match(tt.bracketL) &&
@@ -1801,49 +1822,48 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
     parseClassMemberWithIsStatic(
       classBody: N.ClassBody,
-      member: any,
+      member: N.ClassMember | N.TsIndexSignature,
       state: { hadConstructor: boolean },
       isStatic: boolean,
       constructorAllowsSuper: boolean,
     ): void {
-      const methodOrProp: N.ClassMethod | N.ClassProperty = member;
-      const prop: N.ClassProperty = member;
-      const propOrIdx: N.ClassProperty | N.TsIndexSignature = member;
+      const modifiers = this.tsParseModifiers([
+        "abstract",
+        "readonly",
+        "declare",
+      ]);
 
-      let abstract = false,
-        readonly = false;
+      Object.assign(member, modifiers);
 
-      const mod = this.tsParseModifier(["abstract", "readonly"]);
-      switch (mod) {
-        case "readonly":
-          readonly = true;
-          abstract = !!this.tsParseModifier(["abstract"]);
-          break;
-        case "abstract":
-          abstract = true;
-          readonly = !!this.tsParseModifier(["readonly"]);
-          break;
-      }
+      const idx = this.tsTryParseIndexSignature(member);
+      if (idx) {
+        classBody.body.push(idx);
 
-      if (abstract) methodOrProp.abstract = true;
-      if (readonly) propOrIdx.readonly = true;
-
-      if (!abstract && !isStatic && !methodOrProp.accessibility) {
-        const idx = this.tsTryParseIndexSignature(member);
-        if (idx) {
-          classBody.body.push(idx);
-          return;
+        if (modifiers.abstract) {
+          this.raise(
+            member.start,
+            "Index signatures cannot have the 'abstract' modifier",
+          );
         }
-      }
+        if (isStatic) {
+          this.raise(
+            member.start,
+            "Index signatures cannot have the 'static' modifier",
+          );
+        }
+        if ((member: any).accessibility) {
+          this.raise(
+            member.start,
+            `Index signatures cannot have an accessibility modifier ('${
+              (member: any).accessibility
+            }')`,
+          );
+        }
 
-      if (readonly) {
-        // Must be a property (if not an index signature).
-        methodOrProp.static = isStatic;
-        this.parseClassPropertyName(prop);
-        this.parsePostMemberNameModifiers(methodOrProp);
-        this.pushClassProperty(classBody, prop);
         return;
       }
+
+      /*:: invariant(member.type !== "TSIndexSignature") */
 
       super.parseClassMemberWithIsStatic(
         classBody,
@@ -1859,6 +1879,20 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): void {
       const optional = this.eat(tt.question);
       if (optional) methodOrProp.optional = true;
+
+      if ((methodOrProp: any).readonly && this.match(tt.parenL)) {
+        this.raise(
+          methodOrProp.start,
+          "Class methods cannot have the 'readonly' modifier",
+        );
+      }
+
+      if ((methodOrProp: any).declare && this.match(tt.parenL)) {
+        this.raise(
+          methodOrProp.start,
+          "Class methods cannot have the 'declare' modifier",
+        );
+      }
     }
 
     // Note: The reason we do this in `parseExpressionStatement` and not `parseStatement`
@@ -2001,6 +2035,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
 
       const type = this.tsTryParseTypeAnnotation();
       if (type) node.typeAnnotation = type;
+
+      if (node.declare && this.match(tt.equal)) {
+        this.raise(
+          this.state.start,
+          "'declare' class fields cannot have an initializer",
+        );
+      }
+
       return super.parseClassProperty(node);
     }
 

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -743,18 +743,19 @@ export type ClassPrivateMethod = NodeBase &
     computed: false,
   };
 
-export type ClassProperty = ClassMemberBase & {
-  type: "ClassProperty",
-  key: Expression,
-  value: ?Expression, // TODO: Not in spec that this is nullable.
+export type ClassProperty = ClassMemberBase &
+  DeclarationBase & {
+    type: "ClassProperty",
+    key: Expression,
+    value: ?Expression, // TODO: Not in spec that this is nullable.
 
-  typeAnnotation?: ?TypeAnnotationBase, // TODO: Not in spec
-  variance?: ?FlowVariance, // TODO: Not in spec
+    typeAnnotation?: ?TypeAnnotationBase, // TODO: Not in spec
+    variance?: ?FlowVariance, // TODO: Not in spec
 
-  // TypeScript only: (TODO: Not in spec)
-  readonly?: true,
-  definite?: true,
-};
+    // TypeScript only: (TODO: Not in spec)
+    readonly?: true,
+    definite?: true,
+  };
 
 export type ClassPrivateProperty = NodeBase & {
   type: "ClassPrivateProperty",

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-field-initializer/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-field-initializer/input.ts
@@ -1,0 +1,3 @@
+class A {
+  declare bar: string = "test";
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-field-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-field-initializer/output.json
@@ -1,0 +1,170 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 43,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 43,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 43,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 43,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 41,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 31
+                }
+              },
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 20,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 13
+                  },
+                  "identifierName": "bar"
+                },
+                "name": "bar"
+              },
+              "computed": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 23,
+                "end": 31,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 25,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 21
+                    }
+                  }
+                }
+              },
+              "value": {
+                "type": "StringLiteral",
+                "start": 34,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 30
+                  }
+                },
+                "extra": {
+                  "rawValue": "test",
+                  "raw": "\"test\""
+                },
+                "value": "test"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-field/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-field/input.ts
@@ -1,0 +1,4 @@
+class A {
+  declare foo;
+  declare bar: string;
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-field/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-field/output.json
@@ -1,0 +1,187 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 49,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 49,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 49,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 49,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 14
+                }
+              },
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 20,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 13
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 27,
+              "end": 47,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 22
+                }
+              },
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 35,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 13
+                  },
+                  "identifierName": "bar"
+                },
+                "name": "bar"
+              },
+              "computed": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 38,
+                "end": 46,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 40,
+                  "end": 46,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 21
+                    }
+                  }
+                }
+              },
+              "value": null
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-method/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-method/input.ts
@@ -1,0 +1,3 @@
+class A {
+  declare foo() {}
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/declare-method/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/declare-method/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Class methods cannot have the 'declare' modifier (2:2)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/method-readonly/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/method-readonly/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token, expected \";\" (2:14)"
+  "throws": "Class methods cannot have the 'readonly' modifier (2:4)"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Ref: https://github.com/microsoft/TypeScript/pull/33401

I also updated the parser to generate more useful errors when a class member has a disallowed modifier (e.g. `readonly method() {}`) 

cc @babel/typescript 