### PR TITLE
Use `make -j` for parallel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ matrix:
       env: JOB=lint
   # We test the latest version on circleci
     - node_js: "11"
-    - node_js: "10"
-  # Move `windows` build to be the fourth since it is slow
+  # Move `windows` build to be the third since it is slow
     - os: windows
       node_js: "node"
       env:
@@ -38,8 +37,9 @@ matrix:
       # https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9
       - YARN_GPG=no
   # Continue node_js matrix
-    - node_js: "8"
     - node_js: "6"
+    - node_js: "10"
+    - node_js: "8"
     - node_js: "node"
       env: JOB=babel-parser-flow-tests
     - node_js: "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,6 @@ cache:
 
 os: linux
 
-node_js:
-  # We test the latest version on circleci
-  - "11"
-  - "10"
-  - "8"
-  - "6"
-
 env:
   global:
     - PATH=$HOME/.yarn/bin:$PATH
@@ -21,33 +14,33 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
 
-install:
-  # the `make test-ci` script runs this command already
-  - if [ "$JOB" != "test" ] && [ "$JOB" != "lint" ]; then yarn install; fi
-  - if [ "$JOB" = "lint" ]; then make bootstrap; fi
-
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
-  - if [ "$JOB" = "babel-parser-flow-tests" ]; then make bootstrap-flow; fi
-  - if [ "$JOB" = "babel-parser-test262-tests" ]; then make bootstrap-test262; fi
 
 script:
-  - if [ "$JOB" = "test" ]; then make test-ci; fi
-  - if [ "$JOB" = "lint" ]; then make lint && make flow; fi
-  - if [ "$JOB" = "babel-parser-flow-tests" ]; then make test-flow-ci; fi
-  - if [ "$JOB" = "babel-parser-test262-tests" ]; then make test-test262-ci; fi
+  - if [ "$JOB" = "test" ]; then make -j test-ci; fi
+  - if [ "$JOB" = "lint" ]; then make -j code-quality-ci; fi
+  - if [ "$JOB" = "babel-parser-flow-tests" ]; then make -j test-flow-ci; fi
+  - if [ "$JOB" = "babel-parser-test262-tests" ]; then make -j test-test262-ci; fi
 
 matrix:
   fast_finish: true
   include:
+    - node_js: "node"
+      env: JOB=lint
+  # We test the latest version on circleci
+    - node_js: "11"
+    - node_js: "10"
+  # Move `windows` build to be the fourth since it is slow
     - os: windows
       node_js: "node"
       env:
       - JOB=test
       # https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9
       - YARN_GPG=no
-    - node_js: "node"
-      env: JOB=lint
+  # Continue node_js matrix
+    - node_js: "8"
+    - node_js: "6"
     - node_js: "node"
       env: JOB=babel-parser-flow-tests
     - node_js: "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ env:
     - PATH=$HOME/.yarn/bin:$PATH
     - JOB=test
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-
+install: skip
 before_script:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-MAKEFLAGS = -j1
 FLOW_COMMIT = 09669846b7a7ca5a6c23c12d56bb3bebdafd67e9
 TEST262_COMMIT = ce2dfd49d13740e995c96c34686d45c7960e628c
 
@@ -9,21 +8,42 @@ SOURCES = packages codemods
 
 .PHONY: build build-dist watch lint fix clean test-clean test-only test test-ci publish bootstrap
 
-build: clean clean-lib
-	yarn gulp build
-	node packages/babel-standalone/scripts/generate.js
-	node packages/babel-types/scripts/generateTypeHelpers.js
-	# call build again as the generated files might need to be compiled again.
-	yarn gulp build
-	# generate flow and typescript typings
-	node packages/babel-types/scripts/generators/flow.js > packages/babel-types/lib/index.js.flow
-	node packages/babel-types/scripts/generators/typescript.js > packages/babel-types/lib/index.d.ts
+build: build-bundle
 ifneq ("$(BABEL_COVERAGE)", "true")
-	make build-standalone
-	make build-preset-env-standalone
+	$(MAKE) build-standalone
 endif
 
-build-standalone:
+build-bundle: clean clean-lib
+	yarn gulp build
+	$(MAKE) generate-standalone generate-type-helpers
+	# call build again as the generated files might need to be compiled again.
+	yarn gulp build
+	$(MAKE) build-typings
+	$(MAKE) build-dist
+
+build-bundle-ci: bootstrap-only
+	$(MAKE) build-bundle
+
+generate-standalone:
+	node packages/babel-standalone/scripts/generate.js
+
+generate-type-helpers:
+	node packages/babel-types/scripts/generateTypeHelpers.js
+
+build-typings: build-flow-typings build-typescript-typings
+
+build-flow-typings:
+	node packages/babel-types/scripts/generators/flow.js > packages/babel-types/lib/index.js.flow
+
+build-typescript-typings:
+	node packages/babel-types/scripts/generators/typescript.js > packages/babel-types/lib/index.d.ts
+
+build-standalone: build-babel-standalone build-preset-env-standalone
+
+build-standalone-ci: build-bundle-ci
+	$(MAKE) build-standalone
+
+build-babel-standalone:
 	yarn gulp build-babel-standalone
 
 build-preset-env-standalone:
