### PR TITLE
chore: bump source-map-support to 0.5.16

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.13",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.0",
-    "source-map-support": "^0.5.14"
+    "source-map-support": "^0.5.16"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 👍 
| Any Dependency Changes?  | Bumped `source-map-support` to 0.5.16
| License                  | MIT

Follow up to #10614 

The patch that landed in 0.5.14 had a small issue which could cause a crash. This was fixed in 0.5.16. See https://github.com/evanw/node-source-map-support/issues/260 for more info
