### PR TITLE
fix: add computed property support for object Ref

### DIFF
--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed-exec/exec.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed-exec/exec.js
@@ -1,0 +1,20 @@
+var key, x, y, z;
+// impure
+key = 1;
+var { [key++]: { y, ...x } } = { 1: { a: 1, y: 1 } };
+expect(x).toEqual({ a: 1 });
+expect(key).toBe(2);
+expect(y).toBe(1);
+
+// takes care of the order
+
+key = 1;
+var {
+  [++key]: { y, ...rest_y },
+  [++key]: { z, ...rest_z }
+} = {2: { y: 2, z: 3 }, 3: { y: 2, z: 3 } };
+expect(y).toBe(2);
+expect(rest_y).toEqual({z: 3});
+expect(z).toBe(3);
+expect(rest_z).toEqual({ y: 2 });
+

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed-exec/exec.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed-exec/exec.js
@@ -17,4 +17,4 @@ expect(y).toBe(2);
 expect(rest_y).toEqual({z: 3});
 expect(z).toBe(3);
 expect(rest_z).toEqual({ y: 2 });
-
+expect(key).toBe(3);

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/input.js
@@ -1,0 +1,20 @@
+var key, x, y, z;
+// impure
+key = 1;
+var { [key++]: { y, ...x } } = { 1: { a: 1, y: 1 } };
+expect(x).toEqual({ a: 1 });
+expect(key).toBe(2);
+expect(y).toBe(1);
+
+// takes care of the order
+
+key = 1;
+var {
+  [++key]: { y, ...rest_y },
+  [++key]: { z, ...rest_z }
+} = {2: { y: 2, z: 3 }, 3: { y: 2, z: 3 } };
+expect(y).toBe(2);
+expect(rest_y).toEqual({z: 3});
+expect(z).toBe(3);
+expect(rest_z).toEqual({ y: 2 });
+

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/input.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/input.js
@@ -17,4 +17,4 @@ expect(y).toBe(2);
 expect(rest_y).toEqual({z: 3});
 expect(z).toBe(3);
 expect(rest_z).toEqual({ y: 2 });
-
+expect(key).toBe(3);

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/output.js
@@ -1,0 +1,61 @@
+var key, x, y, z; // impure
+
+key = 1;
+
+var _ref = key++,
+    {
+  [_ref]: {
+    y
+  }
+} = {
+  1: {
+    a: 1,
+    y: 1
+  }
+},
+    x = babelHelpers.objectWithoutProperties({
+  1: {
+    a: 1,
+    y: 1
+  }
+}[_ref], ["y"]);
+
+expect(x).toEqual({
+  a: 1
+});
+expect(key).toBe(2);
+expect(y).toBe(1); // takes care of the order
+
+key = 1;
+
+var _$ = {
+  2: {
+    y: 2,
+    z: 3
+  },
+  3: {
+    y: 2,
+    z: 3
+  }
+},
+    _ref2 = ++key,
+    _ref3 = ++key,
+    {
+  [_ref3]: {
+    y
+  },
+  [_ref2]: {
+    z
+  }
+} = _$,
+    rest_y = babelHelpers.objectWithoutProperties(_$[_ref3], ["y"]),
+    rest_z = babelHelpers.objectWithoutProperties(_$[_ref2], ["z"]);
+
+expect(y).toBe(2);
+expect(rest_y).toEqual({
+  z: 3
+});
+expect(z).toBe(3);
+expect(rest_z).toEqual({
+  y: 2
+});

--- a/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/output.js
+++ b/packages/babel-plugin-proposal-object-rest-spread/test/fixtures/object-rest/object-ref-computed/output.js
@@ -59,3 +59,4 @@ expect(z).toBe(3);
 expect(rest_z).toEqual({
   y: 2
 });
+expect(key).toBe(3);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/6341#issuecomment-564896831
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

In this PR we add support for computed properties when generating `objRef` for `object-rest-spread`. In the following example
```js
var prop = "a";
var obj = { a: { b: 42 } };
var {
  [prop]: { ...x }
} = obj;

// transformed on v7.7.5

var prop = "a";
var obj = {
  a: {
    b: 42
  }
};

var {} = obj,
    x = _extends({}, obj.prop);
```

Here the `objRef` is `obj.prop`, which is the parent path of the rest element `...x`. Apparently `obj.prop` is incorrect because `[prop]` is a _computed_ property. This is fixed by adding `computed` argument when building `t.memberExpression` for `objRef`.

However, the computed properties could be impure: which means we could not evaluate these properties twice. Therefore we refactored the interface of `replaceImpureComputedKeys` and reuse it to _cache_ the computed properties.

Note that although this PR only addresses https://github.com/babel/babel/issues/6341#issuecomment-564896831, #6341 can also be closed after merging this PR because I can not reproduce OP's issue on REPL. ([link](https://babeljs.io/repl#?browsers=&build=&builtIns=usage&spec=false&loose=false&code_lz=MYewdgzgLgBAhjAvDA3jAjALhgBgDQwBM26BAzNoTAL4BQoksAZkjABQCUSAfBveNFQwA2k04BdbADc4AGwIA6JQCcApoOqs4QA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=Node-12&version=7.7.5&externalPlugins=%40babel%2Fplugin-proposal-object-rest-spread%407.7.4))