### PR TITLE
rename `assertsModifier` to `asserts`

### DIFF
--- a/packages/babel-generator/src/generators/typescript.js
+++ b/packages/babel-generator/src/generators/typescript.js
@@ -197,7 +197,7 @@ export function TSTypeReference(node) {
 }
 
 export function TSTypePredicate(node) {
-  if (node.assertsModifier) {
+  if (node.asserts) {
     this.word("asserts");
     this.space();
   }

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -904,8 +904,8 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const t: N.TsTypeAnnotation = this.startNode();
         this.expect(returnToken);
 
-        const assertsModifier = this.tsTryParse(
-          this.tsParseTypePredicateAssertsModifier.bind(this),
+        const asserts = this.tsTryParse(
+          this.tsParseTypePredicateAsserts.bind(this),
         );
 
         const typePredicateVariable =
@@ -913,7 +913,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           this.tsTryParse(this.tsParseTypePredicatePrefix.bind(this));
 
         if (!typePredicateVariable) {
-          if (!assertsModifier) {
+          if (!asserts) {
             // : type
             return this.tsParseTypeAnnotation(/* eatColon */ false, t);
           }
@@ -921,7 +921,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // : asserts foo
           const node = this.startNodeAtNode(t);
           node.parameterName = this.parseIdentifier();
-          node.assertsModifier = assertsModifier;
+          node.asserts = asserts;
           t.typeAnnotation = this.finishNode(node, "TSTypePredicate");
           return this.finishNode(t, "TSTypeAnnotation");
         }
@@ -931,7 +931,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         const node = this.startNodeAtNode(t);
         node.parameterName = typePredicateVariable;
         node.typeAnnotation = type;
-        node.assertsModifier = assertsModifier;
+        node.asserts = asserts;
         t.typeAnnotation = this.finishNode(node, "TSTypePredicate");
         return this.finishNode(t, "TSTypeAnnotation");
       });
@@ -959,7 +959,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
     }
 
-    tsParseTypePredicateAssertsModifier(): boolean {
+    tsParseTypePredicateAsserts(): boolean {
       if (!this.tsIsIdentifier()) {
         return false;
       }

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/output.json
@@ -164,7 +164,7 @@
                       }
                     }
                   },
-                  "assertsModifier": true
+                  "asserts": true
                 }
               },
               "id": null,
@@ -346,7 +346,7 @@
                     },
                     "name": "value"
                   },
-                  "assertsModifier": true
+                  "asserts": true
                 }
               },
               "id": null,

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/output.json
@@ -156,7 +156,7 @@
               },
               "name": "value"
             },
-            "assertsModifier": true
+            "asserts": true
           }
         },
         "declare": true

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-with-predicate/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-with-predicate/output.json
@@ -186,7 +186,7 @@
                 }
               }
             },
-            "assertsModifier": true
+            "asserts": true
           }
         },
         "declare": true

--- a/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/output.json
@@ -186,7 +186,7 @@
                 }
               }
             },
-            "assertsModifier": true
+            "asserts": true
           }
         },
         "body": {
@@ -334,7 +334,7 @@
               },
               "name": "value"
             },
-            "assertsModifier": true
+            "asserts": true
           }
         },
         "body": {

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -175,11 +175,11 @@ defineType("TSTypeReference", {
 
 defineType("TSTypePredicate", {
   aliases: ["TSType"],
-  visitor: ["parameterName", "typeAnnotation", "assertsModifier"],
+  visitor: ["parameterName", "typeAnnotation", "asserts"],
   fields: {
     parameterName: validateType(["Identifier", "TSThisType"]),
     typeAnnotation: validateOptionalType("TSTypeAnnotation"),
-    assertsModifier: validate(bool),
+    asserts: validate(bool),
   },
 });
 


### PR DESCRIPTION
see https://github.com/babel/babel/pull/10543#issuecomment-547571501

It's just a global replace.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/10543#issuecomment-547571501, https://github.com/typescript-eslint/typescript-eslint/issues/1158
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
