### PR TITLE
fix: Exclude catch clause from let identifier error

### DIFF
--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -383,7 +383,11 @@ export default class LValParser extends NodeUtils {
             checkClashes[key] = true;
           }
         }
-        if (bindingType === BIND_LEXICAL && expr.name === "let") {
+        if (
+          bindingType === BIND_LEXICAL &&
+          expr.name === "let" &&
+          !this.scope.inCatchBlock
+        ) {
           this.raise(
             expr.start,
             "'let' is not allowed to be used as a name in 'let' or 'const' declarations.",

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -17,7 +17,7 @@ import type {
 import type { Pos, Position } from "../util/location";
 import { isStrictBindReservedWord } from "../util/identifier";
 import { NodeUtils } from "./node";
-import { type BindingTypes, BIND_NONE, BIND_LEXICAL } from "../util/scopeflags";
+import { type BindingTypes, BIND_NONE } from "../util/scopeflags";
 
 export default class LValParser extends NodeUtils {
   // Forward-declaration: defined in expression.js
@@ -348,6 +348,7 @@ export default class LValParser extends NodeUtils {
     bindingType: BindingTypes = BIND_NONE,
     checkClashes: ?{ [key: string]: boolean },
     contextDescription: string,
+    disallowLetBinding?: boolean,
   ): void {
     switch (expr.type) {
       case "Identifier":
@@ -383,11 +384,7 @@ export default class LValParser extends NodeUtils {
             checkClashes[key] = true;
           }
         }
-        if (
-          bindingType === BIND_LEXICAL &&
-          expr.name === "let" &&
-          !this.scope.inCatchBlock
-        ) {
+        if (disallowLetBinding && expr.name === "let") {
           this.raise(
             expr.start,
             "'let' is not allowed to be used as a name in 'let' or 'const' declarations.",
@@ -412,6 +409,7 @@ export default class LValParser extends NodeUtils {
             bindingType,
             checkClashes,
             "object destructuring pattern",
+            disallowLetBinding,
           );
         }
         break;
@@ -424,6 +422,7 @@ export default class LValParser extends NodeUtils {
               bindingType,
               checkClashes,
               "array destructuring pattern",
+              disallowLetBinding,
             );
           }
         }

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1021,7 +1021,7 @@ export default class StatementParser extends ExpressionParser {
       kind === "var" ? BIND_VAR : BIND_LEXICAL,
       undefined,
       "variable declaration",
-      kind === "var" ? false : true,
+      kind !== "var",
     );
   }
 

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1021,6 +1021,7 @@ export default class StatementParser extends ExpressionParser {
       kind === "var" ? BIND_VAR : BIND_LEXICAL,
       undefined,
       "variable declaration",
+      kind === "var" ? false : true,
     );
   }
 

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -108,6 +108,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       bindingType: BindingTypes = BIND_NONE,
       checkClashes: ?{ [key: string]: boolean },
       contextDescription: string,
+      disallowLetBinding?: boolean,
     ): void {
       switch (expr.type) {
         case "ObjectPattern":
@@ -117,11 +118,18 @@ export default (superClass: Class<Parser>): Class<Parser> =>
               bindingType,
               checkClashes,
               "object destructuring pattern",
+              disallowLetBinding,
             );
           });
           break;
         default:
-          super.checkLVal(expr, bindingType, checkClashes, contextDescription);
+          super.checkLVal(
+            expr,
+            bindingType,
+            checkClashes,
+            contextDescription,
+            disallowLetBinding,
+          );
       }
     }
 

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -70,9 +70,6 @@ export default class ScopeHandler<IScope: Scope = Scope> {
   get treatFunctionsAsVar() {
     return this.treatFunctionsAsVarInScope(this.currentScope());
   }
-  get inCatchBlock() {
-    return (this.currentScope().flags & SCOPE_SIMPLE_CATCH) > 0;
-  }
 
   createScope(flags: ScopeFlags): Scope {
     return new Scope(flags);

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -70,6 +70,9 @@ export default class ScopeHandler<IScope: Scope = Scope> {
   get treatFunctionsAsVar() {
     return this.treatFunctionsAsVarInScope(this.currentScope());
   }
+  get inCatchBlock() {
+    return (this.currentScope().flags & SCOPE_SIMPLE_CATCH) > 0;
+  }
 
   createScope(flags: ScopeFlags): Scope {
     return new Scope(flags);

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-catch-block/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-catch-block/input.js
@@ -1,0 +1,3 @@
+try {} catch (err) {
+  let let;
+}

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-catch-block/options.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-catch-block/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "'let' is not allowed to be used as a name in 'let' or 'const' declarations. (2:6)"
+}

--- a/packages/babel-parser/test/fixtures/es2015/let/try-catch-let/input.js
+++ b/packages/babel-parser/test/fixtures/es2015/let/try-catch-let/input.js
@@ -1,0 +1,1 @@
+try {} catch (let) {}

--- a/packages/babel-parser/test/fixtures/es2015/let/try-catch-let/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/try-catch-let/output.json
@@ -1,0 +1,117 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 21,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 21
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 21,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 21
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TryStatement",
+        "start": 0,
+        "end": 21,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 21
+          }
+        },
+        "block": {
+          "type": "BlockStatement",
+          "start": 4,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            }
+          },
+          "body": [],
+          "directives": []
+        },
+        "handler": {
+          "type": "CatchClause",
+          "start": 7,
+          "end": 21,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 21
+            }
+          },
+          "param": {
+            "type": "Identifier",
+            "start": 14,
+            "end": 17,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 14
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              },
+              "identifierName": "let"
+            },
+            "name": "let"
+          },
+          "body": {
+            "type": "BlockStatement",
+            "start": 19,
+            "end": 21,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 21
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        },
+        "finalizer": null
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10413 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I added a new getter in `scope` to know if the current scope is a catch block, and then use that property to exclude catch blocks from the original condition

I also tried to go the other way around and implicitly exclude the catch block by raising the error not on lexical binding, but only on `let` and `const` declarations, but i couldn’t find a way to check the kind of the variable declaration when handling an identifier's name

I think other solution could be adding a new scope flag for catch blocks, but i'm not really sure

What do you guys think? 