### PR TITLE
Tune eslint packages test configuration

### DIFF
--- a/eslint/babel-eslint-parser/test/integration.js
+++ b/eslint/babel-eslint-parser/test/integration.js
@@ -16,6 +16,8 @@ const baseEslintOpts = {
   parser: "current-babel-eslint",
   parserOptions: {
     sourceType: "script",
+    requireConfigFile: false,
+    babelOptions: { configFile: false }
   },
 };
 

--- a/eslint/babel-eslint-parser/test/non-regression.js
+++ b/eslint/babel-eslint-parser/test/non-regression.js
@@ -18,25 +18,22 @@ function verifyAndAssertMessagesWithSpecificESLint(
       node: true,
       es6: true,
     },
+    ...overrideConfig,
     parserOptions: {
       sourceType,
       ecmaFeatures: {
         globalReturn: true,
       },
+      requireConfigFile: false,
       babelOptions: {
         configFile: path.resolve(
           __dirname,
           "./fixtures/config/babel.config.js",
         ),
       },
+      ...overrideConfig?.parserOptions
     },
   };
-
-  if (overrideConfig) {
-    for (const key in overrideConfig) {
-      config[key] = overrideConfig[key];
-    }
-  }
 
   const messages = linter.verify(code, config);
 

--- a/eslint/babel-eslint-parser/test/non-regression.js
+++ b/eslint/babel-eslint-parser/test/non-regression.js
@@ -31,7 +31,7 @@ function verifyAndAssertMessagesWithSpecificESLint(
           "./fixtures/config/babel.config.js",
         ),
       },
-      ...overrideConfig?.parserOptions
+      ...overrideConfig?.parserOptions,
     },
   };
 
@@ -1563,7 +1563,7 @@ describe("verify", () => {
     );
   });
 
-  it("no-implicit-globals in script", () => {
+  it("no-implicit-globals in script: globalReturn is false", () => {
     verifyAndAssertMessages(
       "var leakedGlobal = 1;",
       { "no-implicit-globals": 1 },
@@ -1573,7 +1573,28 @@ describe("verify", () => {
       "script",
       {
         env: {},
-        parserOptions: { ecmaVersion: 6, sourceType: "script" },
+        parserOptions: {
+          ecmaVersion: 6,
+          sourceType: "script",
+          ecmaFeatures: { globalReturn: false },
+        },
+      },
+    );
+  });
+
+  it("no-implicit-globals in script: globalReturn is true", () => {
+    verifyAndAssertMessages(
+      "var leakedGlobal = 1;",
+      { "no-implicit-globals": 1 },
+      [],
+      "script",
+      {
+        env: {},
+        parserOptions: {
+          ecmaVersion: 6,
+          sourceType: "script",
+          ecmaFeatures: { globalReturn: true },
+        },
       },
     );
   });

--- a/eslint/babel-eslint-parser/test/non-regression.js
+++ b/eslint/babel-eslint-parser/test/non-regression.js
@@ -21,9 +21,6 @@ function verifyAndAssertMessagesWithSpecificESLint(
     ...overrideConfig,
     parserOptions: {
       sourceType,
-      ecmaFeatures: {
-        globalReturn: true,
-      },
       requireConfigFile: false,
       babelOptions: {
         configFile: path.resolve(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | ESLint integration test should not load root babel configuration
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is extracted from a messy working branch on the upcoming Yarn 2 support: https://github.com/JLHwung/babel/commits/standalone-rollup-bundle

As a follow up to #10705 , the integration test should not read root babel configuration.

