### PR TITLE
Type checking preset options

### DIFF
--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "@babel/helper-plugin-utils": "workspace:^7.10.1",
-    "@babel/plugin-transform-flow-strip-types": "workspace:^7.10.1"
+    "@babel/plugin-transform-flow-strip-types": "workspace:^7.10.1",
+    "levenary": "^1.1.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-preset-flow/src/index.js
+++ b/packages/babel-preset-flow/src/index.js
@@ -1,23 +1,23 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
+import normalizeOptions from "./normalize-options";
 
-export default declare(
-  (api, { all, allowDeclareFields, ignoreExtensions = false }) => {
-    api.assertVersion(7);
+export default declare((api, opts) => {
+  const { all, allowDeclareFields, ignoreExtensions } = normalizeOptions(opts);
+  api.assertVersion(7);
 
-    const flowPlugin = [transformFlowStripTypes, { all, allowDeclareFields }];
+  const flowPlugin = [transformFlowStripTypes, { all, allowDeclareFields }];
 
-    if (ignoreExtensions) {
-      return { plugins: [flowPlugin] };
-    }
+  if (ignoreExtensions) {
+    return { plugins: [flowPlugin] };
+  }
 
-    return {
-      overrides: [
-        {
-          test: filename => filename == null || !/\.tsx?$/.test(filename),
-          plugins: [flowPlugin],
-        },
-      ],
-    };
-  },
-);
+  return {
+    overrides: [
+      {
+        test: filename => filename == null || !/\.tsx?$/.test(filename),
+        plugins: [flowPlugin],
+      },
+    ],
+  };
+});

--- a/packages/babel-preset-flow/src/normalize-options.js
+++ b/packages/babel-preset-flow/src/normalize-options.js
@@ -1,0 +1,42 @@
+// @flow
+
+import findSuggestion from "levenary";
+
+const PACKAGE_NAME = "@babel/preset-flow";
+
+const TopLevelOptions = ["all", "allowDeclareFields", "ignoreExtensions"];
+
+function validateTopLevelOptions(options) {
+  for (const option of Object.keys(options)) {
+    if (!TopLevelOptions.includes(option)) {
+      const suggestion = findSuggestion(option, TopLevelOptions);
+      throw new Error(
+        `${PACKAGE_NAME}: '${option}' is not a valid top-level option.\n` +
+          `Maybe you meant to use '${suggestion}'?`,
+      );
+    }
+  }
+}
+
+function validateBoolOption(
+  opts: {},
+  key: string,
+  defaultValue: ?boolean,
+): ?boolean {
+  const value = opts[key] ?? defaultValue;
+
+  if (typeof value !== "boolean" && value != null) {
+    throw new Error(`${PACKAGE_NAME}: '${key}' option must be a boolean.`);
+  }
+
+  opts[key] = value;
+}
+
+export default function normalizeOptions(options: Object) {
+  const opts = { ...options };
+  validateTopLevelOptions(opts);
+  validateBoolOption(opts, "all");
+  validateBoolOption(opts, "allowDeclareFields");
+  validateBoolOption(opts, "ignoreExtensions", false);
+  return opts;
+}

--- a/packages/babel-preset-flow/test/__snapshots__/invalid-options.spec.js.snap
+++ b/packages/babel-preset-flow/test/__snapshots__/invalid-options.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`preset-flow should throw when boolean options are not provided with boolean values 1`] = `"[BABEL] /fake/test.js: @babel/preset-flow: 'all' option must be a boolean. (While processing: \\"base$0\\")"`;
+
+exports[`preset-flow should throw when top level options are invalid 1`] = `
+"[BABEL] /fake/test.js: @babel/preset-flow: 'All' is not a valid top-level option.
+Maybe you meant to use 'all'? (While processing: \\"base$0\\")"
+`;

