### PR TITLE
fix typo in babel-preset-env

### DIFF
--- a/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js
+++ b/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js
@@ -197,7 +197,7 @@ export const InstanceProperties: ObjectMap<string[]> = {
   forEach: ["es.array.for-each", "web.dom-collections.for-each"],
   includes: ["es.array.includes", "es.string.includes"],
   indexOf: ["es.array.index-of"],
-  italic: ["es.string.italics"],
+  italics: ["es.string.italics"],
   join: ["es.array.join"],
   keys: ArrayNatureIteratorsWithTag,
   lastIndex: ["esnext.array.last-index"],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In babel-preset-env, `String#italics` is incorrectly defined as `String#italic` for core-js@3.

With a browserslist of `defaults`, we got the following results:

Case 1: not work because `italics` is not polyfilled.

```js
// input
console.log('text'.italics());

// output
console.log('text'.italics());
```

Case 2: still not work because `italic` is not a function, and the polyfill is useless.

```js
// input
console.log('text'.italic());

// output
import "core-js/modules/es.string.italics";
console.log('text'.italic());
```