### PR TITLE
fix: skip merging large input sourcemaps

### DIFF
--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -178,7 +178,7 @@ declare module "convert-source-map" {
     SourceMap: SourceMap,
     Converter: Converter,
     fromObject(obj: SourceMap | SourceMapGenerator): Converter,
-    fromJSON(str: string): Converter,
+    fromJSON(str: string | Buffer): Converter,
     fromBase64(str: string): Converter,
     fromComment(str: string): Converter,
     fromMapFileComment(str: string, dir: string): Converter,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10875 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR addresses #10875 where a large input source map is consumed and causing OOM error. It is not an ideal fix but still preserve basic support for practical size input source map.

Note that #10885 misidentified the memory bottleneck. But I preserve the change here since we need to detect the source map file size.

Ideally the mergeSourceMap in babel generator should operate in a streaming mode. But this does not fit in a patch release.

I don't consider it as a regression since in 7.6.4 the `inputSourceMap` is not working properly on external sourcemaps.

@artisb45 @midgethoen Though the URL does not change, [here](https://gist.github.com/JLHwung/a4e735de002261d84764b8c3ed136c24) is a new fix. You can download it and overwrite `node_modules/@babel/core/lib/transformation/normalize-file.js`.