### PR TITLE
fix: update asserts types

### DIFF
--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1227,6 +1227,7 @@ export type TsTypePredicate = TsTypeBase & {
   type: "TSTypePredicate",
   parameterName: Identifier | TsThisType,
   typeAnnotation: TsTypeAnnotation,
+  asserts?: boolean,
 };
 
 // `typeof` operator

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -175,11 +175,12 @@ defineType("TSTypeReference", {
 
 defineType("TSTypePredicate", {
   aliases: ["TSType"],
-  visitor: ["parameterName", "typeAnnotation", "asserts"],
+  visitor: ["parameterName", "typeAnnotation"],
+  builder: ["parameterName", "typeAnnotation", "asserts"],
   fields: {
     parameterName: validateType(["Identifier", "TSThisType"]),
     typeAnnotation: validateOptionalType("TSTypeAnnotation"),
-    asserts: validate(bool),
+    asserts: validateOptional(bool),
   },
 });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Update `asserts` related type definitions
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a byproduct of #10677. We align the `asserts` definition to the current behaviour (optional boolean) and remove `asserts` from visitors since it's not an AST Node.