### PR TITLE
fix(helper): update spelling of _assertThisInitialized helper

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -713,7 +713,7 @@ helpers.objectWithoutProperties = helper("7.0.0-beta.0")`
 helpers.assertThisInitialized = helper("7.0.0-beta.0")`
   export default function _assertThisInitialized(self) {
     if (self === void 0) {
-      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+      throw new ReferenceError("this hasn't been initialized - super() hasn't been called");
     }
     return self;
   }

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -2,7 +2,7 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
@@ -4,7 +4,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/extend-builtins/spec/output.js
@@ -2,7 +2,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-data-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-getter-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-not-defined-on-parent/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/call-semantics-setter-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-data-defined-on-parent/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-getter-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-not-defined-on-parent/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/get-semantics-setter-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-assign/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-assign/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-update/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/memoized-update/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-data-defined-on-parent/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-getter-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-data-on-obj/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-getter-on-obj/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-not-on-obj/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-not-defined-on-parent-setter-on-obj/output.js
@@ -6,7 +6,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set/set-semantics-setter-defined-on-parent/output.js
@@ -2,7 +2,7 @@
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function set(target, property, value, receiver) { if (typeof Reflect !== "undefined" && Reflect.set) { set = Reflect.set; } else { set = function set(target, property, value, receiver) { var base = _superPropBase(target, property); var desc; if (base) { desc = Object.getOwnPropertyDescriptor(base, property); if (desc.set) { desc.set.call(receiver, value); return true; } else if (!desc.writable) { return false; } } desc = Object.getOwnPropertyDescriptor(receiver, property); if (desc) { if (!desc.writable) { return false; } desc.value = value; Object.defineProperty(receiver, property, desc); } else { _defineProperty(receiver, property, value); } return true; }; } return set(target, property, value, receiver); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose-classCallCheck/with-superClass/output.js
@@ -1,4 +1,4 @@
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/derived-constructor-must-call-super/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow(ReferenceError, "this hasn't been initialised");
+expect(() => new Foo()).toThrow(ReferenceError, "this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
@@ -2,7 +2,7 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-2/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super-4/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/derived-constructor-must-call-super/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -2,7 +2,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/exec.js
@@ -7,4 +7,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -2,7 +2,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/exec.js
@@ -10,4 +10,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-2/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-3/exec.js
@@ -8,4 +8,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/this-not-allowed-before-super-in-derived-classes-5/exec.js
@@ -6,4 +6,4 @@ class Foo extends Bar {
   }
 }
 
-expect(() => new Foo()).toThrow("this hasn't been initialised");
+expect(() => new Foo()).toThrow("this hasn't been initialized");

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -21,7 +21,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 

--- a/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class-and-super/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-class-and-super/output.js
@@ -2,7 +2,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -6,7 +6,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialized - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

~~I have not updated the tests yet, since I'm not sure if this is something worth changing. Let me know if it's worth it and I'll clone the repository and update all the tests (28 instances)~~, EDIT: done.

The spelling in the name of the helper is "initialized" (American English), but the text of the error itself said "initialised" (International English). I suggest making both American English, since that's more common in JS
