### PR TITLE
fix: Object.getOwnPropertySymbols called on non-object

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -399,7 +399,7 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
       var source = (arguments[i] != null) ? arguments[i] : {};
       var ownKeys = Object.keys(Object(source));
       if (typeof Object.getOwnPropertySymbols === 'function') {
-        ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
+        ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(Object(source)).filter(function(sym) {
           return Object.getOwnPropertyDescriptor(source, sym).enumerable;
         }));
       }

--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -396,10 +396,10 @@ helpers.objectSpread = helper("7.0.0-beta.0")`
 
   export default function _objectSpread(target) {
     for (var i = 1; i < arguments.length; i++) {
-      var source = (arguments[i] != null) ? arguments[i] : {};
-      var ownKeys = Object.keys(Object(source));
+      var source = (arguments[i] != null) ? Object(arguments[i]) : {};
+      var ownKeys = Object.keys(source);
       if (typeof Object.getOwnPropertySymbols === 'function') {
-        ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(Object(source)).filter(function(sym) {
+        ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
           return Object.getOwnPropertyDescriptor(source, sym).enumerable;
         }));
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix related #10482 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is related to https://github.com/babel/babel/pull/10683
`TypeError: Object.getOwnPropertySymbols called on non-object` occurred in android default browser (android 4.x 5.x) when it uses the spread operator. 
Because this browser dose not support Object.getOwnPropertySymbols with non-object argument.

<img width="532" alt="スクリーンショット 2019-12-20 23 13 18" src="https://user-images.githubusercontent.com/14991643/71260483-552bb280-237e-11ea-9475-76b7c3053e4e.png">


