### PR TITLE
chore: separate build-standalone with coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,28 @@ aliases:
     keys:
       - v1-yarn-cache
 
+  - &save-node-modules-cache
+    paths:
+      - node_modules
+    key: v1-yarn-deps-{{ checksum "yarn.lock" }}
+
+  - &save-yarn-cache
+    paths:
+      - ~/.yarn-cache
+    key: v1-yarn-cache
+
+  - &artifact_babel
+    path: ~/babel/packages/babel-standalone/babel.js
+
+  - &artifact_babel_min
+    path: ~/babel/packages/babel-standalone/babel.min.js
+
+  - &artifact_env
+    path: ~/babel/packages/babel-preset-env-standalone/babel-preset-env.js
+
+  - &artifact_env_min
+    path: ~/babel/packages/babel-preset-env-standalone/babel-preset-env.min.js
+
   - &test262_workdir
     working_directory: ~/babel/babel-test262-runner
 
@@ -28,6 +50,25 @@ executors:
     working_directory: ~/babel
 
 jobs:
+  build-standalone:
+    executor: node-executor
+    steps:
+      - checkout
+      - restore_cache: *restore-yarn-cache
+      - restore_cache: *restore-node-modules-cache
+        # Builds babel-standalone with the regular Babel config
+        # test-ci-coverage doesn't test babel-standalone, as trying to gather coverage
+      - run: IS_PUBLISH=true make -j build-standalone-ci
+          # data for a JS file that's several megabytes large is bound to fail. Here,
+          # we just run the babel-standalone test separately.
+      - run: yarn jest "\-standalone/test"
+      - store_artifacts: *artifact_babel
+      - store_artifacts: *artifact_babel_min
+      - store_artifacts: *artifact_env
+      - store_artifacts: *artifact_env_min
+      - save_cache: *save-node-modules-cache
+      - save_cache: *save-yarn-cache
+
   test262:
     executor: node-executor
     steps:
@@ -81,6 +122,8 @@ jobs:
             cat ~/diff.tap | $(npm bin)/tap-merge | $(npm bin)/tap-mocha-reporter xunit | tee ~/test-results/test262/results.xml
           <<: *test262_workdir
       - store_test_results: *artifact_test262_xunit
+      - save_cache: *save-node-modules-cache
+      - save_cache: *save-yarn-cache
 
   publish-verdaccio:
     executor: node-executor
@@ -112,6 +155,9 @@ jobs:
 
 workflows:
   version: 2
+  build-standalone:
+    jobs:
+      - build-standalone
   test262-master:
     jobs:
       - test262:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
         # Builds babel-standalone with the regular Babel config
         # test-ci-coverage doesn't test babel-standalone, as trying to gather coverage
       - run: IS_PUBLISH=true make -j build-standalone-ci
-          # data for a JS file that's several megabytes large is bound to fail. Here,
-          # we just run the babel-standalone test separately.
+        # data for a JS file that's several megabytes large is bound to fail. Here,
+        # we just run the babel-standalone test separately.
       - run: yarn jest "\-standalone/test"
       - store_artifacts: *artifact_babel
       - store_artifacts: *artifact_babel_min

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,15 +22,8 @@ jobs:
       - name: Generate coverage report
         run: |
           yarn --version
-          make test-ci-coverage
-          # Builds babel-standalone with the regular Babel config
-          # test-ci-coverage doesn't test babel-standalone, as trying to gather coverage
-          IS_PUBLISH=true make build-standalone
-          # data for a JS file that's several megabytes large is bound to fail. Here,
-          # we just run the babel-standalone test separately.
-          yarn jest "\-standalone/test"
+          make -j test-ci-coverage
       - name: Upload coverage report
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/commit/c5cfc83182a341ae4073c35282f9022d6de59c61#r36536686
| Patch: Bug Fix?          | Yes
| License                  | MIT

This PR fixes regression introduced at c5cfc83182a341ae4073c35282f9022d6de59c61 and separates build-standalone with coverage report.

Since babel REPL requires a predictable link of standalone artifacts, we are still relying on CircleCI to build standalone until https://github.com/actions/upload-artifact/issues/27 is resolved.

The make `-j` flag is also applied to parallelize the build if possible.
