### PR TITLE
Template literal validation

### DIFF
--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -568,6 +568,16 @@ defineType("TemplateLiteral", {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("TemplateElement")),
+        function(node, key, val) {
+          if (val.length !== node.expressions.length + 1) {
+            throw new TypeError(
+              `Length of ${
+                node.type
+              } ${key} should be exactly one more than the number of expressions.\nExpected ${node
+                .expressions.length + 1} ${key} but got ${val.length}`,
+            );
+          }
+        },
       ),
     },
     expressions: {

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -568,25 +568,22 @@ defineType("TemplateLiteral", {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("TemplateElement")),
-        function(node, key, val) {
-          if (
-            Array.isArray(node.expressions) &&
-            val.length !== node.expressions.length + 1
-          ) {
-            throw new TypeError(
-              `Length of ${
-                node.type
-              } ${key} should be exactly one more than the number of expressions.\nExpected ${node
-                .expressions.length + 1} ${key} but got ${val.length}`,
-            );
-          }
-        },
       ),
     },
     expressions: {
       validate: chain(
         assertValueType("array"),
         assertEach(assertNodeType("Expression")),
+        function(node, key, val) {
+          if (node.quasis.length !== val.length + 1) {
+            throw new TypeError(
+              `Number of ${
+                node.type
+              } quasis should be exactly one more than the number of expressions.\nExpected ${val.length +
+                1} quasis but got ${node.quasis.length}`,
+            );
+          }
+        },
       ),
     },
   },

