### PR TITLE
Use scope flags to check arguments

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -2208,7 +2208,11 @@ export default class ExpressionParser extends LValParser {
       }
     }
 
-    if (this.state.inClassProperty && word === "arguments") {
+    if (
+      this.scope.inClass &&
+      !this.scope.inNonArrowFunction &&
+      word === "arguments"
+    ) {
       this.raise(
         startLoc,
         "'arguments' is not allowed in class field initializer",

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -64,6 +64,9 @@ export default class ScopeHandler<IScope: Scope = Scope> {
   get allowDirectSuper() {
     return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0;
   }
+  get inClass() {
+    return (this.currentThisScope().flags & SCOPE_CLASS) > 0;
+  }
   get inNonArrowFunction() {
     return (this.currentThisScope().flags & SCOPE_FUNCTION) > 0;
   }
@@ -199,7 +202,7 @@ export default class ScopeHandler<IScope: Scope = Scope> {
     }
   }
 
-  // Could be useful for `this`, `new.target`, `super()`, `super.property`, and `super[property]`.
+  // Could be useful for `arguments`, `this`, `new.target`, `super()`, `super.property`, and `super[property]`.
   // $FlowIgnore
   currentThisScope(): IScope {
     for (let i = this.scopeStack.length - 1; ; i--) {

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/input.js
@@ -1,0 +1,5 @@
+function fn() {
+  class A {
+    foo = class B { @bar(arguments) foo };
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties", ["decorators", { "decoratorsBeforeExport": false }]]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/output.json
@@ -1,0 +1,328 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 76,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 1
+    }
+  },
+  "errors": [
+    "SyntaxError: 'arguments' is not allowed in class field initializer (3:25)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 76,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 76,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            },
+            "identifierName": "fn"
+          },
+          "name": "fn"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 14,
+          "end": 76,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 5,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassDeclaration",
+              "start": 18,
+              "end": 74,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 3
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 24,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "identifierName": "A"
+                },
+                "name": "A"
+              },
+              "superClass": null,
+              "body": {
+                "type": "ClassBody",
+                "start": 26,
+                "end": 74,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ClassProperty",
+                    "start": 32,
+                    "end": 70,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 42
+                      }
+                    },
+                    "static": false,
+                    "key": {
+                      "type": "Identifier",
+                      "start": 32,
+                      "end": 35,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 7
+                        },
+                        "identifierName": "foo"
+                      },
+                      "name": "foo"
+                    },
+                    "computed": false,
+                    "value": {
+                      "type": "ClassExpression",
+                      "start": 38,
+                      "end": 69,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 41
+                        }
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 44,
+                        "end": 45,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 17
+                          },
+                          "identifierName": "B"
+                        },
+                        "name": "B"
+                      },
+                      "superClass": null,
+                      "body": {
+                        "type": "ClassBody",
+                        "start": 46,
+                        "end": 69,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 18
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 41
+                          }
+                        },
+                        "body": [
+                          {
+                            "type": "ClassProperty",
+                            "start": 48,
+                            "end": 67,
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 20
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 39
+                              }
+                            },
+                            "decorators": [
+                              {
+                                "type": "Decorator",
+                                "start": 48,
+                                "end": 63,
+                                "loc": {
+                                  "start": {
+                                    "line": 3,
+                                    "column": 20
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 35
+                                  }
+                                },
+                                "expression": {
+                                  "type": "CallExpression",
+                                  "start": 49,
+                                  "end": 63,
+                                  "loc": {
+                                    "start": {
+                                      "line": 3,
+                                      "column": 21
+                                    },
+                                    "end": {
+                                      "line": 3,
+                                      "column": 35
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "Identifier",
+                                    "start": 49,
+                                    "end": 52,
+                                    "loc": {
+                                      "start": {
+                                        "line": 3,
+                                        "column": 21
+                                      },
+                                      "end": {
+                                        "line": 3,
+                                        "column": 24
+                                      },
+                                      "identifierName": "bar"
+                                    },
+                                    "name": "bar"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Identifier",
+                                      "start": 53,
+                                      "end": 62,
+                                      "loc": {
+                                        "start": {
+                                          "line": 3,
+                                          "column": 25
+                                        },
+                                        "end": {
+                                          "line": 3,
+                                          "column": 34
+                                        },
+                                        "identifierName": "arguments"
+                                      },
+                                      "name": "arguments"
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "static": false,
+                            "key": {
+                              "type": "Identifier",
+                              "start": 64,
+                              "end": 67,
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 36
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 39
+                                },
+                                "identifierName": "foo"
+                              },
+                              "name": "foo"
+                            },
+                            "computed": false,
+                            "value": null
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class/input.js
@@ -1,0 +1,5 @@
+function fn() {
+  class A {
+    foo = class B { bar() { arguments } };
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class/output.json
@@ -1,0 +1,311 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 76,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 76,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 76,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            },
+            "identifierName": "fn"
+          },
+          "name": "fn"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 14,
+          "end": 76,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 5,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassDeclaration",
+              "start": 18,
+              "end": 74,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 3
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 24,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "identifierName": "A"
+                },
+                "name": "A"
+              },
+              "superClass": null,
+              "body": {
+                "type": "ClassBody",
+                "start": 26,
+                "end": 74,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ClassProperty",
+                    "start": 32,
+                    "end": 70,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 42
+                      }
+                    },
+                    "static": false,
+                    "key": {
+                      "type": "Identifier",
+                      "start": 32,
+                      "end": 35,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 7
+                        },
+                        "identifierName": "foo"
+                      },
+                      "name": "foo"
+                    },
+                    "computed": false,
+                    "value": {
+                      "type": "ClassExpression",
+                      "start": 38,
+                      "end": 69,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 41
+                        }
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 44,
+                        "end": 45,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 17
+                          },
+                          "identifierName": "B"
+                        },
+                        "name": "B"
+                      },
+                      "superClass": null,
+                      "body": {
+                        "type": "ClassBody",
+                        "start": 46,
+                        "end": 69,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 18
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 41
+                          }
+                        },
+                        "body": [
+                          {
+                            "type": "ClassMethod",
+                            "start": 48,
+                            "end": 67,
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 20
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 39
+                              }
+                            },
+                            "static": false,
+                            "key": {
+                              "type": "Identifier",
+                              "start": 48,
+                              "end": 51,
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 20
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 23
+                                },
+                                "identifierName": "bar"
+                              },
+                              "name": "bar"
+                            },
+                            "computed": false,
+                            "kind": "method",
+                            "id": null,
+                            "generator": false,
+                            "async": false,
+                            "params": [],
+                            "body": {
+                              "type": "BlockStatement",
+                              "start": 54,
+                              "end": 67,
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 26
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 39
+                                }
+                              },
+                              "body": [
+                                {
+                                  "type": "ExpressionStatement",
+                                  "start": 56,
+                                  "end": 65,
+                                  "loc": {
+                                    "start": {
+                                      "line": 3,
+                                      "column": 28
+                                    },
+                                    "end": {
+                                      "line": 3,
+                                      "column": 37
+                                    }
+                                  },
+                                  "expression": {
+                                    "type": "Identifier",
+                                    "start": 56,
+                                    "end": 65,
+                                    "loc": {
+                                      "start": {
+                                        "line": 3,
+                                        "column": 28
+                                      },
+                                      "end": {
+                                        "line": 3,
+                                        "column": 37
+                                      },
+                                      "identifierName": "arguments"
+                                    },
+                                    "name": "arguments"
+                                  }
+                                }
+                              ],
+                              "directives": []
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10771 
| Patch: Bug Fix?          | Y
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we introduce `inClass` accessor in `ScopeHandler` and use it to check `arguments` keyword. Please refer to this [thread](https://github.com/babel/babel/issues/10771#issuecomment-559277848) for the background.