### PR TITLE
@babel/eslint-parser: update scope analysis for ClassPrivateProperty

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -34,6 +34,7 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
     "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "@babel/plugin-proposal-pipeline-operator": "^7.0.0",
+    "@babel/plugin-proposal-private-methods": "^7.7.4",
     "@babel/plugin-syntax-bigint": "^7.7.4",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-syntax-export-default-from": "^7.0.0",

--- a/eslint/babel-eslint-parser/src/analyze-scope.js
+++ b/eslint/babel-eslint-parser/src/analyze-scope.js
@@ -16,16 +16,16 @@ const flowFlippedAliasKeys = t.FLIPPED_ALIAS_KEYS.Flow.concat([
   "ObjectPattern",
   "RestElement",
 ]);
-const visitorKeysMap = Object.entries(t.VISITOR_KEYS).reduce(function(
-  acc,
-  [key, value],
-) {
-  if (flowFlippedAliasKeys.indexOf(value) === -1) {
-    acc[key] = value;
-  }
-  return acc;
-},
-{});
+
+const visitorKeysMap = Object.entries(t.VISITOR_KEYS).reduce(
+  (acc, [key, value]) => {
+    if (!flowFlippedAliasKeys.includes(value)) {
+      acc[key] = value;
+    }
+    return acc;
+  },
+  {},
+);
 
 const propertyTypes = {
   // loops
@@ -164,6 +164,11 @@ class Referencer extends OriginalReferencer {
 
   ClassPrivateProperty(node) {
     this._visitClassProperty(node);
+  }
+
+  // TODO: Update to visit type annotations when TypeScript/Flow support this syntax.
+  ClassPrivateMethod(node) {
+    super.MethodDefinition(node);
   }
 
   DeclareModule(node) {

--- a/eslint/babel-eslint-parser/test/babel-eslint-parser.js
+++ b/eslint/babel-eslint-parser/test/babel-eslint-parser.js
@@ -270,7 +270,7 @@ describe("babylon-to-espree", () => {
     assert.strictEqual(babylonAST.tokens[1].type, "Punctuator");
   });
 
-  // Espree doesn't support the private fields yet
+  // Espree doesn't support private fields yet
   it("hash (token)", () => {
     const code = "class A { #x }";
     const babylonAST = parseForESLint(code, {

--- a/eslint/babel-eslint-parser/test/fixtures/config/babel.config.js
+++ b/eslint/babel-eslint-parser/test/fixtures/config/babel.config.js
@@ -18,5 +18,6 @@ module.exports = {
     ["@babel/plugin-proposal-decorators", { decoratorsBeforeExport: false }],
     ["@babel/plugin-proposal-pipeline-operator", { proposal: "minimal" }],
     "@babel/plugin-syntax-bigint",
+    "@babel/plugin-proposal-private-methods",
   ],
 };

--- a/eslint/babel-eslint-parser/test/non-regression.js
+++ b/eslint/babel-eslint-parser/test/non-regression.js
@@ -1763,27 +1763,77 @@ describe("verify", () => {
     );
   });
 
-  describe("private class properties", () => {
-    it("should not be undefined", () => {
-      verifyAndAssertMessages(
-        `
-            class C {
-              #d = 1;
-            }
-        `,
-        { "no-undef": 1 },
-      );
+  describe("class field declarations", () => {
+    describe("field declarations", () => {
+      it("should not be undefined", () => {
+        verifyAndAssertMessages(
+          `
+              class C {
+                d = 1;
+              }
+          `,
+          { "no-undef": 1 },
+        );
+      });
+
+      it("should not be unused", () => {
+        verifyAndAssertMessages(
+          `
+              export class C {
+                d = 1;
+              }
+          `,
+          { "no-unused-vars": 1 },
+        );
+      });
     });
 
-    it("should not be unused", () => {
-      verifyAndAssertMessages(
-        `
-            export class C {
-              #d = 1;
-            }
-        `,
-        { "no-unused-vars": 1 },
-      );
+    describe("private field declarations", () => {
+      it("should not be undefined", () => {
+        verifyAndAssertMessages(
+          `
+              class C {
+                #d = 1;
+              }
+          `,
+          { "no-undef": 1 },
+        );
+      });
+
+      it("should not be unused", () => {
+        verifyAndAssertMessages(
+          `
+              export class C {
+                #d = 1;
+              }
+          `,
+          { "no-unused-vars": 1 },
+        );
+      });
+    });
+
+    describe("private methods", () => {
+      it("should not be undefined", () => {
+        verifyAndAssertMessages(
+          `
+              class C {
+                #d() {};
+              }
+          `,
+          { "no-undef": 1 },
+        );
+      });
+
+      it("should not be unused", () => {
+        verifyAndAssertMessages(
+          `
+              export class C {
+                #d() {};
+              }
+          `,
+          { "no-unused-vars": 1 },
+        );
+      });
     });
   });
 
@@ -1849,6 +1899,22 @@ describe("verify", () => {
     verifyAndAssertMessages(
       `
         class A { #a = 1; }
+      `,
+    );
+  });
+
+  it("works with classPrivateMethods", () => {
+    verifyAndAssertMessages(
+      `
+        class A { #a(b, c) {} }
+      `,
+    );
+  });
+
+  it("works with arrow function classPrivateProperties", () => {
+    verifyAndAssertMessages(
+      `
+        class A { #a = (a, b) => {}; }
       `,
     );
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Refs https://github.com/babel/babel/issues/10752 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR updates the scope analysis for `ClassPrivateMethod`s once https://github.com/babel/babel/pull/10914 is merged and we're parsing these nodes correctly.

Note that `ClassPrivateMethod`s still aren't 100% compatible with `no-undef`/`no-unused-vars`, but I didn't want to throw too much into this PR. I'll handle that as part of auditing the the plugin and making sure rules work with `@babel/eslint-parser`.

This is the last known issue on the parser side of things!

These changes rely on https://github.com/babel/babel/pull/10914 being merged first.