### PR TITLE
Reduce standalone build size

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,7 @@ module.exports = function(api) {
     exclude: ["transform-typeof-symbol"],
   };
   const envOpts = Object.assign({}, envOptsNoTargets);
+  let transformRuntimeOpts = null;
 
   let convertESM = true;
   let ignoreLib = true;
@@ -48,6 +49,17 @@ module.exports = function(api) {
         node: "current",
       };
       break;
+  }
+
+  if (includeRuntime) {
+    const babelRuntimePackageJSONPath = require.resolve(
+      "@babel/runtime/package.json"
+    );
+    const path = require("path");
+    transformRuntimeOpts = {
+      version: require(babelRuntimePackageJSONPath).version,
+      absoluteRuntime: path.dirname(babelRuntimePackageJSONPath),
+    };
   }
 
   const config = {
@@ -123,10 +135,7 @@ module.exports = function(api) {
         ],
         plugins: [
           includeRuntime
-            ? [
-                "@babel/transform-runtime",
-                { version: require("@babel/runtime/package").version },
-              ]
+            ? ["@babel/transform-runtime", transformRuntimeOpts]
             : null,
         ].filter(Boolean),
       },

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -3,7 +3,6 @@
   "version": "7.7.2",
   "description": "Babel compiler core.",
   "main": "lib/index.js",
-  "_main:used-by-babel-standalone": "src/index.js",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
@@ -35,9 +34,7 @@
   },
   "browser": {
     "./lib/config/files/index.js": "./lib/config/files/index-browser.js",
-    "./lib/transform-file.js": "./lib/transform-file-browser.js"
-  },
-  "_browser:used-by-babel-standalone": {
+    "./lib/transform-file.js": "./lib/transform-file-browser.js",
     "./src/config/files/index.js": "./src/config/files/index-browser.js",
     "./src/transform-file.js": "./src/transform-file-browser.js"
   },

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.2",
   "description": "Babel compiler core.",
   "main": "lib/index.js",
+  "_main:used-by-babel-standalone": "src/index.js",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
@@ -35,6 +36,10 @@
   "browser": {
     "./lib/config/files/index.js": "./lib/config/files/index-browser.js",
     "./lib/transform-file.js": "./lib/transform-file-browser.js"
+  },
+  "_browser:used-by-babel-standalone": {
+    "./src/config/files/index.js": "./src/config/files/index-browser.js",
+    "./src/transform-file.js": "./src/transform-file-browser.js"
   },
   "dependencies": {
     "@babel/code-frame": "^7.5.5",

--- a/scripts/gulp-tasks.js
+++ b/scripts/gulp-tasks.js
@@ -88,7 +88,6 @@ function webpackBuild(opts) {
       }),
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": '"production"',
-        "process.env": JSON.stringify({ NODE_ENV: "production" }),
         BABEL_VERSION: JSON.stringify(babelVersion),
         VERSION: JSON.stringify(version),
       }),

--- a/scripts/gulp-tasks.js
+++ b/scripts/gulp-tasks.js
@@ -29,10 +29,7 @@ function generateResolveAlias() {
   const alias = {};
   const packagePath = path.resolve(process.cwd(), "packages");
   fs.readdirSync(packagePath).forEach(folder => {
-    if (["babel-core"].includes(folder)) {
-      return;
-    }
-    alias[folder.replace("babel-", "@babel/")] = path.resolve(
+    alias[folder.replace("babel-", "@babel/") + "$"] = path.resolve(
       packagePath,
       folder,
       "src"
@@ -100,8 +97,6 @@ function webpackBuild(opts) {
     resolve: {
       //todo: remove resolve.alias when babel packages offer ESModule entry
       alias: generateResolveAlias(),
-      aliasFields: ["_browser:used-by-babel-standalone", "browser"],
-      mainFields: ["_main:used-by-babel-standalone", "main"],
       plugins: [
         // Dedupe packages that are used across multiple plugins.
         // This replaces DedupePlugin from Webpack 1.x


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

In this PR we build babel-standalone against the `src` version of `@babel/*` dependencies instead of `lib`, which is specified in their `package.json`. By doing so the `transform-runtime` can replace babel helper calls by runtime helper imports. It is impossible to achieve this on `lib` version where the helpers are inlined.

Here is a brief summary on the number of inlined `function _interopRequireDefault(obj)` declarations in the artifacts. (produced by [this script](https://gist.github.com/JLHwung/a42e22b86c1b91a1382287279c39f639), lower is better) 

| | 7.7.1 | This branch
| --- | --- | --- |
| @babel/standalone | 151 | 4 |
| @babel/preset-env-standalone | 101 | 0 |

Note that there are still 4 inlined `_interopRequireDefault` declaration not removed in `@babel/standalone`, all of which comes from third party dependencies, i.e. `regenerator-runtime`.