### PR TITLE
chore: cache chocolatey installation temporary files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
         - JOB=test
         # https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9
         - YARN_GPG=no
+      cache:
+        yarn: true
+        directories:
+          - $HOME/AppData/Local/Temp/chocolatey
     # Continue node_js matrix
     - node_js: "6"
     - node_js: "10"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | It should reduce the request to `https://chocolatey.org/api/v2/` from our Travis server
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Add `$HOME/AppData/Local/Temp/chocolatey` to the cache directories on windows build.

<s>Unfortunately the API is still [down](https://travis-ci.com/JLHwung/babel/jobs/267916636) for a while.</s>

The cache is working: https://travis-ci.com/babel/babel/jobs/267918585#L210