### PR TITLE
Prepare @babel/core for asynchronicity

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -183,6 +183,7 @@ function buildRollup(packages) {
               rollupCommonJs({
                 include: [
                   /node_modules/,
+                  "packages/babel-runtime/regenerator/**",
                   "packages/babel-preset-env/data/*.js",
                   // Rollup doesn't read export maps, so it loads the cjs fallback
                   "packages/babel-compat-data/*.js",

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const path = require("path");
-
 module.exports = function(api) {
   const env = api.env();
 
@@ -35,21 +33,19 @@ module.exports = function(api) {
 
   switch (env) {
     // Configs used during bundling builds.
-    case "rollup":
-      envOpts.targets = {
-        node: nodeVersion,
-      };
     case "standalone":
+      includeRegeneratorRuntime = true;
+      unambiguousSources.push("packages/babel-runtime/regenerator");
+    case "rollup":
       convertESM = false;
       ignoreLib = false;
-      includeRegeneratorRuntime = true;
       // rollup-commonjs will converts node_modules to ESM
       unambiguousSources.push(
         "**/node_modules",
         "packages/babel-preset-env/data",
         "packages/babel-compat-data"
       );
-      // targets to browserslists: defaults
+      if (env === "rollup") envOpts.targets = { node: nodeVersion };
       break;
     case "production":
       // Config during builds before publish.
@@ -77,7 +73,6 @@ module.exports = function(api) {
       helpers: false, // Helpers are handled by rollup when needed
       regenerator: true,
       version: require(babelRuntimePkgPath).version,
-      absoluteRuntime: path.dirname(babelRuntimePkgPath),
     };
   }
 

--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -4,6 +4,7 @@
 
 declare module "resolve" {
   declare export default {
+    (string, {| basedir: string |}, (err: ?Error, res: string) => void): void;
     sync: (string, {| basedir: string |}) => string;
   };
 }

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -49,6 +49,7 @@
     "@babel/types": "^7.7.4",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.0",
     "lodash": "^4.17.13",
     "resolve": "^1.3.2",

--- a/packages/babel-core/src/config/config-descriptors.js
+++ b/packages/babel-core/src/config/config-descriptors.js
@@ -5,8 +5,8 @@ import { loadPlugin, loadPreset } from "./files";
 import { getItemDescriptor } from "./item";
 
 import {
-  makeWeakCache,
-  makeStrongCache,
+  makeWeakCacheSync,
+  makeStrongCacheSync,
   type CacheConfigurator,
 } from "./caching";
 
@@ -130,11 +130,11 @@ export function createUncachedDescriptors(
 }
 
 const PRESET_DESCRIPTOR_CACHE = new WeakMap();
-const createCachedPresetDescriptors = makeWeakCache(
+const createCachedPresetDescriptors = makeWeakCacheSync(
   (items: PluginList, cache: CacheConfigurator<string>) => {
     const dirname = cache.using(dir => dir);
-    return makeStrongCache((alias: string) =>
-      makeStrongCache((passPerPreset: boolean) =>
+    return makeStrongCacheSync((alias: string) =>
+      makeStrongCacheSync((passPerPreset: boolean) =>
         createPresetDescriptors(items, dirname, alias, passPerPreset).map(
           // Items are cached using the overall preset array identity when
           // possibly, but individual descriptors are also cached if a match
@@ -147,10 +147,10 @@ const createCachedPresetDescriptors = makeWeakCache(
 );
 
 const PLUGIN_DESCRIPTOR_CACHE = new WeakMap();
-const createCachedPluginDescriptors = makeWeakCache(
+const createCachedPluginDescriptors = makeWeakCacheSync(
   (items: PluginList, cache: CacheConfigurator<string>) => {
     const dirname = cache.using(dir => dir);
-    return makeStrongCache((alias: string) =>
+    return makeStrongCacheSync((alias: string) =>
       createPluginDescriptors(items, dirname, alias).map(
         // Items are cached using the overall plugin array identity when
         // possibly, but individual descriptors are also cached if a match

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { Handler } from "gensync";
+
 import type {
   ConfigFile,
   IgnoreFile,
@@ -11,13 +13,15 @@ import type { CallerMetadata } from "../validation/options";
 
 export type { ConfigFile, IgnoreFile, RelativeConfig, FilePackageData };
 
-export function findConfigUpwards(
+// eslint-disable-next-line require-yield
+export function* findConfigUpwards(
   rootDir: string, // eslint-disable-line no-unused-vars
-): string | null {
+): Handler<string | null> {
   return null;
 }
 
-export function findPackageData(filepath: string): FilePackageData {
+// eslint-disable-next-line require-yield
+export function* findPackageData(filepath: string): Handler<FilePackageData> {
   return {
     filepath,
     directories: [],
@@ -26,28 +30,31 @@ export function findPackageData(filepath: string): FilePackageData {
   };
 }
 
-export function findRelativeConfig(
+// eslint-disable-next-line require-yield
+export function* findRelativeConfig(
   pkgData: FilePackageData, // eslint-disable-line no-unused-vars
   envName: string, // eslint-disable-line no-unused-vars
   caller: CallerMetadata | void, // eslint-disable-line no-unused-vars
-): RelativeConfig {
+): Handler<RelativeConfig> {
   return { pkg: null, config: null, ignore: null };
 }
 
-export function findRootConfig(
+// eslint-disable-next-line require-yield
+export function* findRootConfig(
   dirname: string, // eslint-disable-line no-unused-vars
   envName: string, // eslint-disable-line no-unused-vars
   caller: CallerMetadata | void, // eslint-disable-line no-unused-vars
-): ConfigFile | null {
+): Handler<ConfigFile | null> {
   return null;
 }
 
-export function loadConfig(
+// eslint-disable-next-line require-yield
+export function* loadConfig(
   name: string,
   dirname: string,
   envName: string, // eslint-disable-line no-unused-vars
   caller: CallerMetadata | void, // eslint-disable-line no-unused-vars
-): ConfigFile {
+): Handler<ConfigFile> {
   throw new Error(`Cannot load ${name} relative to ${dirname} in a browser`);
 }
 

--- a/packages/babel-core/src/config/files/package.js
+++ b/packages/babel-core/src/config/files/package.js
@@ -1,6 +1,7 @@
 // @flow
 
 import path from "path";
+import type { Handler } from "gensync";
 import { makeStaticFileCache } from "./utils";
 
 import type { ConfigFile, FilePackageData } from "./types";
@@ -12,7 +13,7 @@ const PACKAGE_FILENAME = "package.json";
  * of Babel's config requires general package information to decide when to
  * search for .babelrc files
  */
-export function findPackageData(filepath: string): FilePackageData {
+export function* findPackageData(filepath: string): Handler<FilePackageData> {
   let pkg = null;
   const directories = [];
   let isPackage = true;
@@ -21,7 +22,7 @@ export function findPackageData(filepath: string): FilePackageData {
   while (!pkg && path.basename(dirname) !== "node_modules") {
     directories.push(dirname);
 
-    pkg = readConfigPackage(path.join(dirname, PACKAGE_FILENAME));
+    pkg = yield* readConfigPackage(path.join(dirname, PACKAGE_FILENAME));
 
     const nextLoc = path.dirname(dirname);
     if (dirname === nextLoc) {

--- a/packages/babel-core/src/config/full.js
+++ b/packages/babel-core/src/config/full.js
@@ -1,5 +1,8 @@
 // @flow
 
+import gensync, { type Handler } from "gensync";
+import { forwardAsync } from "../gensync-utils/async";
+
 import { mergeOptions } from "./util";
 import * as context from "../index";
 import Plugin from "./plugin";
@@ -12,7 +15,11 @@ import {
 } from "./config-chain";
 import type { UnloadedDescriptor } from "./config-descriptors";
 import traverse from "@babel/traverse";
-import { makeWeakCache, type CacheConfigurator } from "./caching";
+import {
+  makeWeakCache,
+  makeWeakCacheSync,
+  type CacheConfigurator,
+} from "./caching";
 import { validate, type CallerMetadata } from "./validation/options";
 import { validatePluginObject } from "./validation/plugins";
 import makeAPI from "./helpers/config-api";
@@ -45,10 +52,10 @@ type SimpleContext = {
   caller: CallerMetadata | void,
 };
 
-export default function loadFullConfig(
+export default gensync<[any], ResolvedConfig | null>(function* loadFullConfig(
   inputOpts: mixed,
-): ResolvedConfig | null {
-  const result = loadPrivatePartialConfig(inputOpts);
+): Handler<ResolvedConfig | null> {
+  const result = yield* loadPrivatePartialConfig(inputOpts);
   if (!result) {
     return null;
   }
@@ -63,28 +70,29 @@ export default function loadFullConfig(
       throw new Error("Assertion failure - plugins and presets exist");
     }
 
-    const ignored = (function recurseDescriptors(
+    const ignored = yield* (function* recurseDescriptors(
       config: {
         plugins: Array<UnloadedDescriptor>,
         presets: Array<UnloadedDescriptor>,
       },
       pass: Array<Plugin>,
     ) {
-      const plugins = config.plugins.reduce((acc, descriptor) => {
+      const plugins = [];
+      for (const descriptor of config.plugins) {
         if (descriptor.options !== false) {
-          acc.push(loadPluginDescriptor(descriptor, context));
+          plugins.push(yield* loadPluginDescriptor(descriptor, context));
         }
-        return acc;
-      }, []);
-      const presets = config.presets.reduce((acc, descriptor) => {
+      }
+
+      const presets = [];
+      for (const descriptor of config.presets) {
         if (descriptor.options !== false) {
-          acc.push({
-            preset: loadPresetDescriptor(descriptor, context),
+          presets.push({
+            preset: yield* loadPresetDescriptor(descriptor, context),
             pass: descriptor.ownPass ? [] : pass,
           });
         }
-        return acc;
-      }, []);
+      }
 
       // resolve presets
       if (presets.length > 0) {
@@ -99,7 +107,7 @@ export default function loadFullConfig(
         for (const { preset, pass } of presets) {
           if (!preset) return true;
 
-          const ignored = recurseDescriptors(
+          const ignored = yield* recurseDescriptors(
             {
               plugins: preset.plugins,
               presets: preset.presets,
@@ -165,61 +173,61 @@ export default function loadFullConfig(
     options: opts,
     passes: passes,
   };
-}
+});
 
 /**
  * Load a generic plugin/preset from the given descriptor loaded from the config object.
  */
-const loadDescriptor = makeWeakCache(
-  (
-    { value, options, dirname, alias }: UnloadedDescriptor,
-    cache: CacheConfigurator<SimpleContext>,
-  ): LoadedDescriptor => {
-    // Disabled presets should already have been filtered out
-    if (options === false) throw new Error("Assertion failure");
+const loadDescriptor = makeWeakCache(function*(
+  { value, options, dirname, alias }: UnloadedDescriptor,
+  cache: CacheConfigurator<SimpleContext>,
+): Handler<LoadedDescriptor> {
+  // Disabled presets should already have been filtered out
+  if (options === false) throw new Error("Assertion failure");
 
-    options = options || {};
+  options = options || {};
 
-    let item = value;
-    if (typeof value === "function") {
-      const api = {
-        ...context,
-        ...makeAPI(cache),
-      };
-      try {
-        item = value(api, options, dirname);
-      } catch (e) {
-        if (alias) {
-          e.message += ` (While processing: ${JSON.stringify(alias)})`;
-        }
-        throw e;
+  let item = value;
+  if (typeof value === "function") {
+    const api = {
+      ...context,
+      ...makeAPI(cache),
+    };
+    try {
+      item = value(api, options, dirname);
+    } catch (e) {
+      if (alias) {
+        e.message += ` (While processing: ${JSON.stringify(alias)})`;
       }
+      throw e;
     }
+  }
 
-    if (!item || typeof item !== "object") {
-      throw new Error("Plugin/Preset did not return an object.");
-    }
+  if (!item || typeof item !== "object") {
+    throw new Error("Plugin/Preset did not return an object.");
+  }
 
-    if (typeof item.then === "function") {
-      throw new Error(
-        `You appear to be using an async plugin, ` +
-          `which your current version of Babel does not support. ` +
-          `If you're using a published plugin, ` +
-          `you may need to upgrade your @babel/core version.`,
-      );
-    }
+  if (typeof item.then === "function") {
+    yield* []; // if we want to support async plugins
 
-    return { value: item, options, dirname, alias };
-  },
-);
+    throw new Error(
+      `You appear to be using an async plugin, ` +
+        `which your current version of Babel does not support. ` +
+        `If you're using a published plugin, ` +
+        `you may need to upgrade your @babel/core version.`,
+    );
+  }
+
+  return { value: item, options, dirname, alias };
+});
 
 /**
  * Instantiate a plugin for the given descriptor, returning the plugin/options pair.
  */
-function loadPluginDescriptor(
+function* loadPluginDescriptor(
   descriptor: UnloadedDescriptor,
   context: SimpleContext,
-): Plugin {
+): Handler<Plugin> {
   if (descriptor.value instanceof Plugin) {
     if (descriptor.options) {
       throw new Error(
@@ -230,54 +238,55 @@ function loadPluginDescriptor(
     return descriptor.value;
   }
 
-  return instantiatePlugin(loadDescriptor(descriptor, context), context);
+  return yield* instantiatePlugin(
+    yield* loadDescriptor(descriptor, context),
+    context,
+  );
 }
 
-const instantiatePlugin = makeWeakCache(
-  (
-    { value, options, dirname, alias }: LoadedDescriptor,
-    cache: CacheConfigurator<SimpleContext>,
-  ): Plugin => {
-    const pluginObj = validatePluginObject(value);
+const instantiatePlugin = makeWeakCache(function*(
+  { value, options, dirname, alias }: LoadedDescriptor,
+  cache: CacheConfigurator<SimpleContext>,
+): Handler<Plugin> {
+  const pluginObj = validatePluginObject(value);
 
-    const plugin = {
-      ...pluginObj,
+  const plugin = {
+    ...pluginObj,
+  };
+  if (plugin.visitor) {
+    plugin.visitor = traverse.explode({
+      ...plugin.visitor,
+    });
+  }
+
+  if (plugin.inherits) {
+    const inheritsDescriptor = {
+      name: undefined,
+      alias: `${alias}$inherits`,
+      value: plugin.inherits,
+      options,
+      dirname,
     };
-    if (plugin.visitor) {
-      plugin.visitor = traverse.explode({
-        ...plugin.visitor,
-      });
-    }
 
-    if (plugin.inherits) {
-      const inheritsDescriptor = {
-        name: undefined,
-        alias: `${alias}$inherits`,
-        value: plugin.inherits,
-        options,
-        dirname,
-      };
-
+    const inherits = yield* forwardAsync(loadPluginDescriptor, run => {
       // If the inherited plugin changes, reinstantiate this plugin.
-      const inherits = cache.invalidate(data =>
-        loadPluginDescriptor(inheritsDescriptor, data),
-      );
+      return cache.invalidate(data => run(inheritsDescriptor, data));
+    });
 
-      plugin.pre = chain(inherits.pre, plugin.pre);
-      plugin.post = chain(inherits.post, plugin.post);
-      plugin.manipulateOptions = chain(
-        inherits.manipulateOptions,
-        plugin.manipulateOptions,
-      );
-      plugin.visitor = traverse.visitors.merge([
-        inherits.visitor || {},
-        plugin.visitor || {},
-      ]);
-    }
+    plugin.pre = chain(inherits.pre, plugin.pre);
+    plugin.post = chain(inherits.post, plugin.post);
+    plugin.manipulateOptions = chain(
+      inherits.manipulateOptions,
+      plugin.manipulateOptions,
+    );
+    plugin.visitor = traverse.visitors.merge([
+      inherits.visitor || {},
+      plugin.visitor || {},
+    ]);
+  }
 
-    return new Plugin(plugin, options, alias);
-  },
-);
+  return new Plugin(plugin, options, alias);
+});
 
 const validateIfOptionNeedsFilename = (
   options: ValidatedOptions,
@@ -318,16 +327,16 @@ const validatePreset = (
 /**
  * Generate a config object that will act as the root of a new nested config.
  */
-const loadPresetDescriptor = (
+function* loadPresetDescriptor(
   descriptor: UnloadedDescriptor,
   context: ConfigContext,
-): ConfigChain | null => {
-  const preset = instantiatePreset(loadDescriptor(descriptor, context));
+): Handler<ConfigChain | null> {
+  const preset = instantiatePreset(yield* loadDescriptor(descriptor, context));
   validatePreset(preset, context, descriptor);
-  return buildPresetChain(preset, context);
-};
+  return yield* buildPresetChain(preset, context);
+}
 
-const instantiatePreset = makeWeakCache(
+const instantiatePreset = makeWeakCacheSync(
   ({ value, dirname, alias }: LoadedDescriptor): PresetInstance => {
     return {
       options: validate("preset", value),

--- a/packages/babel-core/src/config/index.js
+++ b/packages/babel-core/src/config/index.js
@@ -1,6 +1,7 @@
 // @flow
 
-import loadFullConfig from "./full";
+import gensync from "gensync";
+
 export type {
   ResolvedConfig,
   InputOptions,
@@ -8,12 +9,29 @@ export type {
   Plugin,
 } from "./full";
 
+import loadFullConfig from "./full";
+import { loadPartialConfig as loadPartialConfigRunner } from "./partial";
+
 export { loadFullConfig as default };
-export { loadPartialConfig } from "./partial";
 export type { PartialConfig } from "./partial";
 
-export function loadOptions(opts: {}): Object | null {
-  const config = loadFullConfig(opts);
-
+const loadOptionsRunner = gensync<[mixed], Object | null>(function*(opts) {
+  const config = yield* loadFullConfig(opts);
   return config ? config.options : null;
-}
+});
+
+const maybeErrback = runner => (opts: mixed, callback: Function) => {
+  if (callback === undefined && typeof opts === "function") {
+    callback = opts;
+    opts = undefined;
+  }
+  return callback ? runner.errback(opts, callback) : runner.sync(opts);
+};
+
+export const loadPartialConfig = maybeErrback(loadPartialConfigRunner);
+export const loadPartialConfigSync = loadPartialConfigRunner.sync;
+export const loadPartialConfigAsync = loadPartialConfigRunner.async;
+
+export const loadOptions = maybeErrback(loadOptionsRunner);
+export const loadOptionsSync = loadOptionsRunner.sync;
+export const loadOptionsAsync = loadOptionsRunner.async;

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -1,6 +1,7 @@
 // @flow
 
 import path from "path";
+import gensync, { type Handler } from "gensync";
 import Plugin from "./plugin";
 import { mergeOptions } from "./util";
 import { createItemFromDescriptor } from "./item";
@@ -19,18 +20,21 @@ import {
   type IgnoreFile,
 } from "./files";
 
-function resolveRootMode(rootDir: string, rootMode: RootMode): string {
+function* resolveRootMode(
+  rootDir: string,
+  rootMode: RootMode,
+): Handler<string> {
   switch (rootMode) {
     case "root":
       return rootDir;
 
     case "upward-optional": {
-      const upwardRootDir = findConfigUpwards(rootDir);
+      const upwardRootDir = yield* findConfigUpwards(rootDir);
       return upwardRootDir === null ? rootDir : upwardRootDir;
     }
 
     case "upward": {
-      const upwardRootDir = findConfigUpwards(rootDir);
+      const upwardRootDir = yield* findConfigUpwards(rootDir);
       if (upwardRootDir !== null) return upwardRootDir;
 
       throw Object.assign(
@@ -51,15 +55,17 @@ function resolveRootMode(rootDir: string, rootMode: RootMode): string {
   }
 }
 
-export default function loadPrivatePartialConfig(
-  inputOpts: mixed,
-): {
+type PrivPartialConfig = {
   options: ValidatedOptions,
   context: ConfigContext,
   ignore: IgnoreFile | void,
   babelrc: ConfigFile | void,
   config: ConfigFile | void,
-} | null {
+};
+
+export default function* loadPrivatePartialConfig(
+  inputOpts: mixed,
+): Handler<PrivPartialConfig | null> {
   if (
     inputOpts != null &&
     (typeof inputOpts !== "object" || Array.isArray(inputOpts))
@@ -77,7 +83,7 @@ export default function loadPrivatePartialConfig(
     caller,
   } = args;
   const absoluteCwd = path.resolve(cwd);
-  const absoluteRootDir = resolveRootMode(
+  const absoluteRootDir = yield* resolveRootMode(
     path.resolve(absoluteCwd, rootDir),
     rootMode,
   );
@@ -93,7 +99,7 @@ export default function loadPrivatePartialConfig(
     caller,
   };
 
-  const configChain = buildRootChain(args, context);
+  const configChain = yield* buildRootChain(args, context);
   if (!configChain) return null;
 
   const options = {};
@@ -129,8 +135,10 @@ export default function loadPrivatePartialConfig(
   };
 }
 
-export function loadPartialConfig(inputOpts: mixed): PartialConfig | null {
-  const result = loadPrivatePartialConfig(inputOpts);
+export const loadPartialConfig = gensync<[any], PartialConfig | null>(function*(
+  inputOpts: mixed,
+): Handler<PartialConfig | null> {
+  const result: ?PrivPartialConfig = yield* loadPrivatePartialConfig(inputOpts);
   if (!result) return null;
 
   const { options, babelrc, ignore, config } = result;
@@ -150,7 +158,7 @@ export function loadPartialConfig(inputOpts: mixed): PartialConfig | null {
     ignore ? ignore.filepath : undefined,
     config ? config.filepath : undefined,
   );
-}
+});
 
 export type { PartialConfig };
 

--- a/packages/babel-core/src/config/util.js
+++ b/packages/babel-core/src/config/util.js
@@ -28,3 +28,14 @@ function mergeDefaultFields<T: {}>(target: T, source: T) {
     if (val !== undefined) target[k] = (val: any);
   }
 }
+
+export function isIterableIterator(value: mixed): boolean %checks {
+  return (
+    /*:: value instanceof Generator && */
+    // /*:: "@@iterator" in value && */
+    !!value &&
+    typeof value.next === "function" &&
+    // $FlowIgnore
+    typeof value[Symbol.iterator] === "function"
+  );
+}

--- a/packages/babel-core/src/gensync-utils/async.js
+++ b/packages/babel-core/src/gensync-utils/async.js
@@ -1,0 +1,110 @@
+// @flow
+
+import gensync, { type Gensync, type Handler } from "gensync";
+
+type MaybePromise<T> = T | Promise<T>;
+
+const id = x => x;
+
+const runGenerator = gensync(function*(item) {
+  return yield* item;
+});
+
+// This Gensync returns true if the current execution contect is
+// asynchronous, otherwise it returns false.
+export const isAsync = gensync<[], boolean>({
+  sync: () => false,
+  errback: cb => cb(null, true),
+});
+
+// This function wraps any functions (which could be either synchronous or
+// asynchronous) with a Gensync. If the wrapped function returns a promise
+// but the current execution context is synchronous, it will throw the
+// provided error.
+// This is used to handle user-provided functions which could be asynchronous.
+export function maybeAsync<T, Args: any[]>(
+  fn: (...args: Args) => T,
+  message: string,
+): Gensync<Args, T> {
+  return gensync({
+    sync(...args) {
+      const result = fn.apply(this, args);
+      if (isThenable(result)) throw new Error(message);
+      return result;
+    },
+    async(...args) {
+      return Promise.resolve(fn.apply(this, args));
+    },
+  });
+}
+
+const withKind = (gensync<[any], any>({
+  sync: cb => cb("sync"),
+  async: cb => cb("async"),
+}): <T>(cb: (kind: "sync" | "async") => MaybePromise<T>) => Handler<T>);
+
+// This function wraps a generator (or a Gensync) into another function which,
+// when called, will run the provided generator in a sync or async way, depending
+// on the execution context where this forwardAsync function is called.
+// This is useful, for example, when passing a callback to a function which isn't
+// aware of gensync, but it only knows about synchronous and asynchronous functions.
+// An example is cache.using, which being exposed to the user must be as simple as
+// possible:
+//     yield* forwardAsync(gensyncFn, wrappedFn =>
+//       cache.using(x => {
+//         // Here we don't know about gensync. wrappedFn is a
+//         // normal sync or async function
+//         return wrappedFn(x);
+//       })
+//     )
+export function forwardAsync<ActionArgs: mixed[], ActionReturn, Return>(
+  action: (...args: ActionArgs) => Handler<ActionReturn>,
+  cb: (
+    adapted: (...args: ActionArgs) => MaybePromise<ActionReturn>,
+  ) => MaybePromise<Return>,
+): Handler<Return> {
+  const g = gensync<ActionArgs, ActionReturn>(action);
+  return withKind<Return>(kind => {
+    const adapted = g[kind];
+    return cb(adapted);
+  });
+}
+
+// If the given generator is executed asynchronously, the first time that it
+// is paused (i.e. When it yields a gensync generator which can't be run
+// synchronously), call the "firstPause" callback.
+export const onFirstPause = (gensync<[any, any], any>({
+  name: "onFirstPause",
+  arity: 2,
+  sync: function(item) {
+    return runGenerator.sync(item);
+  },
+  errback: function(item, firstPause, cb) {
+    let completed = false;
+
+    runGenerator.errback(item, (err, value) => {
+      completed = true;
+      cb(err, value);
+    });
+
+    if (!completed) {
+      firstPause();
+    }
+  },
+}): <T>(gen: Generator<*, T, *>, cb: Function) => Handler<T>);
+
+// Wait for the given promise to be resolved
+export const waitFor = (gensync<[any], any>({
+  sync: id,
+  async: id,
+}): <T>(p: T | Promise<T>) => Handler<T>);
+
+export function isThenable(val: mixed): boolean %checks {
+  return (
+    /*:: val instanceof Promise && */
+    !!val &&
+    (typeof val === "object" || typeof val === "function") &&
+    !!val.then &&
+    typeof val.then === "function"
+  );
+}

--- a/packages/babel-core/src/gensync-utils/fs.js
+++ b/packages/babel-core/src/gensync-utils/fs.js
@@ -1,0 +1,21 @@
+// @flow
+
+import fs from "fs";
+import gensync from "gensync";
+
+export const readFile = gensync<[string, "utf8"], string>({
+  sync: fs.readFileSync,
+  errback: fs.readFile,
+});
+
+export const exists = gensync<[string], boolean>({
+  sync(path) {
+    try {
+      fs.accessSync(path);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  errback: (path, cb) => fs.access(path, undefined, err => cb(null, !err)),
+});

--- a/packages/babel-core/src/gensync-utils/resolve.js
+++ b/packages/babel-core/src/gensync-utils/resolve.js
@@ -1,0 +1,9 @@
+// @flow
+
+import resolve from "resolve";
+import gensync from "gensync";
+
+export default gensync<[string, {| basedir: string |}], string>({
+  sync: resolve.sync,
+  errback: resolve,
+});

--- a/packages/babel-core/src/index.js
+++ b/packages/babel-core/src/index.js
@@ -15,7 +15,14 @@ export { default as template } from "@babel/template";
 
 export { createConfigItem } from "./config/item";
 
-export { loadPartialConfig, loadOptions } from "./config";
+export {
+  loadPartialConfig,
+  loadPartialConfigSync,
+  loadPartialConfigAsync,
+  loadOptions,
+  loadOptionsSync,
+  loadOptionsAsync,
+} from "./config";
 
 export { transform, transformSync, transformAsync } from "./transform";
 export {

--- a/packages/babel-core/src/parser/index.js
+++ b/packages/babel-core/src/parser/index.js
@@ -1,3 +1,4 @@
+import type { Handler } from "gensync";
 import { parse } from "@babel/parser";
 import { codeFrameColumns } from "@babel/code-frame";
 import generateMissingPluginMessage from "./util/missing-plugin-helper";
@@ -6,11 +7,11 @@ type AstRoot = BabelNodeFile | BabelNodeProgram;
 
 export type ParseResult = AstRoot;
 
-export default function parser(
+export default function* parser(
   pluginPasses: PluginPasses,
   { parserOpts, highlightCode = true, filename = "unknown" }: Object,
   code: string,
-): ParseResult {
+): Handler<ParseResult> {
   try {
     const results = [];
     for (const plugins of pluginPasses) {
@@ -27,6 +28,7 @@ export default function parser(
     if (results.length === 0) {
       return parse(code, parserOpts);
     } else if (results.length === 1) {
+      yield* []; // If we want to allow async parsers
       if (typeof results[0].then === "function") {
         throw new Error(
           `You appear to be using an async parser plugin, ` +

--- a/packages/babel-core/src/transform.js
+++ b/packages/babel-core/src/transform.js
@@ -1,8 +1,10 @@
 // @flow
-import loadConfig, { type InputOptions } from "./config";
+
+import gensync from "gensync";
+
+import loadConfig, { type InputOptions, type ResolvedConfig } from "./config";
 import {
-  runSync,
-  runAsync,
+  run,
   type FileResult,
   type FileResultCallback,
 } from "./transformation";
@@ -16,6 +18,15 @@ type Transform = {
   (code: string, opts: ?InputOptions): FileResult | null,
 };
 
+const transformRunner = gensync<[string, ?InputOptions], FileResult | null>(
+  function* transform(code, opts) {
+    const config: ResolvedConfig | null = yield* loadConfig(opts);
+    if (config === null) return null;
+
+    return yield* run(config, code);
+  },
+);
+
 export const transform: Transform = (function transform(code, opts, callback) {
   if (typeof opts === "function") {
     callback = opts;
@@ -24,44 +35,10 @@ export const transform: Transform = (function transform(code, opts, callback) {
 
   // For backward-compat with Babel 6, we allow sync transformation when
   // no callback is given. Will be dropped in some future Babel major version.
-  if (callback === undefined) return transformSync(code, opts);
+  if (callback === undefined) return transformRunner.sync(code, opts);
 
-  // Reassign to keep Flowtype happy.
-  const cb = callback;
-
-  // Just delaying the transform one tick for now to simulate async behavior
-  // but more async logic may land here eventually.
-  process.nextTick(() => {
-    let cfg;
-    try {
-      cfg = loadConfig(opts);
-      if (cfg === null) return cb(null, null);
-    } catch (err) {
-      return cb(err);
-    }
-
-    runAsync(cfg, code, null, cb);
-  });
+  transformRunner.errback(code, opts, callback);
 }: Function);
 
-export function transformSync(
-  code: string,
-  opts: ?InputOptions,
-): FileResult | null {
-  const config = loadConfig(opts);
-  if (config === null) return null;
-
-  return runSync(config, code);
-}
-
-export function transformAsync(
-  code: string,
-  opts: ?InputOptions,
-): Promise<FileResult | null> {
-  return new Promise((res, rej) => {
-    transform(code, opts, (err, result) => {
-      if (err == null) res(result);
-      else rej(err);
-    });
-  });
-}
+export const transformSync = transformRunner.sync;
+export const transformAsync = transformRunner.async;

--- a/packages/babel-core/src/transformation/block-hoist-plugin.js
+++ b/packages/babel-core/src/transformation/block-hoist-plugin.js
@@ -11,7 +11,7 @@ export default function loadBlockHoistPlugin(): Plugin {
     // Lazy-init the internal plugin to remove the init-time circular
     // dependency between plugins being passed @babel/core's export object,
     // which loads this file, and this 'loadConfig' loading plugins.
-    const config = loadConfig({
+    const config = loadConfig.sync({
       babelrc: false,
       configFile: false,
       plugins: [blockHoistPlugin],

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 import buildDebug from "debug";
 import cloneDeep from "lodash/cloneDeep";
+import type { Handler } from "gensync";
 import * as t from "@babel/types";
 import type { PluginPasses } from "../config";
 import convertSourceMap, { typeof Converter } from "convert-source-map";
@@ -19,12 +20,12 @@ export type NormalizedFile = {
   inputMap: Converter | null,
 };
 
-export default function normalizeFile(
+export default function* normalizeFile(
   pluginPasses: PluginPasses,
   options: Object,
   code: string,
   ast: ?(BabelNodeFile | BabelNodeProgram),
-): File {
+): Handler<File> {
   code = `${code || ""}`;
 
   if (ast) {
@@ -35,7 +36,7 @@ export default function normalizeFile(
     }
     ast = cloneDeep(ast);
   } else {
-    ast = parser(pluginPasses, options, code);
+    ast = yield* parser(pluginPasses, options, code);
   }
 
   let inputMap = null;

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -1,0 +1,214 @@
+import path from "path";
+import * as babel from "..";
+
+const nodeGte8 = (...args) => {
+  // "minNodeVersion": "8.0.0" <-- For Ctrl+F when dropping node 6
+  const testFn = process.version.slice(0, 3) === "v6." ? it.skip : it;
+  testFn(...args);
+};
+
+describe("asynchronicity", () => {
+  const base = path.join(__dirname, "fixtures", "async");
+  let cwd;
+
+  beforeEach(function() {
+    cwd = process.cwd();
+    process.chdir(base);
+  });
+
+  afterEach(function() {
+    process.chdir(cwd);
+  });
+
+  describe("config file", () => {
+    describe("async function", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("config-file-async-function");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"You appear to be using an async configuration, which your current version of Babel does` +
+            ` not support. We may add support for this in the future, but if you're on the most recent` +
+            ` version of @babel/core and still seeing this error, then you'll need to synchronously` +
+            ` return your config."`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("config-file-async-function");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"You appear to be using an async configuration, which your current version of Babel does` +
+            ` not support. We may add support for this in the future, but if you're on the most recent` +
+            ` version of @babel/core and still seeing this error, then you'll need to synchronously` +
+            ` return your config."`,
+        );
+      });
+    });
+
+    describe("promise", () => {
+      it("called synchronously", () => {
+        process.chdir("config-file-promise");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"You appear to be using an async configuration, which your current version of Babel does` +
+            ` not support. We may add support for this in the future, but if you're on the most recent` +
+            ` version of @babel/core and still seeing this error, then you'll need to synchronously` +
+            ` return your config."`,
+        );
+      });
+
+      it("called asynchronously", async () => {
+        process.chdir("config-file-promise");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"You appear to be using an async configuration, which your current version of Babel does` +
+            ` not support. We may add support for this in the future, but if you're on the most recent` +
+            ` version of @babel/core and still seeing this error, then you'll need to synchronously` +
+            ` return your config."`,
+        );
+      });
+    });
+
+    describe("cache.using", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("config-cache");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"You appear to be using an async cache handler, which your current version of Babel does` +
+            ` not support. We may add support for this in the future, but if you're on the most recent` +
+            ` version of @babel/core and still seeing this error, then you'll need to synchronously` +
+            ` handle your caching logic."`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("config-cache");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"You appear to be using an async cache handler, which your current version of Babel does` +
+            ` not support. We may add support for this in the future, but if you're on the most recent` +
+            ` version of @babel/core and still seeing this error, then you'll need to synchronously` +
+            ` handle your caching logic."`,
+        );
+      });
+    });
+  });
+
+  describe("plugin", () => {
+    describe("factory function", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("plugin");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
+            ` does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("plugin");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
+            ` does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+    });
+
+    describe(".pre", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("plugin-pre");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"unknown: You appear to be using an plugin with an async .pre, which your current version` +
+            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("plugin-pre");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"unknown: You appear to be using an plugin with an async .pre, which your current version` +
+            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+    });
+
+    describe(".post", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("plugin-post");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"unknown: You appear to be using an plugin with an async .post, which your current version` +
+            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("plugin-post");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"unknown: You appear to be using an plugin with an async .post, which your current version` +
+            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+    });
+
+    describe("inherits", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("plugin-inherits");
+
+        expect(() =>
+          babel.transformSync(""),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
+            ` does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("plugin-inherits");
+
+        await expect(
+          babel.transformAsync(""),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"[BABEL] unknown: You appear to be using an async plugin, which your current version of Babel` +
+            ` does not support. If you're using a published plugin, you may need to upgrade your` +
+            ` @babel/core version."`,
+        );
+      });
+    });
+  });
+});

--- a/packages/babel-core/test/caching-api.js
+++ b/packages/babel-core/test/caching-api.js
@@ -1,10 +1,12 @@
-import { makeStrongCache } from "../lib/config/caching";
+import gensync from "gensync";
+import { makeStrongCacheSync, makeStrongCache } from "../lib/config/caching";
+import { waitFor } from "../lib/gensync-utils/async";
 
 describe("caching API", () => {
   it("should allow permacaching with .forever()", () => {
     let count = 0;
 
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.forever();
       return { arg, count: count++ };
     });
@@ -21,7 +23,7 @@ describe("caching API", () => {
   it("should allow disabling caching with .never()", () => {
     let count = 0;
 
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.never();
       return { arg, count: count++ };
     });
@@ -41,7 +43,7 @@ describe("caching API", () => {
     let count = 0;
     let other = "default";
 
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       const val = cache.using(() => other);
 
       return { arg, val, count: count++ };
@@ -82,7 +84,7 @@ describe("caching API", () => {
     let count = 0;
     let other = "default";
 
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       const val = cache.invalidate(() => other);
 
       return { arg, val, count: count++ };
@@ -124,7 +126,7 @@ describe("caching API", () => {
     let other = "default";
     let another = "another";
 
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       const val = cache.using(() => other);
       const val2 = cache.invalidate(() => another);
 
@@ -223,7 +225,7 @@ describe("caching API", () => {
   it("should auto-permacache by default", () => {
     let count = 0;
 
-    const fn = makeStrongCache(arg => ({ arg, count: count++ }));
+    const fn = makeStrongCacheSync(arg => ({ arg, count: count++ }));
 
     expect(fn("one")).toEqual({ arg: "one", count: 0 });
     expect(fn("one")).toBe(fn("one"));
@@ -235,7 +237,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you set permacaching and use .using", () => {
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.forever();
 
       cache.using(() => null);
@@ -245,7 +247,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you set permacaching and use .invalidate", () => {
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.forever();
 
       cache.invalidate(() => null);
@@ -255,7 +257,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you set permacaching and use .never", () => {
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.forever();
 
       cache.never();
@@ -265,7 +267,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you set no caching and use .using", () => {
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.never();
 
       cache.using(() => null);
@@ -275,7 +277,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you set no caching and use .invalidate", () => {
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.never();
 
       cache.invalidate(() => null);
@@ -285,7 +287,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you set no caching and use .never", () => {
-    const fn = makeStrongCache((arg, cache) => {
+    const fn = makeStrongCacheSync((arg, cache) => {
       cache.never();
 
       cache.using(() => null);
@@ -295,7 +297,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you configure .forever after exiting", () => {
-    const fn = makeStrongCache((arg, cache) => cache);
+    const fn = makeStrongCacheSync((arg, cache) => cache);
 
     expect(() => fn().forever()).toThrow(
       /Cannot change caching after evaluation/,
@@ -303,7 +305,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you configure .never after exiting", () => {
-    const fn = makeStrongCache((arg, cache) => cache);
+    const fn = makeStrongCacheSync((arg, cache) => cache);
 
     expect(() => fn().never()).toThrow(
       /Cannot change caching after evaluation/,
@@ -311,7 +313,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you configure .using after exiting", () => {
-    const fn = makeStrongCache((arg, cache) => cache);
+    const fn = makeStrongCacheSync((arg, cache) => cache);
 
     expect(() => fn().using(() => null)).toThrow(
       /Cannot change caching after evaluation/,
@@ -319,7 +321,7 @@ describe("caching API", () => {
   });
 
   it("should throw if you configure .invalidate after exiting", () => {
-    const fn = makeStrongCache((arg, cache) => cache);
+    const fn = makeStrongCacheSync((arg, cache) => cache);
 
     expect(() => fn().invalidate(() => null)).toThrow(
       /Cannot change caching after evaluation/,
@@ -330,7 +332,7 @@ describe("caching API", () => {
     it("should allow permacaching with cache(true)", () => {
       let count = 0;
 
-      const fn = makeStrongCache((arg, cache) => {
+      const fn = makeStrongCacheSync((arg, cache) => {
         cache = cache.simple();
 
         cache(true);
@@ -349,7 +351,7 @@ describe("caching API", () => {
     it("should allow disabling caching with cache(false)", () => {
       let count = 0;
 
-      const fn = makeStrongCache((arg, cache) => {
+      const fn = makeStrongCacheSync((arg, cache) => {
         cache = cache.simple();
 
         cache(false);
@@ -371,7 +373,7 @@ describe("caching API", () => {
       let count = 0;
       let other = "default";
 
-      const fn = makeStrongCache((arg, cache) => {
+      const fn = makeStrongCacheSync((arg, cache) => {
         cache = cache.simple();
 
         const val = cache(() => other);
@@ -408,6 +410,62 @@ describe("caching API", () => {
 
       expect(fn("two")).toEqual({ arg: "two", val: "new", count: 3 });
       expect(fn("two")).toBe(fn("two"));
+    });
+  });
+
+  describe("async", () => {
+    const wait = gensync({
+      sync: () => {},
+      errback: (t, cb) => setTimeout(cb, t),
+    });
+
+    it("should throw if the cache is configured asynchronously", async () => {
+      const fn = gensync(
+        makeStrongCache(function*(arg, cache) {
+          yield* wait(1000);
+          cache.never();
+          return { arg };
+        }),
+      ).async;
+
+      await expect(fn("bar")).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Cannot change caching after evaluation has completed."`,
+      );
+    });
+
+    it("should allow asynchronous cache invalidation functions", async () => {
+      const fn = gensync(
+        makeStrongCache(function*(arg, cache) {
+          yield* waitFor(
+            cache.using(async () => {
+              await wait.async(50);
+              return "x";
+            }),
+          );
+          return { arg };
+        }),
+      ).async;
+
+      const [res1, res2] = await Promise.all([fn("foo"), fn("foo")]);
+
+      expect(res1).toBe(res2);
+    });
+
+    it("should allow synchronous yield before cache configuration", async () => {
+      const fn = gensync(
+        makeStrongCache(function*(arg, cache) {
+          yield* gensync({
+            sync: () => 2,
+            errback: cb => cb(null, 2),
+          })();
+          cache.forever();
+          return { arg };
+        }),
+      ).async;
+
+      const [res1, res2] = await Promise.all([fn("foo"), fn("foo")]);
+
+      expect(res1).toBe(res2);
     });
   });
 });

--- a/packages/babel-core/test/config-loading.js
+++ b/packages/babel-core/test/config-loading.js
@@ -1,5 +1,7 @@
-import loadConfig, { loadPartialConfig } from "../lib/config";
+import loadConfigRunner, { loadPartialConfig } from "../lib/config";
 import path from "path";
+
+const loadConfig = loadConfigRunner.sync;
 
 describe("@babel/core config loading", () => {
   const FILEPATH = path.join(

--- a/packages/babel-core/test/fixtures/async/config-cache/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/config-cache/babel.config.js
@@ -1,0 +1,12 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = function(api) {
+  api.cache.using(async () => {
+    await wait(50);
+    return 2;
+  })
+
+  return {
+    plugins: ["./plugin"],
+  };
+};

--- a/packages/babel-core/test/fixtures/async/config-cache/plugin.js
+++ b/packages/babel-core/test/fixtures/async/config-cache/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/config-file-async-function/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/config-file-async-function/babel.config.js
@@ -1,0 +1,11 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = async function(api) {
+  await wait(50);
+
+  api.cache.never();
+
+  return {
+    plugins: ["./plugin"],
+  };
+};

--- a/packages/babel-core/test/fixtures/async/config-file-async-function/plugin.js
+++ b/packages/babel-core/test/fixtures/async/config-file-async-function/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/config-file-promise/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/config-file-promise/babel.config.js
@@ -1,0 +1,5 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = wait(50).then(() => ({
+    plugins: ["./plugin"],
+}));

--- a/packages/babel-core/test/fixtures/async/config-file-promise/plugin.js
+++ b/packages/babel-core/test/fixtures/async/config-file-promise/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-inherits/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-inherits/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-inherits/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-inherits/plugin.js
@@ -1,0 +1,10 @@
+module.exports = function plugin({ types: t }) {
+  return {
+    inherits: require("./plugin2"),
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-inherits/plugin2.js
+++ b/packages/babel-core/test/fixtures/async/plugin-inherits/plugin2.js
@@ -1,0 +1,13 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = async function plugin({ types: t }) {
+  await wait(50);
+
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success 2"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-post/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-post/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-post/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-post/plugin.js
@@ -1,0 +1,15 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = function plugin({ types: t }) {
+  return {
+    async post() {
+      await wait(50);
+    },
+
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-pre/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pre/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-pre/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pre/plugin.js
@@ -1,0 +1,15 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = function plugin({ types: t }) {
+  return {
+    async pre() {
+      await wait(50);
+    },
+
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin/plugin.js
@@ -1,0 +1,13 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+module.exports = async function plugin({ types: t }) {
+  await wait(50);
+
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+};

--- a/scripts/rollup-plugin-babel-source.js
+++ b/scripts/rollup-plugin-babel-source.js
@@ -37,13 +37,20 @@ module.exports = function() {
       return null;
     },
     resolveId(importee) {
-      let packageFolderName;
-      const matches = importee.match(/^@babel\/([^/]+)$/);
-      if (matches) {
-        packageFolderName = `babel-${matches[1]}`;
+      if (importee === "@babel/runtime/regenerator") {
+        return path.join(
+          dirname,
+          "packages",
+          "babel-runtime",
+          "regenerator",
+          "index.js"
+        );
       }
 
-      if (packageFolderName) {
+      const matches = importee.match(/^@babel\/([^/]+)$/);
+      if (matches) {
+        const packageFolderName = `babel-${matches[1]}`;
+
         // resolve babel package names to their src index file
         const packageFolder = path.join(dirname, "packages", packageFolderName);
         const packageJson = require(path.join(packageFolder, "package.json"));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | First step for #9888
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In this PR, I am refactoring `@babel/core` to use [`gensync`](https://github.com/loganfsmyth/gensync/). It's a tool by @loganfsmyth which allows defining functions as generators which can then be run either synchronously or asynchronously, pushinc control to the edges of the program.

For example, it allows doing this:

```js
const fs = require("fs-for-gensync");

const readJSON = gensync(function* (path) {
  const contents = yield* fs.readFile(path, "utf8"); // Sync or async? It doesn't matter
  return JSON.parse(contents);
});

readJson.sync("file.json"); // internally calls fs.readFileSync(path, encoding)
readJson.async("file.json"); // internally calls fs.readFile(path, encoding, cb)
```

By doing so, we will be able to easily allow some parts of Babel to be asynchronous. I identified 4 possible parts:
- `.pre` functions of plugins
- `.post` functions of plugins
- Configuration functions (i.e. in `babel.config.json`)
- Configuration file loading

The latter is necessary because, starting from node v12.11.0, is a user has `"type": "module"` in their `package.json` we won't be able to load `babel.config.js` using `require` but we'll need to use `import()`. (https://github.com/nodejs/modules/issues/389)

Since JavaScript doesn't have native algebraic effects<sup>[1]</sup>, which would have allowed me to use `yield` only in those 4 places, we have to use `yield*` in the whole call stack. The last two parts are deep inside `@babel/core`, and that's why `yield*` spread almost everywhere.

This PR already makes I/O actions asynchronous when using the async functions.

This PR aligns the API of all the functions which could interact with the disk: now `parse`, `transform`, `transformFile`, `transformFromAst`, `loadPartialConfig` and `loadOptions` all have three version:
- `fooSync`, which synchronously returns the result;
- `fooAsync`, which returns a promise;
- `foo`, which accepts a callback. From compatibility reasons, some of these behave synchronously when the callback is not provided.

TODO:
- [x] https://github.com/loganfsmyth/gensync/pull/1
- [x] Unify caching logic for generators and normal functions
- [x] Test performance differences

<sup>[1]</sup> I learned exactly what they are while preparing this PR

---

**Performance differences**: Not significant.
In order to test this PR, I compiled every file inside `packages/*/src` (405 files) both synchronously and asynchronously, using the following script. It's always run using `node demo.js --sync && node demo.js --sync && node demo.js --sync && node demo.js --sync && node demo.js --async && node demo.js --async && node demo.js --async && node demo.js --async`.

<details>

```js
"use strict";

const load = name => require(`./packages/babel-${name}`);

const babel = load("core");
const fs = require("fs");

function walkSync(dir, filelist) {
  const files = fs.readdirSync(dir);
  filelist = filelist || [];
  files.forEach(file => {
    if (fs.statSync(dir + "/" + file).isDirectory()) {
      filelist = walkSync(dir + "/" + file, filelist);
    } else {
      filelist.push(dir + "/" + file);
    }
  });
  return filelist;
}

const files = [];

const packages = fs.readdirSync("packages");
for (const name of packages) {
  if (name === "README.md" || name.startsWith("babel-runtime")) continue;
  files.push.apply(files, walkSync("packages/" + name + "/src"));
}


const start = process.hrtime();
global.results = {};

if (process.argv.includes("--sync")) {
  process.env.SYNC_OR_ASYNC = "sync";
  for (const file of files) {
    global.results[file] = babel.transformFileSync(file);
  }
  console.log("Sync: " + process.hrtime(start));
} else {
  process.env.SYNC_OR_ASYNC = "async";
  let i = 0;
  for (const file of files) {
    i++;
    babel.transformFile(file, (err, out) => {
      if (err) {
        console.log(err);
        process.exit(1);
      }
      global.results[file] = out;
  
      if (--i === 0) console.log("Async: " + process.hrtime(start));
    });
  }
}
```

</details>

<details>
<summary>Results</summary>

`NODE_ENV` is always `"test"`

- `master` branch, with `api.cache.never()`:
  ```
  Sync: 5,886560734
  Sync: 5,885043757
  Sync: 5,867874524
  Sync: 5,803315282
  Async: 5,949791895
  Async: 5,789683786
  Async: 5,806937770
  Async: 5,853401118
  ```
- `core-async` branch, with `api.cache.never()`:
  ```
  Sync: 5,960720491
  Sync: 5,894450713
  Sync: 5,891051295
  Sync: 5,946484727
  Async: 5,913818398
  Async: 5,929368030
  Async: 6,11599499
  Async: 6,58814871
  ```

- `master` branch, with `api.cache.using(() => process.env.SYNC_OR_ASYNC)`:
  ```
  Sync: 5,883534231
  Sync: 4,840278891
  Sync: 4,994791415
  Sync: 4,897095093
  Async: 4,874467892
  Async: 4,824938870
  Async: 4,826639093
  Async: 4,851304427
  ```
- `core-async` branch, with `api.cache.using(() => process.env.SYNC_OR_ASYNC)`:
  ```
  Sync: 4,866956272
  Sync: 4,820806372
  Sync: 4,857302419
  Sync: 4,783584388
  Async: 5,869067030
  Async: 5,931280575
  Async: 6,17525481
  Async: 5,993042102
  ```
</details>

**Conclusion**: When running synchronously, the performance is almost the same. On the other hand, when running asynchronously this branch is consistently a bit slower than `master`. I think that it's because `gensync` waits one tick for each yielded value, the same as `await` behaves in async functions.