### PR TITLE
Remove unused parser methods

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -1892,20 +1892,6 @@ export default class ExpressionParser extends LValParser {
     );
   }
 
-  isStrictBody(node: { body: N.BlockStatement }): boolean {
-    const isBlockStatement = node.body.type === "BlockStatement";
-
-    if (isBlockStatement && node.body.directives.length) {
-      for (const directive of node.body.directives) {
-        if (directive.value.value === "use strict") {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-
   parseFunctionBodyAndFinish(
     node: N.BodilessFunctionOrMethodBase,
     type: string,

--- a/packages/babel-parser/src/parser/util.js
+++ b/packages/babel-parser/src/parser/util.js
@@ -58,16 +58,6 @@ export default class UtilParser extends Tokenizer {
     }
   }
 
-  // eat() for relational operators.
-
-  eatRelational(op: "<" | ">"): boolean {
-    if (this.isRelational(op)) {
-      this.next();
-      return true;
-    }
-    return false;
-  }
-
   // Tests whether parsed token is a contextual keyword.
 
   isContextual(name: string): boolean {

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -174,26 +174,6 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
     }
 
-    isStrictBody(node: { body: N.BlockStatement }): boolean {
-      const isBlockStatement = node.body.type === "BlockStatement";
-
-      if (isBlockStatement && node.body.body.length > 0) {
-        for (const directive of node.body.body) {
-          if (
-            directive.type === "ExpressionStatement" &&
-            directive.expression.type === "Literal"
-          ) {
-            if (directive.expression.value === "use strict") return true;
-          } else {
-            // Break for the first non literal expression
-            break;
-          }
-        }
-      }
-
-      return false;
-    }
-
     isValidDirective(stmt: N.Statement): boolean {
       return (
         stmt.type === "ExpressionStatement" &&


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Remove two unused methods.

I found these two from the coverage report: https://codecov.io/gh/babel/babel/src/b91720c1ccbfc066cbc6af7e3db6114acefac17a/packages/babel-parser/src/parser/util.js

And the GitHub Code search
`eatRelational`: https://github.com/babel/babel/search?q=eatRelational&unscoped_q=eatRelational
`isStrictBody`: https://github.com/babel/babel/search?q=isStrictBody&unscoped_q=isStrictBody