### PR TITLE
Fix parentheses on replaceWithMultiple for JSX

### DIFF
--- a/packages/babel-traverse/src/path/modification.js
+++ b/packages/babel-traverse/src/path/modification.js
@@ -115,7 +115,9 @@ export function insertAfter(nodes) {
       }),
     );
   } else if (
-    (this.isNodeType("Expression") && !this.isJSXElement()) ||
+    (this.isNodeType("Expression") &&
+      !this.isJSXElement() &&
+      !parentPath.isJSXElement()) ||
     (parentPath.isForStatement() && this.key === "init")
   ) {
     if (this.node) {

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -1,6 +1,11 @@
 import traverse from "../lib";
 import { parse } from "@babel/parser";
+import generate from "@babel/generator";
 import * as t from "@babel/types";
+
+function generateCode(path) {
+  return generate(path.parentPath.node).code;
+}
 
 describe("path/replacement", function() {
   describe("replaceWith", function() {
@@ -95,6 +100,25 @@ describe("path/replacement", function() {
       }).toThrow(
         /You passed `path\.replaceWith\(\)` a falsy node, use `path\.remove\(\)` instead/,
       );
+    });
+  });
+  describe("replaceWithMultiple", () => {
+    it("ReplaceWithMultiple for a JSXElement with a JSXElement parent", () => {
+      const ast = parse(`<div><span><p></p><h></h></span></div>`, {
+        plugins: ["jsx"],
+      });
+      let path;
+      traverse(ast, {
+        Program: _path => {
+          path = _path.get("body.0");
+        },
+        JSXElement: path => {
+          if (path.node.openingElement.name.name === "span") {
+            path.replaceWithMultiple(path.node.children.filter(t.isJSXElement));
+          }
+        },
+      });
+      expect(generateCode(path)).toBe("<div><p></p><h></h></div>;");
     });
   });
 });

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -3,10 +3,6 @@ import { parse } from "@babel/parser";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-function generateCode(path) {
-  return generate(path.parentPath.node).code;
-}
-
 describe("path/replacement", function() {
   describe("replaceWith", function() {
     it("replaces declaration in ExportDefaultDeclaration node", function() {
@@ -107,18 +103,14 @@ describe("path/replacement", function() {
       const ast = parse(`<div><span><p></p><h></h></span></div>`, {
         plugins: ["jsx"],
       });
-      let path;
       traverse(ast, {
-        Program: _path => {
-          path = _path.get("body.0");
-        },
         JSXElement: path => {
           if (path.node.openingElement.name.name === "span") {
             path.replaceWithMultiple(path.node.children.filter(t.isJSXElement));
           }
         },
       });
-      expect(generateCode(path)).toBe("<div><p></p><h></h></div>;");
+      expect(generate(ast).code).toBe("<div><p></p><h></h></div>;");
     });
   });
 });

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -103,7 +103,7 @@ describe("path/replacement", function() {
     });
   });
   describe("replaceWithMultiple", () => {
-    it("ReplaceWithMultiple for a JSXElement with a JSXElement parent", () => {
+    it("does not add extra parentheses for a JSXElement with a JSXElement parent", () => {
       const ast = parse(`<div><span><p></p><h></h></span></div>`, {
         plugins: ["jsx"],
       });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9851
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`replaceWithMultiple()` first sets the node to replace to null then add the new nodes after it through `insertAfter()`. 

`insertAfter()` already checks for when the node is a `JSXElement` so that it proceeds to inserting the new nodes to the container. To fix the issue, we want to also check if the parent is a `JSXElement`.