### PR TITLE
Nit: Use ?.  in the example used by the proposal readme

### DIFF
--- a/packages/babel-helper-builder-react-jsx/src/index.js
+++ b/packages/babel-helper-builder-react-jsx/src/index.js
@@ -91,9 +91,7 @@ You can turn on the 'throwIfNamespace' flag to bypass this warning.`,
       value.value = value.value.replace(/\n\s+/g, " ");
 
       // "raw" JSXText should not be used from a StringLiteral because it needs to be escaped.
-      if (value.extra && value.extra.raw) {
-        delete value.extra.raw;
-      }
+      delete value.extra?.raw;
     }
 
     if (t.isJSXNamespacedName(node.name)) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The only reason for this PR is that I noticed that these lines are used in the readme of the optional chaining proposal as a use case for optional chains after `delete`. :stuck_out_tongue:

https://github.com/tc39/proposal-optional-chaining#optional-deletion (click on `Why do we support optional deletion?`)

(cc @claudepache, in case you'll want to update the link in the readme)