### PR TITLE
fix prepublish-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ clone-license:
 	./scripts/clone-license.sh
 
 prepublish-build: clean-lib clean-runtime-helpers
-	NODE_ENV=production BABEL_ENV=production $(MAKE) build-dist
+	NODE_ENV=production BABEL_ENV=production $(MAKE) build
 	$(MAKE) clone-license
 
 prepublish:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `make prepublish` throws error
| Patch: Bug Fix?          | yes
| License                  | MIT

This PR fixes a regression introduced at #10506. Before that `build-dist` depended on `build`, but in #10506, `build` is revised to include `build-dist` as the last step, therefore `prepublish-build` should 
call `build` instead of `build-dist`.