### PR TITLE
"regenerator-runtime" import now can be controlled through include/exclude option

### DIFF
--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -47,9 +47,10 @@ const getPlugin = (pluginName: string) => {
 export const transformIncludesAndExcludes = (opts: Array<string>): Object => {
   return opts.reduce(
     (result, opt) => {
-      const target = opt.match(/^(es|es6|es7|esnext|web)\./)
-        ? "builtIns"
-        : "plugins";
+      const target =
+        opt === "regenerator-runtime" || opt.match(/^(es|es6|es7|esnext|web)\./)
+          ? "builtIns"
+          : "plugins";
       result[target].add(opt);
       return result;
     },
@@ -249,7 +250,13 @@ export default declare((api, opts) => {
     getOptionSpecificExcludesFor({ loose }),
     pluginSyntaxMap,
   );
+
   removeUnnecessaryItems(pluginNames, overlappingPlugins);
+
+  const regenerator =
+    (pluginNames.has("transform-regenerator") ||
+      include.builtIns.has("regenerator-runtime")) &&
+    !exclude.builtIns.has("regenerator-runtime");
 
   const polyfillPlugins = getPolyfillPlugins({
     useBuiltIns,
@@ -259,7 +266,7 @@ export default declare((api, opts) => {
     exclude: exclude.builtIns,
     proposals,
     shippedProposals,
-    regenerator: pluginNames.has("transform-regenerator"),
+    regenerator,
     debug,
   });
 

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -54,6 +54,7 @@ const getValidIncludesAndExcludes = (
         ? [...Object.keys(corejs2Polyfills), ...defaultWebIncludes]
         : Object.keys(corejs3Polyfills)
       : []),
+    "regenerator-runtime",
   ]);
 
 const pluginToRegExp = (plugin: PluginListItem) => {

--- a/packages/babel-preset-env/test/fixtures/preset-options/exclude-regenerator/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/exclude-regenerator/input.mjs
@@ -1,0 +1,4 @@
+
+export async function foo() {
+    return await new Promise(resolve => setTimeout(resolve, 1000));
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/exclude-regenerator/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/exclude-regenerator/options.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": "IE 11",
+        "useBuiltIns": "usage",
+        "corejs": 3,
+        "modules": false,
+        "exclude": ["regenerator-runtime"]
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/exclude-regenerator/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/exclude-regenerator/output.mjs
@@ -1,0 +1,22 @@
+import "core-js/modules/es.object.to-string";
+import "core-js/modules/es.promise";
+export function foo() {
+  return regeneratorRuntime.async(function foo$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return regeneratorRuntime.awrap(new Promise(function (resolve) {
+            return setTimeout(resolve, 1000);
+          }));
+
+        case 2:
+          return _context.abrupt("return", _context.sent);
+
+        case 3:
+        case "end":
+          return _context.stop();
+      }
+    }
+  });
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/include-regenerator/input.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/include-regenerator/input.mjs
@@ -1,0 +1,4 @@
+
+export async function foo() {
+    return await new Promise(resolve => setTimeout(resolve, 1000));
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/include-regenerator/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options/include-regenerator/options.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": "IE 11",
+        "useBuiltIns": "usage",
+        "corejs": 3,
+        "modules": false,
+        "include": ["regenerator-runtime"]
+      }
+    ]
+  ]
+}

--- a/packages/babel-preset-env/test/fixtures/preset-options/include-regenerator/output.mjs
+++ b/packages/babel-preset-env/test/fixtures/preset-options/include-regenerator/output.mjs
@@ -1,0 +1,23 @@
+import "core-js/modules/es.object.to-string";
+import "core-js/modules/es.promise";
+import "regenerator-runtime/runtime";
+export function foo() {
+  return regeneratorRuntime.async(function foo$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return regeneratorRuntime.awrap(new Promise(function (resolve) {
+            return setTimeout(resolve, 1000);
+          }));
+
+        case 2:
+          return _context.abrupt("return", _context.sent);
+
+        case 3:
+        case "end":
+          return _context.stop();
+      }
+    }
+  });
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10759
| Patch: Bug Fix?          | Sort of (see #10759)
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | Will add if needed
| Any Dependency Changes?  | No
| License                  | MIT

When using `core-js` you can control what polyfills gets added or omitted from the generated code using `include`/`exclude` preset options. This PR adds the same functionality for `regenerator-runtime`.

With this, you could remove global `regenerator-runtime` imports by adding `regenerator-runtime` to the `exclude` option. This is required if you want to use `transform-runtime` to replace `regenerator-runtime` imports from global ones to a pure local.

This also allows to forcibly add import for `regenerator-runtime`, which could also be useful.

I will be glad to update the documentation as well if this PR will get accepted.