### PR TITLE
Fix: inputSourceMap should work when it is an external file

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -157,7 +157,7 @@ function parser(
 
 // eslint-disable-next-line max-len
 const INLINE_SOURCEMAP_REGEX = /^[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(?:.*)$/;
-const EXTERNAL_SOURCEMAP_REGEX = /^[@#][ \t]+sourceMappingURL=([^\s'"`]+?)[ \t]*$/;
+const EXTERNAL_SOURCEMAP_REGEX = /^[@#][ \t]+sourceMappingURL=(?:[^\s'"`]+?)[ \t]*$/;
 
 function extractCommentsFromList(regex, comments, lastComment) {
   if (comments) {

--- a/packages/babel-core/src/transformation/normalize-file.js
+++ b/packages/babel-core/src/transformation/normalize-file.js
@@ -65,7 +65,8 @@ export default function normalizeFile(
       if (typeof options.filename === "string" && lastComment) {
         try {
           inputMap = convertSourceMap.fromMapFileComment(
-            lastComment,
+            // fromMapFileComment requires the whole comment block
+            `//${lastComment}`,
             path.dirname(options.filename),
           );
         } catch (err) {

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/input.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/input.js
@@ -1,0 +1,5 @@
+var foo = function () {
+  return 4;
+};
+
+//# sourceMappingURL=input.js.map

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/input.js.map
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["original.js"],"names":[],"mappings":"AAAA,UAAU,Y;SAAM,C;CAAC","sourcesContent":["var foo = () => 4;"]}

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/options.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/options.json
@@ -1,0 +1,3 @@
+{
+  "inputSourceMap": true
+}

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/output.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/output.js
@@ -1,0 +1,3 @@
+var foo = function () {
+  return 4;
+};

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/source-map.json
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-external/source-map.json
@@ -1,0 +1,7 @@
+{
+  "mappings": "AAAA,IAAA,GAAA,GAAU,Y;SAAM,C;AAAC,CAAjB",
+  "names": [],
+  "sources": ["original.js"],
+  "sourcesContent": ["var foo = () => 4;"],
+  "version": 3
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10534 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes invalid `fromMapFileComment` call signature via prepending parsed comment text by `//`, which is [required in `convert-source-map`](https://github.com/thlorenz/convert-source-map/blob/ad25a3e4373c641a2241cf1470b81ae123e4c23d/index.js#L15).

This PR is a follow up to #9960.