### PR TITLE
Add CodeSandbox CI Config

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "bootstrap",
+  "buildCommand": false,
+  "sandboxes": ["kypop"]
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
+    "bootstrap": "make bootstrap",
     "build": "make build",
     "fix": "make fix",
     "lint": "make lint",


### PR DESCRIPTION
After I've heard some interest from people at Babel about CodeSandbox CI I decided to start fiddling around with it. We've made some changes to CodeSandbox CI to make it work, and this is the result! You can see the service in action here: https://github.com/CompuIves/babel/pull/1.

To have a better idea of what CodeSandbox CI does you can read more about it here: https://u2edh.csb.app/. I recommend merging this PR first before installing the GitHub App, to ensure that all future PRs will work from the get-go.

The gist of it is:

The goal of this app is to make it easier for you to test your library without publishing to npm yet. Since CodeSandbox is already used for bug reports we wanted to make it possible to also test the PR version of your library with the existing bug reports.

In an ideal flow, it would work like this:

Someone opens an issue for a bug with a sandbox reproducible
Someone opens a fix PR mentioning the issue
We build the library from the PR, fork the sandbox repro and install the new library in that sandbox
This way you will only have to open the generated sandbox to confirm that the fix works. No need to clone, install or test locally.

I'm curious what you think of this! Here's a generated sandbox as reference, it's a mini Babel REPL that you can use to play with the version of the library at that moment: https://codesandbox.io/s/babel-playground-44xtv

