### PR TITLE
Try different name for used-by feature again [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel",
+  "name": "@babel/core",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
`Used by` continues to use `babel` so trying this out again?

![Screenshot 2019-10-01 at 3 05 19 PM](https://user-images.githubusercontent.com/588473/65992298-eadd3300-e45c-11e9-89f0-91ca463a65f6.png)