### PR TITLE
Support removing nodes when deeply inside a traversal

### DIFF
--- a/packages/babel-traverse/src/context.js
+++ b/packages/babel-traverse/src/context.js
@@ -9,6 +9,9 @@ export default class TraversalContext {
     this.scope = scope;
     this.state = state;
     this.opts = opts;
+
+    const parentContext = parentPath?.context;
+    if (parentContext) parentContext.child = this;
   }
 
   parentPath: NodePath;
@@ -16,6 +19,7 @@ export default class TraversalContext {
   state;
   opts;
   queue: ?Array<NodePath> = null;
+  child: ?TraversalContext = null;
 
   /**
    * This method does a simple check to determine whether or not we really need to attempt
@@ -150,6 +154,8 @@ export default class TraversalContext {
   visit(node, key) {
     const nodes = node[key];
     if (!nodes) return false;
+
+    if (this.parentPath?.removed) return false;
 
     if (Array.isArray(nodes)) {
       return this.visitMultiple(nodes, node, key);

--- a/packages/babel-traverse/src/path/index.js
+++ b/packages/babel-traverse/src/path/index.js
@@ -199,6 +199,7 @@ export default class NodePath {
   get removed() {
     return !!(this._traverseFlags & REMOVED);
   }
+
   set removed(v) {
     if (v) {
       this._traverseFlags |= REMOVED;

--- a/packages/babel-traverse/src/path/removal.js
+++ b/packages/babel-traverse/src/path/removal.js
@@ -40,9 +40,16 @@ export function _remove() {
 }
 
 export function _markRemoved() {
+  if (this.removed) return;
+
   // this.shouldSkip = true; this.removed = true;
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
   this.node = null;
+
+  const queue = this.context?.child?.queue;
+  if (queue) {
+    for (const path of queue) path._markRemoved();
+  }
 }
 
 export function _assertUnremoved() {

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -33,4 +33,46 @@ describe("removal", function() {
       expect(generateCode(rootPath)).toBe("x = () => {};");
     });
   });
+
+  it("can remove during deep traversal without error", function() {
+    const ast = parse(`const { foo } = props;`);
+
+    let calls = 0;
+    traverse(ast, {
+      ObjectPattern(path) {
+        // Removing the declarator removes the declaration.
+        path.parentPath.remove();
+      },
+
+      Expression: {
+        exit() {
+          calls++;
+        },
+      },
+    });
+
+    expect(calls).toBe(0);
+    expect(generate(ast).code).toBe("");
+  });
+
+  it("can remove during reallly deep traversal without error", function() {
+    const ast = parse(`const { foo } = props;`);
+
+    let calls = 0;
+    traverse(ast, {
+      ObjectPattern(path) {
+        // Removing the declaration.
+        path.parentPath.parentPath.remove();
+      },
+
+      Expression: {
+        exit() {
+          calls++;
+        },
+      },
+    });
+
+    expect(calls).toBe(0);
+    expect(generate(ast).code).toBe("");
+  });
 });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Possibly
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

We had an issue where removing a `VariableDeclarator` when inside the `id` key (in this case an `ObjectPattern`) would still iterate the `init` key. Well, when it tried to determine if it the init was a `ReferencedIdentifier`, it would pass a null `parent` to [`isReferenced`](https://github.com/babel/babel/blob/70c0ed512a5fb2e8f461c7d14e493a3ce131e686/packages/babel-types/src/validators/isReferenced.js#L7) (because removing the declarator turns `path.node = null`). That threw an error.

This could probably be extended to `shouldSkip` and `shouldStop` as well.
