### PR TITLE
chore: bump source-map-support to 0.5.14

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.13",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.0",
-    "source-map-support": "^0.5.9"
+    "source-map-support": "^0.5.14"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9883 
| Any Dependency Changes?  | Bumped `source-map-support` to 0.5.14
| License                  | MIT

For the background, see https://github.com/babel/babel/issues/9883#issuecomment-537225724