@@ -35,24 +55,47 @@ prepublish-build-standalone:
 prepublish-build-preset-env-standalone:
 	BABEL_ENV=production IS_PUBLISH=true yarn gulp build-babel-preset-env-standalone
 
-build-dist: build
+build-dist: build-polyfill-dist build-plugin-transform-runtime-dist
+
+build-polyfill-dist:
 	cd packages/babel-polyfill; \
-	scripts/build-dist.sh
+    scripts/build-dist.sh
+
+build-plugin-transform-runtime-dist:
 	cd packages/babel-plugin-transform-runtime; \
-	node scripts/build-dist.js
+    node scripts/build-dist.js
 
-watch: clean clean-lib
-
+build-no-bundle: clean clean-lib
+	BABEL_ENV=development yarn gulp build-no-bundle
 	# Ensure that build artifacts for types are created during local
 	# development too.
-	BABEL_ENV=development yarn gulp build-no-bundle
-	node packages/babel-types/scripts/generateTypeHelpers.js
-	node packages/babel-types/scripts/generators/flow.js > packages/babel-types/lib/index.js.flow
-	node packages/babel-types/scripts/generators/typescript.js > packages/babel-types/lib/index.d.ts
+	$(MAKE) generate-type-helpers
+	$(MAKE) build-typings
+
+watch: build-no-bundle
 	BABEL_ENV=development yarn gulp watch
+
+code-quality-ci: flowcheck-ci lint-ci
+
+flowcheck-ci: bootstrap-flowcheck
+	$(MAKE) flow
+
+code-quality: flow lint
 
 flow:
 	yarn flow check --strip-root
+
+bootstrap-flowcheck: bootstrap-only
+	yarn gulp build-babel-types
+	$(MAKE) build-typings
+
+lint-ci: lint-js-ci lint-ts-ci
+
+lint-js-ci: bootstrap-only
+	$(MAKE) lint-js
+
+lint-ts-ci: bootstrap-flowcheck
+	$(MAKE) lint-ts
 
 lint: lint-js lint-ts
 
@@ -62,7 +105,9 @@ lint-js:
 lint-ts:
 	scripts/tests/typescript/lint.sh
 
-fix: fix-json
+fix: fix-json fix-js
+
+fix-js:
 	yarn eslint scripts $(SOURCES) '*.js' --format=codeframe --fix
 
 fix-json:
@@ -82,18 +127,20 @@ test-clean:
 # Does not work on Windows; use "yarn jest" instead
 test-only:
 	BABEL_ENV=test ./scripts/test.sh
-	make test-clean
+	$(MAKE) test-clean
 
 test: lint test-only
 
-test-ci: bootstrap
+test-ci: jest-ci
+
+jest-ci: build-standalone-ci
 	BABEL_ENV=test yarn jest --maxWorkers=4 --ci
-	make test-clean
+	$(MAKE) test-clean
 
 # Does not work on Windows
 test-ci-coverage: SHELL:=/bin/bash
 test-ci-coverage:
-	BABEL_COVERAGE=true BABEL_ENV=test make bootstrap
+	BABEL_COVERAGE=true BABEL_ENV=test $(MAKE) bootstrap
 	BABEL_ENV=test TEST_TYPE=cov ./scripts/test-cov.sh
 	bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json
 
@@ -106,7 +153,8 @@ bootstrap-flow:
 test-flow:
 	node scripts/tests/flow/run_babel_parser_flow_tests.js
 
-test-flow-ci: bootstrap test-flow
+test-flow-ci: build-bundle-ci bootstrap-flow
+	$(MAKE) test-flow
 
 test-flow-update-whitelist:
 	node scripts/tests/flow/run_babel_parser_flow_tests.js --update-whitelist
@@ -117,10 +165,12 @@ bootstrap-test262:
 	git clone --branch=master --single-branch --shallow-since=2019-01-01 https://github.com/tc39/test262.git build/test262
 	cd build/test262 && git checkout $(TEST262_COMMIT)
 
+	
 test-test262:
 	node scripts/tests/test262/run_babel_parser_test262.js
 
-test-test262-ci: bootstrap test-test262
+test-test262-ci: build-bundle-ci bootstrap-test262
+	$(MAKE) test-test262
 
 test-test262-update-whitelist:
 	node scripts/tests/test262/run_babel_parser_test262.js --update-whitelist
@@ -129,18 +179,14 @@ test-test262-update-whitelist:
 clone-license:
 	./scripts/clone-license.sh
 
-prepublish-build:
-	make clean-lib
-	rm -rf packages/babel-runtime/helpers
-	rm -rf packages/babel-runtime-corejs2/helpers
-	rm -rf packages/babel-runtime-corejs2/core-js
-	NODE_ENV=production BABEL_ENV=production make build-dist
-	make clone-license
+prepublish-build: clean-lib clean-runtime-helpers
+	NODE_ENV=production BABEL_ENV=production $(MAKE) build-dist
+	$(MAKE) clone-license
 
 prepublish:
