### PR TITLE
fix: add missing available plugins to babel-preset-env-standalone

### DIFF
--- a/packages/babel-preset-env-standalone/package.json
+++ b/packages/babel-preset-env-standalone/package.json
@@ -14,10 +14,13 @@
   "devDependencies": {
     "@babel/plugin-proposal-dynamic-import": "^7.7.0",
     "@babel/plugin-proposal-json-strings": "^7.0.0",
+    "@babel/plugin-syntax-json-strings": "^7.2.0",
+    "@babel/plugin-syntax-top-level-await": "^7.7.0",
     "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.0",
     "@babel/plugin-transform-new-target": "^7.4.4",
     "@babel/preset-env": "^7.7.1",
-    "@babel/standalone": "^7.7.3"
+    "@babel/standalone": "^7.7.3",
+    "lodash": "^4.17.13"
   },
   "keywords": [
     "babel",

--- a/packages/babel-preset-env-standalone/src/available-plugins.js
+++ b/packages/babel-preset-env-standalone/src/available-plugins.js
@@ -5,6 +5,8 @@ const notIncludedPlugins = {
   "transform-new-target": require("@babel/plugin-transform-new-target"),
   "proposal-json-strings": require("@babel/plugin-proposal-json-strings"),
   "proposal-dynamic-import": require("@babel/plugin-proposal-dynamic-import"),
+  "syntax-json-strings": require("@babel/plugin-syntax-json-strings"),
+  "syntax-top-level-await": require("@babel/plugin-syntax-top-level-await"),
 };
 
 Object.keys(notIncludedPlugins).forEach(pluginName => {

--- a/packages/babel-preset-env-standalone/test/available-plugins.js
+++ b/packages/babel-preset-env-standalone/test/available-plugins.js
@@ -1,0 +1,14 @@
+import expectedAvailablePlugins from "@babel/preset-env/lib/available-plugins";
+import actualAvailablePlugins from "../lib/available-plugins";
+import difference from "lodash/difference";
+describe("available-plugins", () => {
+  it("should be a superset of available-plugins in @babel/preset-env", () => {
+    const expectedPluginList = Object.keys(expectedAvailablePlugins);
+    expectedPluginList.sort();
+
+    const actualPluginList = Object.keys(actualAvailablePlugins);
+    actualPluginList.sort();
+    // If this test is failed, add the missing plugins to ./src/available-plugins
+    expect(difference(expectedPluginList, actualPluginList)).toEqual([]);
+  });
+});

--- a/packages/babel-preset-env-standalone/test/available-plugins.js
+++ b/packages/babel-preset-env-standalone/test/available-plugins.js
@@ -1,14 +1,19 @@
 import expectedAvailablePlugins from "@babel/preset-env/lib/available-plugins";
-import actualAvailablePlugins from "../lib/available-plugins";
 import difference from "lodash/difference";
-describe("available-plugins", () => {
-  it("should be a superset of available-plugins in @babel/preset-env", () => {
-    const expectedPluginList = Object.keys(expectedAvailablePlugins);
-    expectedPluginList.sort();
 
-    const actualPluginList = Object.keys(actualAvailablePlugins);
-    actualPluginList.sort();
-    // If this test is failed, add the missing plugins to ./src/available-plugins
-    expect(difference(expectedPluginList, actualPluginList)).toEqual([]);
-  });
-});
+// build-babel-preset-env-standalone in CI coverage tests is skipped, so we skip this test as well
+(process.env.TEST_TYPE === "cov" ? describe.skip : describe)(
+  "available-plugins",
+  () => {
+    const actualAvailablePlugins = require("../lib/available-plugins").default;
+    it("should be a superset of available-plugins in @babel/preset-env", () => {
+      const expectedPluginList = Object.keys(expectedAvailablePlugins);
+      expectedPluginList.sort();
+
+      const actualPluginList = Object.keys(actualAvailablePlugins);
+      actualPluginList.sort();
+      // If this test is failed, add the missing plugins to ./src/available-plugins
+      expect(difference(expectedPluginList, actualPluginList)).toEqual([]);
+    });
+  },
+);

--- a/packages/babel-preset-env-standalone/test/babel-preset-env.js
+++ b/packages/babel-preset-env-standalone/test/babel-preset-env.js
@@ -1,3 +1,4 @@
+// build-babel-standalone in CI coverage tests is skipped, so we skip this test as well
 (process.env.TEST_TYPE === "cov" ? describe.skip : describe)(
   "babel-preset-env-standalone",
   () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes babel/website#2046
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | Added lodash to devDependencies
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR adds missing plugins to `./src/available-plugins`. A future-proof unit test is added: if we add new plugins to `env`, we will not forget to sync them with `env-standalone`.