### PR TITLE
[decorators] fix: support string literal properties

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer-legacy.js
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-legacy.js
@@ -281,7 +281,10 @@ export default {
     path.replaceWith(
       t.callExpression(state.addHelper("initializerDefineProperty"), [
         t.cloneNode(path.get("left.object").node),
-        t.stringLiteral(path.get("left.property").node.name),
+        t.stringLiteral(
+          path.get("left.property").node.name ||
+            path.get("left.property").node.value,
+        ),
         t.cloneNode(path.get("right.arguments")[0].node),
         t.cloneNode(path.get("right.arguments")[1].node),
       ]),

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/string-literal-properties/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-class-prototype-properties/string-literal-properties/exec.js
@@ -1,0 +1,29 @@
+function dec(target, name, descriptor) {
+  expect(target).toBeTruthy();
+  expect(typeof name).toBe("string");
+  expect(typeof descriptor).toBe("object");
+
+  target.decoratedProps = (target.decoratedProps || []).concat([name]);
+
+  return descriptor;
+}
+
+class Example {
+  @dec "a-prop";
+}
+
+let inst = new Example();
+
+expect(Example.prototype).toHaveProperty("decoratedProps");
+expect(inst.decoratedProps).toEqual([
+  "a-prop"
+]);
+
+expect(inst).toHaveProperty("a-prop");
+expect(inst["a-prop"]).toBeUndefined();
+
+const descs = Object.getOwnPropertyDescriptors(inst);
+
+expect(descs["a-prop"].enumerable).toBeTruthy();
+expect(descs["a-prop"].writable).toBeTruthy();
+expect(descs["a-prop"].configurable).toBeTruthy();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #10059 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

As suggested in the issue ticket. Add a basic test case for this too
