### PR TITLE
Fix generator missing parens around an arrow returning function type

### DIFF
--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -35,14 +35,22 @@ export function NullableTypeAnnotation(node: Object, parent: Object): boolean {
   return t.isArrayTypeAnnotation(parent);
 }
 
-export function FunctionTypeAnnotation(node: Object, parent: Object): boolean {
+export function FunctionTypeAnnotation(
+  node: Object,
+  parent: Object,
+  printStack: Array<Object>,
+): boolean {
   return (
     // (() => A) | (() => B)
     t.isUnionTypeAnnotation(parent) ||
     // (() => A) & (() => B)
     t.isIntersectionTypeAnnotation(parent) ||
     // (() => A)[]
-    t.isArrayTypeAnnotation(parent)
+    t.isArrayTypeAnnotation(parent) ||
+    // <T>(A: T): (T => T[]) => B => [A, B]
+    (t.isTypeAnnotation(parent) &&
+      // Check grandparent
+      t.isArrowFunctionExpression(printStack[printStack.length - 3]))
   );
 }
 

--- a/packages/babel-generator/test/fixtures/flow/arrow-functions/input.js
+++ b/packages/babel-generator/test/fixtures/flow/arrow-functions/input.js
@@ -5,3 +5,4 @@ const bar4 = x => {};
 const bar5 = (x): string => {};
 const bar6 = (x: number) => {};
 const bar7 = <T>(x) => {};
+const bar8 = <T>(x: T): (T => T[]) => y => [x, y];

--- a/packages/babel-generator/test/fixtures/flow/arrow-functions/output.js
+++ b/packages/babel-generator/test/fixtures/flow/arrow-functions/output.js
@@ -11,3 +11,5 @@ const bar5 = (x): string => {};
 const bar6 = (x: number) => {};
 
 const bar7 = <T>(x) => {};
+
+const bar8 = <T>(x: T): ((T) => T[]) => y => [x, y];


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10517
| Patch: Bug Fix?          | Y
| Major: Breaking Change?  | N
| Minor: New Feature?      | N
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
