### PR TITLE
chore: download compat-table when build-data is run

### DIFF
--- a/packages/babel-preset-env/.gitignore
+++ b/packages/babel-preset-env/.gitignore
@@ -8,3 +8,4 @@ test/tmp
 .nyc_output
 tmp
 babel-preset-env-*.tgz
+/build

--- a/packages/babel-preset-env/.npmignore
+++ b/packages/babel-preset-env/.npmignore
@@ -15,3 +15,4 @@ babel-preset-env-*.tgz
 flow-typed
 .github
 .idea
+/build

--- a/packages/babel-preset-env/CONTRIBUTING.md
+++ b/packages/babel-preset-env/CONTRIBUTING.md
@@ -63,9 +63,9 @@ If you want to mark a new proposal as shipped, add it to [this list](https://git
 
 ### Update [`plugins.json`](https://github.com/babel/babel/blob/master/packages/babel-preset-env/data/plugins.json)
 
-Until `compat-table` is a standalone npm module for data we are using the git url
+Until `compat-table` is a standalone npm module for data we are using the git commit in `scripts/download-compat-table.sh`
 
-`"compat-table": "kangax/compat-table#[latest-commit-hash]"`,
+`COMPAT_TABLE_COMMIT=[latest-commit-hash]`,
 
 So we update and then run `npm run build-data`. If there are no changes, then `plugins.json` will be the same.
 

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-preset-env",
   "main": "lib/index.js",
   "scripts": {
-    "build-data": "node ./scripts/build-data.js; node ./scripts/build-modules-support.js"
+    "build-data": "./scripts/download-compat-table.sh; node ./scripts/build-data.js; node ./scripts/build-modules-support.js"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.7.4",
@@ -76,7 +76,6 @@
     "@babel/helper-plugin-test-runner": "^7.7.4",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "caniuse-db": "1.0.30000969",
-    "compat-table": "kangax/compat-table#4195aca631ad904cb0efeb62a9c2d8c8511706f8",
     "electron-to-chromium": "1.3.113"
   }
 }

--- a/packages/babel-preset-env/scripts/build-data.js
+++ b/packages/babel-preset-env/scripts/build-data.js
@@ -46,7 +46,7 @@ const renameTests = (tests, getName, category) =>
 // environments (node4 and chrome45), as well as familial relationships (edge
 // and ie11) can be handled properly.
 
-const envs = require("compat-table/environments");
+const envs = require("../build/compat-table/environments");
 
 const byTestSuite = suite => browser => {
   return Array.isArray(browser.test_suites)
@@ -56,7 +56,7 @@ const byTestSuite = suite => browser => {
 
 const compatSources = ["es5", "es6", "es2016plus", "esnext"].reduce(
   (result, source) => {
-    const data = require(`compat-table/data-${source}`);
+    const data = require(`../build/compat-table/data-${source}`);
     data.browsers = pickBy(envs, byTestSuite(source));
     result.push(data);
     return result;

--- a/packages/babel-preset-env/scripts/download-compat-table.sh
+++ b/packages/babel-preset-env/scripts/download-compat-table.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+COMPAT_TABLE_COMMIT=4195aca631ad904cb0efeb62a9c2d8c8511706f8
+rm -rf build/compat-table
+mkdir -p build
+git clone --branch=gh-pages --single-branch --shallow-since=2019-11-14 https://github.com/kangax/compat-table.git build/compat-table
+cd build/compat-table && git checkout -qf $COMPAT_TABLE_COMMIT


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | improve `yarn install` a little bit
| Any Dependency Changes?  | `compat-table` is removed from npm dev dependencies, it is never officially published, though
| License                  | MIT

This PR removes `compat-table` dev dependencies so that [all of its `dependencies`](https://github.com/kangax/compat-table/blob/7ce9da287cc9c22ee37619e378f859753ca0642c/package.json#L14), which intends to build `compat-table` website, can be skipped during `yarn install`.