### PR TITLE
helper-module-transforms: dereference imported template tag

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -183,6 +183,7 @@ const rewriteReferencesVisitor = {
 
       if (
         (path.parentPath.isCallExpression({ callee: path.node }) ||
+          path.parentPath.isOptionalCallExpression({ callee: path.node }) ||
           path.parentPath.isTaggedTemplateExpression({ tag: path.node })) &&
         t.isMemberExpression(ref)
       ) {

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.js
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.js
@@ -182,7 +182,8 @@ const rewriteReferencesVisitor = {
       ref.loc = path.node.loc;
 
       if (
-        path.parentPath.isCallExpression({ callee: path.node }) &&
+        (path.parentPath.isCallExpression({ callee: path.node }) ||
+          path.parentPath.isTaggedTemplateExpression({ tag: path.node })) &&
         t.isMemberExpression(ref)
       ) {
         path.replaceWith(t.sequenceExpression([t.numericLiteral(0), ref]));

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/input.mjs
@@ -8,3 +8,4 @@ foo2;
 foo3;
 foo3();
 foo3``;
+foo3?.();

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/input.mjs
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/input.mjs
@@ -7,3 +7,4 @@ foo;
 foo2;
 foo3;
 foo3();
+foo3``;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/output.js
@@ -6,3 +6,4 @@ foo4.default;
 foo4.foo3;
 (0, foo4.foo3)();
 (0, foo4.foo3)``;
+(0, foo4.foo3)?.();

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/import/output.js
@@ -5,3 +5,4 @@ foo4.default;
 foo4.default;
 foo4.foo3;
 (0, foo4.foo3)();
+(0, foo4.foo3)``;

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/options.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/strict/options.json
@@ -2,6 +2,7 @@
   "plugins": [
     "external-helpers",
     "syntax-object-rest-spread",
+    "syntax-optional-chaining",
     [
       "transform-modules-commonjs",
       { "strict": true, "mjsStrictNamespace": false }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes: #10933
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Prevent imported template tags to be called with an implied receiver.