### PR TITLE
Disable submodule exports

### DIFF
--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -4,6 +4,7 @@
   "description": "Transforms Object.assign into object spread syntax",
   "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-object-assign-to-object-spread",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-object-assign-to-object-spread",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -4,6 +4,7 @@
   "description": "Remove unused catch bindings",
   "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-remove-unused-catch-binding",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/codemods/babel-plugin-codemod-remove-unused-catch-binding",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "private": true,
   "repository": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-config-internal",
   "main": "lib/index.js",

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "private": true,
   "repository": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-config-internal",
   "main": "lib/index.js",

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -4,6 +4,7 @@
   "description": "ESLint parser that allows for linting of experimental syntax transformed by Babel",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
+  "type": "commonjs",
   "private": true,
   "repository": {
     "type": "git",

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "private": true,
   "repository": {
     "type": "git",

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -24,6 +24,7 @@
     "access": "public"
   },
   "license": "MIT",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/babel/babel.git",

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -25,6 +25,7 @@
   },
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/babel/babel.git",

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -17,6 +17,7 @@
   ],
   "author": "Jason Quense @monasticpanic",
   "license": "MIT",
+  "type": "commonjs",
   "private": true,
   "engines": {
     "node": ">=10.9"

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -18,6 +18,7 @@
   "author": "Jason Quense @monasticpanic",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "private": true,
   "engines": {
     "node": ">=10.9"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "babel",
   "private": true,
   "license": "MIT",
+  "type": "commonjs",
   "scripts": {
     "bootstrap": "make bootstrap",
     "build": "make build",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "scripts": {
     "bootstrap": "make bootstrap",
     "build": "make build",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -6,6 +6,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to annotate paths and nodes with #__PURE__ comment",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to bindify decorators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-bindify-decorators/package.json
+++ b/packages/babel-helper-bindify-decorators/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-bindify-decorators",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to build binary assignment operator visitors",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to build react jsx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to call delegate",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-call-delegate/package.json
+++ b/packages/babel-helper-call-delegate/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.4",
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
+  "type": "commonjs",
   "description": "Compile class public and private fields, private methods and decorators to ES6",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-create-class-features-plugin",
   "main": "lib/index.js",

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -4,6 +4,7 @@
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "description": "Compile class public and private fields, private methods and decorators to ES6",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-create-class-features-plugin",
   "main": "lib/index.js",

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.4",
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
+  "type": "commonjs",
   "description": "Compile ESNext Regular Expressions to ES5",
   "repository": {
     "type": "git",

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -4,6 +4,7 @@
   "author": "The Babel Team (https://babeljs.io/team)",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "description": "Compile ESNext Regular Expressions to ES5",
   "repository": {
     "type": "git",

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to define a map",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-define-map/package.json
+++ b/packages/babel-helper-define-map/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-define-map",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to explode an assignable expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-explode-assignable-expression/package.json
+++ b/packages/babel-helper-explode-assignable-expression/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to explode class",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-explode-class/package.json
+++ b/packages/babel-helper-explode-class/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-explode-class",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to support fixtures",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to change the property 'name' of every function",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-function-name",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to get function arity",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-get-function-arity/package.json
+++ b/packages/babel-helper-get-function-arity/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to hoist variables",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to replace certain member expressions with function calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -5,6 +5,7 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -5,6 +5,7 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to optimise call expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to support test runner",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -5,6 +5,7 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to check for literal RegEx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-regex/package.json
+++ b/packages/babel-helper-regex/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-regex",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to remap async functions to generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -4,6 +4,7 @@
   "description": "Helper function to replace supers",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -5,6 +5,7 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -4,6 +4,7 @@
   "description": "Helper to wrap functions inside a function call.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -5,6 +5,7 @@
   "author": "suchipi <me@suchipi.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin contains helper functions that’ll be placed at the top of the generated code",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-external-helpers",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -4,6 +4,7 @@
   "description": "Turn async generator functions into ES2015 generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-async-generator-functions/package.json
+++ b/packages/babel-plugin-proposal-async-generator-functions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms static class properties as well as properties declared with the property initializer syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-class-properties/package.json
+++ b/packages/babel-plugin-proposal-class-properties/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-class-properties",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.4",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -4,6 +4,7 @@
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -4,6 +4,7 @@
   "description": "Compile do expressions to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-do-expressions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-dynamic-import/package.json
+++ b/packages/babel-plugin-proposal-dynamic-import/package.json
@@ -4,6 +4,7 @@
   "description": "Transform import() expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-dynamic-import/package.json
+++ b/packages/babel-plugin-proposal-dynamic-import/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -4,6 +4,7 @@
   "description": "Compile export default to ES2015",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -4,6 +4,7 @@
   "description": "Compile export namespace to ES2015",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace-from",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-export-namespace-from/package.json
+++ b/packages/babel-plugin-proposal-export-namespace-from/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-namespace-from",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -4,6 +4,7 @@
   "description": "Compile function bind operator to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-bind",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -4,6 +4,7 @@
   "description": "Compile the function.sent meta property to valid ES2015 code",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -4,6 +4,7 @@
   "description": "Escape U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in JS strings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-json-strings/package.json
+++ b/packages/babel-plugin-proposal-json-strings/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -4,6 +4,7 @@
   "description": "Transforms logical assignment operators into short-circuited assignments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-proposal-logical-assignment-operators/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-logical-assignment-operators",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -4,6 +4,7 @@
   "description": "Remove nullish coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-nullish-coalescing-operator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-proposal-nullish-coalescing-operator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-nullish-coalescing-operator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -4,6 +4,7 @@
   "description": "Remove numeric separators from Decimal, Binary, Hex and Octal literals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-numeric-separator/package.json
+++ b/packages/babel-plugin-proposal-numeric-separator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -4,6 +4,7 @@
   "description": "Compile object rest and spread to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-object-rest-spread/package.json
+++ b/packages/babel-plugin-proposal-object-rest-spread/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -4,6 +4,7 @@
   "description": "Compile optional catch bindings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-optional-catch-binding/package.json
+++ b/packages/babel-plugin-proposal-optional-catch-binding/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -4,6 +4,7 @@
   "description": "Transform optional chaining operators into a series of nil checks",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-optional-chaining/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-partial-application/package.json
+++ b/packages/babel-plugin-proposal-partial-application/package.json
@@ -4,6 +4,7 @@
   "description": "Introduces a new ? token in an argument list which allows for partially applying an argument list to a call expression",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-partial-application",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-partial-application/package.json
+++ b/packages/babel-plugin-proposal-partial-application/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-partial-application",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -4,6 +4,7 @@
   "description": "Transform pipeline operator into call expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-pipeline-operator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-private-methods/package.json
+++ b/packages/babel-plugin-proposal-private-methods/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms private class methods",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-methods",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-private-methods/package.json
+++ b/packages/babel-plugin-proposal-private-methods/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-private-methods",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -4,6 +4,7 @@
   "description": "Wraps Throw Expressions in an IIFE",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -4,6 +4,7 @@
   "description": "Compile Unicode property escapes in Unicode regular expressions to ES5.",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-proposal-unicode-property-regex/package.json
+++ b/packages/babel-plugin-proposal-unicode-property-regex/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of async generator functions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-async-generators/package.json
+++ b/packages/babel-plugin-syntax-async-generators/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-bigint/package.json
+++ b/packages/babel-plugin-syntax-bigint/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of BigInt literals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-bigint/package.json
+++ b/packages/babel-plugin-syntax-bigint/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of class properties",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-class-properties/package.json
+++ b/packages/babel-plugin-syntax-class-properties/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-class-properties",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of decorators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-decorators",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of do expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-do-expressions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-dynamic-import/package.json
+++ b/packages/babel-plugin-syntax-dynamic-import/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of import()",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-dynamic-import/package.json
+++ b/packages/babel-plugin-syntax-dynamic-import/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of export default from",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-export-namespace-from/package.json
+++ b/packages/babel-plugin-syntax-export-namespace-from/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of export namespace from",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-export-namespace-from/package.json
+++ b/packages/babel-plugin-syntax-export-namespace-from/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of the flow syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of function bind",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-bind",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of the function.sent meta property",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-import-meta/package.json
+++ b/packages/babel-plugin-syntax-import-meta/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of import.meta",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-meta",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-import-meta/package.json
+++ b/packages/babel-plugin-syntax-import-meta/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-import-meta",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-json-strings/package.json
+++ b/packages/babel-plugin-syntax-json-strings/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of the U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in JS strings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-json-strings/package.json
+++ b/packages/babel-plugin-syntax-json-strings/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of jsx",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of the logical assignment operators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-syntax-logical-assignment-operators/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-logical-assignment-operators",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of the nullish-coalescing operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-syntax-nullish-coalescing-operator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of Decimal, Binary, Hex and Octal literals that contain a Numeric Literal Separator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-numeric-separator/package.json
+++ b/packages/babel-plugin-syntax-numeric-separator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of object rest/spread",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-object-rest-spread/package.json
+++ b/packages/babel-plugin-syntax-object-rest-spread/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-optional-catch-binding/package.json
+++ b/packages/babel-plugin-syntax-optional-catch-binding/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of optional catch bindings",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-optional-catch-binding/package.json
+++ b/packages/babel-plugin-syntax-optional-catch-binding/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-optional-chaining/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of optional properties",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-optional-chaining/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-partial-application/package.json
+++ b/packages/babel-plugin-syntax-partial-application/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of partial application syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-partial-application",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-partial-application/package.json
+++ b/packages/babel-plugin-syntax-partial-application/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-partial-application",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of the pipeline operator",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-pipeline-operator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of Throw Expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-top-level-await/package.json
+++ b/packages/babel-plugin-syntax-top-level-await/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of top-level await in modules",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-top-level-await",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-top-level-await/package.json
+++ b/packages/babel-plugin-syntax-top-level-await/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-top-level-await",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -4,6 +4,7 @@
   "description": "Allow parsing of TypeScript syntax",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-typescript",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 arrow functions to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -4,6 +4,7 @@
   "description": "Turn async functions into ES2015 generators",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -4,6 +4,7 @@
   "description": "Babel plugin to ensure function declarations at the block level are block scoped",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 block scoping (const and let) to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 classes to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 computed properties to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 destructuring to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -4,6 +4,7 @@
   "description": "Compile regular expressions using the `s` (`dotAll`) flag to ES5.",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -4,6 +4,7 @@
   "description": "Compile objects with duplicate keys to valid strict ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -4,6 +4,7 @@
   "description": "Compile exponentiation operator to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -4,6 +4,7 @@
   "description": "Turn flow type annotations into comments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -4,6 +4,7 @@
   "description": "Strip flow type annotations from your output code.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 for...of to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -4,6 +4,7 @@
   "description": "Apply ES2015 function.name semantics to all functions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms all the ES2015 'instanceof' methods",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-instanceof",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-instanceof",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -4,6 +4,7 @@
   "description": "Babel plugin to fix buggy JScript named function expressions",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jscript",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-jscript",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 unicode string and number literals to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -4,6 +4,7 @@
   "description": "Ensure that reserved words are quoted in property accesses",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms ES2015 modules to AMD",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms ES2015 modules to CommonJS",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms ES2015 modules to SystemJS",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin transforms ES2015 modules to UMD",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -4,6 +4,7 @@
   "description": "Compile regular expressions using named groups to ES5.",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -4,6 +4,7 @@
   "description": "Transforms new.target meta property",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-assign",
   "author": "Jed Watson",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -6,6 +6,7 @@
   "author": "Jed Watson",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -4,6 +4,7 @@
   "description": "Turn Object.setPrototypeOf to assignments",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-set-prototype-of-to-assign",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-set-prototype-of-to-assign",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 object super to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 default and rest parameters to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -4,6 +4,7 @@
   "description": "Ensure that reserved words are quoted in object property keys",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES5 property mutator shorthand syntax to Object.defineProperty",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-mutators",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-mutators",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -4,6 +4,7 @@
   "description": "Babel plugin for turning __proto__ into a shallow property clone",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-proto-to-assign",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -4,6 +4,7 @@
   "description": "Treat React JSX elements as value types and hoist them to the highest scope",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-constant-elements",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-constant-elements",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -4,6 +4,7 @@
   "description": "Add displayName to React.createClass calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -4,6 +4,7 @@
   "description": "Turn JSX elements into exploded React objects",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-inline-elements",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-inline-elements",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -4,6 +4,7 @@
   "description": "Turn JSX into React Pre-0.12 function calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-compat",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-compat",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -4,6 +4,7 @@
   "description": "Add a __self prop to all JSX Elements",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -4,6 +4,7 @@
   "description": "Add a __source prop to all JSX Elements",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -4,6 +4,7 @@
   "description": "Turn JSX into React function calls",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -10,6 +10,7 @@
     "regenerator-transform": "^0.14.0"
   },
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -4,6 +4,7 @@
   "description": "Ensure that no reserved words are used.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -4,6 +4,7 @@
   "description": "Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 shorthand properties to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 spread to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 sticky regex to an ES5 RegExp constructor",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -4,6 +4,7 @@
   "description": "This plugin places a 'use strict'; directive at the top of all files to enable strict mode",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 template literals to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -4,6 +4,7 @@
   "description": "This transformer wraps all typeof expressions with a method that replicates native behaviour. (ie. returning “symbol” for symbols)",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -4,6 +4,7 @@
   "description": "Transform TypeScript into ES.next",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -4,6 +4,7 @@
   "description": "Compile ES2015 Unicode regex to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-polyfill/package.json
+++ b/packages/babel-polyfill/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -5,6 +5,7 @@
   "author": "Henry Zhu <hi@henryzoo.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -5,6 +5,7 @@
   "author": "James Kyle <me@thejameskyle.com>",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-flow",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-0/package.json
+++ b/packages/babel-preset-stage-0/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-1/package.json
+++ b/packages/babel-preset-stage-1/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-2/package.json
+++ b/packages/babel-preset-stage-2/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-stage-3/package.json
+++ b/packages/babel-preset-stage-3/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -4,6 +4,7 @@
   "description": "Babel preset for TypeScript.",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-typescript",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.4",
   "description": "babel require hook",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -4,6 +4,7 @@
   "description": "babel require hook",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.6",
   "description": "babel's modular runtime helpers with core-js@2 polyfilling",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -4,6 +4,7 @@
   "description": "babel's modular runtime helpers with core-js@2 polyfilling",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -4,7 +4,6 @@
   "description": "babel's modular runtime helpers with core-js@2 polyfilling",
   "license": "MIT",
   "type": "commonjs",
-  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.6",
   "description": "babel's modular runtime helpers with core-js@3 polyfilling",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -4,7 +4,6 @@
   "description": "babel's modular runtime helpers with core-js@3 polyfilling",
   "license": "MIT",
   "type": "commonjs",
-  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -4,6 +4,7 @@
   "description": "babel's modular runtime helpers with core-js@3 polyfilling",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.6",
   "description": "babel's modular runtime helpers",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -4,6 +4,7 @@
   "description": "babel's modular runtime helpers",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -4,7 +4,6 @@
   "description": "babel's modular runtime helpers",
   "license": "MIT",
   "type": "commonjs",
-  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -5,6 +5,7 @@
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://babeljs.io/",
   "license": "MIT",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "type": "commonjs",
+  "exports": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR adds `exports: false` to every package except `@babel/runtime(-corejs[23])?`. By doing so we are stating explicitly that every package does not offer submodule exports, i.e. `import "@babel/core/src/config"` will bail because this file belongs to internal implementation details.

Note that even we don't specify `exports: false`, the following imports will still bail
```
import "@babel/core/src/config/index.js";
```
because the subpath `./src/config/index.js` is _not_ defined as export path in package.json. So it should not break anyone.

**Merge Tips**
This PR includes commits in #10849. Therefore it is intended to merge #10849 first and then use `Reabse to Merge` option to merge this one.