### PR TITLE
Add filename to transform error

### DIFF
--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -259,7 +259,7 @@ export default class File {
   ): Error {
     let loc = node && (node.loc || node._loc);
 
-    msg = `${this.opts.filename}: ${msg}`;
+    msg = `${this.opts.filename ?? "unknown"}: ${msg}`;
 
     if (!loc && node) {
       const state = {

--- a/packages/babel-core/src/transformation/file/generate.js
+++ b/packages/babel-core/src/transformation/file/generate.js
@@ -41,7 +41,7 @@ export default function generateCode(
 
     if (typeof result.then === "function") {
       throw new Error(
-        `You appear to be using an async parser plugin, ` +
+        `You appear to be using an async codegen plugin, ` +
           `which your current version of Babel does not support. ` +
           `If you're using a published plugin, ` +
           `you may need to upgrade your @babel/core version.`,

--- a/packages/babel-core/src/transformation/index.js
+++ b/packages/babel-core/src/transformation/index.js
@@ -55,19 +55,28 @@ export function runSync(
     ast,
   );
 
+  const opts = file.opts;
   try {
     transformFile(file, config.passes);
   } catch (e) {
-    e.message = `${file.opts.filename ?? "unknown"}: ${e.message}`;
+    e.message = `${opts.filename ?? "unknown"}: ${e.message}`;
     if (!e.code) {
       e.code = "BABEL_TRANSFORM_ERROR";
     }
     throw e;
   }
 
-  const opts = file.opts;
-  const { outputCode, outputMap } =
-    opts.code !== false ? generateCode(config.passes, file) : {};
+  let outputCode, outputMap;
+  try {
+    ({ outputCode, outputMap } =
+      opts.code !== false ? generateCode(config.passes, file) : {});
+  } catch (e) {
+    e.message = `${opts.filename ?? "unknown"}: ${e.message}`;
+    if (!e.code) {
+      e.code = "BABEL_GENERATE_ERROR";
+    }
+    throw e;
+  }
 
   return {
     metadata: file.metadata,

--- a/packages/babel-core/src/transformation/index.js
+++ b/packages/babel-core/src/transformation/index.js
@@ -55,7 +55,15 @@ export function runSync(
     ast,
   );
 
-  transformFile(file, config.passes);
+  try {
+    transformFile(file, config.passes);
+  } catch (e) {
+    e.message = `${file.opts.filename ?? "unknown"}: ${e.message}`;
+    if (!e.code) {
+      e.code = "BABEL_TRANSFORM_ERROR";
+    }
+    throw e;
+  }
 
   const opts = file.opts;
   const { outputCode, outputMap } =

--- a/packages/babel-core/src/transformation/index.js
+++ b/packages/babel-core/src/transformation/index.js
@@ -68,8 +68,9 @@ export function runSync(
 
   let outputCode, outputMap;
   try {
-    ({ outputCode, outputMap } =
-      opts.code !== false ? generateCode(config.passes, file) : {});
+    if (opts.code !== false) {
+      ({ outputCode, outputMap } = generateCode(config.passes, file));
+    }
   } catch (e) {
     e.message = `${opts.filename ?? "unknown"}: ${e.message}`;
     if (!e.code) {

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -107,7 +107,7 @@ function parser(
     } else if (results.length === 1) {
       if (typeof results[0].then === "function") {
         throw new Error(
-          `You appear to be using an async codegen plugin, ` +
+          `You appear to be using an async parser plugin, ` +
             `which your current version of Babel does not support. ` +
             `If you're using a published plugin, you may need to upgrade ` +
             `your @babel/core version.`,
@@ -121,6 +121,7 @@ function parser(
       err.message +=
         "\nConsider renaming the file to '.mjs', or setting sourceType:module " +
         "or sourceType:unambiguous in your Babel config for this file.";
+      // err.code will be changed to BABEL_PARSE_ERROR later.
     }
 
     const { loc, missingPlugin } = err;

--- a/packages/babel-core/test/fixtures/plugins/build-code-frame-error/options.json
+++ b/packages/babel-core/test/fixtures/plugins/build-code-frame-error/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "undefined: someMsg\n> 1 | function f() {}"
+  "throws": "unknown: someMsg\n> 1 | function f() {}"
 }

--- a/packages/babel-core/test/fixtures/plugins/transform-error/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/transform-error/exec.js
@@ -1,0 +1,15 @@
+var code = "function f() {}";
+transform(code, {
+  plugins: [
+    function() {
+      return {
+        visitor: {
+          FunctionDeclaration: function(path) {
+            throw new Error("someMsg");
+          },
+        },
+      };
+    },
+  ],
+  filename: "/fake/path/example.js"
+});

--- a/packages/babel-core/test/fixtures/plugins/transform-error/options.json
+++ b/packages/babel-core/test/fixtures/plugins/transform-error/options.json
@@ -1,0 +1,4 @@
+{
+  "throws": "/fake/path/example.js: someMsg",
+  "os": ["linux", "darwin"]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10502, fixes #10505 
| Patch: Bug Fix?          | 👍
| Tests Added + Pass?      | Yes
| License                  | MIT

Previous art: In the parsing stage babel-core will add filename to the error message

https://github.com/babel/babel/blob/94fcabc4e3bed021e1a05d6c7a9b0a52261b2018/packages/babel-core/src/transformation/normalize-file.js#L145

In this PR we add `filename` to the error message to both transforming phrase and generating phrase. It should help developer debug which file actually causes babel transformer/generator to throw.