### PR TITLE
Fix(babel-preset-env): check api.caller is a function to avoid to thr…

### DIFF
--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -237,7 +237,7 @@ export default declare((api, opts) => {
       modules !== "auto" || !api.caller || !api.caller(supportsStaticESM),
     shouldTransformDynamicImport:
       modules !== "auto" || !api.caller || !api.caller(supportsDynamicImport),
-    shouldParseTopLevelAwait: api.caller(supportsTopLevelAwait),
+    shouldParseTopLevelAwait: !api.caller || api.caller(supportsTopLevelAwait),
   });
 
   const pluginNames = filterItems(


### PR DESCRIPTION
Fix [#10646](https://github.com/babel/babel/issues/10646)
check api.caller is a function to avoid to throw error: api.caller is not a function.