--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -569,7 +569,10 @@ defineType("TemplateLiteral", {
         assertValueType("array"),
         assertEach(assertNodeType("TemplateElement")),
         function(node, key, val) {
-          if (val.length !== node.expressions.length + 1) {
+          if (
+            Array.isArray(node.expressions) &&
+            val.length !== node.expressions.length + 1
+          ) {
             throw new TypeError(
               `Length of ${
                 node.type

--- a/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
+++ b/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
@@ -36,17 +36,57 @@ exports[`builders es2015 templateElement should validate 5`] = `
 Property raw expected type of string but got undefined"
 `;
 
-exports[`builders es2015 templateLiteral should validate 1`] = `[Function]`;
+exports[`builders es2015 templateLiteral should validate 1`] = `
+Object {
+  "expressions": Array [],
+  "quasis": Array [
+    Object {
+      "tail": false,
+      "type": "TemplateElement",
+      "value": Object {
+        "raw": "foo",
+      },
+    },
+  ],
+  "type": "TemplateLiteral",
+}
+`;
 
-exports[`builders es2015 templateLiteral should validate 2`] = `[Function]`;
+exports[`builders es2015 templateLiteral should validate 2`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "type": "StringLiteral",
+      "value": "baz",
+    },
+  ],
+  "quasis": Array [
+    Object {
+      "tail": false,
+      "type": "TemplateElement",
+      "value": Object {
+        "raw": "foo",
+      },
+    },
+    Object {
+      "tail": false,
+      "type": "TemplateElement",
+      "value": Object {
+        "raw": "bar",
+      },
+    },
+  ],
+  "type": "TemplateLiteral",
+}
+`;
 
 exports[`builders es2015 templateLiteral should validate 3`] = `
-"Length of TemplateLiteral quasis should be exactly one more than the number of expressions.
+"Number of TemplateLiteral quasis should be exactly one more than the number of expressions.
 Expected 3 quasis but got 2"
 `;
 
 exports[`builders es2015 templateLiteral should validate 4`] = `
-"Length of TemplateLiteral quasis should be exactly one more than the number of expressions.
+"Number of TemplateLiteral quasis should be exactly one more than the number of expressions.
 Expected 1 quasis but got 2"
 `;
 

--- a/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
+++ b/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
@@ -35,3 +35,19 @@ exports[`builders es2015 templateElement should validate 5`] = `
 "Property value of TemplateElement expected to have the following:
 Property raw expected type of string but got undefined"
 `;
+
+exports[`builders es2015 templateLiteral should validate 1`] = `[Function]`;
+
+exports[`builders es2015 templateLiteral should validate 2`] = `[Function]`;
+
+exports[`builders es2015 templateLiteral should validate 3`] = `
+"Length of TemplateLiteral quasis should be exactly one more than the number of expressions.
+Expected 3 quasis but got 2"
+`;
+
+exports[`builders es2015 templateLiteral should validate 4`] = `
+"Length of TemplateLiteral quasis should be exactly one more than the number of expressions.
+Expected 1 quasis but got 2"
+`;
+
+exports[`builders es2015 templateLiteral should validate 5`] = `"Property quasis expected type of array but got object"`;

--- a/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
+++ b/packages/babel-types/test/builders/es2015/__snapshots__/templateElement.js.snap
@@ -51,3 +51,5 @@ Expected 1 quasis but got 2"
 `;
 
 exports[`builders es2015 templateLiteral should validate 5`] = `"Property quasis expected type of array but got object"`;
+
+exports[`builders es2015 templateLiteral should validate 6`] = `"Property expressions expected type of array but got null"`;

--- a/packages/babel-types/test/builders/es2015/templateElement.js
+++ b/packages/babel-types/test/builders/es2015/templateElement.js
@@ -41,6 +41,10 @@ describe("builders", function() {
         expect(() =>
           t.templateLiteral({}, ["baz"]),
         ).toThrowErrorMatchingSnapshot();
+
+        expect(() =>
+          t.templateLiteral([foo, bar]),
+        ).toThrowErrorMatchingSnapshot();
       });
     });
   });

--- a/packages/babel-types/test/builders/es2015/templateElement.js
+++ b/packages/babel-types/test/builders/es2015/templateElement.js
@@ -26,12 +26,15 @@ describe("builders", function() {
         const foo = t.templateElement({ raw: "foo" });
         const bar = t.templateElement({ raw: "bar" });
 
-        expect(() => t.templateLiteral([foo], [])).toMatchSnapshot();
+        const baz = t.stringLiteral("baz");
+        const qux = t.stringLiteral("qux");
 
-        expect(() => t.templateLiteral([foo, bar], ["baz"])).toMatchSnapshot();
+        expect(t.templateLiteral([foo], [])).toMatchSnapshot();
+
+        expect(t.templateLiteral([foo, bar], [baz])).toMatchSnapshot();
 
         expect(() =>
-          t.templateLiteral([foo, bar], ["baz", "qux"]),
+          t.templateLiteral([foo, bar], [baz, qux]),
         ).toThrowErrorMatchingSnapshot();
 
         expect(() =>
@@ -39,7 +42,7 @@ describe("builders", function() {
         ).toThrowErrorMatchingSnapshot();
 
         expect(() =>
-          t.templateLiteral({}, ["baz"]),
+          t.templateLiteral({}, [baz]),
         ).toThrowErrorMatchingSnapshot();
 
         expect(() =>

--- a/packages/babel-types/test/builders/es2015/templateElement.js
+++ b/packages/babel-types/test/builders/es2015/templateElement.js
@@ -21,5 +21,27 @@ describe("builders", function() {
         expect(() => t.templateElement("foo")).toThrowErrorMatchingSnapshot();
       });
     });
+    describe("templateLiteral", function() {
+      it("should validate", function() {
+        const foo = t.templateElement({ raw: "foo" });
+        const bar = t.templateElement({ raw: "bar" });
+
+        expect(() => t.templateLiteral([foo], [])).toMatchSnapshot();
+
+        expect(() => t.templateLiteral([foo, bar], ["baz"])).toMatchSnapshot();
+
+        expect(() =>
+          t.templateLiteral([foo, bar], ["baz", "qux"]),
+        ).toThrowErrorMatchingSnapshot();
+
+        expect(() =>
+          t.templateLiteral([foo, bar], []),
+        ).toThrowErrorMatchingSnapshot();
+
+        expect(() =>
+          t.templateLiteral({}, ["baz"]),
+        ).toThrowErrorMatchingSnapshot();
+      });
+    });
   });
 });


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/10486
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

I added a custom validation rule to the definition of `TemplateLiteral` in `packages\babel-types\test\builders\es2015\templateElement.js` to check that the number of quasis is exactly one more than the number of expressions.

I'm open to suggestions about the wording of the TypeError. I based it off of the number of quasis based off the wording of the issue, but I'm not sure if it needs to be in more layman's terms or more generalized or not.