### PR TITLE
@babel/eslint-parser: fix ImportExpression node to match ESTree spec 

### DIFF
--- a/eslint/babel-eslint-parser/src/parse.js
+++ b/eslint/babel-eslint-parser/src/parse.js
@@ -34,7 +34,7 @@ export default function(code, options) {
       plugins: ["estree"],
     },
     caller: {
-      name: "babel-eslint",
+      name: "@babel/eslint-parser",
     },
   };
 

--- a/eslint/babel-eslint-parser/test/babel-eslint-parser.js
+++ b/eslint/babel-eslint-parser/test/babel-eslint-parser.js
@@ -524,5 +524,11 @@ describe("babylon-to-espree", () => {
         const a = 1n;
       `);
     });
+
+    it("Dynamic Import", () => {
+      parseAndAssertSame(`
+        const a = import('a');
+      `);
+    });
   });
 });

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -759,7 +759,6 @@ export default class ExpressionParser extends LValParser {
     node: T,
     optional: boolean,
   ): T {
-    let nodeType = optional ? "OptionalCallExpression" : "CallExpression";
     if (node.callee.type === "Import") {
       if (node.arguments.length !== 1) {
         this.raise(node.start, "import() requires exactly one argument");
@@ -769,13 +768,11 @@ export default class ExpressionParser extends LValParser {
           this.raise(importArg.start, "... is not allowed in import()");
         }
       }
-
-      if (this.hasPlugin("estree")) {
-        nodeType = "ImportExpression";
-        node.source = node.arguments[0];
-      }
     }
-    return this.finishNode(node, nodeType);
+    return this.finishNode(
+      node,
+      optional ? "OptionalCallExpression" : "CallExpression",
+    );
   }
 
   parseCallExpressionArguments(

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -758,7 +758,7 @@ export default class ExpressionParser extends LValParser {
   finishCallExpression<T: N.CallExpression | N.OptionalCallExpression>(
     node: T,
     optional: boolean,
-  ): T {
+  ): N.Expression {
     if (node.callee.type === "Import") {
       if (node.arguments.length !== 1) {
         this.raise(node.start, "import() requires exactly one argument");

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -759,6 +759,7 @@ export default class ExpressionParser extends LValParser {
     node: T,
     optional: boolean,
   ): T {
+    let nodeType = optional ? "OptionalCallExpression" : "CallExpression";
     if (node.callee.type === "Import") {
       if (node.arguments.length !== 1) {
         this.raise(node.start, "import() requires exactly one argument");
@@ -768,11 +769,12 @@ export default class ExpressionParser extends LValParser {
           this.raise(importArg.start, "... is not allowed in import()");
         }
       }
+
+      if (this.hasPlugin("estree")) {
+        nodeType = "ImportExpression";
+      }
     }
-    return this.finishNode(
-      node,
-      optional ? "OptionalCallExpression" : "CallExpression",
-    );
+    return this.finishNode(node, nodeType);
   }
 
   parseCallExpressionArguments(

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -772,6 +772,7 @@ export default class ExpressionParser extends LValParser {
 
       if (this.hasPlugin("estree")) {
         nodeType = "ImportExpression";
+        node.source = node.arguments[0];
       }
     }
     return this.finishNode(node, nodeType);

--- a/packages/babel-parser/src/parser/lval.js
+++ b/packages/babel-parser/src/parser/lval.js
@@ -228,7 +228,7 @@ export default class LValParser extends NodeUtils {
   toReferencedListDeep(
     exprList: $ReadOnlyArray<?Expression>,
     isParenthesizedExpr?: boolean,
-  ): $ReadOnlyArray<?Expression> {
+  ): void {
     this.toReferencedList(exprList, isParenthesizedExpr);
 
     for (const expr of exprList) {
@@ -236,8 +236,6 @@ export default class LValParser extends NodeUtils {
         this.toReferencedListDeep(expr.elements);
       }
     }
-
-    return exprList;
   }
 
   // Parses spread element.

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -415,17 +415,14 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     finishCallExpression<T: N.CallExpression | N.OptionalCallExpression>(
       node: T,
       optional: boolean,
-    ): T | N.EstreeImportExpression {
+    ): N.Expression {
+      super.finishCallExpression(node, optional);
+
       if (node.callee.type === "Import") {
-        const finishedNode: N.EstreeImportExpression = (super.finishCallExpression(
-          node,
-          optional,
-        ): any);
-        finishedNode.type = "ImportExpression";
-        finishedNode.source = node.arguments[0];
-        return finishedNode;
+        ((node: N.Node): N.EstreeImportExpression).type = "ImportExpression";
+        ((node: N.Node): N.EstreeImportExpression).source = node.arguments[0];
       }
 
-      return super.finishCallExpression(node, optional);
+      return node;
     }
   };

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -421,8 +421,18 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       if (node.callee.type === "Import") {
         ((node: N.Node): N.EstreeImportExpression).type = "ImportExpression";
         ((node: N.Node): N.EstreeImportExpression).source = node.arguments[0];
+        delete node.arguments;
+        delete node.callee;
       }
 
       return node;
+    }
+
+    // ImportExpressions do not have an arguments array.
+    toReferencedListDeep(
+      exprList: $ReadOnlyArray<?N.Expression> = [],
+      isParenthesizedExpr?: boolean,
+    ): $ReadOnlyArray<?N.Expression> {
+      return super.toReferencedListDeep(exprList, isParenthesizedExpr);
     }
   };

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -428,11 +428,15 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return node;
     }
 
-    // ImportExpressions do not have an arguments array.
     toReferencedListDeep(
-      exprList: $ReadOnlyArray<?N.Expression> = [],
+      exprList: $ReadOnlyArray<?N.Expression>,
       isParenthesizedExpr?: boolean,
-    ): $ReadOnlyArray<?N.Expression> {
-      return super.toReferencedListDeep(exprList, isParenthesizedExpr);
+    ): void {
+      // ImportExpressions do not have an arguments array.
+      if (!exprList) {
+        return;
+      }
+
+      super.toReferencedListDeep(exprList, isParenthesizedExpr);
     }
   };

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -415,14 +415,17 @@ export default (superClass: Class<Parser>): Class<Parser> =>
     finishCallExpression<T: N.CallExpression | N.OptionalCallExpression>(
       node: T,
       optional: boolean,
-    ): T & { source?: N.Node } {
-      const finishedNode = super.finishCallExpression(node, optional);
-
+    ): T | N.EstreeImportExpression {
       if (node.callee.type === "Import") {
+        const finishedNode: N.EstreeImportExpression = (super.finishCallExpression(
+          node,
+          optional,
+        ): any);
         finishedNode.type = "ImportExpression";
         finishedNode.source = node.arguments[0];
+        return finishedNode;
       }
 
-      return finishedNode;
+      return super.finishCallExpression(node, optional);
     }
   };

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -411,4 +411,18 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         super.toAssignableObjectExpressionProp(prop, isBinding, isLast);
       }
     }
+
+    finishCallExpression<T: N.CallExpression | N.OptionalCallExpression>(
+      node: T,
+      optional: boolean,
+    ): T & { source?: N.Node } {
+      const finishedNode = super.finishCallExpression(node, optional);
+
+      if (node.callee.type === "Import") {
+        finishedNode.type = "ImportExpression";
+        finishedNode.source = node.arguments[0];
+      }
+
+      return finishedNode;
+    }
   };

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1041,8 +1041,6 @@ export type EstreeMethodDefinition = NodeBase & {
 
 export type EstreeImportExpression = NodeBase & {
   type: "ImportExpression",
-  callee: Import,
-  arguments: Array<Expression>,
   source: Expression,
 };
 

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -1013,7 +1013,7 @@ export type FlowInterfaceType = NodeBase & {
   body: FlowObjectTypeAnnotation,
 };
 
-// estree
+// ESTree
 
 export type EstreeProperty = NodeBase & {
   type: "Property",
@@ -1037,6 +1037,13 @@ export type EstreeMethodDefinition = NodeBase & {
   kind?: "get" | "set" | "method",
 
   variance?: ?FlowVariance,
+};
+
+export type EstreeImportExpression = NodeBase & {
+  type: "ImportExpression",
+  callee: Import,
+  arguments: Array<Expression>,
+  source: Expression,
 };
 
 // === === === ===

--- a/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-1/options.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-1/options.json
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "estree"
-  ]
+  "plugins": ["estree"]
 }

--- a/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-2/options.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-2/options.json
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "estree"
-  ]
+  "plugins": ["estree"]
 }

--- a/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-3/options.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-3/options.json
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "estree"
-  ]
+  "plugins": ["estree"]
 }

--- a/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-4/options.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-4/options.json
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "estree"
-  ]
+  "plugins": ["estree"]
 }

--- a/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-5/options.json
+++ b/packages/babel-parser/test/fixtures/core/categorized/invalid-assignment-pattern-5/options.json
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "estree"
-  ]
+  "plugins": ["estree"]
 }

--- a/packages/babel-parser/test/fixtures/estree/bigInt/options.json
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/options.json
@@ -1,6 +1,3 @@
 {
-  "plugins": [
-    "estree",
-    "bigInt"
-  ]
+  "plugins": ["estree", "bigInt"]
 }

--- a/packages/babel-parser/test/fixtures/estree/dynamic-import/basic/input.js
+++ b/packages/babel-parser/test/fixtures/estree/dynamic-import/basic/input.js
@@ -1,0 +1,1 @@
+const a = import("a");

--- a/packages/babel-parser/test/fixtures/estree/dynamic-import/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/dynamic-import/basic/output.json
@@ -1,0 +1,150 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 22,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 22
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 22,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 22
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 22,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 22
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 21,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 21
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                },
+                "identifierName": "a"
+              },
+              "name": "a"
+            },
+            "init": {
+              "type": "ImportExpression",
+              "start": 10,
+              "end": 21,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                }
+              },
+              "callee": {
+                "type": "Import",
+                "start": 10,
+                "end": 16,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 16
+                  }
+                }
+              },
+              "arguments": [
+                {
+                  "type": "Literal",
+                  "start": 17,
+                  "end": 20,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 20
+                    }
+                  },
+                  "value": "a",
+                  "raw": "\"a\""
+                }
+              ],
+              "source": {
+                "type": "Literal",
+                "start": 17,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                },
+                "value": "a",
+                "raw": "\"a\""
+              }
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/dynamic-import/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/dynamic-import/basic/output.json
@@ -89,40 +89,6 @@
                   "column": 21
                 }
               },
-              "callee": {
-                "type": "Import",
-                "start": 10,
-                "end": 16,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 16
-                  }
-                }
-              },
-              "arguments": [
-                {
-                  "type": "Literal",
-                  "start": 17,
-                  "end": 20,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 17
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 20
-                    }
-                  },
-                  "value": "a",
-                  "raw": "\"a\""
-                }
-              ],
               "source": {
                 "type": "Literal",
                 "start": 17,

--- a/packages/babel-parser/test/fixtures/estree/dynamic-import/options.json
+++ b/packages/babel-parser/test/fixtures/estree/dynamic-import/options.json
@@ -1,6 +1,3 @@
 {
-  "plugins": [
-    "estree",
-    "dynamicImport"
-  ]
+  "plugins": ["estree", "dynamicImport"]
 }

--- a/packages/babel-parser/test/fixtures/estree/dynamic-import/options.json
+++ b/packages/babel-parser/test/fixtures/estree/dynamic-import/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "estree",
+    "dynamicImport"
+  ]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Refs https://github.com/babel/babel/issues/10826
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`@babel/parser` currently parses dynamic imports (`import('a')`) as `CallExpression`s (code [here](https://github.com/babel/babel/blob/master/packages/babel-parser/src/parser/expression.js#L784-L802)). The ESTree spec differs from this and gives it its own type called [`ImportExpression`](https://github.com/estree/estree/blob/master/es2020.md#expressions). 