### PR TITLE
Eslint config

### DIFF
--- a/eslint/babel-eslint-plugin-development/README.md
+++ b/eslint/babel-eslint-plugin-development/README.md
@@ -36,3 +36,13 @@ Then, load the plugin in your `.eslintrc` configuration file. You can omit the `
   value, since it might cause problem if `undefined` is redeclared.
 * `@babel/development/plugin-name`: Requires plugins to have a `name` property, which
   can be useful for debugging purposes.
+
+## Recommended Configuration
+
+You can enable this plugin and all its rules by extending the recommended configuration:
+
+```json
+{
+  "extends": ["plugin:@babel/development/recommended"]
+}
+```

--- a/eslint/babel-eslint-plugin-development/src/index.js
+++ b/eslint/babel-eslint-plugin-development/src/index.js
@@ -8,4 +8,14 @@ export default {
     "no-undefined-identifier": noUndefinedIdentifier,
     "plugin-name": pluginName,
   },
+  configs: {
+    recommended: {
+      plugins: ["@babel/development"],
+      rules: {
+        "@babel/development/no-deprecated-clone": "error",
+        "@babel/development/no-undefined-identifier": "error",
+        "@babel/development/plugin-name": "error",
+      },
+    },
+  },
 };

--- a/eslint/babel-eslint-plugin/README.md
+++ b/eslint/babel-eslint-plugin/README.md
@@ -26,14 +26,14 @@ original ones as well!).
 ```json
 {
   "rules": {
-    "babel/new-cap": "error",
-    "babel/camelcase": "error",
-    "babel/no-invalid-this": "error",
-    "babel/object-curly-spacing": "error",
-    "babel/quotes": "error",
-    "babel/semi": "error",
-    "babel/no-unused-expressions": "error",
-    "babel/valid-typeof": "error"
+    "@babel/new-cap": "error",
+    "@babel/camelcase": "error",
+    "@babel/no-invalid-this": "error",
+    "@babel/object-curly-spacing": "error",
+    "@babel/quotes": "error",
+    "@babel/semi": "error",
+    "@babel/no-unused-expressions": "error",
+    "@babel/valid-typeof": "error"
   }
 }
 ```
@@ -52,23 +52,23 @@ Each rule corresponds to a core `eslint` rule, and has the same options.
 
 🛠: means it's autofixable with `--fix`.
 
-- `babel/new-cap`: Ignores capitalized decorators (`@Decorator`)
-- `babel/camelcase: doesn't complain about optional chaining (`var foo = bar?.a_b;`)
-- `babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
-- `babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
-- `babel/quotes`: doesn't complain about JSX fragment shorthand syntax (`<>foo</>;`)
-- `babel/semi`: doesn't fail when using `for await (let something of {})`. Includes class properties (🛠)
-- `babel/no-unused-expressions`: doesn't fail when using `do` expressions or [optional chaining](https://github.com/tc39/proposal-optional-chaining) (`a?.b()`).
-- `babel/valid-typeof`: doesn't complain when used with [BigInt](https://github.com/tc39/proposal-bigint) (`typeof BigInt(9007199254740991) === 'bigint'`).
+- `@babel/new-cap`: Ignores capitalized decorators (`@Decorator`)
+- `@babel/camelcase: doesn't complain about optional chaining (`var foo = bar?.a_b;`)
+- `@babel/no-invalid-this`: doesn't fail when inside class properties (`class A { a = this.b; }`)
+- `@babel/object-curly-spacing`: doesn't complain about `export x from "mod";` or `export * as x from "mod";` (🛠)
+- `@babel/quotes`: doesn't complain about JSX fragment shorthand syntax (`<>foo</>;`)
+- `@babel/semi`: doesn't fail when using `for await (let something of {})`. Includes class properties (🛠)
+- `@babel/no-unused-expressions`: doesn't fail when using `do` expressions or [optional chaining](https://github.com/tc39/proposal-optional-chaining) (`a?.b()`).
+- `@babel/valid-typeof`: doesn't complain when used with [BigInt](https://github.com/tc39/proposal-bigint) (`typeof BigInt(9007199254740991) === 'bigint'`).
 
 #### Deprecated
 
 | Rule                             | Notes                              |
 |:---------------------------------|:-----------------------------------|
-| `babel/generator-star-spacing`   | Use [`generator-star-spacing`](http://eslint.org/docs/rules/generator-star-spacing) since eslint@3.6.0 |
-| `babel/object-shorthand`         | Use [`object-shorthand`](http://eslint.org/docs/rules/object-shorthand) since eslint@0.20.0 |
-| `babel/arrow-parens`             | Use [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens) since eslint@3.10.0 |
-| `babel/func-params-comma-dangle` | Use [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle) since eslint@3.8.0 |
-| `babel/array-bracket-spacing`    | Use [`array-bracket-spacing`](http://eslint.org/docs/rules/array-bracket-spacing) since eslint@3.9.0 |
-| `babel/flow-object-type`         | Use [`flowtype/object-type-delimiter`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-object-type-delimiter) since eslint-plugin-flowtype@2.23.0 |
-| `babel/no-await-in-loop`         | Use [`no-await-in-loop`](http://eslint.org/docs/rules/no-await-in-loop) since eslint@3.12.0 |
+| `@babel/generator-star-spacing`   | Use [`generator-star-spacing`](http://eslint.org/docs/rules/generator-star-spacing) since eslint@3.6.0 |
+| `@babel/object-shorthand`         | Use [`object-shorthand`](http://eslint.org/docs/rules/object-shorthand) since eslint@0.20.0 |
+| `@babel/arrow-parens`             | Use [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens) since eslint@3.10.0 |
+| `@babel/func-params-comma-dangle` | Use [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle) since eslint@3.8.0 |
+| `@babel/array-bracket-spacing`    | Use [`array-bracket-spacing`](http://eslint.org/docs/rules/array-bracket-spacing) since eslint@3.9.0 |
+| `@babel/flow-object-type`         | Use [`flowtype/object-type-delimiter`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-object-type-delimiter) since eslint-plugin-flowtype@2.23.0 |
+| `@babel/no-await-in-loop`         | Use [`no-await-in-loop`](http://eslint.org/docs/rules/no-await-in-loop) since eslint@3.12.0 |

--- a/eslint/babel-eslint-plugin/README.md
+++ b/eslint/babel-eslint-plugin/README.md
@@ -37,6 +37,15 @@ original ones as well!).
   }
 }
 ```
