### PR TITLE
Replace custom "fundSuggestion" function with "levenary"

### DIFF
--- a/lib/third-party-libs.js.flow
+++ b/lib/third-party-libs.js.flow
@@ -190,12 +190,6 @@ declare module "convert-source-map" {
   };
 }
 
-declare module "js-levenshtein" {
-  declare module.exports: {
-    (string, string): number,
-  };
-}
-
 declare module "core-js-compat/data" {
   declare type Target = "node" | "chrome" | "opera" | "edge" | "firefox" | "safari" | "ie" | "ios" | "android" | "electron" | "samsung";
 

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -63,7 +63,7 @@
     "browserslist": "^4.6.0",
     "core-js-compat": "^3.6.0",
     "invariant": "^2.2.2",
-    "levenary": "^1.0.2",
+    "levenary": "^1.1.0",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -63,7 +63,7 @@
     "browserslist": "^4.6.0",
     "core-js-compat": "^3.6.0",
     "invariant": "^2.2.2",
-    "js-levenshtein": "^1.1.3",
+    "levenary": "^1.0.2",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/src/normalize-options.js
+++ b/packages/babel-preset-env/src/normalize-options.js
@@ -8,7 +8,7 @@ import moduleTransformations from "./module-transformations";
 import { TopLevelOptions, ModulesOption, UseBuiltInsOption } from "./options";
 import { defaultWebIncludes } from "./polyfills/corejs2/get-platform-specific-default";
 import { isBrowsersQueryValid } from "./targets-parser";
-import { findSuggestion } from "./utils";
+import findSuggestion from "levenary";
 
 import type {
   BuiltInsOption,

--- a/packages/babel-preset-env/src/targets-parser.js
+++ b/packages/babel-preset-env/src/targets-parser.js
@@ -3,12 +3,8 @@
 import browserslist from "browserslist";
 import invariant from "invariant";
 import semver from "semver";
-import {
-  semverify,
-  isUnreleasedVersion,
-  getLowestUnreleased,
-  findSuggestion,
-} from "./utils";
+import findSuggestion from "levenary";
+import { semverify, isUnreleasedVersion, getLowestUnreleased } from "./utils";
 import browserModulesData from "../data/built-in-modules.json";
 import { TargetNames } from "./options";
 import type { Targets } from "./types";

--- a/packages/babel-preset-env/src/utils.js
+++ b/packages/babel-preset-env/src/utils.js
@@ -4,7 +4,6 @@ import * as t from "@babel/types";
 import type { NodePath } from "@babel/traverse";
 import invariant from "invariant";
 import semver from "semver";
-import levenshtein from "js-levenshtein";
 import { addSideEffect } from "@babel/helper-module-imports";
 import unreleasedLabels from "../data/unreleased-labels";
 import { semverMin } from "./targets-parser";
@@ -51,18 +50,6 @@ export function intersection<T>(
     if (second.has(el) && third.has(el)) result.add(el);
   }
   return result;
-}
-
-export function findSuggestion(options: string[], option: string): string {
-  let levenshteinValue = Infinity;
-  return options.reduce((suggestion, validOption) => {
-    const value = levenshtein(validOption, option);
-    if (value < levenshteinValue) {
-      levenshteinValue = value;
-      return validOption;
-    }
-    return suggestion;
-  }, "");
 }
 
 export function prettifyVersion(version: string) {

--- a/packages/babel-preset-env/test/utils.spec.js
+++ b/packages/babel-preset-env/test/utils.spec.js
@@ -2,7 +2,7 @@
 
 const utils = require("../lib/utils");
 
-const { prettifyTargets, prettifyVersion, semverify, findSuggestion } = utils;
+const { prettifyTargets, prettifyVersion, semverify } = utils;
 
 describe("utils", () => {
   describe("semverify", () => {
@@ -48,16 +48,6 @@ describe("utils", () => {
         electron: "1.6",
         node: "0.12",
       });
-    });
-  });
-
-  describe("findSuggestion", () => {
-    it("returns", () => {
-      const options = ["one", "two", "three"];
-      expect(findSuggestion(options, "onr")).toEqual("one");
-      expect(findSuggestion(options, "tree")).toEqual("three");
-      expect(findSuggestion(options, "")).toEqual("one");
-      expect(findSuggestion(options, "xxx")).toEqual("one");
     });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR is extracted from https://github.com/babel/babel/pull/10899. In https://github.com/babel/babel/pull/10899 I needed to use the `findSuggestion` function in two different libraries, so I would have had to duplicate that code.
Instead of duplicating it, I decided to dig into the universe of fastest levenshtein distance functions on npm to find one with the interface that we actually need.
I initially used `didyoumean2`, but then switched to `levenary` because:
1) it's faster and because :wink:
2) it's created by @tanhauhau 
3) it provides flow typings out of the box.

I extracted this commit to a separate PR because @JLHwung is going to work on some content which touches similar lines/depends on this package, so we can merge this without waiting for https://github.com/babel/babel/pull/10899.