### PR TITLE
fix: Use the recommended property to specify repository URL

### DIFF
--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -6,7 +6,7 @@
   "description": "Compile ESNext Regular Expressions to ES5",
   "repository": {
     "type": "git",
-    "repository": "https://github.com/babel/babel",
+    "url": "https://github.com/babel/babel",
     "directory": "packages/babel-helper-create-regexp-features-plugin"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
Use recommended by npm property to specify repository URL
https://docs.npmjs.com/files/package.json#repository

Otherwise, it breaks some tools which relay on this convention for example "nlf" package
https://github.com/iandotkelly/nlf/blob/master/lib/nlf.js#L284-L285

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
