### PR TITLE
E2E test Babel with itself before publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.1
+
 aliases:
   - &restore-node-modules-cache
     keys:
@@ -39,15 +40,19 @@ aliases:
   - &artifact_test262_xunit
     path: ~/test-results
 
-jobs:
-  test:
-    working_directory: ~/babel
+executors:
+  node-executor:
     docker:
       - image: circleci/node:13
+    working_directory: ~/babel
+
+jobs:
+  test:
+    executor: node-executor
     steps:
       - checkout
-      - restore-cache: *restore-yarn-cache
-      - restore-cache: *restore-node-modules-cache
+      - restore_cache: *restore-yarn-cache
+      - restore_cache: *restore-node-modules-cache
       - run: yarn --version
       - run: make test-ci-coverage
       # Builds babel-standalone with the regular Babel config
@@ -63,14 +68,13 @@ jobs:
       - store_artifacts: *artifact_env_min
       - save_cache: *save-node-modules-cache
       - save_cache: *save-yarn-cache
+
   test262:
-    working_directory: ~/babel
-    docker:
-      - image: circleci/node:12
+    executor: node-executor
     steps:
       - checkout
-      - restore-cache: *restore-yarn-cache
-      - restore-cache: *restore-node-modules-cache
+      - restore_cache: *restore-yarn-cache
+      - restore_cache: *restore-node-modules-cache
       - run:
           name: Build Babel
           command: BABEL_ENV=test make bootstrap
@@ -107,11 +111,32 @@ jobs:
             cat ~/test262.tap | $(npm bin)/tap-mocha-reporter spec || true
           <<: *test262_workdir
 
+  publish-verdaccio:
+    executor: node-executor
+    steps:
+      - checkout
+      - run: yarn install
+      - run: ./scripts/integration-tests/publish-local.sh
+      - persist_to_workspace:
+          root: /tmp/verdaccio-workspace
+          paths:
+            - storage
+            - htpasswd
+
+  e2e-babel:
+    executor: node-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/verdaccio-workspace
+      - run: ./scripts/integration-tests/e2e-babel.sh
+
 workflows:
   version: 2
   test:
     jobs:
       - test
+
   master:
     jobs:
       - test262:
@@ -119,3 +144,10 @@ workflows:
             branches:
               only:
                 - master
+
+  e2e:
+    jobs:
+      - publish-verdaccio
+      - e2e-babel:
+          requires:
+            - publish-verdaccio

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 FLOW_COMMIT = 09669846b7a7ca5a6c23c12d56bb3bebdafd67e9
 TEST262_COMMIT = 8688c4ab79059c3097098605e69f1ee5eda6c409
 
+FORCE_PUBLISH = "@babel/runtime,@babel/runtime-corejs2,@babel/runtime-corejs3,@babel/standalone,@babel/preset-env-standalone"
+
 # Fix color output until TravisCI fixes https://github.com/travis-ci/travis-ci/issues/7967
 export FORCE_COLOR = true
 
@@ -189,7 +191,7 @@ prepublish:
 
 new-version:
 	git pull --rebase
-	yarn lerna version --force-publish="@babel/runtime,@babel/runtime-corejs2,@babel/runtime-corejs3,@babel/standalone,@babel/preset-env-standalone"
+	yarn lerna version --force-publish=$(FORCE_PUBLISH)
 
 # NOTE: Run make new-version first
 publish: prepublish
@@ -205,6 +207,16 @@ else
 endif
 	yarn lerna publish from-git --yes
 	rm -f .npmrc
+	$(MAKE) clean
+
+publish-test:
+ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
+	echo "You probably don't know what you are doing"
+	exit 1
+endif
+	$(MAKE) prepublish-build
+	yarn lerna version patch --force-publish=$(FORCE_PUBLISH)  --no-push --yes --tag-version-prefix="version-e2e-test-"
+	yarn lerna publish from-git --registry http://localhost:4873 --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 
 bootstrap-only: lerna-bootstrap

--- a/scripts/integration-tests/e2e-babel.sh
+++ b/scripts/integration-tests/e2e-babel.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#==============================================================================#
+#                                  SETUP                                       #
+#==============================================================================#
+
+# Start in scripts/integration-tests/ even if run from root directory
+cd "$(dirname "$0")"
+
+source utils/local-registry.sh
+source utils/cleanup.sh
+
+# Echo every command being executed
+set -x
+
+# Go to the root of the monorepo
+cd ../..
+
+#==============================================================================#
+#                                   TEST                                       #
+#==============================================================================#
+
+startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
+yarn upgrade --scope @babel
+
+# Test
+make test-ci
+
+cleanup

--- a/scripts/integration-tests/publish-local.sh
+++ b/scripts/integration-tests/publish-local.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#==============================================================================#
+#                                  SETUP                                       #
+#==============================================================================#
+
+# Start in scripts/integration-tests/ even if run from root directory
+cd "$(dirname "$0")"
+
+source utils/local-registry.sh
+source utils/git.sh
+source utils/cleanup.sh
+
+# Echo every command being executed
+set -x
+
+# Go to the root of the monorepo
+cd ../..
+
+initializeE2Egit
+
+#==============================================================================#
+#                                 PUBLISH                                      #
+#==============================================================================#
+
+make bootstrap-only
+
+startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
+loginLocalRegistry
+
+I_AM_USING_VERDACCIO=I_AM_SURE make publish-test
+
+cleanup

