### PR TITLE
refactor: rewrite available-plugins to esm

### DIFF
--- a/packages/babel-preset-env/src/available-plugins.js
+++ b/packages/babel-preset-env/src/available-plugins.js
@@ -1,47 +1,90 @@
 // @flow
+import syntaxAsyncGenerators from "@babel/plugin-syntax-async-generators";
+import syntaxDynamicImport from "@babel/plugin-syntax-dynamic-import";
+import syntaxJsonStrings from "@babel/plugin-syntax-json-strings";
+import syntaxObjectRestSpread from "@babel/plugin-syntax-object-rest-spread";
+import syntaxOptionalCatchBinding from "@babel/plugin-syntax-optional-catch-binding";
+import syntaxTopLevelAwait from "@babel/plugin-syntax-top-level-await";
+import proposalAsyncGeneratorFunctions from "@babel/plugin-proposal-async-generator-functions";
+import proposalDynamicImport from "@babel/plugin-proposal-dynamic-import";
+import proposalJsonStrings from "@babel/plugin-proposal-json-strings";
+import proposalObjectRestSpread from "@babel/plugin-proposal-object-rest-spread";
+import proposalOptionalCatchBinding from "@babel/plugin-proposal-optional-catch-binding";
+import proposalUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
+import transformAsyncToGenerator from "@babel/plugin-transform-async-to-generator";
+import transformArrowFunctions from "@babel/plugin-transform-arrow-functions";
+import transformBlockScopedFunctions from "@babel/plugin-transform-block-scoped-functions";
+import transformBlockScoping from "@babel/plugin-transform-block-scoping";
+import transformClasses from "@babel/plugin-transform-classes";
+import transformComputedProperties from "@babel/plugin-transform-computed-properties";
+import transformDestructuring from "@babel/plugin-transform-destructuring";
+import transformDotallRegex from "@babel/plugin-transform-dotall-regex";
+import transformDuplicateKeys from "@babel/plugin-transform-duplicate-keys";
+import transformExponentialOperator from "@babel/plugin-transform-exponentiation-operator";
+import transformForOf from "@babel/plugin-transform-for-of";
+import transformFunctionName from "@babel/plugin-transform-function-name";
+import transformLiterals from "@babel/plugin-transform-literals";
+import transformMemberExpressionLiterals from "@babel/plugin-transform-member-expression-literals";
+import transformModulesAmd from "@babel/plugin-transform-modules-amd";
+import transformModulesCommonjs from "@babel/plugin-transform-modules-commonjs";
+import transformModulesSystemjs from "@babel/plugin-transform-modules-systemjs";
+import transformModulesUmd from "@babel/plugin-transform-modules-umd";
+import transformNamedCapturingGroupsRegex from "@babel/plugin-transform-named-capturing-groups-regex";
+import transformNewTarget from "@babel/plugin-transform-new-target";
+import transformObjectSuper from "@babel/plugin-transform-object-super";
+import transformParameters from "@babel/plugin-transform-parameters";
+import transformPropertyLiterals from "@babel/plugin-transform-property-literals";
+import transformRegenerator from "@babel/plugin-transform-regenerator";
+import transformReservedWords from "@babel/plugin-transform-reserved-words";
+import transformShorthandProperties from "@babel/plugin-transform-shorthand-properties";
+import transformSpread from "@babel/plugin-transform-spread";
+import transformStickyRegex from "@babel/plugin-transform-sticky-regex";
+import transformTemplateLiterals from "@babel/plugin-transform-template-literals";
+import transformTypeofSymbol from "@babel/plugin-transform-typeof-symbol";
+import transformUnicodeRegex from "@babel/plugin-transform-unicode-regex";
 
 export default {
-  "syntax-async-generators": require("@babel/plugin-syntax-async-generators"),
-  "syntax-dynamic-import": require("@babel/plugin-syntax-dynamic-import"),
-  "syntax-json-strings": require("@babel/plugin-syntax-json-strings"),
-  "syntax-object-rest-spread": require("@babel/plugin-syntax-object-rest-spread"),
-  "syntax-optional-catch-binding": require("@babel/plugin-syntax-optional-catch-binding"),
-  "syntax-top-level-await": require("@babel/plugin-syntax-top-level-await"),
-  "transform-async-to-generator": require("@babel/plugin-transform-async-to-generator"),
-  "proposal-async-generator-functions": require("@babel/plugin-proposal-async-generator-functions"),
-  "proposal-dynamic-import": require("@babel/plugin-proposal-dynamic-import"),
-  "proposal-json-strings": require("@babel/plugin-proposal-json-strings"),
-  "transform-arrow-functions": require("@babel/plugin-transform-arrow-functions"),
-  "transform-block-scoped-functions": require("@babel/plugin-transform-block-scoped-functions"),
-  "transform-block-scoping": require("@babel/plugin-transform-block-scoping"),
-  "transform-classes": require("@babel/plugin-transform-classes"),
-  "transform-computed-properties": require("@babel/plugin-transform-computed-properties"),
-  "transform-destructuring": require("@babel/plugin-transform-destructuring"),
-  "transform-dotall-regex": require("@babel/plugin-transform-dotall-regex"),
-  "transform-duplicate-keys": require("@babel/plugin-transform-duplicate-keys"),
-  "transform-for-of": require("@babel/plugin-transform-for-of"),
-  "transform-function-name": require("@babel/plugin-transform-function-name"),
-  "transform-literals": require("@babel/plugin-transform-literals"),
-  "transform-member-expression-literals": require("@babel/plugin-transform-member-expression-literals"),
-  "transform-modules-amd": require("@babel/plugin-transform-modules-amd"),
-  "transform-modules-commonjs": require("@babel/plugin-transform-modules-commonjs"),
-  "transform-modules-systemjs": require("@babel/plugin-transform-modules-systemjs"),
-  "transform-modules-umd": require("@babel/plugin-transform-modules-umd"),
-  "transform-named-capturing-groups-regex": require("@babel/plugin-transform-named-capturing-groups-regex"),
-  "transform-object-super": require("@babel/plugin-transform-object-super"),
-  "transform-parameters": require("@babel/plugin-transform-parameters"),
-  "transform-property-literals": require("@babel/plugin-transform-property-literals"),
-  "transform-reserved-words": require("@babel/plugin-transform-reserved-words"),
-  "transform-shorthand-properties": require("@babel/plugin-transform-shorthand-properties"),
-  "transform-spread": require("@babel/plugin-transform-spread"),
-  "transform-sticky-regex": require("@babel/plugin-transform-sticky-regex"),
-  "transform-template-literals": require("@babel/plugin-transform-template-literals"),
-  "transform-typeof-symbol": require("@babel/plugin-transform-typeof-symbol"),
-  "transform-unicode-regex": require("@babel/plugin-transform-unicode-regex"),
-  "transform-exponentiation-operator": require("@babel/plugin-transform-exponentiation-operator"),
-  "transform-new-target": require("@babel/plugin-transform-new-target"),
-  "proposal-object-rest-spread": require("@babel/plugin-proposal-object-rest-spread"),
-  "proposal-optional-catch-binding": require("@babel/plugin-proposal-optional-catch-binding"),
-  "transform-regenerator": require("@babel/plugin-transform-regenerator"),
-  "proposal-unicode-property-regex": require("@babel/plugin-proposal-unicode-property-regex"),
+  "syntax-async-generators": syntaxAsyncGenerators,
+  "syntax-dynamic-import": syntaxDynamicImport,
+  "syntax-json-strings": syntaxJsonStrings,
+  "syntax-object-rest-spread": syntaxObjectRestSpread,
+  "syntax-optional-catch-binding": syntaxOptionalCatchBinding,
+  "syntax-top-level-await": syntaxTopLevelAwait,
+  "transform-async-to-generator": transformAsyncToGenerator,
+  "proposal-async-generator-functions": proposalAsyncGeneratorFunctions,
+  "proposal-dynamic-import": proposalDynamicImport,
+  "proposal-json-strings": proposalJsonStrings,
+  "transform-arrow-functions": transformArrowFunctions,
+  "transform-block-scoped-functions": transformBlockScopedFunctions,
+  "transform-block-scoping": transformBlockScoping,
+  "transform-classes": transformClasses,
+  "transform-computed-properties": transformComputedProperties,
+  "transform-destructuring": transformDestructuring,
+  "transform-dotall-regex": transformDotallRegex,
+  "transform-duplicate-keys": transformDuplicateKeys,
+  "transform-for-of": transformForOf,
+  "transform-function-name": transformFunctionName,
+  "transform-literals": transformLiterals,
+  "transform-member-expression-literals": transformMemberExpressionLiterals,
+  "transform-modules-amd": transformModulesAmd,
+  "transform-modules-commonjs": transformModulesCommonjs,
+  "transform-modules-systemjs": transformModulesSystemjs,
+  "transform-modules-umd": transformModulesUmd,
+  "transform-named-capturing-groups-regex": transformNamedCapturingGroupsRegex,
+  "transform-object-super": transformObjectSuper,
+  "transform-parameters": transformParameters,
+  "transform-property-literals": transformPropertyLiterals,
+  "transform-reserved-words": transformReservedWords,
+  "transform-shorthand-properties": transformShorthandProperties,
+  "transform-spread": transformSpread,
+  "transform-sticky-regex": transformStickyRegex,
+  "transform-template-literals": transformTemplateLiterals,
+  "transform-typeof-symbol": transformTypeofSymbol,
+  "transform-unicode-regex": transformUnicodeRegex,
+  "transform-exponentiation-operator": transformExponentialOperator,
+  "transform-new-target": transformNewTarget,
+  "proposal-object-rest-spread": proposalObjectRestSpread,
+  "proposal-optional-catch-binding": proposalOptionalCatchBinding,
+  "transform-regenerator": transformRegenerator,
+  "proposal-unicode-property-regex": proposalUnicodePropertyRegex,
 };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Rewrite `src/available-plugins.js` to esm imports. This PR blocks #10821 because `rollup-common-js` is [fooled](https://github.com/rollup/rollup-plugin-commonjs/blob/535e8117607731e1e8688be84c3aeb6e5c3b6fa5/src/transform.js#L51) by `export default` in this file and would not transform `require` to `import`.

The key orders are preserved for the sake of reviewing convenience.