### PR TITLE
Do not run eslint/* tests in Node v6

### DIFF
--- a/eslint/babel-eslint-plugin/src/rules/array-bracket-spacing.js
+++ b/eslint/babel-eslint-plugin/src/rules/array-bracket-spacing.js
@@ -37,7 +37,7 @@ module.exports = {
 
         console.log(
           "The babel/array-bracket-spacing rule is deprecated. Please " +
-            "use the built in array-bracket-spacing rule instead."
+            "use the built in array-bracket-spacing rule instead.",
         );
         isWarnedForDeprecation = true;
       },

--- a/eslint/babel-eslint-plugin/src/rules/arrow-parens.js
+++ b/eslint/babel-eslint-plugin/src/rules/arrow-parens.js
@@ -22,7 +22,7 @@ module.exports = {
 
         console.log(
           "The babel/arrow-parens rule is deprecated. Please " +
-            "use the built in arrow-parens rule instead."
+            "use the built in arrow-parens rule instead.",
         );
         isWarnedForDeprecation = true;
       },

--- a/eslint/babel-eslint-plugin/src/rules/func-params-comma-dangle.js
+++ b/eslint/babel-eslint-plugin/src/rules/func-params-comma-dangle.js
@@ -22,7 +22,7 @@ module.exports = {
 
         console.log(
           "The babel/func-params-comma-dangle rule is deprecated. Please " +
-            "use the built in comma-dangle rule instead."
+            "use the built in comma-dangle rule instead.",
         );
         isWarnedForDeprecation = true;
       },

--- a/eslint/babel-eslint-plugin/src/rules/generator-star-spacing.js
+++ b/eslint/babel-eslint-plugin/src/rules/generator-star-spacing.js
@@ -34,7 +34,7 @@ module.exports = {
 
         console.log(
           "The babel/generator-star-spacing rule is deprecated. Please " +
-            "use the built in generator-star-spacing rule instead."
+            "use the built in generator-star-spacing rule instead.",
         );
         isWarnedForDeprecation = true;
       },

--- a/eslint/babel-eslint-plugin/src/rules/new-cap.js
+++ b/eslint/babel-eslint-plugin/src/rules/new-cap.js
@@ -15,5 +15,5 @@ function isDecorator(node) {
 
 module.exports = ruleComposer.filterReports(
   newCapRule,
-  problem => !isDecorator(problem.node)
+  problem => !isDecorator(problem.node),
 );

--- a/eslint/babel-eslint-plugin/src/rules/no-await-in-loop.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-await-in-loop.js
@@ -18,7 +18,7 @@ module.exports = {
 
         console.log(
           "The babel/no-await-in-loop rule is deprecated. Please " +
-            "use the built in no-await-in-loop rule instead."
+            "use the built in no-await-in-loop rule instead.",
         );
         isWarnedForDeprecation = true;
       },

--- a/eslint/babel-eslint-plugin/src/rules/no-unused-expressions.js
+++ b/eslint/babel-eslint-plugin/src/rules/no-unused-expressions.js
@@ -60,5 +60,5 @@ function isOptionalCallExpression(node) {
 module.exports = ruleComposer.filterReports(
   rule,
   problem =>
-    !isInDoStatement(problem.node) && !isOptionalCallExpression(problem.node)
+    !isInDoStatement(problem.node) && !isOptionalCallExpression(problem.node),
 );

--- a/eslint/babel-eslint-plugin/src/rules/object-curly-spacing.js
+++ b/eslint/babel-eslint-plugin/src/rules/object-curly-spacing.js
@@ -23,5 +23,5 @@ module.exports = ruleComposer.filterReports(
     }
 
     return true;
-  }
+  },
 );

--- a/eslint/babel-eslint-plugin/src/rules/object-shorthand.js
+++ b/eslint/babel-eslint-plugin/src/rules/object-shorthand.js
@@ -22,7 +22,7 @@ module.exports = {
 
         console.log(
           "The babel/object-shorthand rule is deprecated. Please " +
-            "use the built in object-shorthand rule instead."
+            "use the built in object-shorthand rule instead.",
         );
         isWarnedForDeprecation = true;
       },

--- a/eslint/babel-eslint-plugin/src/rules/semi.js
+++ b/eslint/babel-eslint-plugin/src/rules/semi.js
@@ -119,5 +119,5 @@ module.exports = ruleComposer.filterReports(
     }
 
     return true;
-  }
+  },
 );

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     "eslint/*/src/**/*.js",
   ],
   // The eslint/* packages use ESLint v6, which has dropped support for Node v6.
