### PR TITLE
Fix parameter expression get binding

### DIFF
--- a/packages/babel-traverse/src/path/lib/virtual-types.js
+++ b/packages/babel-traverse/src/path/lib/virtual-types.js
@@ -64,7 +64,8 @@ export const Expression = {
 };
 
 export const Scope = {
-  types: ["Scopable"],
+  // When pattern is inside the function params, it is a scope
+  types: ["Scopable", "Pattern"],
   checkPath(path) {
     return t.isScope(path.node, path.parent);
   },

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -902,14 +902,14 @@ export default class Scope {
     do {
       const binding = scope.getOwnBinding(name);
       if (binding) {
-        // When a pattern is a Scope, it is a part of parameter expressions.
+        // Check if a pattern is a part of parameter expressions.
         // 9.2.10.28: The closure created by this expression should not have visibility of
         // declarations in the function body. If the binding is not a `param`-kind,
         // then it must be defined inside the function body, thus it should be skipped
         if (
           previousPath &&
           previousPath.isPattern() &&
-          previousPath.isScope() &&
+          previousPath.parentPath.isFunction() &&
           binding.kind !== "param"
         ) {
           // do nothing

--- a/packages/babel-traverse/src/scope/index.js
+++ b/packages/babel-traverse/src/scope/index.js
@@ -897,10 +897,27 @@ export default class Scope {
 
   getBinding(name: string) {
     let scope = this;
+    let previousPath;
 
     do {
       const binding = scope.getOwnBinding(name);
-      if (binding) return binding;
+      if (binding) {
+        // When a pattern is a Scope, it is a part of parameter expressions.
+        // 9.2.10.28: The closure created by this expression should not have visibility of
+        // declarations in the function body. If the binding is not a `param`-kind,
+        // then it must be defined inside the function body, thus it should be skipped
+        if (
+          previousPath &&
+          previousPath.isPattern() &&
+          previousPath.isScope() &&
+          binding.kind !== "param"
+        ) {
+          // do nothing
+        } else {
+          return binding;
+        }
+      }
+      previousPath = scope.path;
     } while ((scope = scope.parent));
   }
 

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -9,8 +9,9 @@ const renameVisitor = {
     }
   },
 
-  Scope(path, state) {
+  "Pattern|Scope"(path, state) {
     if (
+      path.isScope() &&
       !path.scope.bindingIdentifierEquals(
         state.oldName,
         state.binding.identifier,

--- a/packages/babel-traverse/src/scope/lib/renamer.js
+++ b/packages/babel-traverse/src/scope/lib/renamer.js
@@ -9,9 +9,8 @@ const renameVisitor = {
     }
   },
 
-  "Pattern|Scope"(path, state) {
+  Scope(path, state) {
     if (
-      path.isScope() &&
       !path.scope.bindingIdentifierEquals(
         state.oldName,
         state.binding.identifier,

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-1/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-1/input.js
@@ -1,0 +1,7 @@
+let a = "outside";
+
+function f(g = () => a) {
+  let a = "inside";
+  return g();
+}
+

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-1/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-1/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-1/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-1/output.js
@@ -1,0 +1,6 @@
+let a = "outside";
+
+function f(g = () => a) {
+  let z = "inside";
+  return g();
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-1/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-1/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-10/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-10/input.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function r({ a: b }, { [a]: { c } = a }) {
+  g(a);
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-10/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-10/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-10/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-10/output.js
@@ -1,0 +1,11 @@
+let z = "outside";
+
+function r({
+  a: b
+}, {
+  [z]: {
+    c
+  } = z
+}) {
+  g(z);
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-10/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-10/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-2/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-2/input.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function h(a, g = () => a) {
+  return g();
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-2/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-2/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-2/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-2/output.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function h(z, g = () => z) {
+  return g();
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-2/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-2/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-3/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-3/input.js
@@ -1,0 +1,6 @@
+let a = "outside";
+
+function j(g = a) {
+  let a = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-3/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-3/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-3/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-3/output.js
@@ -1,0 +1,6 @@
+let a = "outside";
+
+function j(g = a) {
+  let z = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-3/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-3/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-4/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-4/input.js
@@ -1,0 +1,8 @@
+let a = "outside";
+
+function k([{
+  g = a
+}]) {
+  let a = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-4/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-4/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-4/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-4/output.js
@@ -1,0 +1,8 @@
+let a = "outside";
+
+function k([{
+  g = a
+}]) {
+  let z = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-4/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-4/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-5/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-5/input.js
@@ -1,0 +1,8 @@
+let a = "outside";
+
+function f([{
+  [a]: g
+}]) {
+  let a = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-5/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-5/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-5/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-5/output.js
@@ -1,0 +1,8 @@
+let a = "outside";
+
+function f([{
+  [a]: g
+}]) {
+  let z = "inside";
+  return g;
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-5/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-5/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-6/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-6/input.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function n(g = (a = a) => {}) {
+  let a = "inside";
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-6/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-6/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-6/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-6/output.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function n(g = (a = a) => {}) {
+  let z = "inside";
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-6/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-6/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-7/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-7/input.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function n(a, g = (a = a) => {}) {
+  a = "inside";
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-7/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-7/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-7/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-7/output.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function n(z, g = (a = a) => {}) {
+  z = "inside";
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-7/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-7/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-8/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-8/input.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function q(a, g = (b = a) => b) {
+  g(a);
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-8/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-8/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-8/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-8/output.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function q(z, g = (b = z) => b) {
+  g(z);
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-8/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-8/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-9/input.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-9/input.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function r(a, g = (a, b = a) => a) {
+  g(a);
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-9/options.json
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-9/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-9/output.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-9/output.js
@@ -1,0 +1,5 @@
+let a = "outside";
+
+function r(z, g = (a, b = a) => a) {
+  g(z);
+}

--- a/packages/babel-traverse/test/fixtures/rename/parameter-default-9/plugin.js
+++ b/packages/babel-traverse/test/fixtures/rename/parameter-default-9/plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        path.scope.rename("a", "z");
+      }
+    }
+  };
+};

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -73,6 +73,25 @@ describe("scope", () => {
       ).toBe("Identifier");
     });
 
+    describe("function paramater expression", function() {
+      it("should not has visibility of declarations inside function body", () => {
+        expect(
+          getPath(
+            `var a = "outside"; (function foo(b = a) { let a = "inside" })`,
+          )
+            .get("body.1.expression.params.0")
+            .scope.getBinding("a").path.node.init.value,
+        ).toBe("outside");
+      });
+      it("should has visibility on paramater bindings", () => {
+        expect(
+          getPath(`var a = "outside"; (function foo(b = a, a = "inside") {})`)
+            .get("body.1.expression.params.0")
+            .scope.getBinding("a").path.node.right.value,
+        ).toBe("inside");
+      });
+    });
+
     it("variable declaration", function() {
       expect(getPath("var foo = null;").scope.getBinding("foo").path.type).toBe(
         "VariableDeclarator",

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -73,8 +73,8 @@ describe("scope", () => {
       ).toBe("Identifier");
     });
 
-    describe("function paramater expression", function() {
-      it("should not has visibility of declarations inside function body", () => {
+    describe("function parameter expression", function() {
+      it("should not have visibility of declarations inside function body", () => {
         expect(
           getPath(
             `var a = "outside"; (function foo(b = a) { let a = "inside" })`,
@@ -83,7 +83,7 @@ describe("scope", () => {
             .scope.getBinding("a").path.node.init.value,
         ).toBe("outside");
       });
-      it("should has visibility on paramater bindings", () => {
+      it("should have visibility on parameter bindings", () => {
         expect(
           getPath(`var a = "outside"; (function foo(b = a, a = "inside") {})`)
             .get("body.1.expression.params.0")

--- a/packages/babel-types/src/validators/isScope.js
+++ b/packages/babel-types/src/validators/isScope.js
@@ -4,6 +4,7 @@ import {
   isCatchClause,
   isBlockStatement,
   isScopable,
+  isPattern,
 } from "./generated";
 
 /**
@@ -16,6 +17,10 @@ export default function isScope(node: Object, parent: Object): boolean {
 
   if (isBlockStatement(node) && isCatchClause(parent, { body: node })) {
     return false;
+  }
+
+  if (isPattern(node) && isFunction(parent)) {
+    return true;
   }
 
   return isScopable(node);

--- a/packages/babel-types/src/validators/isScope.js
+++ b/packages/babel-types/src/validators/isScope.js
@@ -19,6 +19,8 @@ export default function isScope(node: Object, parent: Object): boolean {
     return false;
   }
 
+  // If a Pattern is an immediate descendent of a Function, it must be in the params.
+  // Hence we skipped the parentKey === "params" check
   if (isPattern(node) && isFunction(parent)) {
     return true;
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `getBinding` will return declaration inside the function body for patterns in function parameters.
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is a rework of #10055. In this PR I extend the definition of `Scope` to include all the `Pattern` nodes when it immediately descends from the `params` of a Function node. By doing so we can intercept the ancestry queries in `scope.getBinding` and skip the binding if it is _not_ a `param`-kind, because the spec ([9.2.10](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation), Step 28) requires that any closure defined in the parameter expressions should not access the declarations inside the function body.

An example can be found in the `scope` unit test:
https://github.com/babel/babel/blob/fb4125a816f6cc55f608be111939dc7ceccee118/packages/babel-traverse/test/scope.js#L77-L92

Personal sidenote:
This PR is dedicated to @nicolo-ribaudo, who gave insightful comments to #10055, one of my first works when I spent days to merely learn what is scope, and who inspires me and encourages me to work on Babel. Thank you and Merry Christmas @nicolo-ribaudo!