### PR TITLE
refactor: remove unused invalidTemplateEscapePosition tokenizer state

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1442,13 +1442,7 @@ export default class ExpressionParser extends LValParser {
     const elem = this.startNode();
     if (this.state.value === null) {
       if (!isTagged) {
-        // TODO: fix this
-        this.raise(
-          this.state.invalidTemplateEscapePosition || 0,
-          "Invalid escape sequence in template",
-        );
-      } else {
-        this.state.invalidTemplateEscapePosition = null;
+        this.raise(this.state.start + 1, "Invalid escape sequence in template");
       }
     }
     elem.value = {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1122,7 +1122,7 @@ export default class Tokenizer extends LocationParser {
         throwOnInvalid,
       );
       ++this.state.pos;
-      if (code > 0x10ffff) {
+      if (code !== null && code > 0x10ffff) {
         if (throwOnInvalid) {
           this.raise(codePos, "Code point out of bounds");
         } else {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1122,14 +1122,10 @@ export default class Tokenizer extends LocationParser {
         throwOnInvalid,
       );
       ++this.state.pos;
-      if (code === null) {
-        // $FlowFixMe (is this always non-null?)
-        --this.state.invalidTemplateEscapePosition; // to point to the '\'' instead of the 'u'
-      } else if (code > 0x10ffff) {
+      if (code > 0x10ffff) {
         if (throwOnInvalid) {
           this.raise(codePos, "Code point out of bounds");
         } else {
-          this.state.invalidTemplateEscapePosition = codePos - 2;
           return null;
         }
       }
@@ -1274,9 +1270,6 @@ export default class Tokenizer extends LocationParser {
       case charCodes.digit8:
       case charCodes.digit9:
         if (inTemplate) {
-          const codePos = this.state.pos - 1;
-
-          this.state.invalidTemplateEscapePosition = codePos;
           return null;
         }
       default:
@@ -1299,7 +1292,6 @@ export default class Tokenizer extends LocationParser {
             next === charCodes.digit9
           ) {
             if (inTemplate) {
-              this.state.invalidTemplateEscapePosition = codePos;
               return null;
             } else if (this.state.strict) {
               this.raise(codePos, "Octal literal in strict mode");
@@ -1332,7 +1324,6 @@ export default class Tokenizer extends LocationParser {
         this.raise(codePos, "Bad character escape sequence");
       } else {
         this.state.pos = codePos - 1;
-        this.state.invalidTemplateEscapePosition = codePos - 1;
       }
     }
     return n;

--- a/packages/babel-parser/src/tokenizer/state.js
+++ b/packages/babel-parser/src/tokenizer/state.js
@@ -156,8 +156,6 @@ export default class State {
   // `export default foo;` and `export { foo as default };`.
   exportedIdentifiers: Array<string> = [];
 
-  invalidTemplateEscapePosition: ?number = null;
-
   curPosition(): Position {
     return new Position(this.curLine, this.pos - this.lineStart);
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is based on my observation that `this.state.invalidTemplateEscapePosition` always point to the start of `TemplateElement` offset by 1 -- because when `this.state.value` is `null`, it must be an escape sequence and `invalidTemplateEscapePosition` always points to the escape type character immediately following `\`.

By implementing this invariance we can get rid of the unnecessary `invalidTemplateEscapePosition` and fix two `todo` items via removing the code.