### PR TITLE
Incorrect trace position in fixture runner

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.js
@@ -62,11 +62,12 @@ function runModuleInTestContext(id: string, relativeFilename: string) {
   const req = id => runModuleInTestContext(id, filename);
 
   const src = fs.readFileSync(filename, "utf8");
-  const code = `(function (exports, require, module, __filename, __dirname) {${src}\n});`;
+  const code = `(function (exports, require, module, __filename, __dirname) {\n${src}\n});`;
 
   vm.runInContext(code, testContext, {
     filename,
     displayErrors: true,
+    lineOffset: -1,
   }).call(module.exports, module.exports, req, module, filename, dirname);
 
   return module.exports;
@@ -94,10 +95,11 @@ export function runCodeInTestContext(code: string, opts: { filename: string }) {
     // Expose the test options as "opts", but otherwise run the test in a CommonJS-like environment.
     // Note: This isn't doing .call(module.exports, ...) because some of our tests currently
     // rely on 'this === global'.
-    const src = `(function(exports, require, module, __filename, __dirname, opts) {${code}\n});`;
+    const src = `(function(exports, require, module, __filename, __dirname, opts) {\n${code}\n});`;
     return vm.runInContext(src, testContext, {
       filename,
       displayErrors: true,
+      lineOffset: -1,
     })(module.exports, req, module, filename, dirname, opts);
   } finally {
     process.chdir(oldCwd);

--- a/packages/babel-helper-transform-fixture-test-runner/test/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/test/index.js
@@ -40,7 +40,7 @@ describe("helper-transform-fixture-test-runner", function() {
       filename: `${__filename}.fake4`,
     };
     runCodeInTestContext(
-      `try { throw new Error()} catch (e) {
+      `try { throw new Error() } catch (e) {
           opts.stack = e.stack
         }
       `,

--- a/packages/babel-helper-transform-fixture-test-runner/test/index.js
+++ b/packages/babel-helper-transform-fixture-test-runner/test/index.js
@@ -35,4 +35,17 @@ describe("helper-transform-fixture-test-runner", function() {
       );
     }
   });
+  it("should print correct trace position when error is thrown in the first line", () => {
+    const opts = {
+      filename: `${__filename}.fake4`,
+    };
+    runCodeInTestContext(
+      `try { throw new Error()} catch (e) {
+          opts.stack = e.stack
+        }
+      `,
+      opts,
+    );
+    expect(opts.stack).toContain(opts.filename + ":1:13");
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Incorrect callsite position when error is thrown at the first line in the `exec` fixture.
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

In this PR we place the fixture code at the second line and add `lineOffset` to make sure the error stack position is correct.

You can check [this build](https://travis-ci.com/JLHwung/babel/jobs/246390789#L1085) to see that the fixture error stack is incorrect when error is thrown at the first line.