### PR TITLE
Flow enums: fix enum body location

### DIFF
--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -3395,7 +3395,10 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     flowParseEnumDeclaration(node: N.Node): N.Node {
       const id = this.parseIdentifier();
       node.id = id;
-      node.body = this.flowEnumBody(this.startNode(), { enumName: id.name, nameLoc: id.start });
+      node.body = this.flowEnumBody(this.startNode(), {
+        enumName: id.name,
+        nameLoc: id.start,
+      });
       return this.finishNode(node, "EnumDeclaration");
     }
   };

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-explicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-explicit/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumBooleanBody",
-          "start": 22,
-          "end": 44,
+          "start": 7,
+          "end": 46,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 12
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-implicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-implicit/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumBooleanBody",
-          "start": 11,
-          "end": 33,
+          "start": 7,
+          "end": 35,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 12
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-member-not-initialized-explicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-member-not-initialized-explicit/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumBooleanBody",
-          "start": 22,
-          "end": 24,
+          "start": 7,
+          "end": 26,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 4
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-member-not-initialized-implicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/boolean-member-not-initialized-implicit/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumBooleanBody",
-          "start": 11,
-          "end": 25,
+          "start": 7,
+          "end": 27,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 11
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/duplicate-member-name/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/duplicate-member-name/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 18,
+          "start": 7,
+          "end": 20,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 4
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/empty/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/empty/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 9,
-          "end": 8,
+          "start": 7,
+          "end": 10,
           "loc": {
             "start": {
               "line": 1,
-              "column": 9
+              "column": 7
             },
             "end": {
               "line": 1,
-              "column": 8
+              "column": 10
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/enum-name/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/enum-name/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 12,
-          "end": 11,
+          "start": 10,
+          "end": 13,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 0
+              "line": 1,
+              "column": 10
             },
             "end": {
-              "line": 1,
-              "column": 11
+              "line": 2,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/export/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/export/output.json
@@ -79,16 +79,16 @@
           },
           "body": {
             "type": "EnumStringBody",
-            "start": 15,
-            "end": 15,
+            "start": 14,
+            "end": 16,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 15
+                "column": 14
               },
               "end": {
                 "line": 1,
-                "column": 15
+                "column": 16
               }
             },
             "explicitType": false,
