### PR TITLE
breaking: remove parserOpts.objectRestSpread from typescript

### DIFF
--- a/packages/babel-plugin-syntax-typescript/src/index.js
+++ b/packages/babel-plugin-syntax-typescript/src/index.js
@@ -31,12 +31,7 @@ export default declare((api, { isTSX }) => {
       // in TS depends on the extensions, and is purely dependent on 'isTSX'.
       removePlugin(plugins, "jsx");
 
-      parserOpts.plugins.push(
-        "typescript",
-        "classProperties",
-        // TODO: This is enabled by default now, remove in Babel 8
-        "objectRestSpread",
-      );
+      parserOpts.plugins.push("typescript", "classProperties");
 
       if (isTSX) {
         parserOpts.plugins.push("jsx");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Major: Breaking Change?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Although it is technically a breaking change, I don't think it is visible to end users as long as they use babel/core 8.x with syntax-typescript 8.x.