### PR TITLE
Revert "chore: Upgrade source-map to 0.6.1 (#10446)"

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^0.5.1",
     "output-file-sync": "^2.0.0",
     "slash": "^2.0.0",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   },
   "optionalDependencies": {
     "chokidar": "^2.1.8"

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.13",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "^7.6.3"

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -17,7 +17,7 @@
     "@babel/types": "^7.6.3",
     "jsesc": "^2.5.1",
     "lodash": "^4.17.13",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   },
   "devDependencies": {
     "@babel/helper-fixtures": "^7.6.3",

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -20,6 +20,6 @@
     "jest-diff": "^24.8.0",
     "lodash": "^4.17.13",
     "resolve": "^1.3.2",
-    "source-map": "^0.6.1"
+    "source-map": "^0.5.0"
   }
 }


### PR DESCRIPTION
This reverts commit cc080417b995e2903352e7956890e0c74b23d4c9.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10533, fixes #10534 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Ref: https://github.com/babel/babel/pull/10446