### PR TITLE
fix(optional chaining): Optional delete returns true with nullish base

### DIFF
--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-1/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-1/options.json
@@ -1,8 +1,5 @@
 {
   "sourceType": "module",
-  "plugins": [
-    "jsx",
-    "flow"
-  ],
+  "plugins": ["jsx", "flow"],
   "throws": "Unexpected token, expected \"{\" (2:26)"
 }

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-5/options.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/typeof-reserved-invalid-5/options.json
@@ -1,8 +1,5 @@
 {
   "sourceType": "module",
-  "plugins": [
-    "jsx",
-    "flow"
-  ],
+  "plugins": ["jsx", "flow"],
   "throws": "Unexpected token (2:23)"
 }

--- a/packages/babel-plugin-proposal-optional-chaining/src/index.js
+++ b/packages/babel-plugin-proposal-optional-chaining/src/index.js
@@ -14,6 +14,7 @@ export default declare((api, options) => {
     visitor: {
       "OptionalCallExpression|OptionalMemberExpression"(path) {
         const { parentPath, scope } = path;
+        let isDeleteOperation = false;
         const optionals = [];
 
         let optionalPath = path;
@@ -38,6 +39,7 @@ export default declare((api, options) => {
         let replacementPath = path;
         if (parentPath.isUnaryExpression({ operator: "delete" })) {
           replacementPath = parentPath;
+          isDeleteOperation = true;
         }
         for (let i = optionals.length - 1; i >= 0; i--) {
           const node = optionals[i];
@@ -113,7 +115,9 @@ export default declare((api, options) => {
                       scope.buildUndefinedNode(),
                     ),
                   ),
-              scope.buildUndefinedNode(),
+              isDeleteOperation
+                ? t.booleanLiteral(true)
+                : scope.buildUndefinedNode(),
               replacementPath.node,
             ),
           );

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/delete/exec.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/delete/exec.js
@@ -16,7 +16,7 @@ expect(test).toBe(true);
 
 test = delete obj?.b?.b;
 expect(obj.b).toBeUndefined();
-expect(test).toBeUndefined();
+expect(test).toBe(true);
 
 delete obj?.a;
 expect(obj.a).toBeUndefined();

--- a/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/delete/output.js
+++ b/packages/babel-plugin-proposal-optional-chaining/test/fixtures/general/delete/output.js
@@ -7,7 +7,7 @@ const obj = {
     b: 0
   }
 };
-let test = obj === null || obj === void 0 ? void 0 : (_obj$a = obj.a) === null || _obj$a === void 0 ? void 0 : delete _obj$a.b;
-test = obj === null || obj === void 0 ? void 0 : delete obj.a.b;
-test = obj === null || obj === void 0 ? void 0 : (_obj$b = obj.b) === null || _obj$b === void 0 ? void 0 : delete _obj$b.b;
-obj === null || obj === void 0 ? void 0 : delete obj.a;
+let test = obj === null || obj === void 0 ? true : (_obj$a = obj.a) === null || _obj$a === void 0 ? true : delete _obj$a.b;
+test = obj === null || obj === void 0 ? true : delete obj.a.b;
+test = obj === null || obj === void 0 ? true : (_obj$b = obj.b) === null || _obj$b === void 0 ? true : delete _obj$b.b;
+obj === null || obj === void 0 ? true : delete obj.a;

--- a/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/options.json
+++ b/packages/babel-plugin-transform-modules-amd/test/fixtures/regression/9346/options.json
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "transform-modules-amd"
-  ]
+  "plugins": ["transform-modules-amd"]
 }


### PR DESCRIPTION

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10805
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Per issue #10805, the return value when using delete on a nullish base is
currently undefined. The correct return type should be true.