### PR TITLE
Babel should not silently remove unknown options after commander arguments

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -19,7 +19,7 @@
     "compiler"
   ],
   "dependencies": {
-    "commander": "^2.8.1",
+    "commander": "^4.0.1",
     "convert-source-map": "^1.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.0.0",

--- a/packages/babel-cli/src/babel/options.js
+++ b/packages/babel-cli/src/babel/options.js
@@ -163,6 +163,10 @@ commander.option(
 
 commander.version(pkg.version + " (@babel/core " + version + ")");
 commander.usage("[options] <files ...>");
+// register an empty action handler so that commander.js can throw on
+// unknown options _after_ args
+// see https://github.com/tj/commander.js/issues/561#issuecomment-522209408
+commander.action(() => {});
 
 export type CmdOptions = {
   babelOptions: Object,

--- a/packages/babel-cli/test/fixtures/babel/error incorrect options after args/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/error incorrect options after args/in-files/script.js
@@ -1,0 +1,1 @@
+arr.map(x => x * MULTIPLIER);

--- a/packages/babel-cli/test/fixtures/babel/error incorrect options after args/options.json
+++ b/packages/babel-cli/test/fixtures/babel/error incorrect options after args/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["script.js", "--spruce-maps"],
+  "stderrContains": true
+}

--- a/packages/babel-cli/test/fixtures/babel/error incorrect options after args/stderr.txt
+++ b/packages/babel-cli/test/fixtures/babel/error incorrect options after args/stderr.txt
@@ -1,0 +1,1 @@
+error: unknown option '--spruce-maps'

--- a/packages/babel-cli/test/fixtures/babel/error incorrect options before args/in-files/script.js
+++ b/packages/babel-cli/test/fixtures/babel/error incorrect options before args/in-files/script.js
@@ -1,0 +1,1 @@
+arr.map(x => x * MULTIPLIER);

--- a/packages/babel-cli/test/fixtures/babel/error incorrect options before args/options.json
+++ b/packages/babel-cli/test/fixtures/babel/error incorrect options before args/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--spruce-maps", "script.js"],
+  "stderrContains": true
+}

--- a/packages/babel-cli/test/fixtures/babel/error incorrect options before args/stderr.txt
+++ b/packages/babel-cli/test/fixtures/babel/error incorrect options before args/stderr.txt
@@ -1,0 +1,1 @@
+error: unknown option '--spruce-maps'


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #4825
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | `commander.js` is bumped to v4.0.1
| License                  | MIT

In this PR we bump `commander.js` to v4.0.1, which can throw on unknown options _after_ arguments when an action handler is provided. To do so we register an empty action handler so that unknown options error can be thrown.

### Impact analysis of upgrading `commander.js` from 2.8 to 4.0

Breaking changes from 2.0 to 3.0
- Change TypeScript to use overloaded function for .command. 
Not related
- custom event listeners: --no-foo on cli now emits option:no-foo (previously option:foo)
Not related since we are not using custom event listeners
- default value: defining --no-foo after defining --foo leaves the default value unchanged (previously set it to false)
Not related since we don't have any option that has both `--no-` and `--` prefixes.

Breaking changes from 3.0 to 4.0

- keep command object out of program.args when action handler called
Not related since we are not using the command object in an action handler
- Commander is only officially supported on Node 8 and above, and requires Node 6
It should be fine since we will drop Node 6 and 8 soon, too. If CI is good we may say it should work on Node 6 from now on.
- Testing for no arguments is changed
Not related since I can't find any `.args.length` usage in our codebase.
