### PR TITLE
fix: disable caching when babel could not read/write cache

### DIFF
--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -24,6 +24,7 @@ function isCacheDisabled() {
  */
 
 export function save() {
+  if (isCacheDisabled()) return;
   let serialised: string = "{}";
 
   try {
@@ -70,6 +71,9 @@ because it resides in a readonly filesystem. Cache is disabled.`,
 export function load() {
   if (isCacheDisabled()) return;
 
+  process.on("exit", save);
+  process.nextTick(save);
+
   let cacheContent;
 
   try {
@@ -90,9 +94,6 @@ due to a permission issue. Cache is disabled.`,
         throw e;
     }
   }
-
-  process.on("exit", save);
-  process.nextTick(save);
 
   try {
     data = JSON.parse(cacheContent);

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -69,7 +69,10 @@ because it resides in a readonly filesystem. Cache is disabled.`,
  */
 
 export function load() {
-  if (isCacheDisabled()) return;
+  if (isCacheDisabled()) {
+    data = {};
+    return;
+  }
 
   process.on("exit", save);
   process.nextTick(save);
@@ -80,8 +83,6 @@ export function load() {
     cacheContent = fs.readFileSync(FILENAME);
   } catch (e) {
     switch (e.code) {
-      case "ENOENT":
-        return;
       case "EACCES":
       case "EPERM":
         console.warn(
@@ -89,15 +90,15 @@ export function load() {
 due to a permission issue. Cache is disabled.`,
         );
         cacheDisabled = true;
-        return;
+      /* fall through */
       default:
-        throw e;
+        return;
     }
   }
 
   try {
     data = JSON.parse(cacheContent);
-  } catch (err) {}
+  } catch {}
 }
 
 /**

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -41,14 +41,24 @@ export function save() {
     mkdirpSync(path.dirname(FILENAME));
     fs.writeFileSync(FILENAME, serialised);
   } catch (e) {
-    if (e.code === "EACCES" || e.code === "EPERM") {
-      console.warn(
-        `Babel could not write cache to file: ${FILENAME} 
-due to a permission issue. Cache is now disabled.`,
-      );
-      cacheDisabled = true;
-    } else {
-      throw e;
+    switch (e.code) {
+      case "EACCES":
+      case "EPERM":
+        console.warn(
+          `Babel could not write cache to file: ${FILENAME} 
+due to a permission issue. Cache is disabled.`,
+        );
+        cacheDisabled = true;
+        break;
+      case "EROFS":
+        console.warn(
+          `Babel could not write cache to file: ${FILENAME} 
+because it resides in a readonly filesystem. Cache is disabled.`,
+        );
+        cacheDisabled = true;
+        break;
+      default:
+        throw e;
     }
   }
 }
@@ -72,7 +82,7 @@ export function load() {
       case "EPERM":
         console.warn(
           `Babel could not read cache file: ${FILENAME}
-due to a permission issue. Cache is now disabled.`,
+due to a permission issue. Cache is disabled.`,
         );
         cacheDisabled = true;
         return;

--- a/packages/babel-register/src/cache.js
+++ b/packages/babel-register/src/cache.js
@@ -83,8 +83,9 @@ export function load() {
     cacheContent = fs.readFileSync(FILENAME);
   } catch (e) {
     switch (e.code) {
+      // check EACCES only as fs.readFileSync will never throw EPERM on Windows
+      // https://github.com/libuv/libuv/blob/076df64dbbda4320f93375913a728efc40e12d37/src/win/fs.c#L735
       case "EACCES":
-      case "EPERM":
         console.warn(
           `Babel could not read cache file: ${FILENAME}
 due to a permission issue. Cache is disabled.`,

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -78,11 +78,9 @@ describe("@babel/register - caching", () => {
       load();
 
       process.nextTick(() => {
-        process.nextTick(() => {
-          expect(fs.existsSync(testCacheFilename)).toBe(true);
-          expect(get()).toEqual({});
-          cb();
-        });
+        expect(fs.existsSync(testCacheFilename)).toBe(true);
+        expect(get()).toEqual({});
+        cb();
       });
     });
 
@@ -103,11 +101,9 @@ describe("@babel/register - caching", () => {
 
       expect(get()).toEqual({ foo: "bar" });
       process.nextTick(() => {
-        process.nextTick(() => {
-          load();
-          expect(get()).toEqual({});
-          cb();
-        });
+        load();
+        expect(get()).toEqual({});
+        cb();
       });
     });
   });

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -7,12 +7,12 @@ const oldBabelDisableCacheValue = process.env.BABEL_DISABLE_CACHE;
 process.env.BABEL_CACHE_PATH = testCacheFilename;
 delete process.env.BABEL_DISABLE_CACHE;
 
-function writeCache(data) {
+function writeCache(data, mode = 0o666) {
   if (typeof data === "object") {
     data = JSON.stringify(data);
   }
 
-  fs.writeFileSync(testCacheFilename, data);
+  fs.writeFileSync(testCacheFilename, data, { mode });
 }
 
 function cleanCache() {
@@ -84,19 +84,20 @@ describe("@babel/register - caching", () => {
       });
     });
 
-    it("should be disabled when CACHE_PATH is not allowed to read", () => {
-      writeCache({ foo: "bar" });
+    // Only write mode is effective on Windows
+    if (process.platform !== "win32") {
+      it("should be disabled when CACHE_PATH is not allowed to read", () => {
+        writeCache({ foo: "bar" }, 0o266);
 
-      fs.chmodSync(testCacheFilename, 0o375);
-      load();
+        load();
 
-      expect(get()).toEqual({});
-    });
+        expect(get()).toEqual({});
+      });
+    }
 
     it("should be disabled when CACHE_PATH is not allowed to write", cb => {
-      writeCache({ foo: "bar" });
+      writeCache({ foo: "bar" }, 0o466);
 
-      fs.chmodSync(testCacheFilename, 0o575);
       load();
 
       expect(get()).toEqual({ foo: "bar" });

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -74,6 +74,18 @@ describe("@babel/register - caching", () => {
       expect(get()).toEqual({});
     });
 
+    it("should create the cache after load", cb => {
+      load();
+
+      process.nextTick(() => {
+        process.nextTick(() => {
+          expect(fs.existsSync(testCacheFilename)).toBe(true);
+          expect(get()).toEqual({});
+          cb();
+        });
+      });
+    });
+
     it("should be disabled when CACHE_PATH is not allowed to read", () => {
       writeCache({ foo: "bar" });
 

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -73,5 +73,30 @@ describe("@babel/register - caching", () => {
       expect(fs.existsSync(testCacheFilename)).toBe(true);
       expect(get()).toEqual({});
     });
+
+    it("should be disabled when CACHE_PATH is not allowed to read", () => {
+      writeCache({ foo: "bar" });
+
+      fs.chmodSync(testCacheFilename, 0o375);
+      load();
+
+      expect(get()).toEqual({});
+    });
+
+    it("should be disabled when CACHE_PATH is not allowed to write", cb => {
+      writeCache({ foo: "bar" });
+
+      fs.chmodSync(testCacheFilename, 0o575);
+      load();
+
+      expect(get()).toEqual({ foo: "bar" });
+      process.nextTick(() => {
+        process.nextTick(() => {
+          load();
+          expect(get()).toEqual({});
+          cb();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6906, fixes #9649 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Added test on permission issues
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

In this PR we catch the IO error and disable caching when permission issue arises, or it the cache path resides in a readonly filesystem.

The following `existsSync` usage
```js
if (fs.existsSync(file)) {
  fs.readFileSync(file)
}
```
is also replaced as it introduces duplicate IO operations. In general [`fs.existsSync`](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback) should only be used
> if the file won’t be used directly, for example when its existence is a signal from another process.

In the future I will open a separate PR to replace all similar usage in our codebase.