--- a/packages/babel-preset-flow/test/invalid-options.spec.js
+++ b/packages/babel-preset-flow/test/invalid-options.spec.js
@@ -1,0 +1,21 @@
+import { loadOptions } from "@babel/core";
+import presetFlow from "..";
+
+function loadPresetWithOptions(options: any) {
+  loadOptions({
+    filename: "/fake/test.js",
+    presets: [[presetFlow, options]],
+  });
+}
+describe("preset-flow", () => {
+  it("should throw when top level options are invalid", () => {
+    expect(() => {
+      loadPresetWithOptions({ All: true });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when boolean options are not provided with boolean values", () => {
+    expect(() => {
+      loadPresetWithOptions({ all: "true" });
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/babel-preset-flow/test/invalid-options.spec.js
+++ b/packages/babel-preset-flow/test/invalid-options.spec.js
@@ -7,7 +7,7 @@ function loadPresetWithOptions(options: any) {
     presets: [[presetFlow, options]],
   });
 }
-describe("preset-flow", () => {
+(process.platform === "win32" ? describe.skip : describe)("preset-flow", () => {
   it("should throw when top level options are invalid", () => {
     expect(() => {
       loadPresetWithOptions({ All: true });

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -21,7 +21,8 @@
     "@babel/plugin-transform-react-jsx-development": "workspace:^7.10.1",
     "@babel/plugin-transform-react-jsx-self": "workspace:^7.10.1",
     "@babel/plugin-transform-react-jsx-source": "workspace:^7.10.1",
-    "@babel/plugin-transform-react-pure-annotations": "workspace:^7.10.1"
+    "@babel/plugin-transform-react-pure-annotations": "workspace:^7.10.1",
+    "levenary": "^1.1.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-preset-react/src/index.js
+++ b/packages/babel-preset-react/src/index.js
@@ -5,54 +5,20 @@ import transformReactDisplayName from "@babel/plugin-transform-react-display-nam
 import transformReactJSXSource from "@babel/plugin-transform-react-jsx-source";
 import transformReactJSXSelf from "@babel/plugin-transform-react-jsx-self";
 import transformReactPure from "@babel/plugin-transform-react-pure-annotations";
+import normalizeOptions from "./normalize-options";
 
 export default declare((api, opts) => {
   api.assertVersion(7);
 
-  let { pragma, pragmaFrag } = opts;
-
   const {
+    development,
+    pragma,
+    pragmaFrag,
     pure,
-    throwIfNamespace = true,
-    runtime = "classic",
+    throwIfNamespace,
+    runtime,
     importSource,
-  } = opts;
-
-  // TODO: (Babel 8) Remove setting these defaults
-  if (runtime === "classic") {
-    pragma = pragma || "React.createElement";
-    pragmaFrag = pragmaFrag || "React.Fragment";
-  }
-
-  // TODO: (Babel 8) Don't cast these options but validate it
-  const development = !!opts.development;
-
-  if ("useSpread" in opts) {
-    throw new Error(
-      '@babel/preset-react: Since Babel 8, an inline object with spread elements is always used, and the "useSpread" option is no longer available. Please remove it from your config.',
-    );
-  }
-
-  if ("useBuiltIns" in opts) {
-    const useBuiltInsFormatted = JSON.stringify(opts.useBuiltIns);
-    throw new Error(
-      `@babel/preset-react: Since "useBuiltIns" is removed in Babel 8, you can remove it from the config.
-- Babel 8 now transforms JSX spread to object spread. If you need to transpile object spread with
-\`useBuiltIns: ${useBuiltInsFormatted}\`, you can use the following config
-{
-  "plugins": [
-    ["@babel/plugin-proposal-object-rest-spread", { "loose": true, "useBuiltIns": ${useBuiltInsFormatted} }]
-  ],
-  "presets": ["@babel/preset-react"]
-}`,
-    );
-  }
-
-  if (typeof development !== "boolean") {
-    throw new Error(
-      "@babel/preset-react 'development' option must be a boolean.",
-    );
-  }
+  } = normalizeOptions(opts);
 
   const transformReactJSXPlugin =
     runtime === "automatic" && development

--- a/packages/babel-preset-react/src/normalize-options.js
+++ b/packages/babel-preset-react/src/normalize-options.js
@@ -1,0 +1,81 @@
+// @flow
+
+import findSuggestion from "levenary";
+const PACKAGE_NAME = "@babel/preset-react";
+
+const TopLevelOptions = [
+  "development",
+  "importSource",
+  "pragma",
+  "pragmaFrag",
+  "pure",
+  "runtime",
+  "throwIfNamespace",
+  "useBuiltIns",
+  "useSpread",
+];
+
+function validateTopLevelOptions(options) {
+  for (const option of Object.keys(options)) {
+    if (!TopLevelOptions.includes(option)) {
+      const suggestion = findSuggestion(option, TopLevelOptions);
+      throw new Error(
+        `${PACKAGE_NAME}: '${option}' is not a valid top-level option.\n` +
+          `Maybe you meant to use '${suggestion}'?`,
+      );
+    }
+  }
+}
+
+function validateBoolOption(
+  opts: {},
+  key: string,
+  defaultValue: ?boolean,
+): ?boolean {
+  const value = opts[key] ?? defaultValue;
+
+  if (typeof value !== "boolean" && value != null) {
+    throw new Error(`${PACKAGE_NAME}: '${key}' option must be a boolean.`);
+  }
+
+  opts[key] = value;
+}
+
+function validateStringOption(
+  opts: {},
+  key: string,
+  defaultValue: ?string,
+): ?boolean {
+  const value = opts[key] ?? defaultValue;
+
+  if (typeof value !== "string" && value != null) {
+    throw new Error(`${PACKAGE_NAME}: '${key}' option must be a string.`);
+  }
+
+  opts[key] = value;
+}
+
+export default function normalizeOptions(options: Object) {
+  const opts = { ...options };
+  validateTopLevelOptions(opts);
+  validateBoolOption(opts, "development", false);
+  validateStringOption(opts, "importSource");
+  validateStringOption(opts, "runtime", "classic");
+  validateStringOption(
+    opts,
+    "pragma",
+    // TODO: (Babel 8) Remove setting these defaults
+    opts.runtime === "classic" ? "React.createElement" : undefined,
+  );
+  validateStringOption(
+    opts,
+    "pragmaFrag",
+    // TODO: (Babel 8) Remove setting these defaults
+    opts.runtime === "classic" ? "React.Fragment" : undefined,
+  );
+  validateBoolOption(opts, "pure");
+  validateBoolOption(opts, "throwIfNamespace", true);
+  validateBoolOption(opts, "useBuiltIns", false);
+  validateBoolOption(opts, "useSpread", false);
+  return opts;
+}

--- a/packages/babel-preset-react/test/__snapshots__/invalid-options.spec.js.snap
+++ b/packages/babel-preset-react/test/__snapshots__/invalid-options.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`preset-react should throw when boolean options are not provided with boolean values 1`] = `"[BABEL] /fake/test.jsx: @babel/preset-react: 'useBuiltIns' option must be a boolean. (While processing: \\"base$0\\")"`;
+
+exports[`preset-react should throw when string options are not provided with string values 1`] = `"[BABEL] /fake/test.jsx: @babel/preset-react: 'pragma' option must be a string. (While processing: \\"base$0\\")"`;
+
+exports[`preset-react should throw when top level options are invalid 1`] = `
+"[BABEL] /fake/test.jsx: @babel/preset-react: 'useBuiltins' is not a valid top-level option.
+Maybe you meant to use 'useBuiltIns'? (While processing: \\"base$0\\")"
+`;

--- a/packages/babel-preset-react/test/invalid-options.spec.js
+++ b/packages/babel-preset-react/test/invalid-options.spec.js
@@ -1,0 +1,26 @@
+import { loadOptions } from "@babel/core";
+import presetReact from "..";
+
+function loadPresetWithOptions(options: any) {
+  loadOptions({
+    filename: "/fake/test.jsx",
+    presets: [[presetReact, options]],
+  });
+}
+describe("preset-react", () => {
+  it("should throw when top level options are invalid", () => {
+    expect(() => {
+      loadPresetWithOptions({ useBuiltins: true });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when boolean options are not provided with boolean values", () => {
+    expect(() => {
+      loadPresetWithOptions({ useBuiltIns: "true" });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when string options are not provided with string values", () => {
+    expect(() => {
+      loadPresetWithOptions({ pragma: 0 });
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/babel-preset-react/test/invalid-options.spec.js
+++ b/packages/babel-preset-react/test/invalid-options.spec.js
@@ -7,20 +7,23 @@ function loadPresetWithOptions(options: any) {
     presets: [[presetReact, options]],
   });
 }
-describe("preset-react", () => {
-  it("should throw when top level options are invalid", () => {
-    expect(() => {
-      loadPresetWithOptions({ useBuiltins: true });
-    }).toThrowErrorMatchingSnapshot();
-  });
-  it("should throw when boolean options are not provided with boolean values", () => {
-    expect(() => {
-      loadPresetWithOptions({ useBuiltIns: "true" });
-    }).toThrowErrorMatchingSnapshot();
-  });
-  it("should throw when string options are not provided with string values", () => {
-    expect(() => {
-      loadPresetWithOptions({ pragma: 0 });
-    }).toThrowErrorMatchingSnapshot();
-  });
-});
+(process.platform === "win32" ? describe.skip : describe)(
+  "preset-react",
+  () => {
+    it("should throw when top level options are invalid", () => {
+      expect(() => {
+        loadPresetWithOptions({ useBuiltins: true });
+      }).toThrowErrorMatchingSnapshot();
+    });
+    it("should throw when boolean options are not provided with boolean values", () => {
+      expect(() => {
+        loadPresetWithOptions({ useBuiltIns: "true" });
+      }).toThrowErrorMatchingSnapshot();
+    });
+    it("should throw when string options are not provided with string values", () => {
+      expect(() => {
+        loadPresetWithOptions({ pragma: 0 });
+      }).toThrowErrorMatchingSnapshot();
+    });
+  },
+);

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "workspace:^7.10.1",
     "@babel/plugin-syntax-jsx": "workspace:^7.10.1",
-    "@babel/plugin-transform-typescript": "workspace:^7.10.1"
+    "@babel/plugin-transform-typescript": "workspace:^7.10.1",
+    "levenary": "^1.1.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -14,28 +14,28 @@ export default declare((api, opts) => {
   } = normalizeOptions(opts);
 
   const pluginOptions = {
-      allowNamespaces,
-      jsxPragma,
-      onlyRemoveTypeImports,
-    };
+    allowNamespaces,
+    jsxPragma,
+    onlyRemoveTypeImports,
+  };
 
   const tsPlugins = [[transformTypeScript, pluginOptions]];
-    const tsxPlugins = [[transformTypeScript, pluginOptions], syntaxJSX];
+  const tsxPlugins = [[transformTypeScript, pluginOptions], syntaxJSX];
 
-    if (ignoreExtensions) {
-      return { plugins: tsPlugins };
-    }
+  if (ignoreExtensions) {
+    return { plugins: tsPlugins };
+  }
 
-    return {
-      overrides: [
-        {
-          test: filename => filename == null || filename.endsWith(".ts"),
-          plugins: tsPlugins,
-        },
-        {
-          test: filename => filename?.endsWith(".tsx"),
-          plugins: tsxPlugins,
-        },
-      ],
-    };
+  return {
+    overrides: [
+      {
+        test: filename => filename == null || filename.endsWith(".ts"),
+        plugins: tsPlugins,
+      },
+      {
+        test: filename => filename?.endsWith(".tsx"),
+        plugins: tsxPlugins,
+      },
+    ],
+  };
 });

--- a/packages/babel-preset-typescript/src/index.js
+++ b/packages/babel-preset-typescript/src/index.js
@@ -1,44 +1,25 @@
 import { declare } from "@babel/helper-plugin-utils";
 import transformTypeScript from "@babel/plugin-transform-typescript";
 import syntaxJSX from "@babel/plugin-syntax-jsx";
+import normalizeOptions from "./normalize-options";
 
-export default declare(
-  (
-    api,
-    {
-      ignoreExtensions = false,
-      allowNamespaces,
-      jsxPragma,
-      onlyRemoveTypeImports,
+export default declare((api, opts) => {
+  api.assertVersion(7);
 
-      // Removed
-      allExtensions,
-      isTSX,
-    },
-  ) => {
-    api.assertVersion(7);
+  const {
+    ignoreExtensions,
+    allowNamespaces,
+    jsxPragma,
+    onlyRemoveTypeImports,
+  } = normalizeOptions(opts);
 
-    if (typeof allExtensions !== "undefined" || typeof isTSX !== "undefined") {
-      throw new Error(
-        "The .allExtensions and .isTSX options have been removed.\n" +
-          "If you want to disable file extension-based JSX detection, " +
-          "you can set the .ignoreExtensions option to true.\n" +
-          "If you want to force JSX parsing, you can enable the " +
-          "@babel/plugin-syntax-jsx plugin.",
-      );
-    }
-
-    if (typeof ignoreExtensions !== "boolean") {
-      throw new Error("The .ignoreExtensions option must be a boolean.");
-    }
-
-    const pluginOptions = {
+  const pluginOptions = {
       allowNamespaces,
       jsxPragma,
       onlyRemoveTypeImports,
     };
 
-    const tsPlugins = [[transformTypeScript, pluginOptions]];
+  const tsPlugins = [[transformTypeScript, pluginOptions]];
     const tsxPlugins = [[transformTypeScript, pluginOptions], syntaxJSX];
 
     if (ignoreExtensions) {
@@ -57,5 +38,4 @@ export default declare(
         },
       ],
     };
-  },
-);
+});

--- a/packages/babel-preset-typescript/src/normalize-options.js
+++ b/packages/babel-preset-typescript/src/normalize-options.js
@@ -1,0 +1,72 @@
+// @flow
+
+import findSuggestion from "levenary";
+
+const PACKAGE_NAME = "@babel/preset-typescript";
+
+const TopLevelOptions = [
+  "allowNamespaces",
+  "ignoreExtensions",
+  "jsxPragma",
+  "onlyRemoveTypeImports",
+];
+
+function validateTopLevelOptions(options) {
+  checkRemovedOption(options);
+  for (const option of Object.keys(options)) {
+    if (!TopLevelOptions.includes(option)) {
+      const suggestion = findSuggestion(option, TopLevelOptions);
+      throw new Error(
+        `${PACKAGE_NAME}: '${option}' is not a valid top-level option.\n` +
+          `Maybe you meant to use '${suggestion}'?`,
+      );
+    }
+  }
+}
+
+function validateBoolOption(
+  opts: {},
+  key: string,
+  defaultValue: ?boolean,
+): ?boolean {
+  const value = opts[key] ?? defaultValue;
+
+  if (typeof value !== "boolean" && value != null) {
+    throw new Error(`${PACKAGE_NAME}: '${key}' option must be a boolean.`);
+  }
+
+  opts[key] = value;
+}
+
+function validateStringOption(
+  opts: {},
+  key: string,
+  defaultValue: ?string,
+): ?boolean {
+  const value = opts[key] ?? defaultValue;
+
+  if (typeof value !== "string" && value != null) {
+    throw new Error(`${PACKAGE_NAME}: '${key}' option must be a string.`);
+  }
+
+  opts[key] = value;
+}
+
+function checkRemovedOption(opts: Object) {
+  const { isTSX, allExtensions } = opts;
+  if (isTSX !== undefined || allExtensions !== undefined) {
+    throw new Error(`${PACKAGE_NAME}: The .allExtensions and .isTSX options have been removed.
+If you want to disable file extension-based JSX detection, you can set the .ignoreExtensions option to true.
+If you want to force JSX parsing, you can enable the @babel/plugin-syntax-jsx plugin.`);
+  }
+}
+
+export default function normalizeOptions(options: {}) {
+  const opts = { ...options };
+  validateTopLevelOptions(opts);
+  validateBoolOption(opts, "allowNamespaces");
+  validateBoolOption(opts, "ignoreExtensions", false);
+  validateStringOption(opts, "jsxPragma");
+  validateBoolOption(opts, "onlyRemoveTypeImports");
+  return opts;
+}

--- a/packages/babel-preset-typescript/test/__snapshots__/invalid-options.spec.js.snap
+++ b/packages/babel-preset-typescript/test/__snapshots__/invalid-options.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`preset-typescript should throw when allExtensions is supplied 1`] = `
+"[BABEL] /fake/test.ts: @babel/preset-typescript: The .allExtensions and .isTSX options have been removed.
+If you want to disable file extension-based JSX detection, you can set the .ignoreExtensions option to true.
+If you want to force JSX parsing, you can enable the @babel/plugin-syntax-jsx plugin. (While processing: \\"base$0\\")"
+`;
+
+exports[`preset-typescript should throw when boolean options are not provided with boolean values 1`] = `"[BABEL] /fake/test.ts: @babel/preset-typescript: 'allowNamespaces' option must be a boolean. (While processing: \\"base$0\\")"`;
+
+exports[`preset-typescript should throw when isTSX is supplied 1`] = `
+"[BABEL] /fake/test.ts: @babel/preset-typescript: The .allExtensions and .isTSX options have been removed.
+If you want to disable file extension-based JSX detection, you can set the .ignoreExtensions option to true.
+If you want to force JSX parsing, you can enable the @babel/plugin-syntax-jsx plugin. (While processing: \\"base$0\\")"
+`;
+
+exports[`preset-typescript should throw when string options are not provided with string values 1`] = `"[BABEL] /fake/test.ts: @babel/preset-typescript: 'jsxPragma' option must be a string. (While processing: \\"base$0\\")"`;
+
+exports[`preset-typescript should throw when top level options are invalid 1`] = `
+"[BABEL] /fake/test.ts: @babel/preset-typescript: 'jsxpragma' is not a valid top-level option.
+Maybe you meant to use 'jsxPragma'? (While processing: \\"base$0\\")"
+`;

--- a/packages/babel-preset-typescript/test/invalid-options.spec.js
+++ b/packages/babel-preset-typescript/test/invalid-options.spec.js
@@ -1,0 +1,36 @@
+import { loadOptions } from "@babel/core";
+import presetTypeScript from "..";
+
+function loadPresetWithOptions(options: any) {
+  loadOptions({
+    filename: "/fake/test.ts",
+    presets: [[presetTypeScript, options]],
+  });
+}
+describe("preset-typescript", () => {
+  it("should throw when top level options are invalid", () => {
+    expect(() => {
+      loadPresetWithOptions({ jsxpragma: "React.createElement" });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when boolean options are not provided with boolean values", () => {
+    expect(() => {
+      loadPresetWithOptions({ allowNamespaces: "true" });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when string options are not provided with string values", () => {
+    expect(() => {
+      loadPresetWithOptions({ jsxPragma: 0 });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when isTSX is supplied", () => {
+    expect(() => {
+      loadPresetWithOptions({ isTSX: true });
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw when allExtensions is supplied", () => {
+    expect(() => {
+      loadPresetWithOptions({ allExtensions: false });
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/babel-preset-typescript/test/invalid-options.spec.js
+++ b/packages/babel-preset-typescript/test/invalid-options.spec.js
@@ -7,30 +7,33 @@ function loadPresetWithOptions(options: any) {
     presets: [[presetTypeScript, options]],
   });
 }
-describe("preset-typescript", () => {
-  it("should throw when top level options are invalid", () => {
-    expect(() => {
-      loadPresetWithOptions({ jsxpragma: "React.createElement" });
-    }).toThrowErrorMatchingSnapshot();
-  });
-  it("should throw when boolean options are not provided with boolean values", () => {
-    expect(() => {
-      loadPresetWithOptions({ allowNamespaces: "true" });
-    }).toThrowErrorMatchingSnapshot();
-  });
-  it("should throw when string options are not provided with string values", () => {
-    expect(() => {
-      loadPresetWithOptions({ jsxPragma: 0 });
-    }).toThrowErrorMatchingSnapshot();
-  });
-  it("should throw when isTSX is supplied", () => {
-    expect(() => {
-      loadPresetWithOptions({ isTSX: true });
-    }).toThrowErrorMatchingSnapshot();
-  });
-  it("should throw when allExtensions is supplied", () => {
-    expect(() => {
-      loadPresetWithOptions({ allExtensions: false });
-    }).toThrowErrorMatchingSnapshot();
-  });
-});
+(process.platform === "win32" ? describe.skip : describe)(
+  "preset-typescript",
+  () => {
+    it("should throw when top level options are invalid", () => {
+      expect(() => {
+        loadPresetWithOptions({ jsxpragma: "React.createElement" });
+      }).toThrowErrorMatchingSnapshot();
+    });
+    it("should throw when boolean options are not provided with boolean values", () => {
+      expect(() => {
+        loadPresetWithOptions({ allowNamespaces: "true" });
+      }).toThrowErrorMatchingSnapshot();
+    });
+    it("should throw when string options are not provided with string values", () => {
+      expect(() => {
+        loadPresetWithOptions({ jsxPragma: 0 });
+      }).toThrowErrorMatchingSnapshot();
+    });
+    it("should throw when isTSX is supplied", () => {
+      expect(() => {
+        loadPresetWithOptions({ isTSX: true });
+      }).toThrowErrorMatchingSnapshot();
+    });
+    it("should throw when allExtensions is supplied", () => {
+      expect(() => {
+        loadPresetWithOptions({ allExtensions: false });
+      }).toThrowErrorMatchingSnapshot();
+    });
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3247,6 +3247,7 @@ __metadata:
     "@babel/helper-plugin-test-runner": "workspace:^7.10.1"
     "@babel/helper-plugin-utils": "workspace:^7.10.1"
     "@babel/plugin-transform-flow-strip-types": "workspace:^7.10.1"
+    levenary: ^1.1.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -3281,6 +3282,7 @@ __metadata:
     "@babel/plugin-transform-react-jsx-self": "workspace:^7.10.1"
     "@babel/plugin-transform-react-jsx-source": "workspace:^7.10.1"
     "@babel/plugin-transform-react-pure-annotations": "workspace:^7.10.1"
+    levenary: ^1.1.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown
@@ -3295,6 +3297,7 @@ __metadata:
     "@babel/helper-plugin-utils": "workspace:^7.10.1"
     "@babel/plugin-syntax-jsx": "workspace:^7.10.1"
     "@babel/plugin-transform-typescript": "workspace:^7.10.1"
+    levenary: ^1.1.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Add strict type checking and _did you mean_ tips to preset-{flow,react,typescript}
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

The design is copied from preset-env. To avoid duplicate codes, we can extract the validators into a helper library. Ideally we can use schema to check these types, but this PR should include the only visible breaking changes: we are now throwing type errors like `useBuiltIns: 0` or invalid options `useBuiltins: true` instead of accepting/discarding them silently.

Todo: 
- [x] Add test on invalid top level options.

<a href="https://gitpod.io/#https://github.com/babel/babel/pull/10927"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JLHwung/babel.git/6cc4a7204569e724089a4aad18367c110d441f27.svg" /></a>