@@ -143,16 +143,16 @@
           },
           "body": {
             "type": "EnumStringBody",
-            "start": 41,
-            "end": 41,
+            "start": 40,
+            "end": 42,
             "loc": {
               "start": {
                 "line": 3,
-                "column": 23
+                "column": 22
               },
               "end": {
                 "line": 3,
-                "column": 23
+                "column": 24
               }
             },
             "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/inconsistent-member-values-majority-defaulted/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/inconsistent-member-values-majority-defaulted/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 27,
+          "start": 7,
+          "end": 29,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 4,
-              "column": 8
+              "line": 5,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/inconsistent-member-values-mixed-initializers/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/inconsistent-member-values-mixed-initializers/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 29,
+          "start": 7,
+          "end": 31,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 11
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-explicit-type-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-explicit-type-identifier/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 16,
-          "end": 15,
+          "start": 7,
+          "end": 17,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 0
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 1,
-              "column": 15
+              "line": 2,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-boolean-explicit-string/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-boolean-explicit-string/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 21,
-          "end": 30,
+          "start": 7,
+          "end": 32,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 11
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-literal-explicit-symbol/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-literal-explicit-symbol/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumSymbolBody",
-          "start": 21,
-          "end": 27,
+          "start": 7,
+          "end": 29,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 8
+              "line": 3,
+              "column": 1
             }
           },
           "members": []

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-number-explicit-boolean/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-number-explicit-boolean/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumBooleanBody",
-          "start": 22,
-          "end": 28,
+          "start": 7,
+          "end": 30,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 8
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-number-explicit-string/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-number-explicit-string/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 21,
-          "end": 27,
+          "start": 7,
+          "end": 29,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 8
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-string-explicit-boolean/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-string-explicit-boolean/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumBooleanBody",
-          "start": 22,
-          "end": 31,
+          "start": 7,
+          "end": 33,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 11
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-string-explicit-number/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-initializer-string-explicit-number/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumNumberBody",
-          "start": 21,
-          "end": 30,
+          "start": 7,
+          "end": 32,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 11
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-name/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/invalid-member-name/output.json
@@ -66,16 +66,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 22,
+          "start": 7,
+          "end": 24,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 6
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/no-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/no-trailing-comma/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 12,
+          "start": 7,
+          "end": 14,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 3
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/number-explicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/number-explicit/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumNumberBody",
-          "start": 21,
-          "end": 36,
+          "start": 7,
+          "end": 38,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 8
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/number-implicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/number-implicit/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumNumberBody",
-          "start": 11,
-          "end": 26,
+          "start": 7,
+          "end": 28,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 8
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/number-member-not-initialized-explicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/number-member-not-initialized-explicit/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumNumberBody",
-          "start": 21,
-          "end": 23,
+          "start": 7,
+          "end": 25,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 2,
-              "column": 4
+              "line": 3,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/number-member-not-initialized-implicit/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/number-member-not-initialized-implicit/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumNumberBody",
-          "start": 11,
-          "end": 22,
+          "start": 7,
+          "end": 24,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 8
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/reserved-word-enum-name/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/reserved-word-enum-name/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 13,
-          "end": 12,
+          "start": 11,
+          "end": 14,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 0
+              "line": 1,
+              "column": 11
             },
             "end": {
-              "line": 1,
-              "column": 12
+              "line": 2,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/string-explicit-defaulted/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/string-explicit-defaulted/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 21,
-          "end": 28,
+          "start": 7,
+          "end": 30,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 4
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/string-explicit-initialized/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/string-explicit-initialized/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 21,
-          "end": 40,
+          "start": 7,
+          "end": 42,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 10
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/string-implicit-defaulted/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/string-implicit-defaulted/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 18,
+          "start": 7,
+          "end": 20,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 4
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/string-implicit-initialized/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/string-implicit-initialized/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 11,
-          "end": 30,
+          "start": 7,
+          "end": 32,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 10
+              "line": 4,
+              "column": 1
             }
           },
           "explicitType": false,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/string-member-inconsistently-initialized-majority-defaulted/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/string-member-inconsistently-initialized-majority-defaulted/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 21,
-          "end": 39,
+          "start": 7,
+          "end": 41,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 4,
-              "column": 4
+              "line": 5,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/string-member-inconsistently-initialized-majority-initialized/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/string-member-inconsistently-initialized-majority-initialized/output.json
@@ -65,16 +65,16 @@
         },
         "body": {
           "type": "EnumStringBody",
-          "start": 21,
-          "end": 45,
+          "start": 7,
+          "end": 47,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 4,
-              "column": 10
+              "line": 5,
+              "column": 1
             }
           },
           "explicitType": true,

--- a/packages/babel-parser/test/fixtures/flow/enum-declaration/symbol/output.json
+++ b/packages/babel-parser/test/fixtures/flow/enum-declaration/symbol/output.json
@@ -62,16 +62,16 @@
         },
         "body": {
           "type": "EnumSymbolBody",
-          "start": 21,
-          "end": 28,
+          "start": 7,
+          "end": 30,
           "loc": {
             "start": {
-              "line": 2,
-              "column": 2
+              "line": 1,
+              "column": 7
             },
             "end": {
-              "line": 3,
-              "column": 4
+              "line": 4,
+              "column": 1
             }
           },
           "members": [


### PR DESCRIPTION
The location of the Flow enum bodys was incorrect. I fixed this in flow-parser (https://github.com/facebook/flow/commit/498a2092abc6a9b5e2776c45e31aa7354575478a), and this PR fixes this in Babel, making it consistent with flow-parser, and also consistent with what the enum body contains (everything after `enum E`).

The diff also does some minor refactoring and cleaning up:
- Splits out parsing of the enum body into a separate function (separate from parsing the enum declaration overall)
- Rather than have a helper function for enum string bodies, it returns the string members, so the creation of enum bodies is completely contained in the new `flowEnumBody` function.

This incorrect location was discovering when adding support in Prettier https://github.com/prettier/prettier/pull/6860

After this lands and they update their parser deps, Prettier can remove their hacks.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
