### PR TITLE
Use .find instead of .filter to get targetPath in ImportInjector

### DIFF
--- a/packages/babel-helper-module-imports/src/import-injector.js
+++ b/packages/babel-helper-module-imports/src/import-injector.js
@@ -417,10 +417,10 @@ export default class ImportInjector {
       node._blockHoist = blockHoist;
     });
 
-    const targetPath = this._programPath.get("body").filter(p => {
+    const targetPath = this._programPath.get("body").find(p => {
       const val = p.node._blockHoist;
       return Number.isFinite(val) && val < 4;
-    })[0];
+    });
 
     if (targetPath) {
       targetPath.insertBefore(statements);


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

I've committed this directly from GitHub (so haven't run tests myself) but the change is straightforward and .find is available on supported node versions so fingers crossed 😉 
