### PR TITLE
refactor: remove unecessary checkYieldAwaitInDefaultParams

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1839,7 +1839,6 @@ export default class ExpressionParser extends LValParser {
         (allowDirectSuper ? SCOPE_DIRECT_SUPER : 0),
     );
     this.parseFunctionParams((node: any), allowModifiers);
-    this.checkYieldAwaitInDefaultParams();
     this.parseFunctionBodyAndFinish(node, type, true);
     this.scope.exit();
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`this.checkYieldAwaitInDefaultParams()` is called inside `this.parseFunctionParams`,
https://github.com/babel/babel/blob/e9dc74e78768988c51e21741ba982c7240fd30b8/packages/babel-parser/src/parser/statement.js#L1108
therefore it is unnecessary to call it again here.