### PR TITLE
register import equals specifier

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -21,6 +21,7 @@ import {
   BIND_TS_AMBIENT,
   BIND_TS_NAMESPACE,
   BIND_CLASS,
+  BIND_LEXICAL,
 } from "../../util/scopeflags";
 import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";
@@ -1292,6 +1293,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     ): N.TsImportEqualsDeclaration {
       node.isExport = isExport || false;
       node.id = this.parseIdentifier();
+      this.checkLVal(
+        node.id,
+        BIND_LEXICAL,
+        undefined,
+        "import equals declaration",
+      );
       this.expect(tt.eq);
       node.moduleReference = this.tsParseModuleReference();
       this.semicolon();

--- a/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/input.ts
@@ -1,0 +1,2 @@
+import a = require("a");
+export { a };

--- a/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/output.json
@@ -1,0 +1,171 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 38,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 13
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 38,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 13
+      }
+    },
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSImportEqualsDeclaration",
+        "start": 0,
+        "end": 24,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "isExport": false,
+        "id": {
+          "type": "Identifier",
+          "start": 7,
+          "end": 8,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 8
+            },
+            "identifierName": "a"
+          },
+          "name": "a"
+        },
+        "moduleReference": {
+          "type": "TSExternalModuleReference",
+          "start": 11,
+          "end": 23,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 11
+            },
+            "end": {
+              "line": 1,
+              "column": 23
+            }
+          },
+          "expression": {
+            "type": "StringLiteral",
+            "start": 19,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "extra": {
+              "rawValue": "a",
+              "raw": "\"a\""
+            },
+            "value": "a"
+          }
+        }
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 25,
+        "end": 38,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 13
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 34,
+            "end": 35,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 34,
+              "end": 35,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 10
+                },
+                "identifierName": "a"
+              },
+              "name": "a"
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 34,
+              "end": 35,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 10
+                },
+                "identifierName": "a"
+              },
+              "name": "a"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10042 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we register the import equals specifier so that it would not throw if it appears in an export named declaration later.

Note that we does not support transforming ImportEqualsDeclaration yet, but we should be able to parse it.

Credits to @jj-choi