### PR TITLE
Ignore PR job on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,9 +176,17 @@ workflows:
     jobs:
       - approve-test262-run:
           type: approval
+          filters:
+            branches:
+              ignore:
+                - master
       - test262:
           requires:
             - approve-test262-run
+          filters:
+            branches:
+              ignore:
+                - master
   e2e:
     jobs:
       - publish-verdaccio


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Relates to #4987 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Followup to #10579. If we look at a commit which landed after, like https://github.com/babel/babel/commit/1d1101eb7c8d89a2179b098f6dd131b4b479020a, you can see that even though it's passing all checks the PR check is failing since the PR job is not approved to run.

This will incorrectly show all jobs as pending, which is noisy.

This PR aims at fixing this issue. Thanks to @nicolo-ribaudo for pointing it out!