### PR TITLE
chore: remove unnecessary transform-for-of when building babel-parser

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,6 +14,7 @@ module.exports = function(api) {
 
   let convertESM = true;
   let ignoreLib = true;
+  let isStandalone = false;
   const nodeVersion = "6.9";
   // The vast majority of our src files are modules, but we use
   // unambiguous to keep things simple until we get around to renaming
@@ -45,6 +46,7 @@ module.exports = function(api) {
     case "standalone":
       convertESM = false;
       ignoreLib = false;
+      isStandalone = true;
       unambiguousSources.push(
         "**/node_modules",
         "packages/babel-preset-env/data"
@@ -101,14 +103,12 @@ module.exports = function(api) {
       ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
 
       convertESM ? "@babel/transform-modules-commonjs" : null,
+      isStandalone ? ["@babel/transform-for-of", { assumeArray: true }] : null,
     ].filter(Boolean),
     overrides: [
       {
         test: "packages/babel-parser",
-        plugins: [
-          "babel-plugin-transform-charcodes",
-          ["@babel/transform-for-of", { assumeArray: true }],
-        ],
+        plugins: ["babel-plugin-transform-charcodes"],
       },
       {
         test: ["./packages/babel-cli", "./packages/babel-core"],

--- a/babel.config.js
+++ b/babel.config.js
@@ -105,7 +105,12 @@ module.exports = function(api) {
     overrides: [
       {
         test: "packages/babel-parser",
-        plugins: ["babel-plugin-transform-charcodes"],
+        plugins: [
+          "babel-plugin-transform-charcodes",
+          env === "standalone"
+            ? ["@babel/transform-for-of", { assumeArray: true }]
+            : null,
+        ].filter(Boolean),
       },
       {
         test: ["./packages/babel-cli", "./packages/babel-core"],

--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,6 @@ module.exports = function(api) {
 
   let convertESM = true;
   let ignoreLib = true;
-  let isStandalone = false;
   const nodeVersion = "6.9";
   // The vast majority of our src files are modules, but we use
   // unambiguous to keep things simple until we get around to renaming
@@ -46,7 +45,6 @@ module.exports = function(api) {
     case "standalone":
       convertESM = false;
       ignoreLib = false;
-      isStandalone = true;
       unambiguousSources.push(
         "**/node_modules",
         "packages/babel-preset-env/data"
@@ -103,7 +101,6 @@ module.exports = function(api) {
       ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
 
       convertESM ? "@babel/transform-modules-commonjs" : null,
-      isStandalone ? ["@babel/transform-for-of", { assumeArray: true }] : null,
     ].filter(Boolean),
     overrides: [
       {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/plugin-transform-flow-strip-types": "^7.7.4",
+    "@babel/plugin-transform-for-of": "^7.7.4",
     "@babel/plugin-transform-modules-commonjs": "^7.7.0",
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.7.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/plugin-transform-flow-strip-types": "^7.7.4",
-    "@babel/plugin-transform-for-of": "^7.7.4",
     "@babel/plugin-transform-modules-commonjs": "^7.7.0",
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.7.1",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
<s>This PR applies `transform-for-of: assumeArray` on standalone build, of which the size decrease is expected. </s>

It removes this transform from babel-parser build config since it is supported in Node >= 6.