### PR TITLE
chore: introduce envinfo into environment section

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -35,8 +35,6 @@ A clear and concise description of what you expected to happen (or code).
 ```
 
 ```
-<!--- you can delete the questions below if you have pasted `envinfo` results -->
-<!--- 🙂 It is also okay if instead you prefer to fill in the information below -->
 - Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,7 @@ var your => (code) => here;
 **Expected behavior/code**
 A clear and concise description of what you expected to happen (or code).
 
-**Babel Configuration (.babelrc, package.json, cli command)**
+**Babel Configuration (.babelrc, babel.config.js, cli command)**
 
 ```js
 {
@@ -31,6 +31,12 @@ A clear and concise description of what you expected to happen (or code).
 ```
 
 **Environment**
+<!--- Tryme: you can run `npx envinfo --preset babel` and paste the result below ``` -->
+```
+
+```
+<!--- you can delete the questions below if you have pasted `envinfo` results -->
+<!--- :-) It is also okay if instead you prefer to fill in the information below -->
 - Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -31,7 +31,7 @@ A clear and concise description of what you expected to happen (or code).
 ```
 
 **Environment**
-<!--- Tryme: you can run `npx envinfo --preset babel` and paste the result below ``` -->
+<!--- Tip: Instead of filling out the questions below, you can run `npx envinfo --preset babel` and paste the result below ``` -->
 ```
 
 ```

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,7 @@ var your => (code) => here;
 **Expected behavior/code**
 A clear and concise description of what you expected to happen (or code).
 
-**Babel Configuration (.babelrc, babel.config.js, cli command)**
+**Babel Configuration (babel.config.js, .babelrc, package.json#babel, cli command)**
 
 ```js
 {
@@ -36,7 +36,7 @@ A clear and concise description of what you expected to happen (or code).
 
 ```
 <!--- you can delete the questions below if you have pasted `envinfo` results -->
-<!--- :-) It is also okay if instead you prefer to fill in the information below -->
+<!--- 🙂 It is also okay if instead you prefer to fill in the information below -->
 - Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/Regression-v7.md
+++ b/.github/ISSUE_TEMPLATE/Regression-v7.md
@@ -38,12 +38,10 @@ A clear and concise description of what you expected to happen (or code).
 ```
 
 **Environment**
-<!--- Tryme: you can run `npx envinfo --preset babel` and paste the result below ``` -->
+<!--- Tip: Instead of filling out the questions below, you can run `npx envinfo --preset babel` and paste the result below ``` -->
 ```
 
 ```
-<!--- you can delete the questions below if you have pasted `envinfo` results -->
-<!--- 🙂 It is also okay if instead you prefer to fill in the information below -->
 - Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/Regression-v7.md
+++ b/.github/ISSUE_TEMPLATE/Regression-v7.md
@@ -26,7 +26,7 @@ A clear and concise description of what the regression is.
 var your => (code) => here;
 ```
 
-**Babel Configuration (.babelrc, package.json, cli command)**
+**Babel Configuration (.babelrc, babel.config.js, cli command)**
 
 ```js
 {
@@ -38,6 +38,12 @@ var your => (code) => here;
 A clear and concise description of what you expected to happen (or code).
 
 **Environment**
+<!--- Tryme: you can run `npx envinfo --preset babel` and paste the result below ``` -->
+```
+
+```
+<!--- you can delete the questions below if you have pasted `envinfo` results -->
+<!--- :-) It is also okay if instead you prefer to fill in the information below -->
 - Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/Regression-v7.md
+++ b/.github/ISSUE_TEMPLATE/Regression-v7.md
@@ -26,7 +26,10 @@ A clear and concise description of what the regression is.
 var your => (code) => here;
 ```
 
-**Babel Configuration (.babelrc, babel.config.js, cli command)**
+**Expected behavior/code**
+A clear and concise description of what you expected to happen (or code).
+
+**Babel Configuration (babel.config.js, .babelrc, package.json#babel, cli command)**
 
 ```js
 {
@@ -34,16 +37,13 @@ var your => (code) => here;
 }
 ```
 
-**Expected behavior/code**
-A clear and concise description of what you expected to happen (or code).
-
 **Environment**
 <!--- Tryme: you can run `npx envinfo --preset babel` and paste the result below ``` -->
 ```
 
 ```
 <!--- you can delete the questions below if you have pasted `envinfo` results -->
-<!--- :-) It is also okay if instead you prefer to fill in the information below -->
+<!--- 🙂 It is also okay if instead you prefer to fill in the information below -->
 - Babel version(s): [e.g. v6.0.0, v7.0.0-beta.34]
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #8227, Closes #9000
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we introduce `npx envinfo --preset babel` and offer an alternative one-liner to fill in the bug report. Note that it is also okay if user prefer to type in environment information manually.

For the format & information of the generated environment report, please see the upstream PR.

- [ ] https://github.com/tabrindle/envinfo/pull/126