### PR TITLE
add `allowTopLevelThis` option to `transform-modules-systemjs`

### DIFF
--- a/packages/babel-helper-module-transforms/src/index.js
+++ b/packages/babel-helper-module-transforms/src/index.js
@@ -12,7 +12,7 @@ import normalizeAndLoadModuleMetadata, {
   isSideEffectImport,
 } from "./normalize-and-load-metadata";
 
-export { hasExports, isSideEffectImport, isModule };
+export { hasExports, isSideEffectImport, isModule, rewriteThis };
 
 /**
  * Perform all of the generic ES6 module rewriting needed to handle initial

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -10,6 +10,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@babel/helper-hoist-variables": "^7.7.4",
+    "@babel/helper-module-transforms": "^7.7.4",
     "@babel/helper-plugin-utils": "^7.0.0",
     "babel-plugin-dynamic-import-node": "^2.3.0"
   },

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/false/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/false/input.mjs
@@ -1,0 +1,1 @@
+export var v = this;

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/false/options.json
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/false/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["transform-modules-systemjs", {
+      "allowTopLevelThis": false
+    }]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/false/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/false/output.mjs
@@ -1,0 +1,11 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  var v;
+  return {
+    setters: [],
+    execute: function () {
+      _export("v", v = void 0);
+    }
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/true/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/true/input.mjs
@@ -1,0 +1,1 @@
+export var v = this;

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/true/options.json
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/true/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["transform-modules-systemjs", {
+      "allowTopLevelThis": true
+    }]
+  ]
+}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/true/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/allow-top-level-this/true/output.mjs
@@ -1,0 +1,11 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  var v;
+  return {
+    setters: [],
+    execute: function () {
+      _export("v", v = this);
+    }
+  };
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10775 
| Major: Breaking Change?  | See discussion below.
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes, `@babel/plugin-transform-modules-systemjs` now depends on `@babel/helper-module-transforms`.
| License                  | MIT

This PR adds `allowTopLevelThis` option to `transform-modules-systemjs`. To be consistent with other module transforms plugin, the default value of `allowTopLevelThis` is `false`, which means the top level `this` will be replaced by `void 0` by default.

The spec dictates that in the module executing context, `this` is always `undefined`. So the default value does make it align to the specs. Though I am not sure how many people rely on the previous incompliant behaviour. 

- [ ] add document PR if we agree on the interface
