### PR TITLE
fix: remove accessibility of constructor

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.js
+++ b/packages/babel-plugin-transform-typescript/src/index.js
@@ -93,6 +93,7 @@ export default declare(
         // Rest handled by Function visitor
       },
       constructor(path, classPath) {
+        if (path.node.accessibility) path.node.accessibility = null;
         // Collects parameter properties so that we can add an assignment
         // for each of them in the constructor body
         //

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/input.ts
@@ -1,4 +1,5 @@
 class C {
     m(): void;
     public m(x?: number, ...y: number[]): void {}
+    public constructor() {}
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/methods/output.js
@@ -1,4 +1,6 @@
 class C {
   m(x, ...y) {}
 
+  constructor() {}
+
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10644 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The fix is complete as a constructor node may not have `optional` and `abstract` modifier.