### PR TITLE
fix: add inList setter for compatibility with babel-minify

### DIFF
--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -161,6 +161,13 @@ export default class NodePath {
     return !!this.listKey;
   }
 
+  set inList(inList) {
+    if (!inList) {
+      this.listKey = null;
+    }
+    // ignore inList = true as it should depend on `listKey`
+  }
+
   get parentKey() {
     return this.listKey || this.key;
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10654 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Nope
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Ultimately we should deprecate manipulating `inList`. A compatibility setter is offered for [`inList = false` usage](https://github.com/babel/minify/blob/e1d0c52f5b501f5849741be6db56f968094854eb/packages/babel-plugin-minify-simplify/src/index.js#L557) in babel-minify.