### PR TITLE
Disable windows defender on travis to make cache faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,22 @@ matrix:
     - os: windows
       node_js: "node"
       env:
-        - JOB=test
-        # https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9
-        - YARN_GPG=no
+        global:
+          # https://travis-ci.community/t/windows-builds-time-out-during-cache-restore/4642/4
+          - >
+              DISABLE_WINDOWS_DEFENDER=`powershell -Command
+              Set-MpPreference -DisableArchiveScanning \\\$true`
+          - >
+              DISABLE_WINDOWS_DEFENDER=`powershell -Command
+              Set-MpPreference -DisableRealtimeMonitoring \\\$true`
+          - >
+              DISABLE_WINDOWS_DEFENDER=`powershell -Command
+              Set-MpPreference -DisableBehaviorMonitoring \\\$true`
+        jobs:
+          - JOB=test
+          # https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9
+          - YARN_GPG=no
+
       cache:
         yarn: true
         directories:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

https://travis-ci.community/t/windows-builds-time-out-during-cache-restore/4642/3
