### PR TITLE
chore: add access: public to babel parser publish config

### DIFF
--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "publishConfig": {
-    "tag": "next"
+    "access": "public"
   },
   "keywords": [
     "babel",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | babel-parser publish [issues](https://babeljs.slack.com/archives/C0DFJT81H/p1569285761154600?thread_ts=1569285293.154500&cid=C0DFJT81H)
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we unify the publish config of babel-parser with other packages. This change is a follow up to #8573. The `next` tag was introduced at #6982 when `babylon` is not scoped yet. Apparently the `next` tag should be removed now.