### PR TITLE
Add support for native esm to @babel/runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 endif
 	$(MAKE) prepublish-build
 	yarn lerna version patch --force-publish=$(FORCE_PUBLISH)  --no-push --yes --tag-version-prefix="version-e2e-test-"
+	git --no-pager diff HEAD
 	yarn lerna publish from-git --registry http://localhost:4873 --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,6 @@ ifneq ("$(I_AM_USING_VERDACCIO)", "I_AM_SURE")
 endif
 	$(MAKE) prepublish-build
 	yarn lerna version patch --force-publish=$(FORCE_PUBLISH)  --no-push --yes --tag-version-prefix="version-e2e-test-"
-	git --no-pager diff HEAD
 	yarn lerna publish from-git --registry http://localhost:4873 --yes --tag-version-prefix="version-e2e-test-"
 	$(MAKE) clean
 

--- a/Makefile
+++ b/Makefile
@@ -250,8 +250,9 @@ clean-lib:
 			$(call clean-source-lib, $(source))))
 
 clean-runtime-helpers:
-	rm -rf packages/babel-runtime/helpers
-	rm -rf packages/babel-runtime-corejs2/helpers
+	rm -f packages/babel-runtime/helpers/**/*.js
+	rm -f packages/babel-runtime-corejs2/helpers/**/*.js
+	rm -f packages/babel-runtime-corejs3/helpers/**/*.js
 	rm -rf packages/babel-runtime-corejs2/core-js
 
 clean-all:

--- a/packages/babel-runtime-corejs2/helpers/esm/package.json
+++ b/packages/babel-runtime-corejs2/helpers/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/babel-runtime-corejs3/helpers/esm/package.json
+++ b/packages/babel-runtime-corejs3/helpers/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/babel-runtime/helpers/esm/package.json
+++ b/packages/babel-runtime/helpers/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/8462
| Patch: Bug Fix?          | Yes?
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Currently `esm/` helpers are broken: when you try to natively `import` them, they are parsed as scripts and thus throw an error.

Assing `type: module` is a better fix than renaming the files to `*.mjs`, because this isn't a breaking change.

I only tested this PR manually because:
1) Babel can't be built on Node 13.2 which supports unflagged modules (https://github.com/nodejs/node/issues/30581)
2) Jest doesn't support native modules