### PR TITLE
Bump babel-types to ^7.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ yarn-install: clean-all
 	yarn --ignore-engines
 
 lerna-bootstrap: yarn-install
-	yarn lerna bootstrap -- --ignore-engines
+	yarn lerna bootstrap -- -- --ignore-engines
 
 bootstrap: bootstrap-only
 	$(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ yarn-install: clean-all
 	yarn --ignore-engines
 
 lerna-bootstrap: yarn-install
-	yarn lerna bootstrap -- -- --ignore-engines
+	yarn lerna bootstrap
 
 bootstrap: bootstrap-only
 	$(MAKE) build

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -10,6 +10,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/traverse": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -10,6 +10,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-explode-assignable-expression": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -9,7 +9,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.3.0",
+    "@babel/types": "^7.6.3",
     "esutils": "^2.0.0"
   }
 }

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@babel/helper-hoist-variables": "^7.4.4",
     "@babel/traverse": "^7.4.4",
-    "@babel/types": "^7.4.4"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-function-name": "^7.1.0",
-    "@babel/types": "^7.5.5",
+    "@babel/types": "^7.6.3",
     "lodash": "^4.17.13"
   }
 }

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -10,6 +10,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/traverse": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@babel/helper-bindify-decorators": "^7.1.0",
     "@babel/traverse": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@babel/helper-get-function-arity": "^7.0.0",
     "@babel/template": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.4.4"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -10,6 +10,6 @@
   "main": "lib/index.js",
   "author": "Justin Ridgewell <justin@ridgewell.name>",
   "dependencies": {
-    "@babel/types": "^7.5.5"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports",
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -15,7 +15,7 @@
     "@babel/helper-simple-access": "^7.1.0",
     "@babel/helper-split-export-declaration": "^7.4.4",
     "@babel/template": "^7.4.4",
-    "@babel/types": "^7.5.5",
+    "@babel/types": "^7.6.3",
     "lodash": "^4.17.13"
   }
 }

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -13,6 +13,6 @@
     "@babel/helper-wrap-function": "^7.1.0",
     "@babel/template": "^7.1.0",
     "@babel/traverse": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -12,6 +12,6 @@
     "@babel/helper-member-expression-to-functions": "^7.5.5",
     "@babel/helper-optimise-call-expression": "^7.0.0",
     "@babel/traverse": "^7.5.5",
-    "@babel/types": "^7.5.5"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -12,6 +12,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/template": "^7.1.0",
-    "@babel/types": "^7.0.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -9,6 +9,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/types": "^7.4.4"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -12,6 +12,6 @@
     "@babel/helper-function-name": "^7.1.0",
     "@babel/template": "^7.1.0",
     "@babel/traverse": "^7.1.0",
-    "@babel/types": "^7.2.0"
+    "@babel/types": "^7.6.3"
   }
 }

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@babel/template": "^7.6.0",
     "@babel/traverse": "^7.6.2",
-    "@babel/types": "^7.6.0"
+    "@babel/types": "^7.6.3"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "^7.0.0"

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@babel/parser": "^7.6.0",
-    "@babel/types": "^7.6.0"
+    "@babel/types": "^7.6.3"
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10554 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Bumped `@babel/types` dependencies to `^7.6.3` which depends on secure lodash versions. This PR also fixes incorrect lerna bootstrap options introduced at #10249.