### PR TITLE
fix: specify sourceFileName when generating inline sourcemaps

### DIFF
--- a/packages/babel-standalone/src/transformScriptTags.js
+++ b/packages/babel-standalone/src/transformScriptTags.js
@@ -26,18 +26,16 @@ function transformCode(transformFn, script) {
     }
   }
 
-  return transformFn(script.content, {
-    filename: source,
-    ...buildBabelOptions(script),
-  }).code;
+  return transformFn(script.content, buildBabelOptions(script, source)).code;
 }
 
 /**
  * Builds the Babel options for transforming the specified script, using some
  * sensible default presets and plugins if none were explicitly provided.
  */
-function buildBabelOptions(script) {
+function buildBabelOptions(script, filename) {
   return {
+    filename,
     presets: script.presets || ["react", "es2015"],
     plugins: script.plugins || [
       "proposal-class-properties",
@@ -45,6 +43,7 @@ function buildBabelOptions(script) {
       "transform-flow-strip-types",
     ],
     sourceMaps: "inline",
+    sourceFileName: filename,
   };
 }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10786 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Nope
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we specify script url as the `sourceFileName` option when doing in-browser transforms, otherwise the generated sourcemap have incorrected `sources` fields
i.e.

On a script `/foo/script.js`
```js
var a;
var b;
```
babel will generate the following source map since the default `sourceFileName` is `path.relative(filename)`.
```json
{"version":3,"sources":["script.js"],"names":["a","b"],"mappings":";;AAAA,IAAIA,CAAJ;AACA,IAAIC,CAAJ","sourcesContent":["var a;\nvar b;"]}
```