### PR TITLE
Attemp fixing @babel/node and cli errors on Travis on Windows

### DIFF
--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -115,13 +115,6 @@ const buildTest = function(binName, testName, opts) {
   const binLoc = path.join(__dirname, "../lib", binName);
 
   return function(callback) {
-    const dir = process.cwd();
-
-    process.chdir(__dirname);
-    if (fs.existsSync(tmpLoc)) rimraf.sync(tmpLoc);
-    fs.mkdirSync(tmpLoc);
-    process.chdir(tmpLoc);
-
     saveInFiles(opts.inFiles);
 
     let args = [binLoc];
@@ -159,7 +152,6 @@ const buildTest = function(binName, testName, opts) {
           args.map(arg => `"${arg}"`).join(" ") + ": " + err.message;
       }
 
-      process.chdir(dir);
       callback(err);
     });
 
@@ -175,6 +167,26 @@ fs.readdirSync(fixtureLoc).forEach(function(binName) {
 
   const suiteLoc = path.join(fixtureLoc, binName);
   describe("bin/" + binName, function() {
+    let cwd;
+
+    beforeEach(() => {
+      cwd = process.cwd();
+
+      if (fs.existsSync(tmpLoc)) {
+        for (const child of fs.readdirSync(tmpLoc)) {
+          rimraf.sync(path.join(tmpLoc, child));
+        }
+      } else {
+        fs.mkdirSync(tmpLoc);
+      }
+
+      process.chdir(tmpLoc);
+    });
+
+    afterEach(() => {
+      process.chdir(cwd);
+    });
+
     fs.readdirSync(suiteLoc).forEach(function(testName) {
       if (testName.startsWith(".")) return;
 

--- a/packages/babel-node/test/index.js
+++ b/packages/babel-node/test/index.js
@@ -99,7 +99,6 @@ const buildTest = function(binName, testName, opts) {
   const binLoc = path.join(__dirname, "../lib", binName);
 
   return function(callback) {
-    clear();
     saveInFiles(opts.inFiles);
 
     let args = [binLoc];
@@ -146,13 +145,6 @@ const buildTest = function(binName, testName, opts) {
   };
 };
 
-const clear = function() {
-  process.chdir(__dirname);
-  if (fs.existsSync(tmpLoc)) rimraf.sync(tmpLoc);
-  fs.mkdirSync(tmpLoc);
-  process.chdir(tmpLoc);
-};
-
 fs.readdirSync(fixtureLoc).forEach(function(binName) {
   if (binName[0] === ".") return;
 
@@ -162,6 +154,16 @@ fs.readdirSync(fixtureLoc).forEach(function(binName) {
 
     beforeEach(() => {
       cwd = process.cwd();
+
+      if (fs.existsSync(tmpLoc)) {
+        for (const child of fs.readdirSync(tmpLoc)) {
+          rimraf.sync(path.join(tmpLoc, child));
+        }
+      } else {
+        fs.mkdirSync(tmpLoc);
+      }
+
+      process.chdir(tmpLoc);
     });
 
     afterEach(() => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

For some reason, it looks like that the rimraf call didn't properly delete the folder: ([example](https://travis-ci.com/babel/babel/jobs/243556232))

```
   EEXIST: file already exists, mkdir 'C:\Users\travis\build\babel\babel\packages\babel-node\test\tmp'
      150 |   process.chdir(__dirname);
      151 |   if (fs.existsSync(tmpLoc)) rimraf.sync(tmpLoc);
    > 152 |   fs.mkdirSync(tmpLoc);
          |      ^
      153 |   process.chdir(tmpLoc);
      154 | };
```

Lets try to reuse the existing folder rather than deleting and recreating it.

I will try to re-run the Job 4 times and see if it works.
- [x] 1 (https://travis-ci.com/babel/babel/jobs/245171743 - The failure is not related)
- [x] 2 (https://travis-ci.com/babel/babel/jobs/245214787)
- [x] 3
- [x] 4