### PR TITLE
Do not add `.js` extension to injected helper imports when module transform presents

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/imports-hoisting/output.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
-var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral.js"));
+var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
 function _templateObject() {
   const data = (0, _taggedTemplateLiteral2.default)(["foo"]);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/multi-load/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop-loose/multi-load/output.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault.js");
+var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault");
 
 exports.__esModule = true;
 
-var _interopRequireDefault2 = _interopRequireDefault3(require("@babel/runtime/helpers/interopRequireDefault.js"));
+var _interopRequireDefault2 = _interopRequireDefault3(require("@babel/runtime/helpers/interopRequireDefault"));
 
 console.log(_interopRequireDefault2.default);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/imports-hoisting/output.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
-var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral.js"));
+var _taggedTemplateLiteral2 = _interopRequireDefault(require("@babel/runtime/helpers/taggedTemplateLiteral"));
 
 function _templateObject() {
   const data = (0, _taggedTemplateLiteral2.default)(["foo"]);

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/multi-load/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/interop/multi-load/output.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault.js");
+var _interopRequireDefault3 = require("@babel/runtime/helpers/interopRequireDefault");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _interopRequireDefault2 = _interopRequireDefault3(require("@babel/runtime/helpers/interopRequireDefault.js"));
+var _interopRequireDefault2 = _interopRequireDefault3(require("@babel/runtime/helpers/interopRequireDefault"));
 
 console.log(_interopRequireDefault2.default);

--- a/packages/babel-plugin-transform-modules-umd/src/index.js
+++ b/packages/babel-plugin-transform-modules-umd/src/index.js
@@ -133,6 +133,10 @@ export default declare((api, options) => {
   return {
     name: "transform-modules-umd",
 
+    pre() {
+      this.file.set("@babel/plugin-transform-modules-*", "umd");
+    },
+
     visitor: {
       Program: {
         exit(path) {

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/T7041/output.js
@@ -1,4 +1,4 @@
-var _regeneratorRuntime = require("@babel/runtime/regenerator/index.js");
+var _regeneratorRuntime = require("@babel/runtime/regenerator/index");
 
 var _marked =
 /*#__PURE__*/

--- a/packages/babel-plugin-transform-runtime/src/index.js
+++ b/packages/babel-plugin-transform-runtime/src/index.js
@@ -254,7 +254,14 @@ export default declare((api, options, dirname) => {
         if (cached) {
           cached = t.cloneNode(cached);
         } else {
-          cached = addDefault(file.path, source, {
+          const moduleTransforms = file.get(
+            "@babel/plugin-transform-modules-*",
+          );
+          // Remove the trailing `.js` requires by ES Module when module transforms presents
+          const validSource = moduleTransforms
+            ? source.replace(/\.js$/, "")
+            : source;
+          cached = addDefault(file.path, validSource, {
             importedInterop: "uncompiled",
             nameHint,
             blockHoist,

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules-helpers/output.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault");
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/classCallCheck.js"));
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/classCallCheck"));
 
-var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/createClass.js"));
+var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/createClass"));
 
 var _foo = _interopRequireDefault(require("foo"));
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs2/modules/output.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault");
 
-var _Object$keys = require("@babel/runtime-corejs2/core-js/object/keys.js");
+var _Object$keys = require("@babel/runtime-corejs2/core-js/object/keys");
 
-var _Object$defineProperty = require("@babel/runtime-corejs2/core-js/object/define-property.js");
+var _Object$defineProperty = require("@babel/runtime-corejs2/core-js/object/define-property");
 
 _Object$defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-helpers/output.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/classCallCheck.js"));
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/classCallCheck"));
 
-var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/createClass.js"));
+var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs3/helpers/createClass"));
 
 var _foo = _interopRequireDefault(require("foo"));
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules-loose/output.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var _Object$keys = require("@babel/runtime-corejs3/core-js-stable/object/keys.js");
+var _Object$keys = require("@babel/runtime-corejs3/core-js-stable/object/keys");
 
-var _forEachInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/instance/for-each.js");
+var _forEachInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/instance/for-each");
 
 var _context;
 
-var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
 
 exports.__esModule = true;
 var _exportNames = {

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/modules/output.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var _Object$keys = require("@babel/runtime-corejs3/core-js-stable/object/keys.js");
+var _Object$keys = require("@babel/runtime-corejs3/core-js-stable/object/keys");
 
-var _forEachInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/instance/for-each.js");
+var _forEachInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/instance/for-each");
 
 var _context;
 
-var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
 
-var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property.js");
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
 
 _Object$defineProperty(exports, "__esModule", {
   value: true

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-amd/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-amd/input.mjs
@@ -1,0 +1,5 @@
+import foo from "foo";
+
+class Example {
+  method() {}
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-amd/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-amd/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-runtime",
+    "transform-modules-amd",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-amd/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-amd/output.js
@@ -1,0 +1,23 @@
+define(["@babel/runtime/helpers/classCallCheck", "@babel/runtime/helpers/createClass", "foo"], function (_classCallCheck2, _createClass2, _foo) {
+  "use strict";
+
+  var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+  _classCallCheck2 = _interopRequireDefault(_classCallCheck2);
+  _createClass2 = _interopRequireDefault(_createClass2);
+  _foo = _interopRequireDefault(_foo);
+
+  let Example =
+  /*#__PURE__*/
+  function () {
+    function Example() {
+      (0, _classCallCheck2.default)(this, Example);
+    }
+
+    (0, _createClass2.default)(Example, [{
+      key: "method",
+      value: function method() {}
+    }]);
+    return Example;
+  }();
+});

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-commonjs/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-commonjs/input.mjs
@@ -1,0 +1,5 @@
+import foo from "foo";
+
+class Example {
+  method() {}
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-commonjs/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-commonjs/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-runtime",
+    "transform-modules-commonjs",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-commonjs/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-commonjs/output.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck.js"));
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
 
-var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass.js"));
+var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
 
 var _foo = _interopRequireDefault(require("foo"));
 

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-systemjs/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-systemjs/input.mjs
@@ -1,0 +1,5 @@
+import foo from "foo";
+
+class Example {
+  method() {}
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-systemjs/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-systemjs/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-runtime",
+    "transform-modules-amd",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-systemjs/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-systemjs/output.js
@@ -1,0 +1,23 @@
+define(["@babel/runtime/helpers/classCallCheck", "@babel/runtime/helpers/createClass", "foo"], function (_classCallCheck2, _createClass2, _foo) {
+  "use strict";
+
+  var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+  _classCallCheck2 = _interopRequireDefault(_classCallCheck2);
+  _createClass2 = _interopRequireDefault(_createClass2);
+  _foo = _interopRequireDefault(_foo);
+
+  let Example =
+  /*#__PURE__*/
+  function () {
+    function Example() {
+      (0, _classCallCheck2.default)(this, Example);
+    }
+
+    (0, _createClass2.default)(Example, [{
+      key: "method",
+      value: function method() {}
+    }]);
+    return Example;
+  }();
+});

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-umd/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-umd/input.mjs
@@ -1,0 +1,5 @@
+import foo from "foo";
+
+class Example {
+  method() {}
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-umd/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-umd/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-runtime",
+    "transform-modules-umd",
+    "transform-classes"
+  ]
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-umd/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers-umd/output.js
@@ -1,0 +1,35 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["@babel/runtime/helpers/classCallCheck", "@babel/runtime/helpers/createClass", "foo"], factory);
+  } else if (typeof exports !== "undefined") {
+    factory(require("@babel/runtime/helpers/classCallCheck"), require("@babel/runtime/helpers/createClass"), require("foo"));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(global.classCallCheck, global.createClass, global.foo);
+    global.input = mod.exports;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function (_classCallCheck2, _createClass2, _foo) {
+  "use strict";
+
+  var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+  _classCallCheck2 = _interopRequireDefault(_classCallCheck2);
+  _createClass2 = _interopRequireDefault(_createClass2);
+  _foo = _interopRequireDefault(_foo);
+
+  let Example =
+  /*#__PURE__*/
+  function () {
+    function Example() {
+      (0, _classCallCheck2.default)(this, Example);
+    }
+
+    (0, _createClass2.default)(Example, [{
+      key: "method",
+      value: function method() {}
+    }]);
+    return Example;
+  }();
+});

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/input.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/input.mjs
@@ -1,5 +1,6 @@
 import foo from "foo";
 
 class Example {
-  method() {}
+  property
 }
+

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/options.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "transform-runtime",
-    "transform-modules-commonjs",
-    "transform-classes"
+    "proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules-helpers/output.mjs
@@ -1,0 +1,9 @@
+import _defineProperty from "@babel/runtime/helpers/defineProperty.js";
+import foo from "foo";
+
+class Example {
+  constructor() {
+    _defineProperty(this, "property", void 0);
+  }
+
+}

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime/modules/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault.js");
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
 Object.defineProperty(exports, "__esModule", {
   value: true


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10832 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow up to #10549, this PR partially reverts the recently introduced behaviour on the helper imports. It will remove `.js` added in #10549 when other module transforms presents.

The `.js` extension is only required by native ES Modules and we can safely remove it when it _will_ be transformed to other module formats.

**Compatibility Note**:

When using transform-runtime 7.7.6 with
- modules-umd < 7.7.6
- modules-amd < 7.5.0

it will still add the `.js` extension to imports due to lack of context variables. This will cause trouble to AMD users. If you are experience this issue, please upgrade these plugins to 7.7.6.