### PR TITLE
Properly serialize non-json values in parser tests

### DIFF
--- a/packages/babel-parser/test/fixtures/estree/bigInt/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/basic/output.json
@@ -91,7 +91,7 @@
               },
               "value": {
                 "$$ babel internal serialized type": "BigInt",
-                "value": "1n"
+                "value": "1"
               },
               "raw": "1n",
               "bigint": "1"

--- a/packages/babel-parser/test/fixtures/estree/literal/regexp/output.json
+++ b/packages/babel-parser/test/fixtures/estree/literal/regexp/output.json
@@ -89,7 +89,11 @@
                   "column": 13
                 }
               },
-              "value": "/.*/i",
+              "value": {
+                "$$ babel internal serialized type": "RegExp",
+                "source": ".*",
+                "flags": "i"
+              },
               "raw": "/.*/i",
               "regex": {
                 "pattern": ".*",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Follow up to #10854 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

1) I reused the same serialization logic used for BigInts also for RegExps
2) I removed the `.prototype.toJSON` override hack and used the mysterious second parameter of `JSON.stringify`

Please disable whitespace diff while reviewing this PR.