### PR TITLE
Ignore convert-source-map module in browser builds, fixes @babel/core for browsers

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -30,7 +30,8 @@
   },
   "browser": {
     "./lib/config/files/index.js": "./lib/config/files/index-browser.js",
-    "./lib/transform-file.js": "./lib/transform-file-browser.js"
+    "./lib/transform-file.js": "./lib/transform-file-browser.js",
+    "convert-source-map": false
   },
   "dependencies": {
     "@babel/code-frame": "^7.5.5",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

I am using `transformFromAstSync` function from `@babel/core` to compile a code in the browser. The issue is that bundler (webpack in my case) eventually reaches the import of `convert-source-map` module which further imports `fs` and that results in an error since the `fs` module is not present in the browser environment.

There a few workarounds / solutions:
- significantly refactor the `@babel/core` so `convert-source-map` is not imported anymore (it's needed only when dealing with sourceMaps)
- webpack config allows to mock out modules through `config.node = { fs: 'empty' }` but that adds a lot of friction on the consumer side
- all popular bundlers understand `browser` field in the package.json, so we can use it to ignore the  `convert-source-map` import

This PR uses the browser field since it doesn't require any code modifications.

(I was also trying to fork `@babel/core` in meantime but the problem is that every single preset (plugin) imports `@babel/core`, so I would have to fork the whole plugin ecosystem which is not feasible.)