### PR TITLE
refactor: Improve error message in @babel/core

### DIFF
--- a/packages/babel-core/src/config/files/configuration.js
+++ b/packages/babel-core/src/config/files/configuration.js
@@ -18,7 +18,7 @@ import type { CallerMetadata } from "../validation/options";
 
 const debug = buildDebug("babel:config:loading:files:configuration");
 
-const ROOT_CONFIG_FILENAMES = [
+export const ROOT_CONFIG_FILENAMES = [
   "babel.config.js",
   "babel.config.cjs",
   "babel.config.json",

--- a/packages/babel-core/src/config/files/index-browser.js
+++ b/packages/babel-core/src/config/files/index-browser.js
@@ -51,6 +51,8 @@ export function loadConfig(
   throw new Error(`Cannot load ${name} relative to ${dirname} in a browser`);
 }
 
+export const ROOT_CONFIG_FILENAMES = [];
+
 // eslint-disable-next-line no-unused-vars
 export function resolvePlugin(name: string, dirname: string): string | null {
   return null;

--- a/packages/babel-core/src/config/files/index.js
+++ b/packages/babel-core/src/config/files/index.js
@@ -14,6 +14,7 @@ export {
   findRelativeConfig,
   findRootConfig,
   loadConfig,
+  ROOT_CONFIG_FILENAMES,
 } from "./configuration";
 export type {
   ConfigFile,

--- a/packages/babel-core/src/config/partial.js
+++ b/packages/babel-core/src/config/partial.js
@@ -12,7 +12,12 @@ import {
   type RootMode,
 } from "./validation/options";
 
-import { findConfigUpwards, type ConfigFile, type IgnoreFile } from "./files";
+import {
+  findConfigUpwards,
+  ROOT_CONFIG_FILENAMES,
+  type ConfigFile,
+  type IgnoreFile,
+} from "./files";
 
 function resolveRootMode(rootDir: string, rootMode: RootMode): string {
   switch (rootMode) {
@@ -31,7 +36,9 @@ function resolveRootMode(rootDir: string, rootMode: RootMode): string {
       throw Object.assign(
         (new Error(
           `Babel was run with rootMode:"upward" but a root could not ` +
-            `be found when searching upward from "${rootDir}"`,
+            `be found when searching upward from "${rootDir}".\n` +
+            `One of the following config files must be in the directory tree: ` +
+            `"${ROOT_CONFIG_FILENAMES.join(", ")}".`,
         ): any),
         {
           code: "BABEL_ROOT_NOT_FOUND",
@@ -40,7 +47,7 @@ function resolveRootMode(rootDir: string, rootMode: RootMode): string {
       );
     }
     default:
-      throw new Error(`Assertion failure - unknown rootMode value`);
+      throw new Error(`Assertion failure - unknown rootMode value.`);
   }
 }
 


### PR DESCRIPTION
Hi 👋 

I would like to propose updating the error message when running babel with `rootMode:"upward"` so user gets feedback on what's expected.

Motivation:

Given I have a repository and I migrated recently to babel 7.x and still using just `.babelrc` for configuration. I ran a script provided to me by a third-party library which tried to search for my config but failed with this error. I would like to understand more about what is expected of me from an error message.