### PR TITLE
refactor: remove inClassProperty parser state

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1389,7 +1389,7 @@ export default class ExpressionParser extends LValParser {
     if (this.eat(tt.dot)) {
       const metaProp = this.parseMetaProperty(node, meta, "target");
 
-      if (!this.scope.inNonArrowFunction && !this.state.inClassProperty) {
+      if (!this.scope.inNonArrowFunction && !this.scope.inClass) {
         let error = "new.target can only be used in functions";
 
         if (this.hasPlugin("classProperties")) {

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -1048,11 +1048,9 @@ export default class StatementParser extends ExpressionParser {
     }
 
     const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
-    const oldInClassProperty = this.state.inClassProperty;
     const oldYieldPos = this.state.yieldPos;
     const oldAwaitPos = this.state.awaitPos;
     this.state.maybeInArrowParameters = false;
-    this.state.inClassProperty = false;
     this.state.yieldPos = -1;
     this.state.awaitPos = -1;
     this.scope.enter(functionFlags(node.async, node.generator));
@@ -1084,7 +1082,6 @@ export default class StatementParser extends ExpressionParser {
     }
 
     this.state.maybeInArrowParameters = oldMaybeInArrowParameters;
-    this.state.inClassProperty = oldInClassProperty;
     this.state.yieldPos = oldYieldPos;
     this.state.awaitPos = oldAwaitPos;
 
@@ -1575,13 +1572,10 @@ export default class StatementParser extends ExpressionParser {
   parseClassPrivateProperty(
     node: N.ClassPrivateProperty,
   ): N.ClassPrivateProperty {
-    this.state.inClassProperty = true;
-
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
 
     node.value = this.eat(tt.eq) ? this.parseMaybeAssign() : null;
     this.semicolon();
-    this.state.inClassProperty = false;
 
     this.scope.exit();
 
@@ -1593,8 +1587,6 @@ export default class StatementParser extends ExpressionParser {
       this.expectPlugin("classProperties");
     }
 
-    this.state.inClassProperty = true;
-
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
 
     if (this.match(tt.eq)) {
@@ -1605,7 +1597,6 @@ export default class StatementParser extends ExpressionParser {
       node.value = null;
     }
     this.semicolon();
-    this.state.inClassProperty = false;
 
     this.scope.exit();
 

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -64,7 +64,6 @@ export default class State {
   inType: boolean = false;
   noAnonFunctionType: boolean = false;
   inPropertyName: boolean = false;
-  inClassProperty: boolean = false;
   hasFlowComment: boolean = false;
   isIterator: boolean = false;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Test is passed | yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR refactors the `new.target` detection logic, so we can remove unnecessary `inClassProperty` parser state.

We are now going to prove that `!this.scope.inNonArrowFunction && !this.state.inClassProperty` is equivalent of `!this.scope.inNonArrowFunction && !this.scope.inClass`.

By definition of `state.inClassProperty`, `scope.inClass: true` implies that `state.inClassProperty: true`, therefore `!state.inClassProperty` implies `!scope.inClass`.

Now we asserts that under the condition of `this.scope.inNonArrowFunction: false`, `!scope.inClass` implies `!state.inClassProperty`.

If `scope.inClass: false` and `scope.inClassProperty: true`, we know that `thisScope` has been changed from `SCOPE_CLASS` to another scope type. Now by the definition of `thisScope`

https://github.com/babel/babel/blob/416ce3563877cff5098ac5b665d53947027f589b/packages/babel-parser/src/util/scope.js#L211-L212

and the definition of `SCOPE_VAR`

https://github.com/babel/babel/blob/416ce3563877cff5098ac5b665d53947027f589b/packages/babel-parser/src/util/scopeflags.js#L16

`thisScope` can only be one of `SCOPE_PROGRAM, SCOPE_FUNCTION, SCOPE_TS_MODULE`, since `SCOPE_PROGRAM` and `SCOPE_TS_MODULE` can not be nested inside class properties, `thisScope` must be `SCOPE_FUNCTION` and it also satisfies `!SCOPE_ARROW`, which means `this.scope.inNonArrowFunction: true`, but it contradicts the condition.

Q.E.D.