### PR TITLE
babel-eslint-parser: remove allowImportExportEverywhere

### DIFF
--- a/eslint/babel-eslint-parser/README.md
+++ b/eslint/babel-eslint-parser/README.md
@@ -51,7 +51,6 @@ Additional configuration options can be set in your ESLint configuration under t
 
 - `requireConfigFile` (default `true`) can be set to `false` to allow @babel/eslint-parser to run on files that do not have a Babel configuration associated with them. This can be useful for linting files that are not transformed by Babel (such as tooling configuration files), though we recommend using the default parser via [glob-based configuration](https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns). Note: @babel/eslint-parser will not parse any experimental syntax when no configuration file is found.
 - `sourceType` can be set to `"module"`(default) or `"script"` if your code isn't using ECMAScript modules.
-- `allowImportExportEverywhere` (default `false`) can be set to `true` to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. Otherwise import and export declarations can only appear at a program's top level.
 - `ecmaFeatures.globalReturn` (default `false`) allow return statements in the global scope when used with `sourceType: "script"`.
 - `babelOptions` passes through Babel's configuration [loading](https://babeljs.io/docs/en/options#config-loading-options) and [merging](https://babeljs.io/docs/en/options#config-merging-options) options (for instance, in case of a monorepo). When not defined, @babel/eslint-parser will use Babel's default configuration file resolution logic.
 
@@ -62,7 +61,6 @@ module.exports = {
   parser: "@babel/eslint-parser",
   parserOptions: {
     sourceType: "module",
-    allowImportExportEverywhere: false,
     ecmaFeatures: {
       globalReturn: false,
     },

--- a/eslint/babel-eslint-parser/src/parse.js
+++ b/eslint/babel-eslint-parser/src/parse.js
@@ -26,7 +26,7 @@ export default function(code, options) {
     ignore: options.babelOptions.ignore,
     only: options.babelOptions.only,
     parserOpts: {
-      allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
+      allowImportExportEverywhere: true,
       allowReturnOutsideFunction: true,
       allowSuperOutsideMethod: true,
       ranges: true,
@@ -34,7 +34,7 @@ export default function(code, options) {
       plugins: ["estree"],
     },
     caller: {
-      name: "babel-eslint",
+      name: "@babel/eslint-parser",
     },
   };
 

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/arguments-in-nested-class-decorator-call-expression/options.json
@@ -1,3 +1,6 @@
 {
-  "plugins": ["classProperties", ["decorators", { "decoratorsBeforeExport": false }]]
+  "plugins": [
+    "classProperties",
+    ["decorators", { "decoratorsBeforeExport": false }]
+  ]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm actually not entirely sure when this was removed, but it doesn't look like this is an option we have in Espree any more (though it still exists in [Acorn](https://github.com/acornjs/acorn/tree/master/acorn#interface)) and I don't think is necessary any more? Please let me know if I'm missing something!