### PR TITLE
Add master branch workflow for test262 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ workflows:
   nightly:
       triggers:
         - schedule:
-            cron: "0 0 * * *"
+            cron: "0 5 * * *"
             filters:
               branches:
                 only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,10 +116,9 @@ workflows:
     jobs:
       - test
   master:
-    filters:
-      branches:
-        only:
-          - master
     jobs:
-      - test
-      - test262
+      - test262:
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,13 +115,11 @@ workflows:
   test:
     jobs:
       - test
-  nightly:
-      triggers:
-        - schedule:
-            cron: "0 5 * * *"
-            filters:
-              branches:
-                only:
-                  - master
-      jobs:
-        - test262
+  master:
+    filters:
+      branches:
+        only:
+          - master
+    jobs:
+      - test
+      - test262

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,10 @@ jobs:
           <<: *test262_workdir
       - store_artifacts: *artifact_test262_tap
       - run:
-          name: Convert Tap output to Xunit
+          name: Output test262 results
           command: |
-            mkdir -p ~/test-results/test262
-            cat ~/test262.tap | $(npm bin)/tap-mocha-reporter xunit | tee ~/test-results/test262/results.xml
+            cat ~/test262.tap | $(npm bin)/tap-mocha-reporter spec || true
           <<: *test262_workdir
-      - store_test_results: *artifact_test262_xunit
 
 
 workflows:
@@ -117,8 +115,4 @@ workflows:
       - test
   master:
     jobs:
-      - test262:
-          filters:
-            branches:
-              only:
-                - master
+      - test262

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,17 @@ aliases:
   - &artifact_env_min
     path: ~/babel/packages/babel-preset-env-standalone/babel-preset-env.min.js
 
+  - &test262_workdir
+    working_directory: ~/babel/babel-test262-runner
+
+  - &artifact_test262_tap
+    path: ~/test262.tap
+
+  - &artifact_test262_xunit
+    path: ~/test-results
+
 jobs:
-  build:
+  test:
     working_directory: ~/babel
     docker:
       - image: circleci/node:12
@@ -54,3 +63,65 @@ jobs:
       - store_artifacts: *artifact_env_min
       - save_cache: *save-node-modules-cache
       - save_cache: *save-yarn-cache
+  test262:
+    working_directory: ~/babel
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - restore-cache: *restore-yarn-cache
+      - restore-cache: *restore-node-modules-cache
+      - run:
+          name: Build Babel
+          command: BABEL_ENV=test make bootstrap
+      - run:
+          name: Link Babel
+          command: |
+            cd packages
+            for package in */; do
+              cd $package
+              yarn link
+              cd ..
+            done
+      - run:
+          name: Setup Test Runner
+          command: |
+            git clone --recurse-submodules https://github.com/babel/babel-test262-runner
+            cd babel-test262-runner
+            yarn
+            yarn add tap-mocha-reporter --dev
+            curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq
+            chmod +x ./jq
+            for package in ../packages/*/package.json; do
+              yarn link $(./jq -j ".name" $package)
+            done
+            node lib/download-node
+      - run:
+          name: Run Test262
+          command: node lib/run-tests I_AM_SURE | tee ~/test262.tap
+          <<: *test262_workdir
+      - store_artifacts: *artifact_test262_tap
+      - run:
+          name: Convert Tap output to Xunit
+          command: |
+            mkdir -p ~/test-results/test262
+            cat ~/test262.tap | $(npm bin)/tap-mocha-reporter xunit | tee ~/test-results/test262/results.xml
+          <<: *test262_workdir
+      - store_test_results: *artifact_test262_xunit
+
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test
+  nightly:
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only:
+                  - master
+      jobs:
+        - test262

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,4 +115,8 @@ workflows:
       - test
   master:
     jobs:
-      - test262
+      - test262:
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
Fixes #10500

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A (doesn't completely fix anything yet. only a step towards the goal
| Patch: Bug Fix?          | N/A
| Major: Breaking Change?  | N/A
| Minor: New Feature?      | N/A
| Tests Added + Pass?      | test262 tests added. Definitely don't pass 😝 
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No direct dependencies. Dependencies for CI
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR adds a master branch job for running test262 tests. The results of
these tests will be stored in build artifacts which will be used to
compare with test262 runs on PR (future work!). Robin has also done a
lot of work to ensure all babel packages are properly linked to the
test runner. Additionally, Nicolo has helped in mentorship and
contributions to babel-test262-runner which is used here (https://github.com/babel/babel-test262-runner/compare/a59509...399abd).

Co-authored-by: Robin Ricard <rricard2@bloomberg.net>
