### PR TITLE
chore: specify github protocol

### DIFF
--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -76,7 +76,7 @@
     "@babel/helper-plugin-test-runner": "^7.7.4",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "caniuse-db": "1.0.30000969",
-    "compat-table": "github:kangax/compat-table#4195aca631ad904cb0efeb62a9c2d8c8511706f8",
+    "compat-table": "https://github.com/kangax/compat-table#4195aca631ad904cb0efeb62a9c2d8c8511706f8",
     "electron-to-chromium": "1.3.113"
   }
 }

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -76,7 +76,7 @@
     "@babel/helper-plugin-test-runner": "^7.7.4",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "caniuse-db": "1.0.30000969",
-    "compat-table": "kangax/compat-table#4195aca631ad904cb0efeb62a9c2d8c8511706f8",
+    "compat-table": "github:kangax/compat-table#4195aca631ad904cb0efeb62a9c2d8c8511706f8",
     "electron-to-chromium": "1.3.113"
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Yarn v2 will throw invalid file path kangax/compat-table on install
| Any Dependency Changes?  |
| License                  | MIT

In this PR we specify the `github:` protocol for the `compat-table` dependencies. It is supported by both npm and yarn.

Note after merging this PR, installing `compat-table` on yarn 2 still fails due to https://github.com/yarnpkg/berry/issues/637