### PR TITLE
Add support for babel.config.json

### DIFF
--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -19,6 +19,11 @@ import type { CallerMetadata } from "../validation/options";
 const debug = buildDebug("babel:config:loading:files:configuration");
 
 const BABEL_CONFIG_JS_FILENAME = "babel.config.js";
+const BABEL_CONFIG_JSON_FILENAME = "babel.config.json";
+const ROOT_CONFIG_FILENAMES = [
+  BABEL_CONFIG_JS_FILENAME,
+  BABEL_CONFIG_JSON_FILENAME,
+];
 
 const BABELRC_FILENAME = ".babelrc";
 const BABELRC_JS_FILENAME = ".babelrc.js";
@@ -27,7 +32,10 @@ const BABELIGNORE_FILENAME = ".babelignore";
 export function findConfigUpwards(rootDir: string): string | null {
   let dirname = rootDir;
   while (true) {
-    if (fs.existsSync(path.join(dirname, BABEL_CONFIG_JS_FILENAME))) {
+    if (
+      fs.existsSync(path.join(dirname, BABEL_CONFIG_JS_FILENAME)) ||
+      fs.existsSync(path.join(dirname, BABEL_CONFIG_JSON_FILENAME))
+    ) {
       return dirname;
     }
 
@@ -110,11 +118,15 @@ export function findRootConfig(
   envName: string,
   caller: CallerMetadata | void,
 ): ConfigFile | null {
-  const filepath = path.resolve(dirname, BABEL_CONFIG_JS_FILENAME);
+  let conf = null;
+  for (const filename of ROOT_CONFIG_FILENAMES) {
+    const filepath = path.resolve(dirname, filename);
 
-  const conf = readConfig(filepath, envName, caller);
-  if (conf) {
-    debug("Found root config %o in %o.", BABEL_CONFIG_JS_FILENAME, dirname);
+    conf = readConfig(filepath, envName, caller);
+    if (conf) {
+      debug("Found root config %o in %o.", filename, dirname);
+      break;
+    }
   }
   return conf;
 }

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -944,6 +944,52 @@ describe("buildConfigChain", function() {
       }
     });
 
+    it("should load babel.config.json", () => {
+      const filename = fixture("config-files", "babel-config-json", "src.js");
+
+      expect(
+        loadOptions({
+          filename,
+          cwd: path.dirname(filename),
+        }),
+      ).toEqual({
+        ...getDefaults(),
+        filename: filename,
+        cwd: path.dirname(filename),
+        root: path.dirname(filename),
+        comments: true,
+      });
+    });
+
+    it("should load babel.config.js", () => {
+      const filename = fixture("config-files", "babel-config-js", "src.js");
+
+      expect(
+        loadOptions({
+          filename,
+          cwd: path.dirname(filename),
+        }),
+      ).toEqual({
+        ...getDefaults(),
+        filename: filename,
+        cwd: path.dirname(filename),
+        root: path.dirname(filename),
+        comments: true,
+      });
+    });
+
+    it("should whtow if both babel.config.json and babel.config.js are used", () => {
+      const filename = fixture(
+        "config-files",
+        "babel-config-js-and-json",
+        "src.js",
+      );
+
+      expect(() =>
+        loadOptions({ filename, cwd: path.dirname(filename) }),
+      ).toThrow(/Multiple configuration files found/);
+    });
+
     it("should load .babelrc", () => {
       const filename = fixture("config-files", "babelrc", "src.js");
 

--- a/packages/babel-core/test/fixtures/config/config-files/babel-config-js-and-json/babel.config.js
+++ b/packages/babel-core/test/fixtures/config/config-files/babel-config-js-and-json/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  comments: true
+};

--- a/packages/babel-core/test/fixtures/config/config-files/babel-config-js-and-json/babel.config.json
+++ b/packages/babel-core/test/fixtures/config/config-files/babel-config-js-and-json/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "comments": true
+}

--- a/packages/babel-core/test/fixtures/config/config-files/babel-config-js/babel.config.js
+++ b/packages/babel-core/test/fixtures/config/config-files/babel-config-js/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  comments: true
+};

--- a/packages/babel-core/test/fixtures/config/config-files/babel-config-json/babel.config.json
+++ b/packages/babel-core/test/fixtures/config/config-files/babel-config-json/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "comments": true
+}


### PR DESCRIPTION
Implements support for `babel.config.json` in addition to the existing `babel.config.js`. This allows root configuration to be static JSON, which has many benefits including better cacheability, easier linting, better autocomplete, and better upgrade tools. See #10495 for more details.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #10495 
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT