### PR TITLE
Do not transpile typeof helper with itself in babel/runtime

### DIFF
--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -24,6 +24,7 @@
     "@babel/core": "^7.7.4",
     "@babel/helper-plugin-test-runner": "^7.7.4",
     "@babel/helpers": "^7.7.4",
+    "@babel/plugin-transform-typeof-symbol": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/runtime": "^7.7.4",
     "@babel/template": "^7.7.4",

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -158,7 +158,7 @@ function buildHelper(
     presets: [
       [
         "@babel/preset-env",
-        { modules: false, exclude: ["transform-typeof-symbol"] },
+        { modules: false, exclude: ["@babel/plugin-transform-typeof-symbol"] },
       ],
     ],
     plugins: [
@@ -177,7 +177,6 @@ function buildHelper(
         exclude: /typeof/,
         plugins: ["@babel/plugin-transform-typeof-symbol"],
       },
-      {},
     ],
   }).code;
 }

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -151,8 +151,6 @@ function buildHelper(
   );
   tree.body.push(...helper.nodes);
 
-  console.log(helperFilename);
-
   return babel.transformFromAst(tree, null, {
     filename: helperFilename,
     presets: [

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -9,6 +9,7 @@ const t = require("@babel/types");
 
 const transformRuntime = require("../");
 
+const runtimeVersion = require("@babel/runtime/package.json").version;
 const corejs2Definitions = require("../lib/runtime-corejs2-definitions").default();
 const corejs3Definitions = require("../lib/runtime-corejs3-definitions").default();
 
@@ -150,15 +151,33 @@ function buildHelper(
   );
   tree.body.push(...helper.nodes);
 
+  console.log(helperFilename);
+
   return babel.transformFromAst(tree, null, {
-    presets: [[require("@babel/preset-env"), { modules: false }]],
+    filename: helperFilename,
+    presets: [
+      [
+        "@babel/preset-env",
+        { modules: false, exclude: ["transform-typeof-symbol"] },
+      ],
+    ],
     plugins: [
-      [transformRuntime, { corejs, useESModules: esm }],
+      [
+        transformRuntime,
+        { corejs, useESModules: esm, version: runtimeVersion },
+      ],
       buildRuntimeRewritePlugin(
         runtimeName,
         path.relative(path.dirname(helperFilename), pkgDirname),
         helperName
       ),
+    ],
+    overrides: [
+      {
+        exclude: /typeof/,
+        plugins: ["@babel/plugin-transform-typeof-symbol"],
+      },
+      {},
     ],
   }).code;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I noticed that the `typeof.js` helper also contained a copy of itself as `_typeof2`: https://unpkg.com/browse/@babel/runtime@7.7.4/helpers/typeof.js
This PR removes it:
```js
function _typeof(obj) {
  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
    module.exports = _typeof = function _typeof(obj) {
      return typeof obj;
    };
  } else {
    module.exports = _typeof = function _typeof(obj) {
      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
    };
  }

  return _typeof(obj);
}

module.exports = _typeof;
```

In other helpers it is still transformed:
```js
var _typeof = require("../helpers/typeof");

var toPrimitive = require("./toPrimitive");

function _toPropertyKey(arg) {
  var key = toPrimitive(arg, "string");
  return _typeof(key) === "symbol" ? key : String(key);
}

module.exports = _toPropertyKey;
```