### PR TITLE
add auto package label github workflow

### DIFF
--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -1,0 +1,12 @@
+name: Pull Request Label
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: csi-lk/package-labeler@v1.0.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          workspace: "packages"
+          prefix: "pkg: "


### PR DESCRIPTION
Have created a reusable Github action to dynamically label pull requests affecting packages in a monorepo / workspace that I think would work well for Babel's PR triaging process.

This PR adds a `Pull Request Label` 'Github Actions' workflow to auto label incoming pull requests by their scope (currently a manual task)

It works by testing to see what files have changed under the `packages` dir and adds a label per directory in format `pkg: {folder-name}`

Eg if I update `packages/babel-cli/index.js` it will add the label `pkg: babel-cli`

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 👎
| Patch: Bug Fix?          | 👎
| Major: Breaking Change?  | 👎
| Minor: New Feature?      | 👎
| Tests Added + Pass?      | 👍
| Documentation PR Link    | https://github.com/csi-lk/package-labeler
| Any Dependency Changes?  | 👎
| License                  | MIT
