### PR TITLE
Fix some incorrect typeof parsing in flow

### DIFF
--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-1/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-1/input.js
@@ -1,0 +1,2 @@
+// @flow
+interface I extends X, bool {}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-1/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-1/output.json
@@ -1,0 +1,197 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 30
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type bool (2:23)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 30
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start": 9,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 30
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 19,
+          "end": 20,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 11
+            },
+            "identifierName": "I"
+          },
+          "name": "I"
+        },
+        "typeParameters": null,
+        "extends": [
+          {
+            "type": "InterfaceExtends",
+            "start": 29,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 20
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 20
+                },
+                "end": {
+                  "line": 2,
+                  "column": 21
+                },
+                "identifierName": "X"
+              },
+              "name": "X"
+            },
+            "typeParameters": null
+          },
+          {
+            "type": "InterfaceExtends",
+            "start": 32,
+            "end": 36,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 23
+              },
+              "end": {
+                "line": 2,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 32,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 23
+                },
+                "end": {
+                  "line": 2,
+                  "column": 27
+                },
+                "identifierName": "bool"
+              },
+              "name": "bool"
+            },
+            "typeParameters": null
+          }
+        ],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 37,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 28
+            },
+            "end": {
+              "line": 2,
+              "column": 30
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-2/input.js
@@ -1,0 +1,2 @@
+// @flow
+interface I extends X, bool.m {}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-multiple-reserved-invalid-2/output.json
@@ -1,0 +1,229 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 32
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type bool (2:23)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 32
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start": 9,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 32
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 19,
+          "end": 20,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 11
+            },
+            "identifierName": "I"
+          },
+          "name": "I"
+        },
+        "typeParameters": null,
+        "extends": [
+          {
+            "type": "InterfaceExtends",
+            "start": 29,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 20
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 20
+                },
+                "end": {
+                  "line": 2,
+                  "column": 21
+                },
+                "identifierName": "X"
+              },
+              "name": "X"
+            },
+            "typeParameters": null
+          },
+          {
+            "type": "InterfaceExtends",
+            "start": 32,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 23
+              },
+              "end": {
+                "line": 2,
+                "column": 29
+              }
+            },
+            "id": {
+              "type": "QualifiedTypeIdentifier",
+              "start": 32,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 23
+                },
+                "end": {
+                  "line": 2,
+                  "column": 29
+                }
+              },
+              "qualification": {
+                "type": "Identifier",
+                "start": 32,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 27
+                  },
+                  "identifierName": "bool"
+                },
+                "name": "bool"
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 37,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 28
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 29
+                  },
+                  "identifierName": "m"
+                },
+                "name": "m"
+              }
+            },
+            "typeParameters": null
+          }
+        ],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 39,
+          "end": 41,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 30
+            },
+            "end": {
+              "line": 2,
+              "column": 32
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-1/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-1/input.js
@@ -1,0 +1,2 @@
+// @flow
+interface I extends bool {}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-1/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-1/output.json
@@ -1,0 +1,164 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 36,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 27
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type bool (2:20)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 36,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 27
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start": 9,
+        "end": 36,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 27
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 19,
+          "end": 20,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 11
+            },
+            "identifierName": "I"
+          },
+          "name": "I"
+        },
+        "typeParameters": null,
+        "extends": [
+          {
+            "type": "InterfaceExtends",
+            "start": 29,
+            "end": 33,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 20
+              },
+              "end": {
+                "line": 2,
+                "column": 24
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 33,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 20
+                },
+                "end": {
+                  "line": 2,
+                  "column": 24
+                },
+                "identifierName": "bool"
+              },
+              "name": "bool"
+            },
+            "typeParameters": null
+          }
+        ],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 34,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 25
+            },
+            "end": {
+              "line": 2,
+              "column": 27
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-2/input.js
@@ -1,0 +1,2 @@
+// @flow
+interface I extends bool.m {}

--- a/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interface-types/extends-reserved-invalid-2/output.json
@@ -1,0 +1,196 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 38,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 29
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type bool (2:20)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 38,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 29
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start": 9,
+        "end": 38,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 29
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 19,
+          "end": 20,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 11
+            },
+            "identifierName": "I"
+          },
+          "name": "I"
+        },
+        "typeParameters": null,
+        "extends": [
+          {
+            "type": "InterfaceExtends",
+            "start": 29,
+            "end": 35,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 20
+              },
+              "end": {
+                "line": 2,
+                "column": 26
+              }
+            },
+            "id": {
+              "type": "QualifiedTypeIdentifier",
+              "start": 29,
+              "end": 35,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 20
+                },
+                "end": {
+                  "line": 2,
+                  "column": 26
+                }
+              },
+              "qualification": {
+                "type": "Identifier",
+                "start": 29,
+                "end": 33,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 24
+                  },
+                  "identifierName": "bool"
+                },
+                "name": "bool"
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 34,
+                "end": 35,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 26
+                  },
+                  "identifierName": "m"
+                },
+                "name": "m"
+              }
+            },
+            "typeParameters": null
+          }
+        ],
+        "implements": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 36,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 27
+            },
+            "end": {
+              "line": 2,
+              "column": 29
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/implements-reserved-type-invalid-2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/implements-reserved-type-invalid-2/input.js
@@ -1,0 +1,1 @@
+class Foo implements Bar, string {}

--- a/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/implements-reserved-type-invalid-2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/interfaces-module-and-script/implements-reserved-type-invalid-2/output.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 30,
+  "end": 35,
   "loc": {
     "start": {
       "line": 1,
@@ -9,16 +9,16 @@
     },
     "end": {
       "line": 1,
-      "column": 30
+      "column": 35
     }
   },
   "errors": [
-    "SyntaxError: Unexpected reserved type string (1:21)"
+    "SyntaxError: Unexpected reserved type string (1:26)"
   ],
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 30,
+    "end": 35,
     "loc": {
       "start": {
         "line": 1,
@@ -26,7 +26,7 @@
       },
       "end": {
         "line": 1,
-        "column": 30
+        "column": 35
       }
     },
     "sourceType": "module",
@@ -35,7 +35,7 @@
       {
         "type": "ClassDeclaration",
         "start": 0,
-        "end": 30,
+        "end": 35,
         "loc": {
           "start": {
             "line": 1,
@@ -43,7 +43,7 @@
           },
           "end": {
             "line": 1,
-            "column": 30
+            "column": 35
           }
         },
         "id": {
@@ -68,7 +68,7 @@
           {
             "type": "ClassImplements",
             "start": 21,
-            "end": 27,
+            "end": 24,
             "loc": {
               "start": {
                 "line": 1,
@@ -76,13 +76,13 @@
               },
               "end": {
                 "line": 1,
-                "column": 27
+                "column": 24
               }
             },
             "id": {
               "type": "Identifier",
               "start": 21,
-              "end": 27,
+              "end": 24,
               "loc": {
                 "start": {
                   "line": 1,
@@ -90,7 +90,40 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 27
+                  "column": 24
+                },
+                "identifierName": "Bar"
+              },
+              "name": "Bar"
+            },
+            "typeParameters": null
+          },
+          {
+            "type": "ClassImplements",
+            "start": 26,
+            "end": 32,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 26
+              },
+              "end": {
+                "line": 1,
+                "column": 32
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 26,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 26
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
                 },
                 "identifierName": "string"
               },
@@ -101,16 +134,16 @@
         ],
         "body": {
           "type": "ClassBody",
-          "start": 28,
-          "end": 30,
+          "start": 33,
+          "end": 35,
           "loc": {
             "start": {
               "line": 1,
-              "column": 28
+              "column": 33
             },
             "end": {
               "line": 1,
-              "column": 30
+              "column": 35
             }
           },
           "body": []

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/132/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/132/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: Cannot overwrite reserved type number (1:9)"
+    "SyntaxError: Unexpected reserved type number (1:9)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/133/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/133/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: Cannot overwrite reserved type string (1:11)"
+    "SyntaxError: Unexpected reserved type string (1:11)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-1/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-1/input.js
@@ -1,0 +1,2 @@
+// @flow
+const x: typeof interface = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-1/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-1/options.json
@@ -1,0 +1,8 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "jsx",
+    "flow"
+  ],
+  "throws": "Unexpected token, expected \"{\" (2:26)"
+}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-2/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-2/input.js
@@ -1,0 +1,2 @@
+// @flow
+const x: typeof type.interface = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-2/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-2/output.json
@@ -1,0 +1,239 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 47,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 38
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type interface (2:21)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 47,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 38
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 9,
+        "end": 47,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 38
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 15,
+            "end": 46,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 37
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2,
+                  "column": 30
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 16,
+                "end": 39,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 30
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 18,
+                  "end": 39,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 30
+                    }
+                  },
+                  "argument": {
+                    "type": "GenericTypeAnnotation",
+                    "start": 25,
+                    "end": 39,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 30
+                      }
+                    },
+                    "typeParameters": null,
+                    "id": {
+                      "type": "QualifiedTypeIdentifier",
+                      "start": 25,
+                      "end": 39,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 30
+                        }
+                      },
+                      "qualification": {
+                        "type": "Identifier",
+                        "start": 25,
+                        "end": 29,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 20
+                          },
+                          "identifierName": "type"
+                        },
+                        "name": "type"
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 30,
+                        "end": 39,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 21
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 30
+                          },
+                          "identifierName": "interface"
+                        },
+                        "name": "interface"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 42,
+              "end": 46,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 33
+                },
+                "end": {
+                  "line": 2,
+                  "column": 37
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-3/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-3/input.js
@@ -1,0 +1,2 @@
+// @flow
+const x: typeof stuff.number = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-3/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-3/output.json
@@ -1,0 +1,239 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 45,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 36
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type number (2:22)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 45,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 36
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 9,
+        "end": 45,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 36
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 15,
+            "end": 44,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 35
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 37,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2,
+                  "column": 28
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 16,
+                "end": 37,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 28
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 18,
+                  "end": 37,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 28
+                    }
+                  },
+                  "argument": {
+                    "type": "GenericTypeAnnotation",
+                    "start": 25,
+                    "end": 37,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 28
+                      }
+                    },
+                    "typeParameters": null,
+                    "id": {
+                      "type": "QualifiedTypeIdentifier",
+                      "start": 25,
+                      "end": 37,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 28
+                        }
+                      },
+                      "qualification": {
+                        "type": "Identifier",
+                        "start": 25,
+                        "end": 30,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 21
+                          },
+                          "identifierName": "stuff"
+                        },
+                        "name": "stuff"
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 31,
+                        "end": 37,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 22
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 28
+                          },
+                          "identifierName": "number"
+                        },
+                        "name": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 40,
+              "end": 44,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 31
+                },
+                "end": {
+                  "line": 2,
+                  "column": 35
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-4/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-4/input.js
@@ -1,0 +1,2 @@
+// @flow
+const x: typeof static = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-4/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-4/output.json
@@ -1,0 +1,207 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 30
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved word 'static' (2:16)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 30
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 9,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 30
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 15,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 29
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2,
+                  "column": 22
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 16,
+                "end": 31,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 22
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 18,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 22
+                    }
+                  },
+                  "argument": {
+                    "type": "GenericTypeAnnotation",
+                    "start": 25,
+                    "end": 31,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 22
+                      }
+                    },
+                    "typeParameters": null,
+                    "id": {
+                      "type": "Identifier",
+                      "start": 25,
+                      "end": 31,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 22
+                        },
+                        "identifierName": "static"
+                      },
+                      "name": "static"
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 34,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 25
+                },
+                "end": {
+                  "line": 2,
+                  "column": 29
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-5/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-5/input.js
@@ -1,0 +1,2 @@
+// @flow
+const x: typeof typeof = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-5/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-5/options.json
@@ -1,0 +1,8 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "jsx",
+    "flow"
+  ],
+  "throws": "Unexpected token (2:23)"
+}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-6/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-6/input.js
@@ -1,0 +1,2 @@
+// @flow
+const x: typeof d.i\u{6e}terface = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-6/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-6/output.json
@@ -1,0 +1,239 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 49,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 40
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved type interface (2:18)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 49,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 40
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 9,
+        "end": 49,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 40
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 15,
+            "end": 48,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 39
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 41,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2,
+                  "column": 32
+                },
+                "identifierName": "x"
+              },
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 16,
+                "end": 41,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 32
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 18,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 32
+                    }
+                  },
+                  "argument": {
+                    "type": "GenericTypeAnnotation",
+                    "start": 25,
+                    "end": 41,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 32
+                      }
+                    },
+                    "typeParameters": null,
+                    "id": {
+                      "type": "QualifiedTypeIdentifier",
+                      "start": 25,
+                      "end": 41,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 32
+                        }
+                      },
+                      "qualification": {
+                        "type": "Identifier",
+                        "start": 25,
+                        "end": 26,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 17
+                          },
+                          "identifierName": "d"
+                        },
+                        "name": "d"
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 27,
+                        "end": 41,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 18
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 32
+                          },
+                          "identifierName": "interface"
+                        },
+                        "name": "interface"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 44,
+              "end": 48,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 35
+                },
+                "end": {
+                  "line": 2,
+                  "column": 39
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-valid/input.js
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-valid/input.js
@@ -1,0 +1,15 @@
+// @flow
+const a: typeof default = "hi";
+const b: typeof stuff.default = "hi";
+
+const c: typeof any = "hi";
+const d: typeof bool = "hi";
+const e: typeof boolean = "hi";
+const f: typeof empty = "hi";
+const g: typeof false = "hi";
+const h: typeof mixed = "hi";
+const i: typeof null = "hi";
+const j: typeof number = "hi";
+const k: typeof string = "hi";
+const l: typeof true = "hi";
+const m: typeof void = "hi";

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-valid/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-valid/output.json
@@ -1,0 +1,1620 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 407,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 15,
+      "column": 28
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 407,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 15,
+        "column": 28
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 9,
+        "end": 40,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 31
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 15,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 30
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2,
+                  "column": 23
+                },
+                "identifierName": "a"
+              },
+              "name": "a",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 16,
+                "end": 32,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 23
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 18,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 23
+                    }
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "start": 25,
+                    "end": 32,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 23
+                      },
+                      "identifierName": "default"
+                    },
+                    "name": "default"
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 35,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 26
+                },
+                "end": {
+                  "line": 2,
+                  "column": 30
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow",
+            "start": 0,
+            "end": 8,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 41,
+        "end": 78,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 37
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 47,
+            "end": 77,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 36
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 47,
+              "end": 70,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 6
+                },
+                "end": {
+                  "line": 3,
+                  "column": 29
+                },
+                "identifierName": "b"
+              },
+              "name": "b",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 48,
+                "end": 70,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 29
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 50,
+                  "end": 70,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 29
+                    }
+                  },
+                  "argument": {
+                    "type": "GenericTypeAnnotation",
+                    "start": 57,
+                    "end": 70,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 29
+                      }
+                    },
+                    "typeParameters": null,
+                    "id": {
+                      "type": "QualifiedTypeIdentifier",
+                      "start": 57,
+                      "end": 70,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 29
+                        }
+                      },
+                      "qualification": {
+                        "type": "Identifier",
+                        "start": 57,
+                        "end": 62,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 21
+                          },
+                          "identifierName": "stuff"
+                        },
+                        "name": "stuff"
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 63,
+                        "end": 70,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 22
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 29
+                          },
+                          "identifierName": "default"
+                        },
+                        "name": "default"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 73,
+              "end": 77,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 32
+                },
+                "end": {
+                  "line": 3,
+                  "column": 36
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 80,
+        "end": 107,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 27
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 86,
+            "end": 106,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 6
+              },
+              "end": {
+                "line": 5,
+                "column": 26
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 86,
+              "end": 99,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 6
+                },
+                "end": {
+                  "line": 5,
+                  "column": 19
+                },
+                "identifierName": "c"
+              },
+              "name": "c",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 87,
+                "end": 99,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 19
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 89,
+                  "end": 99,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 19
+                    }
+                  },
+                  "argument": {
+                    "type": "AnyTypeAnnotation",
+                    "start": 96,
+                    "end": 99,
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 19
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 102,
+              "end": 106,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 22
+                },
+                "end": {
+                  "line": 5,
+                  "column": 26
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 108,
+        "end": 136,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 28
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 114,
+            "end": 135,
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 6
+              },
+              "end": {
+                "line": 6,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 114,
+              "end": 128,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 6
+                },
+                "end": {
+                  "line": 6,
+                  "column": 20
+                },
+                "identifierName": "d"
+              },
+              "name": "d",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 115,
+                "end": 128,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 117,
+                  "end": 128,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 20
+                    }
+                  },
+                  "argument": {
+                    "type": "BooleanTypeAnnotation",
+                    "start": 124,
+                    "end": 128,
+                    "loc": {
+                      "start": {
+                        "line": 6,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 20
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 131,
+              "end": 135,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 23
+                },
+                "end": {
+                  "line": 6,
+                  "column": 27
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 137,
+        "end": 168,
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 31
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 143,
+            "end": 167,
+            "loc": {
+              "start": {
+                "line": 7,
+                "column": 6
+              },
+              "end": {
+                "line": 7,
+                "column": 30
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 143,
+              "end": 160,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 6
+                },
+                "end": {
+                  "line": 7,
+                  "column": 23
+                },
+                "identifierName": "e"
+              },
+              "name": "e",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 144,
+                "end": 160,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 23
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 146,
+                  "end": 160,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 23
+                    }
+                  },
+                  "argument": {
+                    "type": "BooleanTypeAnnotation",
+                    "start": 153,
+                    "end": 160,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 23
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 163,
+              "end": 167,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 26
+                },
+                "end": {
+                  "line": 7,
+                  "column": 30
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 169,
+        "end": 198,
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 0
+          },
+          "end": {
+            "line": 8,
+            "column": 29
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 175,
+            "end": 197,
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 6
+              },
+              "end": {
+                "line": 8,
+                "column": 28
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 175,
+              "end": 190,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 6
+                },
+                "end": {
+                  "line": 8,
+                  "column": 21
+                },
+                "identifierName": "f"
+              },
+              "name": "f",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 176,
+                "end": 190,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 178,
+                  "end": 190,
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 21
+                    }
+                  },
+                  "argument": {
+                    "type": "EmptyTypeAnnotation",
+                    "start": 185,
+                    "end": 190,
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 21
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 193,
+              "end": 197,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 24
+                },
+                "end": {
+                  "line": 8,
+                  "column": 28
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 199,
+        "end": 228,
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 29
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 205,
+            "end": 227,
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 6
+              },
+              "end": {
+                "line": 9,
+                "column": 28
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 205,
+              "end": 220,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 6
+                },
+                "end": {
+                  "line": 9,
+                  "column": 21
+                },
+                "identifierName": "g"
+              },
+              "name": "g",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 206,
+                "end": 220,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 208,
+                  "end": 220,
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 21
+                    }
+                  },
+                  "argument": {
+                    "type": "BooleanLiteralTypeAnnotation",
+                    "start": 215,
+                    "end": 220,
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 21
+                      }
+                    },
+                    "value": false
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 223,
+              "end": 227,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 24
+                },
+                "end": {
+                  "line": 9,
+                  "column": 28
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 229,
+        "end": 258,
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 0
+          },
+          "end": {
+            "line": 10,
+            "column": 29
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 235,
+            "end": 257,
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 6
+              },
+              "end": {
+                "line": 10,
+                "column": 28
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 235,
+              "end": 250,
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 6
+                },
+                "end": {
+                  "line": 10,
+                  "column": 21
+                },
+                "identifierName": "h"
+              },
+              "name": "h",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 236,
+                "end": 250,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 238,
+                  "end": 250,
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 21
+                    }
+                  },
+                  "argument": {
+                    "type": "MixedTypeAnnotation",
+                    "start": 245,
+                    "end": 250,
+                    "loc": {
+                      "start": {
+                        "line": 10,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 10,
+                        "column": 21
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 253,
+              "end": 257,
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 24
+                },
+                "end": {
+                  "line": 10,
+                  "column": 28
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 259,
+        "end": 287,
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 0
+          },
+          "end": {
+            "line": 11,
+            "column": 28
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 265,
+            "end": 286,
+            "loc": {
+              "start": {
+                "line": 11,
+                "column": 6
+              },
+              "end": {
+                "line": 11,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 265,
+              "end": 279,
+              "loc": {
+                "start": {
+                  "line": 11,
+                  "column": 6
+                },
+                "end": {
+                  "line": 11,
+                  "column": 20
+                },
+                "identifierName": "i"
+              },
+              "name": "i",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 266,
+                "end": 279,
+                "loc": {
+                  "start": {
+                    "line": 11,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 11,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 268,
+                  "end": 279,
+                  "loc": {
+                    "start": {
+                      "line": 11,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 20
+                    }
+                  },
+                  "argument": {
+                    "type": "NullLiteralTypeAnnotation",
+                    "start": 275,
+                    "end": 279,
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 20
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 282,
+              "end": 286,
+              "loc": {
+                "start": {
+                  "line": 11,
+                  "column": 23
+                },
+                "end": {
+                  "line": 11,
+                  "column": 27
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 288,
+        "end": 318,
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 0
+          },
+          "end": {
+            "line": 12,
+            "column": 30
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 294,
+            "end": 317,
+            "loc": {
+              "start": {
+                "line": 12,
+                "column": 6
+              },
+              "end": {
+                "line": 12,
+                "column": 29
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 294,
+              "end": 310,
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 6
+                },
+                "end": {
+                  "line": 12,
+                  "column": 22
+                },
+                "identifierName": "j"
+              },
+              "name": "j",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 295,
+                "end": 310,
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 22
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 297,
+                  "end": 310,
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 22
+                    }
+                  },
+                  "argument": {
+                    "type": "NumberTypeAnnotation",
+                    "start": 304,
+                    "end": 310,
+                    "loc": {
+                      "start": {
+                        "line": 12,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 12,
+                        "column": 22
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 313,
+              "end": 317,
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 25
+                },
+                "end": {
+                  "line": 12,
+                  "column": 29
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 319,
+        "end": 349,
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 0
+          },
+          "end": {
+            "line": 13,
+            "column": 30
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 325,
+            "end": 348,
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 6
+              },
+              "end": {
+                "line": 13,
+                "column": 29
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 325,
+              "end": 341,
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 6
+                },
+                "end": {
+                  "line": 13,
+                  "column": 22
+                },
+                "identifierName": "k"
+              },
+              "name": "k",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 326,
+                "end": 341,
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 22
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 328,
+                  "end": 341,
+                  "loc": {
+                    "start": {
+                      "line": 13,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 13,
+                      "column": 22
+                    }
+                  },
+                  "argument": {
+                    "type": "StringTypeAnnotation",
+                    "start": 335,
+                    "end": 341,
+                    "loc": {
+                      "start": {
+                        "line": 13,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 13,
+                        "column": 22
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 344,
+              "end": 348,
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 25
+                },
+                "end": {
+                  "line": 13,
+                  "column": 29
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 350,
+        "end": 378,
+        "loc": {
+          "start": {
+            "line": 14,
+            "column": 0
+          },
+          "end": {
+            "line": 14,
+            "column": 28
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 356,
+            "end": 377,
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 6
+              },
+              "end": {
+                "line": 14,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 356,
+              "end": 370,
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 6
+                },
+                "end": {
+                  "line": 14,
+                  "column": 20
+                },
+                "identifierName": "l"
+              },
+              "name": "l",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 357,
+                "end": 370,
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 359,
+                  "end": 370,
+                  "loc": {
+                    "start": {
+                      "line": 14,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 14,
+                      "column": 20
+                    }
+                  },
+                  "argument": {
+                    "type": "BooleanLiteralTypeAnnotation",
+                    "start": 366,
+                    "end": 370,
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 20
+                      }
+                    },
+                    "value": true
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 373,
+              "end": 377,
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 23
+                },
+                "end": {
+                  "line": 14,
+                  "column": 27
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 379,
+        "end": 407,
+        "loc": {
+          "start": {
+            "line": 15,
+            "column": 0
+          },
+          "end": {
+            "line": 15,
+            "column": 28
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 385,
+            "end": 406,
+            "loc": {
+              "start": {
+                "line": 15,
+                "column": 6
+              },
+              "end": {
+                "line": 15,
+                "column": 27
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 385,
+              "end": 399,
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 6
+                },
+                "end": {
+                  "line": 15,
+                  "column": 20
+                },
+                "identifierName": "m"
+              },
+              "name": "m",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 386,
+                "end": 399,
+                "loc": {
+                  "start": {
+                    "line": 15,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 15,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TypeofTypeAnnotation",
+                  "start": 388,
+                  "end": 399,
+                  "loc": {
+                    "start": {
+                      "line": 15,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 20
+                    }
+                  },
+                  "argument": {
+                    "type": "VoidTypeAnnotation",
+                    "start": 395,
+                    "end": 399,
+                    "loc": {
+                      "start": {
+                        "line": 15,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 20
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "init": {
+              "type": "StringLiteral",
+              "start": 402,
+              "end": 406,
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 23
+                },
+                "end": {
+                  "line": 15,
+                  "column": 27
+                }
+              },
+              "extra": {
+                "rawValue": "hi",
+                "raw": "\"hi\""
+              },
+              "value": "hi"
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow",
+      "start": 0,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_name/options.json
+++ b/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_name/options.json
@@ -1,4 +1,0 @@
-{
-  "sourceType": "module",
-  "plugins": ["jsx", "flow"]
-}

--- a/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_param_name/output.json
+++ b/packages/babel-parser/test/fixtures/flow/typeapp-call/underscore_is_illegal_type_param_name/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: Cannot overwrite reserved type _ (2:13)",
+    "SyntaxError: Unexpected reserved type _ (2:13)",
     "SyntaxError: `_` is only allowed as a type argument to call or new (2:19)"
   ],
   "program": {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10571
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Went and matched parsing behavior in flow parser v0.111.1, and the error message in cases where user wasn't technically overwriting.