-	make bootstrap-only
-	make prepublish-build
-	make test
+	$(MAKE) bootstrap-only
+	$(MAKE) prepublish-build
+	$(MAKE) test
 
 new-version:
 	git pull --rebase
@@ -149,7 +195,7 @@ new-version:
 # NOTE: Run make new-version first
 publish: prepublish
 	yarn lerna publish from-git --require-scripts
-	make clean
+	$(MAKE) clean
 
 publish-ci: prepublish
 ifneq ("$(NPM_TOKEN)", "")
@@ -160,20 +206,27 @@ else
 endif
 	yarn lerna publish from-git --require-scripts --yes
 	rm -f .npmrc
-	make clean
+	$(MAKE) clean
 
-bootstrap-only: clean-all
+bootstrap-only: lerna-bootstrap
+
+yarn-install: clean-all
 	yarn --ignore-engines
+
+lerna-bootstrap: yarn-install
 	yarn lerna bootstrap -- --ignore-engines
 
 bootstrap: bootstrap-only
-	make build
-	cd packages/babel-plugin-transform-runtime; \
-	node scripts/build-dist.js
+	$(MAKE) build
 
 clean-lib:
 	$(foreach source, $(SOURCES), \
 		$(call clean-source-lib, $(source)))
+
+clean-runtime-helpers:
+	rm -rf packages/babel-runtime/helpers
+	rm -rf packages/babel-runtime-corejs2/helpers
+	rm -rf packages/babel-runtime-corejs2/core-js
 
 clean-all:
 	rm -rf node_modules
@@ -183,7 +236,7 @@ clean-all:
 	$(foreach source, $(SOURCES), \
 		$(call clean-source-all, $(source)))
 
-	make clean
+	$(MAKE) clean
 
 define clean-source-lib
 	rm -rf $(1)/*/lib

--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,11 @@ build-dist: build-polyfill-dist build-plugin-transform-runtime-dist
 
 build-polyfill-dist:
 	cd packages/babel-polyfill; \
-    scripts/build-dist.sh
+	scripts/build-dist.sh
 
 build-plugin-transform-runtime-dist:
 	cd packages/babel-plugin-transform-runtime; \
-    node scripts/build-dist.js
+	node scripts/build-dist.js
 
 build-no-bundle: clean clean-lib
 	BABEL_ENV=development yarn gulp build-no-bundle
@@ -165,7 +165,6 @@ bootstrap-test262:
 	git clone --branch=master --single-branch --shallow-since=2019-01-01 https://github.com/tc39/test262.git build/test262
 	cd build/test262 && git checkout $(TEST262_COMMIT)
 
-	
 test-test262:
 	node scripts/tests/test262/run_babel_parser_test262.js
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lerna-changelog": "^0.5.0",
     "lint-staged": "^9.2.0",
     "lodash": "^4.17.13",
-    "merge-stream": "^1.0.1",
     "output-file-sync": "^2.0.0",
     "prettier": "^1.17.1",
     "pump": "^3.0.0",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

This PR introduces general improvements to current build scripts. The following jobs have seen significant time reduce

| Travis Job | Control | Experiment |
| --- | --- | --- |
| lint | [4min 57s](https://travis-ci.com/babel/babel/jobs/239869697) | [3min 14s](https://travis-ci.com/JLHwung/babel/jobs/239949154) |
| parser-flow-test | [3min 38s](https://travis-ci.com/babel/babel/jobs/239869699) | [2min 28s](https://travis-ci.com/JLHwung/babel/jobs/239949161) |
| parser-test262-test | [3min 48s](https://travis-ci.com/babel/babel/jobs/239869700) | [2min 51s](https://travis-ci.com/JLHwung/babel/jobs/239949162) |

The following improvements are implemented:

- Provide `gulp build-babel-types` for `make lint`, so that `lint` does not have to build all babel packages.
- Remove `merge-stream` by refactoring `buildBabel`
- Introduce `make code-quality`: an umbrella rule (with parallelism) of `make lint && make flow`.
- Skip `make build-standalone` and `make build-preset-env-standalone` in `lint`, `parser-flow-test` and `parser-test262-test` jobs.
- Parallelize `make bootstrap-only` and `make bootstrap-flow` as they requests different services and writes to different destinations.
- Parallelize `make bootstrap-only` and `make bootstrap-test262` for the same reason above
- Parallelize `make build-standalone` and `make build-preset-env-standalone` as they writes to different destinations.
- Replace nested `make` call to `$(MAKE)` variable

Note that now the lint job will run first since it is less expensive than unit testing.

Other thoughts: I did a rough measure on travis: it will take 2 min for machine setup + yarn install + lerna bootstrap, even with yarn cache. Could we merge `lint`, `parser-flow-test` and `parser-test262-test` into one job so that we can remove machine setup overhead?