### PR TITLE
Circumvent typeof transform for umd build template

### DIFF
--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/export-default-arrow-renaming-module-umd/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/export-default-arrow-renaming-module-umd/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -14,7 +14,9 @@ import { types as t, template } from "@babel/core";
 const buildPrerequisiteAssignment = template(`
   GLOBAL_REFERENCE = GLOBAL_REFERENCE || {}
 `);
-
+// Note: we avoid comparing typeof results with "object" or "symbol" otherwise
+// they will be processed by `transform-typeof-symbol`, which in return could
+// cause typeof helper used before declaration
 const buildWrapper = template(`
   (function (global, factory) {
     if (typeof define === "function" && define.amd) {
@@ -28,8 +30,8 @@ const buildWrapper = template(`
       GLOBAL_TO_ASSIGN;
     }
   })(
-    typeof globalThis === "object" ? globalThis
-      : typeof self === "object" ? self
+    typeof globalThis !== "undefined" ? globalThis
+      : typeof self !== "undefined" ? self
       : this,
     function(IMPORT_NAMES) {
   })

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-10/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-10/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-11/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-11/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-2/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-3/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-4/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-5/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-6/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-7/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-7/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-8/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-8/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-9/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default-9/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-default/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-2/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-3/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-4/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-5/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from-6/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-from/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-2/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-3/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-4/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named-5/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/export-named/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/exports-variable/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/get-module-name-option/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/get-module-name-option/output.js
@@ -10,6 +10,6 @@
     factory();
     global.myCustomModuleName = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/hoist-function-exports/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.evens);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _evens) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _evens) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-default/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-default/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo) {
   "use strict";
 
   _foo = babelHelpers.interopRequireDefault(_foo);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-false-with-overrides/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-false-with-overrides/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBAR, global.fooBAR, global.fizzBuzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-false/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-false/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBar, global.fooBar, global.fizzbuzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-true-with-overrides/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-true-with-overrides/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBAR, global.mylib.fooBar, global.fizz.buzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-true/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-exact-globals-true/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBar, global.mylibFooBar, global.fizzbuzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-glob/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-glob/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (foo) {
   "use strict";
 
   foo = babelHelpers.interopRequireWildcard(foo);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-mixing/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-mixing/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo) {
   "use strict";
 
   _foo = babelHelpers.interopRequireWildcard(_foo);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-named/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports-named/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo) {
   "use strict";
 
   _foo.bar;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/imports/output.js
@@ -10,6 +10,6 @@
     factory(global.foo, global.fooBar, global.fooBar);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo, _fooBar, _fooBar2) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo, _fooBar, _fooBar2) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-namespace/output.js
@@ -11,7 +11,7 @@
     global.foo = global.foo || {};
     global.foo.bar = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-very-nested-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global-in-very-nested-namespace/output.js
@@ -13,7 +13,7 @@
     global.foo.bar.baz = global.foo.bar.baz || {};
     global.foo.bar.baz.qux = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id-with-overridden-global/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.baz = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-id/output.js
@@ -10,7 +10,7 @@
     factory();
     global.MyLib = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 
   foobar();

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name-with-overridden-global/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name-with-overridden-global/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.looseModuleNameWithOverriddenGlobalInput = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/module-name/output.js
@@ -10,7 +10,7 @@
     factory();
     global.looseModuleNameInput = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 
   foobar();

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/non-default-imports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/non-default-imports/output.js
@@ -10,6 +10,6 @@
     factory(global.render);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_render) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_render) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/override-export-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/override-export-name/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/override-import-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/override-import-name/output.js
@@ -10,6 +10,6 @@
     factory(global.Promise);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_es6Promise) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_es6Promise) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/overview/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/overview/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo, global.fooBar, global.fooBar);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, foo2, _fooBar, _fooBar2) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, foo2, _fooBar, _fooBar2) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/remap/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/loose/remap/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   _exports.__esModule = true;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/regression/4192/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/regression/4192/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-10/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-10/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-11/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-11/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-2/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-3/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-4/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-5/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-6/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-7/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-7/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-8/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-8/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-9/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default-9/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-default/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-2/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-3/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-4/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-5/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-6/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from-6/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-from/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _foo) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-2/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-2/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-3/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-3/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-4/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-4/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-5/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named-5/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/export-named/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/exports-variable/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/exports-variable/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/get-module-name-option/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/get-module-name-option/output.js
