### PR TITLE
Use the local version of babel in test262 job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,17 +101,12 @@ jobs:
       - run:
           name: Setup Test Runner
           command: |
-            git clone --recurse-submodules https://github.com/jbhoosreddy/babel-test262-runner
+            git clone --recurse-submodules https://github.com/babel/babel-test262-runner
             cd babel-test262-runner
             git fetch origin local-babel
             git checkout local-babel
             yarn
             yarn add tap-mocha-reporter --dev
-            #  curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq
-            #  chmod +x ./jq
-            #  for package in ../packages/*/package.json; do
-            #    yarn link $(./jq -j ".name" $package)
-            #  done
             node lib/download-node
       - run:
           name: Download master branch Test262 artifact

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,15 +101,17 @@ jobs:
       - run:
           name: Setup Test Runner
           command: |
-            git clone --recurse-submodules https://github.com/babel/babel-test262-runner
+            git clone --recurse-submodules https://github.com/jbhoosreddy/babel-test262-runner
             cd babel-test262-runner
+            git fetch origin local-babel
+            git checkout local-babel
             yarn
             yarn add tap-mocha-reporter --dev
-            curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq
-            chmod +x ./jq
-            for package in ../packages/*/package.json; do
-              yarn link $(./jq -j ".name" $package)
-            done
+            #  curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq
+            #  chmod +x ./jq
+            #  for package in ../packages/*/package.json; do
+            #    yarn link $(./jq -j ".name" $package)
+            #  done
             node lib/download-node
       - run:
           name: Download master branch Test262 artifact
@@ -117,7 +119,7 @@ jobs:
           <<: *test262_workdir
       - run:
           name: Run Test262
-          command: node lib/run-tests I_AM_SURE | tee ~/test262.tap
+          command: BABEL_PATH=.. node lib/run-tests I_AM_SURE | tee ~/test262.tap
           <<: *test262_workdir
       - store_artifacts: *artifact_test262_tap
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,6 @@ jobs:
           command: |
             git clone --recurse-submodules https://github.com/babel/babel-test262-runner
             cd babel-test262-runner
-            git fetch origin local-babel
-            git checkout local-babel
             yarn
             yarn add tap-mocha-reporter --dev
             node lib/download-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,15 +90,6 @@ jobs:
           name: Build Babel
           command: BABEL_ENV=test make bootstrap
       - run:
-          name: Link Babel
-          command: |
-            cd packages
-            for package in */; do
-              cd $package
-              yarn link
-              cd ..
-            done
-      - run:
           name: Setup Test Runner
           command: |
             git clone --recurse-submodules https://github.com/babel/babel-test262-runner


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Raised in https://github.com/babel/babel/pull/10556#pullrequestreview-302201436, this PR attempts to use a local copy of babel by directly referencing it instead of using `yarn link` to link all packages.

Relates to: https://github.com/babel/babel-test262-runner/pull/25

**I didn't realize this before but using the local copy instead of the published packages means the the stack traces are much more usable, apparently!**