### PR TITLE
fix: rewriteBindingInitVisitor should skip on scopable node

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -80,10 +80,7 @@ export default function rewriteLiveReferences(
  * A visitor to inject export update statements during binding initialization.
  */
 const rewriteBindingInitVisitor = {
-  ClassProperty(path) {
-    path.skip();
-  },
-  Function(path) {
+  Scope(path) {
     path.skip();
   },
   ClassDeclaration(path) {

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/input.mjs
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/input.mjs
@@ -1,0 +1,4 @@
+export function bug() {}
+{
+  let bug = 2;
+}

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-modules-amd"
+  ]
+}

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/output.js
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/output.js
@@ -1,0 +1,14 @@
+define(["exports"], function (_exports) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.bug = bug;
+
+  function bug() {}
+
+  {
+    let bug = 2;
+  }
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #9346 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `rewriteBindingInitVisitor` is used in module transform helper to inject `exports` statement after ExportDeclaration. Since ExportDeclaration is only allowed in top-level scope, it should skip when it visits a scopable node. Therefore the `Function` and `ClassProperty` visitor should be replaced by `Scope` visitor.

This issue impacts all module related transforms.