### PR TITLE
Update chokidar to v3

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -29,7 +29,7 @@
     "source-map": "^0.5.0"
   },
   "optionalDependencies": {
-    "chokidar": "^2.1.8"
+    "chokidar": "^3.3.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"


### PR DESCRIPTION
chokidar depends on fsevents. Version 3 updates fsevents to version 2 which is based on napi. V1.x is now deprecated. Therefore chokidar should now urgently be updated to v3.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