+
+Or, to perform all these steps at once, just extend from the recommended configuration instead:
+
+```json
+{
+  "extends": ["plugin:@babel/eslint-plugin/recommended"]
+}
+```
+
 ### Rules
 
 Each rule corresponds to a core `eslint` rule, and has the same options.

--- a/eslint/babel-eslint-plugin/src/index.js
+++ b/eslint/babel-eslint-plugin/src/index.js
@@ -16,22 +16,50 @@ import validTypeof from "./rules/valid-typeof";
 
 module.exports = {
   rules: {
-    "array-bracket-spacing": arrayBracketSpacing,
-    "arrow-parens": arrowParens,
-    "flow-object-type": flowObjectType,
-    "func-params-comma-dangle": funcParamsCommaDangle,
-    "generator-star-spacing": generatorStarSpacing,
-    "new-cap": newCap,
     camelcase,
-    "no-await-in-loop": noAwaitInLoop,
+    "new-cap": newCap,
     "no-invalid-this": noInvalidThis,
     "no-unused-expressions": noUnusedExpressions,
     "object-curly-spacing": objectCurlySpacing,
-    "object-shorthand": objectShorthand,
     quotes,
     semi,
     "valid-typeof": validTypeof,
+
+    // Deprecated rules:
+    "generator-star-spacing": generatorStarSpacing,
+    "object-shorthand": objectShorthand,
+    "arrow-parens": arrowParens,
+    "func-params-comma-dangle": funcParamsCommaDangle,
+    "array-bracket-spacing": arrayBracketSpacing,
+    "flow-object-type": flowObjectType,
+    "no-await-in-loop": noAwaitInLoop,
   },
+  configs: {
+    recommended: {
+      parser: "@babel/eslint-parser",
+      plugins: ["@babel/eslint-plugin"],
+      rules: {
+        camelcase: "off",
+        "new-cap": "off",
+        "no-invalid-this": "off",
+        "no-unused-expressions": "off",
+        "object-curly-spacing": "off",
+        quotes: "off",
+        semi: "off",
+        "valid-typeof": "off",
+
+        "@babel/camelcase": "error",
+        "@babel/new-cap": "error",
+        "@babel/no-invalid-this": "error",
+        "@babel/no-unused-expressions": "error",
+        "@babel/object-curly-spacing": "error",
+        "@babel/quotes": "error",
+        "@babel/semi": "error",
+        "@babel/valid-typeof": "error",
+      },
+    },
+  },
+  // `rulesConfig` only works on ESLint 1.x:
   rulesConfig: {
     "array-bracket-spacing": "off",
     "arrow-parens": "off",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #10752 (partially)
| Patch: Bug Fix?          | Yes |
| Major: Breaking Change?  | No |
| Minor: New Feature?      | Yes |
| Tests Added + Pass?      | N/A |
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
These commits add `recommended` ESLint configs to the two plugins. With this, users can enable the plugins and activate their rules in a single line.

While doing this work, I noticed that the documentation for `@babel/eslint-plugin` had some typos, so I fixed those.

I also noticed that `@babel/eslint-plugin` exports a `rulesConfig`, which was [removed in ESLint 2](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-2.0.0.md#plugins-no-longer-have-default-configurations). I left that in with a comment, since removing it would be a breaking change, but then again this whole package is being renamed, so maybe now is a good time to remove it. 