### PR TITLE
Move coverage to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,28 +9,6 @@ aliases:
     keys:
       - v1-yarn-cache
 
-  - &save-node-modules-cache
-    paths:
-      - node_modules
-    key: v1-yarn-deps-{{ checksum "yarn.lock" }}
-
-  - &save-yarn-cache
-    paths:
-      - ~/.yarn-cache
-    key: v1-yarn-cache
-
-  - &artifact_babel
-    path: ~/babel/packages/babel-standalone/babel.js
-
-  - &artifact_babel_min
-    path: ~/babel/packages/babel-standalone/babel.min.js
-
-  - &artifact_env
-    path: ~/babel/packages/babel-preset-env-standalone/babel-preset-env.js
-
-  - &artifact_env_min
-    path: ~/babel/packages/babel-preset-env-standalone/babel-preset-env.min.js
-
   - &test262_workdir
     working_directory: ~/babel/babel-test262-runner
 
@@ -50,28 +28,6 @@ executors:
     working_directory: ~/babel
 
 jobs:
-  test:
-    executor: node-executor
-    steps:
-      - checkout
-      - restore_cache: *restore-yarn-cache
-      - restore_cache: *restore-node-modules-cache
-      - run: yarn --version
-      - run: make test-ci-coverage
-      # Builds babel-standalone with the regular Babel config
-      - run: IS_PUBLISH=true make build
-      # test-ci-coverage doesn't test babel-standalone, as trying to gather coverage
-      # data for a JS file that's several megabytes large is bound to fail. Here,
-      # we just run the babel-standalone test separately.
-      - run: ./node_modules/.bin/jest packages/babel-standalone/test/
-      - run: ./node_modules/.bin/jest packages/babel-preset-env-standalone/test/
-      - store_artifacts: *artifact_babel
-      - store_artifacts: *artifact_babel_min
-      - store_artifacts: *artifact_env
-      - store_artifacts: *artifact_env_min
-      - save_cache: *save-node-modules-cache
-      - save_cache: *save-yarn-cache
-
   test262:
     executor: node-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,6 @@ jobs:
 
 workflows:
   version: 2
-  test:
-    jobs:
-      - test
   test262-master:
     jobs:
       - test262:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,22 +18,7 @@ jobs:
       - name: Environment log
         id: env
         run: |
-          echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
           yarn --version
-      - name: Get node_modules cache
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Get yarn cache
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.env.outputs.yarn-cache-dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Generate coverage report
         run: |
           yarn --version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,46 @@
+name: Report Coverage
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [13.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get node_modules cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Test and generate coverage
+        run: |
+          yarn --version
+          make test-ci-coverage
+          # Builds babel-standalone with the regular Babel config
+          # test-ci-coverage doesn't test babel-standalone, as trying to gather coverage
+          IS_PUBLISH=true make build-standalone
+          # data for a JS file that's several megabytes large is bound to fail. Here,
+          # we just run the babel-standalone test separately.
+          yarn jest "\-standalone/test"
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,11 +9,17 @@ jobs:
       matrix:
         node-version: [13.x]
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout code
+        uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Environment log
+        id: env
+        run: |
+          echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
+          yarn --version
       - name: Get node_modules cache
         uses: actions/cache@v1
         with:
@@ -22,15 +28,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+        uses: actions/cache@v1
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
+          path: ${{ steps.env.outputs.yarn-cache-dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Test and generate coverage
+      - name: Generate coverage report
         run: |
           yarn --version
           make test-ci-coverage
@@ -40,7 +44,8 @@ jobs:
           # data for a JS file that's several megabytes large is bound to fail. Here,
           # we just run the babel-standalone test separately.
           yarn jest "\-standalone/test"
-      - uses: codecov/codecov-action@v1
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `ENOMEM: not enough memory, stat /home/circleci/babel/packages/just/click/the/rerun/button`
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR moves the coverage report job to GitHub Actions. The ENOMEM error should be alleviated because

| | CPU | RAM |
| --- | --- | --- |
| [GitHub](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources) | 2 core | 7GB |
| [CircleCI](https://circleci.com/docs/2.0/configuration-reference/#docker-executor) | 2 core | 4GB |

Merge tips:
Please add `CODECOV_TOKEN` to the `Settings > Secrets` after merging to master. See https://github.com/codecov/codecov-action#usage