+  // TODO: Remove this process.version check in Babel 8.
   testRegex: `./(packages|codemods${
     /^v6./u.test(process.version) ? "" : "|eslint"
   })/[^/]+/test/.+\\.m?js$`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,50 @@
+module.exports = {
+  collectCoverageFrom: [
+    "packages/*/src/**/*.mjs",
+    "packages/*/src/**/*.js",
+    "codemods/*/src/**/*.mjs",
+    "codemods/*/src/**/*.js",
+    "eslint/*/src/**/*.mjs",
+    "eslint/*/src/**/*.js",
+  ],
+  // The eslint/* packages use ESLint v6, which has dropped support for Node v6.
+  testRegex: `./(packages|codemods${
+    /^v6./u.test(process.version) ? "" : "|eslint"
+  })/[^/]+/test/.+\\.m?js$`,
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/test/fixtures/",
+    "/test/debug-fixtures/",
+    "/babel-parser/test/expressions/",
+    "/test/tmp/",
+    "/test/__data__/",
+    "/test/helpers/",
+    "<rootDir>/test/warning\\.js",
+    "<rootDir>/build/",
+    "_browser\\.js",
+  ],
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["<rootDir>/test/testSetupFile.js"],
+  transformIgnorePatterns: [
+    "/node_modules/",
+    "<rootDir>/packages/babel-standalone/babel(\\.min)?\\.js",
+    "<rootDir>/packages/babel-preset-env-standalone/babel-preset-env(\\.min)?\\.js",
+    "/test/(fixtures|tmp|__data__)/",
+    "<rootDir>/(packages|codemods|eslint)/[^/]+/lib/",
+  ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "<rootDir>/packages/babel-standalone/babel(\\.min)?\\.js",
+    "<rootDir>/packages/babel-preset-env-standalone/babel-preset-env(\\.min)?\\.js",
+    "/test/(fixtures|tmp|__data__)/",
+  ],
+  modulePathIgnorePatterns: [
+    "/test/fixtures/",
+    "/test/tmp/",
+    "/test/__data__/",
+    "<rootDir>/build/",
+  ],
+  moduleNameMapper: {
+    "^@babel/([a-zA-Z0-9_-]+)$": "<rootDir>/packages/babel-$1/",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -89,54 +89,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "packages/*/src/**/*.mjs",
-      "packages/*/src/**/*.js",
-      "codemods/*/src/**/*.mjs",
-      "codemods/*/src/**/*.js",
-      "eslint/*/src/**/*.mjs",
-      "eslint/*/src/**/*.js"
-    ],
-    "testRegex": "./(packages|codemods|eslint)/[^/]+/test/.+\\.m?js$",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/test/fixtures/",
-      "/test/debug-fixtures/",
-      "/babel-parser/test/expressions/",
-      "/test/tmp/",
-      "/test/__data__/",
-      "/test/helpers/",
-      "<rootDir>/test/warning\\.js",
-      "<rootDir>/build/",
-      "_browser\\.js"
-    ],
-    "testEnvironment": "node",
-    "setupFilesAfterEnv": [
-      "<rootDir>/test/testSetupFile.js"
-    ],
-    "transformIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/packages/babel-standalone/babel(\\.min)?\\.js",
-      "<rootDir>/packages/babel-preset-env-standalone/babel-preset-env(\\.min)?\\.js",
-      "/test/(fixtures|tmp|__data__)/",
-      "<rootDir>/(packages|codemods)/[^/]+/lib/"
-    ],
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/packages/babel-standalone/babel(\\.min)?\\.js",
-      "<rootDir>/packages/babel-preset-env-standalone/babel-preset-env(\\.min)?\\.js",
-      "/test/(fixtures|tmp|__data__)/"
-    ],
-    "modulePathIgnorePatterns": [
-      "/test/fixtures/",
-      "/test/tmp/",
-      "/test/__data__/",
-      "<rootDir>/build/"
-    ],
-    "moduleNameMapper": {
-      "^@babel/([a-zA-Z0-9_-]+)$": "<rootDir>/packages/babel-$1/"
-    }
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | refs https://github.com/babel/babel/issues/10709
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The `eslint/* package tests are failing in Node v6 because ESLint v6 dropped support for Node <8. This is a stopgap measure until Babel follows suit.

One thing to note: this repo is already using ESLint v6, but ESLint didn't add any Node>=8 syntax until a later minor release, which is why it's passing in CI in Node v6 right now. If we upgrade, linting will begin failing as well.