### PR TITLE
chore: remove output-file-sync dependency

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -25,7 +25,6 @@
     "glob": "^7.0.0",
     "lodash": "^4.17.13",
     "make-dir": "^2.1.0",
-    "output-file-sync": "^2.0.0",
     "slash": "^2.0.0",
     "source-map": "^0.5.0"
   },

--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -1,7 +1,6 @@
 // @flow
 
 import defaults from "lodash/defaults";
-import outputFileSync from "output-file-sync";
 import { sync as makeDirSync } from "make-dir";
 import slash from "slash";
 import path from "path";
@@ -9,6 +8,11 @@ import fs from "fs";
 
 import * as util from "./util";
 import { type CmdOptions } from "./options";
+
+function outputFileSync(filePath: string, data: string | Buffer): void {
+  makeDirSync(path.dirname(filePath));
+  fs.writeFileSync(filePath, data);
+}
 
 export default async function({
   cliOptions,

--- a/packages/babel-cli/test/index.js
+++ b/packages/babel-cli/test/index.js
@@ -1,7 +1,7 @@
 const readdir = require("fs-readdir-recursive");
 const helper = require("@babel/helper-fixtures");
 const rimraf = require("rimraf");
-const outputFileSync = require("output-file-sync");
+const { sync: makeDirSync } = require("make-dir");
 const child = require("child_process");
 const merge = require("lodash/merge");
 const path = require("path");
@@ -12,6 +12,11 @@ const tmpLoc = path.join(__dirname, "tmp");
 
 const fileFilter = function(x) {
   return x !== ".DS_Store";
+};
+
+const outputFileSync = function(filePath, data) {
+  makeDirSync(path.dirname(filePath));
+  fs.writeFileSync(filePath, data);
 };
 
 const presetLocs = [path.join(__dirname, "../../babel-preset-react")];

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.6.3",
     "@babel/helper-fixtures": "^7.6.3",
     "fs-readdir-recursive": "^1.0.0",
-    "output-file-sync": "^2.0.0"
+    "make-dir": "^2.1.0"
   },
   "bin": {
     "babel-node": "./bin/babel-node.js"

--- a/packages/babel-node/test/index.js
+++ b/packages/babel-node/test/index.js
@@ -2,7 +2,7 @@ const includes = require("lodash/includes");
 const readdir = require("fs-readdir-recursive");
 const helper = require("@babel/helper-fixtures");
 const rimraf = require("rimraf");
-const outputFileSync = require("output-file-sync");
+const { sync: makeDirSync } = require("make-dir");
 const child = require("child_process");
 const merge = require("lodash/merge");
 const path = require("path");
@@ -13,6 +13,11 @@ const tmpLoc = path.join(__dirname, "tmp");
 
 const fileFilter = function(x) {
   return x !== ".DS_Store";
+};
+
+const outputFileSync = function(filePath, data) {
+  makeDirSync(path.dirname(filePath));
+  fs.writeFileSync(filePath, data);
 };
 
 const presetLocs = [


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | Yes, removed `output-file-sync` dependency
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR replaces `output-file-sync` by `make-dir` + `fs.writeFileSync`. Under the hood `output-file-sync` uses [`mkdirp` + `fs.writeFileSync`](https://github.com/shinnn/output-file-sync/blob/2b7664b027fae76a76de5f58947ed97e151d2ba6/index.js#L111-L118) and adds options checking. As we didn't use options in our codebase, it's safe to replace `output-file-sync`.