@@ -10,6 +10,6 @@
     factory();
     global.myCustomModuleName = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/hoist-function-exports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/hoist-function-exports/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.evens);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, _evens) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, _evens) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-default/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-default/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo) {
   "use strict";
 
   _foo = babelHelpers.interopRequireDefault(_foo);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-false-with-overrides/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBAR, global.fooBAR, global.fizzBuzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-false/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-false/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBar, global.fooBar, global.fizzbuzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-true-with-overrides/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBAR, global.mylib.fooBar, global.fizz.buzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-true/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-exact-globals-true/output.js
@@ -10,7 +10,7 @@
     factory(global.fooBar, global.mylibFooBar, global.fizzbuzz);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_fooBar, _fooBar2, _fizzbuzz) {
   "use strict";
 
   _fooBar = babelHelpers.interopRequireDefault(_fooBar);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-glob/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-glob/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (foo) {
   "use strict";
 
   foo = babelHelpers.interopRequireWildcard(foo);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-mixing/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-mixing/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo) {
   "use strict";
 
   _foo = babelHelpers.interopRequireWildcard(_foo);

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-named/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports-named/output.js
@@ -10,7 +10,7 @@
     factory(global.foo);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo) {
   "use strict";
 
   _foo.bar;

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/imports/output.js
@@ -10,6 +10,6 @@
     factory(global.foo, global.fooBar, global.fooBar);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_foo, _fooBar, _fooBar2) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_foo, _fooBar, _fooBar2) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-namespace/output.js
@@ -11,7 +11,7 @@
     global.foo = global.foo || {};
     global.foo.bar = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global-in-very-nested-namespace/output.js
@@ -13,7 +13,7 @@
     global.foo.bar.baz = global.foo.bar.baz || {};
     global.foo.bar.baz.qux = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id-with-overridden-global/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.baz = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-id/output.js
@@ -10,7 +10,7 @@
     factory();
     global.MyLib = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 
   foobar();

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name-with-overridden-global/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name-with-overridden-global/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.umdModuleNameWithOverriddenGlobalInput = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/module-name/output.js
@@ -10,7 +10,7 @@
     factory();
     global.umdModuleNameInput = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 
   foobar();

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/non-default-imports/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/non-default-imports/output.js
@@ -10,6 +10,6 @@
     factory(global.render);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_render) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_render) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/override-export-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/override-export-name/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/override-import-name/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/override-import-name/output.js
@@ -10,6 +10,6 @@
     factory(global.Promise);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_es6Promise) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_es6Promise) {
   "use strict";
 });

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/overview/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/overview/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports, global.foo, global.fooBar, global.fooBar);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports, foo2, _fooBar, _fooBar2) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports, foo2, _fooBar, _fooBar2) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/remap/output.js
+++ b/packages/babel-plugin-transform-modules-umd/test/fixtures/umd/remap/output.js
@@ -10,7 +10,7 @@
     factory(mod.exports);
     global.input = mod.exports;
   }
-})(typeof globalThis === "object" ? globalThis : typeof self === "object" ? self : this, function (_exports) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_exports) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/modules-umd/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/modules-umd/output.js
@@ -1,5 +1,3 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define([], factory);
@@ -12,7 +10,7 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
     factory();
     global.input = mod.exports;
   }
-})((typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === "object" ? globalThis : (typeof self === "undefined" ? "undefined" : _typeof(self)) === "object" ? self : this, function () {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 
   import("foo"); // warns

--- a/packages/babel-preset-env/test/fixtures/modules/modules-umd/output.js
+++ b/packages/babel-preset-env/test/fixtures/modules/modules-umd/output.js
@@ -1,5 +1,3 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["a"], factory);
@@ -12,7 +10,7 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
     factory(global.a);
     global.input = mod.exports;
   }
-})((typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === "object" ? globalThis : (typeof self === "undefined" ? "undefined" : _typeof(self)) === "object" ? self : this, function (_a) {
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_a) {
   "use strict";
 
   _a = _interopRequireDefault(_a);

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/input.mjs
@@ -1,0 +1,2 @@
+var globalThis = {};
+typeof globalThis;

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/options.json
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/options.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "modules": "umd",
+        "targets": [
+          "Safari 8",
+          "IE 11"
+        ]
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/output.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define([], factory);
+  } else if (typeof exports !== "undefined") {
+    factory();
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory();
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
+  "use strict";
+
+  function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+  var globalThis = {};
+
+  _typeof(globalThis);
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10662 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we revise the umd module build template to avoid typeof transforms. It is not an ideal fix as ultimately we should hoist helper declaration to the program block if referenced by any nodes in the build template.

On the other hand we may skip polyfilling the `typeof` calls in build template as it is rare to assign a symbol to these global properties.

This PR is a follow-up to #10477.