### PR TITLE
fix typo: identifer -> identifier

### DIFF
--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -197,7 +197,7 @@ describe("generation", function() {
 
     const id2 = fn.body.body[0].expression;
     id2.name += "2";
-    id2.loc.identiferName = "bar";
+    id2.loc.identifierName = "bar";
 
     const generated = generate(
       ast,

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -384,7 +384,7 @@ export default class ExpressionParser extends LValParser {
          * so for ?? operator we need to check in this case the right expression to have parenthesis
          * second case a && b ?? c
          * here a && b => This is considered as a logical expression in the ast tree
-         * c => identifer
+         * c => identifier
          * so now here for ?? operator we need to check the left expression to have parenthesis
          * if the parenthesis is missing we raise an error and throw it
          */

--- a/packages/babel-types/src/definitions/core.js
+++ b/packages/babel-types/src/definitions/core.js
@@ -407,7 +407,7 @@ defineType("Identifier", {
     name: {
       validate: chain(function(node, key, val) {
         if (!isIdentifierName(val)) {
-          throw new TypeError(`"${val}" is not a valid identifer name`);
+          throw new TypeError(`"${val}" is not a valid identifier name`);
         }
       }, assertValueType("string")),
     },


### PR DESCRIPTION
Initially I only noticed the `babel-types` typo, but searching revealed two more - including one in a test that shouldn't be passing with the typo? Weird.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | - 
| Patch: Bug Fix?          | -
| Major: Breaking Change?  | -
| Minor: New Feature?      | -
| Tests Added + Pass?      | (Unchanged)
| Documentation PR Link    | -
| Any Dependency Changes?  | -
| License                  | MIT
