### PR TITLE
Filename detection should respect short flags

### DIFF
--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "@babel/register": "^7.7.7",
-    "commander": "^2.8.1",
+    "commander": "^4.0.1",
     "core-js": "^3.2.1",
     "lodash": "^4.17.13",
     "node-environment-flags": "^1.0.5",

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -169,15 +169,15 @@ if (program.eval || program.print) {
       }
 
       if (arg[0] === "-") {
-        const camelArg = arg
-          .slice(2)
-          .replace(/-(\w)/, (s, c) => c.toUpperCase());
-        const parsedArg = program[camelArg];
-        if (
-          arg === "-r" ||
-          arg === "--require" ||
-          (parsedArg && parsedArg !== true)
-        ) {
+        const parsedOption = program.options.find(option => {
+          return option.long === arg || option.short === arg;
+        });
+        if (parsedOption === undefined) {
+          return;
+        }
+        const optionName = parsedOption.name();
+        const parsedArg = program[optionName];
+        if (optionName === "require" || (parsedArg && parsedArg !== true)) {
           ignoreNext = true;
         }
       } else {

--- a/packages/babel-node/src/_babel-node.js
+++ b/packages/babel-node/src/_babel-node.js
@@ -175,7 +175,7 @@ if (program.eval || program.print) {
         if (parsedOption === undefined) {
           return;
         }
-        const optionName = parsedOption.name();
+        const optionName = parsedOption.attributeName();
         const parsedArg = program[optionName];
         if (optionName === "require" || (parsedArg && parsedArg !== true)) {
           ignoreNext = true;

--- a/packages/babel-node/test/fixtures/babel-node/--presets/in-files/index.js
+++ b/packages/babel-node/test/fixtures/babel-node/--presets/in-files/index.js
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/packages/babel-node/test/fixtures/babel-node/--presets/in-files/presetFile.js
+++ b/packages/babel-node/test/fixtures/babel-node/--presets/in-files/presetFile.js
@@ -1,0 +1,4 @@
+module.exports = function () {
+  console.log("Preset was loaded, so --presets was used.");
+  return {};
+};

--- a/packages/babel-node/test/fixtures/babel-node/--presets/options.json
+++ b/packages/babel-node/test/fixtures/babel-node/--presets/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--presets", "./presetFile.js", "index"]
+}

--- a/packages/babel-node/test/fixtures/babel-node/--presets/stdout.txt
+++ b/packages/babel-node/test/fixtures/babel-node/--presets/stdout.txt
@@ -1,0 +1,2 @@
+Preset was loaded, so --presets was used.
+foo

--- a/packages/babel-node/test/fixtures/babel-node/-b/in-files/index.js
+++ b/packages/babel-node/test/fixtures/babel-node/-b/in-files/index.js
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/packages/babel-node/test/fixtures/babel-node/-b/in-files/presetFile.js
+++ b/packages/babel-node/test/fixtures/babel-node/-b/in-files/presetFile.js
@@ -1,0 +1,4 @@
+module.exports = function () {
+  console.log("Preset was loaded, so -b was used.");
+  return {};
+};

--- a/packages/babel-node/test/fixtures/babel-node/-b/options.json
+++ b/packages/babel-node/test/fixtures/babel-node/-b/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["-b", "./presetFile.js", "index"]
+}

--- a/packages/babel-node/test/fixtures/babel-node/-b/stdout.txt
+++ b/packages/babel-node/test/fixtures/babel-node/-b/stdout.txt
@@ -1,0 +1,2 @@
+Preset was loaded, so -b was used.
+foo


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9349
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | Yes, `commander` is bumped to v4.0.1 to be consistent with babel-cli.
| License                  | MIT

In this PR we fixed the filename detection logic by respecting the short flags (e.g. `-v`) other than long flags `--version`. The previous ad-hoc approach is thus replaced by `program.options` API.