### PR TITLE
Restore `@babel/parser` tests

### DIFF
--- a/packages/babel-parser/test/fixtures/core/uncategorised/369/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/369/output.json
@@ -13,6 +13,7 @@
     }
   },
   "errors": [
+    "SyntaxError: Invalid parenthesized assignment pattern (1:1)",
     "SyntaxError: Invalid left-hand side in assignment expression (1:1)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/core/uncategorised/374/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/374/output.json
@@ -13,6 +13,7 @@
     }
   },
   "errors": [
+    "SyntaxError: Invalid parenthesized assignment pattern (1:5)",
     "SyntaxError: Invalid left-hand side in for-in statement (1:5)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/core/uncategorised/556/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/556/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: You're trying to assign to a parenthesized expression, eg. instead of `({a}) = 0` use `({a} = 0)` (1:1)"
+    "SyntaxError: Invalid parenthesized assignment pattern (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/core/uncategorised/558/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/558/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: You're trying to assign to a parenthesized expression, eg. instead of `([a]) = 0` use `([a] = 0)` (1:1)"
+    "SyntaxError: Invalid parenthesized assignment pattern (1:0)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/parenthesized-lhs-array/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/parenthesized-lhs-array/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: You're trying to assign to a parenthesized expression, eg. instead of `([a]) = 0` use `([a] = 0)` (1:1)"
+    "SyntaxError: Invalid parenthesized assignment pattern (1:1)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/parenthesized-lhs-object/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/parenthesized-lhs-object/output.json
@@ -13,7 +13,7 @@
     }
   },
   "errors": [
-    "SyntaxError: You're trying to assign to a parenthesized expression, eg. instead of `({a}) = 0` use `({a} = 0)` (1:1)"
+    "SyntaxError: Invalid parenthesized assignment pattern (1:1)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/223/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/223/output.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 22,
+  "end": 20,
   "loc": {
     "start": {
       "line": 1,
@@ -9,16 +9,16 @@
     },
     "end": {
       "line": 1,
-      "column": 22
+      "column": 20
     }
   },
   "errors": [
-    "SyntaxError: Object pattern can't contain getter or setter (1:8)"
+    "SyntaxError: Object pattern can't contain getter or setter (1:7)"
   ],
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 22,
+    "end": 20,
     "loc": {
       "start": {
         "line": 1,
@@ -26,7 +26,7 @@
       },
       "end": {
         "line": 1,
-        "column": 22
+        "column": 20
       }
     },
     "sourceType": "script",
@@ -35,7 +35,7 @@
       {
         "type": "ExpressionStatement",
         "start": 0,
-        "end": 22,
+        "end": 20,
         "loc": {
           "start": {
             "line": 1,
@@ -43,66 +43,66 @@
           },
           "end": {
             "line": 1,
-            "column": 22
+            "column": 20
           }
         },
         "expression": {
           "type": "AssignmentExpression",
-          "start": 2,
-          "end": 20,
+          "start": 1,
+          "end": 19,
           "loc": {
             "start": {
               "line": 1,
-              "column": 2
+              "column": 1
             },
             "end": {
               "line": 1,
-              "column": 20
+              "column": 19
             }
           },
           "operator": "=",
           "left": {
             "type": "ObjectPattern",
-            "start": 2,
-            "end": 16,
+            "start": 1,
+            "end": 15,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 2
+                "column": 1
               },
               "end": {
                 "line": 1,
-                "column": 16
+                "column": 15
               }
             },
             "properties": [
               {
                 "type": "ObjectMethod",
-                "start": 4,
-                "end": 14,
+                "start": 3,
+                "end": 13,
                 "loc": {
                   "start": {
                     "line": 1,
-                    "column": 4
+                    "column": 3
                   },
                   "end": {
                     "line": 1,
-                    "column": 14
+                    "column": 13
                   }
                 },
                 "method": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 8,
-                  "end": 9,
+                  "start": 7,
+                  "end": 8,
                   "loc": {
                     "start": {
                       "line": 1,
-                      "column": 8
+                      "column": 7
                     },
                     "end": {
                       "line": 1,
-                      "column": 9
+                      "column": 8
                     },
                     "identifierName": "x"
                   },
@@ -116,16 +116,16 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 12,
-                  "end": 14,
+                  "start": 11,
+                  "end": 13,
                   "loc": {
                     "start": {
                       "line": 1,
-                      "column": 12
+                      "column": 11
                     },
                     "end": {
                       "line": 1,
-                      "column": 14
+                      "column": 13
                     }
                   },
                   "body": [],
@@ -136,16 +136,16 @@
           },
           "right": {
             "type": "NumericLiteral",
-            "start": 19,
-            "end": 20,
+            "start": 18,
+            "end": 19,
             "loc": {
               "start": {
                 "line": 1,
-                "column": 19
+                "column": 18
               },
               "end": {
                 "line": 1,
-                "column": 20
+                "column": 19
               }
             },
             "extra": {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment/invalid-group-assignment/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment/invalid-group-assignment/output.json
@@ -13,6 +13,7 @@
     }
   },
   "errors": [
+    "SyntaxError: Invalid parenthesized assignment pattern (1:1)",
     "SyntaxError: Invalid left-hand side in assignment expression (1:1)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0047/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0047/output.json
@@ -13,6 +13,7 @@
     }
   },
   "errors": [
+    "SyntaxError: Invalid parenthesized assignment pattern (1:1)",
     "SyntaxError: Invalid left-hand side in assignment expression (1:1)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0056/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0056/output.json
@@ -13,6 +13,7 @@
     }
   },
   "errors": [
+    "SyntaxError: Invalid parenthesized assignment pattern (1:5)",
     "SyntaxError: Invalid left-hand side in for-in statement (1:5)"
   ],
   "program": {

--- a/packages/babel-parser/test/fixtures/estree/bigInt/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/basic/output.json
@@ -89,7 +89,10 @@
                   "column": 12
                 }
               },
-              "value": "1",
+              "value": {
+                "$$ babel internal serialized type": "BigInt",
+                "value": "1n"
+              },
               "raw": "1n",
               "bigint": "1"
             }

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -232,7 +232,7 @@ function ppJSON(v) {
   if (v && typeof v === "object" && v[serialized]) {
     switch (v[serialized]) {
       case "BigInt":
-        return typeof BigInt === "undefined" ? null : v.value;
+        return typeof BigInt === "undefined" ? "null" : v.value;
     }
   }
 

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -131,11 +131,13 @@ function overrideToJSON(cb) {
     };
   }
 
-  cb();
+  const result = cb();
 
   for (const obj of notJSONparseableObj) {
     obj.prototype.toJSON = originalToJSONMap.get(obj);
   }
+
+  return result;
 }
 
 function runTest(test, parseFunction) {
@@ -226,12 +228,14 @@ function addPath(str, pt) {
 }
 
 function misMatch(exp, act) {
-  overrideToJSON(() => {
+  return overrideToJSON(() => {
     if (
       exp instanceof RegExp ||
       act instanceof RegExp ||
       exp instanceof Error ||
-      act instanceof Error
+      act instanceof Error ||
+      typeof exp === "bigint" ||
+      typeof act === "bigint"
     ) {
       const left = ppJSON(exp);
       const right = ppJSON(act);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Since a test is considered as failed if `misMatch(expected, actual) !== undefined`, the missing returns effectively disabled parser tests.
