### PR TITLE
fix: remove filename annotation in buildCodeFrameError

### DIFF
--- a/packages/babel-core/src/transformation/file/file.js
+++ b/packages/babel-core/src/transformation/file/file.js
@@ -259,8 +259,6 @@ export default class File {
   ): Error {
     let loc = node && (node.loc || node._loc);
 
-    msg = `${this.opts.filename ?? "unknown"}: ${msg}`;
-
     if (!loc && node) {
       const state = {
         loc: null,

--- a/packages/babel-core/test/fixtures/plugins/build-code-frame-error/exec.js
+++ b/packages/babel-core/test/fixtures/plugins/build-code-frame-error/exec.js
@@ -1,16 +1,18 @@
-var code = "function f() {}";
-transform(code, {
-  plugins: [
-    function() {
-      return {
-        visitor: {
-          FunctionDeclaration: function(path) {
-            throw path.buildCodeFrameError("someMsg");
+expect(() => {
+  var code = "function f() {}";
+  transform(code, {
+    plugins: [
+      function() {
+        return {
+          visitor: {
+            FunctionDeclaration: function(path) {
+              throw path.buildCodeFrameError("someMsg");
+            },
           },
-        },
-      };
-    },
-  ],
-  // hard to assert on ANSI escape codes
-  highlightCode: false,
-});
+        };
+      },
+    ],
+    // hard to assert on ANSI escape codes
+    highlightCode: false,
+  });
+}).toThrow(/^unknown: someMsg\s+> 1 \| function f\(\) {}/);

--- a/packages/babel-core/test/fixtures/plugins/build-code-frame-error/options.json
+++ b/packages/babel-core/test/fixtures/plugins/build-code-frame-error/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "unknown: someMsg\n> 1 | function f() {}"
-}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10531 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

In this PR we remove filename annotation on `buildCodeFrameError` because
1) The transform phase in `runSync` will add filename annotation
2) `buildCodeFrameError` is only used in the plugin visitors, which is executed in the transform phase.

This PR does not introduce breaking changes because both `buildCodeFrameError` and `runSync` are in babel-core.