### PR TITLE
Add support for babel.config.mjs and .babelrc.mjs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -107,6 +107,10 @@ module.exports = function(api) {
       ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
 
       convertESM ? "@babel/transform-modules-commonjs" : null,
+      // Until Jest supports native mjs, we must simulate it 🤷
+      env === "test" || env === "development"
+        ? "@babel/plugin-proposal-dynamic-import"
+        : null,
     ].filter(Boolean),
     overrides: [
       {

--- a/packages/babel-core/src/config/files/import.js
+++ b/packages/babel-core/src/config/files/import.js
@@ -1,0 +1,7 @@
+// We keep this in a seprate file so that in older node versions, where
+// import() isn't supported, we can try/catch around the require() call
+// when loading this file.
+
+export default function import_(filepath: string) {
+  return import(filepath);
+}

--- a/packages/babel-core/src/config/files/module-types.js
+++ b/packages/babel-core/src/config/files/module-types.js
@@ -1,5 +1,6 @@
 import { isAsync, waitFor } from "../../gensync-utils/async";
 import type { Handler } from "gensync";
+import path from "path";
 
 let import_;
 try {
@@ -28,8 +29,8 @@ export default function* loadCjsOrMjsDefault(
   }
 }
 
-function guessJSModuleType(path: string): "cjs" | "mjs" | "unknown" {
-  switch (path.slice(-4)) {
+function guessJSModuleType(filename: string): "cjs" | "mjs" | "unknown" {
+  switch (path.extname(filename)) {
     case ".cjs":
       return "cjs";
     case ".mjs":
@@ -41,6 +42,7 @@ function guessJSModuleType(path: string): "cjs" | "mjs" | "unknown" {
 
 function loadCjsDefault(filepath: string) {
   const module = (require(filepath): mixed);
+  // TODO (Babel 8): Remove "undefined" fallback
   return module?.__esModule ? module.default || undefined : module;
 }
 

--- a/packages/babel-core/src/config/files/module-types.js
+++ b/packages/babel-core/src/config/files/module-types.js
@@ -1,0 +1,57 @@
+import { isAsync, waitFor } from "../../gensync-utils/async";
+import type { Handler } from "gensync";
+
+let import_;
+try {
+  // Node < 13.3 doesn't support import() syntax.
+  import_ = require("./import").default;
+} catch {}
+
+export default function* loadCjsOrMjsDefault(
+  filepath: string,
+  asyncError: string,
+): Handler<mixed> {
+  switch (guessJSModuleType(filepath)) {
+    case "cjs":
+      return loadCjsDefault(filepath);
+    case "unknown":
+      try {
+        return loadCjsDefault(filepath);
+      } catch (e) {
+        if (e.code !== "ERR_REQUIRE_ESM") throw e;
+      }
+    case "mjs":
+      if (yield* isAsync()) {
+        return yield* waitFor(loadMjsDefault(filepath));
+      }
+      throw new Error(asyncError);
+  }
+}
+
+function guessJSModuleType(path: string): "cjs" | "mjs" | "unknown" {
+  switch (path.slice(-4)) {
+    case ".cjs":
+      return "cjs";
+    case ".mjs":
+      return "mjs";
+    default:
+      return "unknown";
+  }
+}
+
+function loadCjsDefault(filepath: string) {
+  const module = (require(filepath): mixed);
+  return module?.__esModule ? module.default || undefined : module;
+}
+
+async function loadMjsDefault(filepath: string) {
+  if (!import_) {
+    throw new Error(
+      "Internal error: Native ECMAScript modules aren't supported" +
+        " by this platform.\n",
+    );
+  }
+
+  const module = await import_(filepath);
+  return module.default;
+}

--- a/packages/babel-core/test/fixtures/config/config-files-templates/.babelrc.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates/.babelrc.mjs
@@ -1,0 +1,8 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+
+module.exports = new Promise(resolve => resolve({
+  default: {
+    comments: true
+  }
+}));
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/config/config-files-templates/babel.config.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files-templates/babel.config.mjs
@@ -1,0 +1,8 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+
+module.exports = new Promise(resolve => resolve({
+  default: {
+    comments: true
+  }
+}));
+module.exports.__esModule = true;

--- a/packages/babel-core/test/fixtures/config/config-files/babelrc-mjs-error/.babelrc.mjs
+++ b/packages/babel-core/test/fixtures/config/config-files/babelrc-mjs-error/.babelrc.mjs
@@ -1,0 +1,8 @@
+// Until Jest supports native mjs, we must simulate it 🤷
+
+module.exports = new Promise(resolve => resolve({
+  default: function () {
+    throw new Error("Babelrc threw an error");
+  }
+}));
+module.exports.__esModule = true;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/10755
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2150
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

**NOTE**: This PR is a diff on top of https://github.com/babel/babel/pull/10507, but they can be reviewed in any order.

This PR adds support for `*.mjs` config files: this is one of the last steps (with https://github.com/babel/babel/pull/10783) to support as configuration files all the extensions natively supported by nodejs.

Since native ECMAScript modules can only be loaded asynchronously, `.mjs` files can only be used when calling Babel with `.parseAsync`, `.transformFileAsync`, `.transformAsync`, `.loadPartialConfigAsync` or `.loadOptionsAsync`. Synchronous calls will throw an error. This is a problem for `@babel/eslint-parser` which will still only support synchronous configuration files, but the ESLint team is working on allowing asynchronous ESLint calls.