### PR TITLE
Fix pragmaFrag spelling in error message

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/index.js
+++ b/packages/babel-plugin-transform-react-jsx/src/index.js
@@ -80,7 +80,7 @@ export default declare((api, options) => {
       ) {
         throw new Error(
           "transform-react-jsx: pragma has been set but " +
-            "pragmafrag has not been set",
+            "pragmaFrag has not been set",
         );
       }
     },

--- a/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-pragma-set-but-not-pragmafrag-and-frag-used/options.json
+++ b/packages/babel-plugin-transform-react-jsx/test/fixtures/react/throw-if-pragma-set-but-not-pragmafrag-and-frag-used/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "transform-react-jsx: pragma has been set but pragmafrag has not been set"
+  "throws": "transform-react-jsx: pragma has been set but pragmaFrag has not been set"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | Nope
| Major: Breaking Change?  | Nope
| Minor: New Feature?      | Nope
| Tests Added + Pass?      | Nope
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Nope
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Sorry for disturbing with a small change.
But I got this error, then I added the parameter following the error, then realized the spelling in the error was wrong and added the correct capitalization looking up from the docs.
Might help someone else not make the same mistake.