--- a/scripts/integration-tests/utils/cleanup.sh
+++ b/scripts/integration-tests/utils/cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+function cleanup {
+  echo "Cleaning up."
+  stopLocalRegistry
+
+  if [ -n "$GIT_E2E_SETUP" ]; then
+    cleanupE2Egit
+  fi
+}
+
+# Error messages are redirected to stderr
+function handle_error {
+  echo "$(basename $0): ERROR! An error was encountered executing line $1." 1>&2;
+  cleanup
+  echo "Exiting with error." 1>&2;
+  exit 1
+}
+
+function handle_exit {
+  cleanup
+  echo "Exiting without error." 1>&2;
+  exit
+}
+
+# Exit the script with a helpful error message when any error is encountered
+trap 'set +x; handle_error $LINENO $BASH_COMMAND' ERR
+
+# Cleanup before exit on any termination signal
+trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP

--- a/scripts/integration-tests/utils/git.sh
+++ b/scripts/integration-tests/utils/git.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+original_git_branch=`git rev-parse --abbrev-ref HEAD`
+tmp_branch_name="integration-tests-$(date +'%F-%H-%M-%N')"
+original_user_name=`git config user.name`
+original_user_email=`git config user.email`
+
+export GIT_E2E_SETUP="true"
+
+function initializeE2Egit {
+  git checkout -b $tmp_branch_name
+
+  # This is needed by lerna, which commits when publishing
+  git config user.name "Babel E2E Test"
+  git config user.email "babel-e2e@example.com"
+}
+
+function cleanupE2Egit {
+  # Delete release tags
+  git tag -d $(git tag -l "version-e2e-test-*")
+
+  # Checkout the prev branch
+  git checkout -f $original_git_branch
+  git branch -D $tmp_branch_name
+
+  # Restore git user
+  git config user.name "$original_user_name"
+  git config user.email "$original_user_email"
+}

--- a/scripts/integration-tests/utils/git.sh
+++ b/scripts/integration-tests/utils/git.sh
@@ -19,7 +19,7 @@ function cleanupE2Egit {
   # Delete release tags
   git tag -d $(git tag -l "version-e2e-test-*")
 
-  # Checkout the prev branch
+  # Checkout the previous branch
   git checkout -f $original_git_branch
   git branch -D $tmp_branch_name
 

--- a/scripts/integration-tests/utils/local-registry.sh
+++ b/scripts/integration-tests/utils/local-registry.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copied from https://github.com/facebook/create-react-app/blob/053f9774d3f592c17741d2a86de66a7ca58f90c0/tasks/local-registry.sh
+
+custom_registry_url=http://localhost:4873
+original_npm_registry_url=`npm get registry`
+original_yarn_registry_url=`yarn config get registry`
+default_verdaccio_package=verdaccio@~4.3.3
+
+function startLocalRegistry {
+  # Start local registry
+  tmp_registry_log=`mktemp`
+  echo "Registry output file: $tmp_registry_log"
+  (cd && nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &)
+
+  # Wait for Verdaccio to boot
+  grep -q "http address" <(tail -f $tmp_registry_log)
+
+  # Set registry to local registry
+  npm set registry "$custom_registry_url"
+  yarn config set registry "$custom_registry_url"
+}
+
+function loginLocalRegistry {
+  # Login so we can publish packages
+  (cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
+}
+
+function stopLocalRegistry {
+  # Restore the original NPM and Yarn registry URLs and stop Verdaccio
+  fuser -k 4873/tcp
+  npm set registry "$original_npm_registry_url"
+  yarn config set registry "$original_yarn_registry_url"
+}

--- a/scripts/integration-tests/verdaccio-config.yml
+++ b/scripts/integration-tests/verdaccio-config.yml
@@ -1,0 +1,61 @@
+#
+# This is the default config file. It allows all users to do anything,
+# so don't use it on production systems.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+#
+
+# path to a directory with all packages
+storage: /tmp/verdaccio-workspace/storage
+
+auth:
+  htpasswd:
+    file: /tmp/verdaccio-workspace/htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    # max_users: 1000
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# You can specify HTTP/1.1 server keep alive timeout in seconds for incoming connections.
+# A value of 0 makes the http server behave similarly to Node.js versions prior to 8.0.0, which did not have a keep-alive timeout.
+# WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enough.
+server:
+  keepAliveTimeout: 60
+
+middlewares:
+  audit:
+    enabled: true
+
+# log settings
+logs:
+  - { type: stdout, format: pretty, level: http }
+  #- {type: file, path: verdaccio.log, level: info}
+#experiments:
+#  # support for npm token command
+#  token: false


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6134
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR adds a CircleCI workflow which
1) Publishes Babel on an internal `verdaccio` registry
2) Upgrades the `@babel/*` versions used by our repo, so that it uses the new "published" version
3) Builds Babel and runs the tests

I created the workflow as two separate jobs so that if we decide to add other e2e tests (e.g. `create-react-app`, `istanbul`, ...) we can run them in parallel after "publishing" Babel only once.

I initially planned to only run these tests using a cronjob once a day, but since it only takes 7 minutes and it's run in parallel with all the other Travis/Circle tests, we could always run it.
This will probably need to change when we add other e2e tests.

~~The `Introduce a bug` commit is an example of a bug which isn't caught by our unit tests but which fails the e2e test~~ :smile: