### PR TITLE
When reading a new string, U+2028/2029 should correctly set the new column

### DIFF
--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1159,6 +1159,7 @@ export default class Tokenizer extends LocationParser {
       ) {
         ++this.state.pos;
         ++this.state.curLine;
+        this.state.lineStart = this.state.pos;
       } else if (isNewLine(ch)) {
         throw this.raise(this.state.start, "Unterminated string constant");
       } else {

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/directive-line-separator/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/directive-line-separator/output.json
@@ -41,7 +41,7 @@
           },
           "end": {
             "line": 2,
-            "column": 15
+            "column": 7
           }
         },
         "value": {
@@ -55,7 +55,7 @@
             },
             "end": {
               "line": 2,
-              "column": 14
+              "column": 6
             }
           },
           "value": "before after",

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/directive-paragraph-separator/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/directive-paragraph-separator/output.json
@@ -41,7 +41,7 @@
           },
           "end": {
             "line": 2,
-            "column": 15
+            "column": 7
           }
         },
         "value": {
@@ -55,7 +55,7 @@
             },
             "end": {
               "line": 2,
-              "column": 14
+              "column": 6
             }
           },
           "value": "before after",

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/string-line-separator/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/string-line-separator/output.json
@@ -40,7 +40,7 @@
           },
           "end": {
             "line": 2,
-            "column": 17
+            "column": 8
           }
         },
         "expression": {
@@ -54,7 +54,7 @@
             },
             "end": {
               "line": 2,
-              "column": 15
+              "column": 6
             }
           },
           "extra": {

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/string-paragraph-separator/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/string-paragraph-separator/output.json
@@ -40,7 +40,7 @@
           },
           "end": {
             "line": 2,
-            "column": 17
+            "column": 8
           }
         },
         "expression": {
@@ -54,7 +54,7 @@
             },
             "end": {
               "line": 2,
-              "column": 15
+              "column": 6
             }
           },
           "extra": {

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/template-line-separator/input.js
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/template-line-separator/input.js
@@ -1,0 +1,2 @@
+(`before after`);
+//      ^ That's a U+2028 LINE SEPARATOR UTF-16 char (between 'before' and 'after')

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/template-line-separator/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/template-line-separator/output.json
@@ -1,0 +1,128 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 101,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 83
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 101,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 83
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 8
+          }
+        },
+        "expression": {
+          "type": "TemplateLiteral",
+          "start": 1,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            }
+          },
+          "expressions": [],
+          "quasis": [
+            {
+              "type": "TemplateElement",
+              "start": 2,
+              "end": 14,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 5
+                }
+              },
+              "value": {
+                "raw": "before after",
+                "cooked": "before after"
+              },
+              "tail": true
+            }
+          ],
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 0
+          }
+        },
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": "      ^ That's a U+2028 LINE SEPARATOR UTF-16 char (between 'before' and 'after')",
+            "start": 18,
+            "end": 101,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 0
+              },
+              "end": {
+                "line": 3,
+                "column": 83
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": "      ^ That's a U+2028 LINE SEPARATOR UTF-16 char (between 'before' and 'after')",
+      "start": 18,
+      "end": 101,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 83
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/template-paragraph-separator/input.js
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/template-paragraph-separator/input.js
@@ -1,0 +1,2 @@
+(`before after`);
+//      ^ That's a U+2029 PARAGRAPH SEPARATOR UTF-16 char (between 'before' and 'after')

--- a/packages/babel-parser/test/fixtures/es2019/json-strings/template-paragraph-separator/output.json
+++ b/packages/babel-parser/test/fixtures/es2019/json-strings/template-paragraph-separator/output.json
@@ -1,0 +1,128 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 106,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 88
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 106,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 88
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 8
+          }
+        },
+        "expression": {
+          "type": "TemplateLiteral",
+          "start": 1,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            }
+          },
+          "expressions": [],
+          "quasis": [
+            {
+              "type": "TemplateElement",
+              "start": 2,
+              "end": 14,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 5
+                }
+              },
+              "value": {
+                "raw": "before after",
+                "cooked": "before after"
+              },
+              "tail": true
+            }
+          ],
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 0
+          }
+        },
+        "trailingComments": [
+          {
+            "type": "CommentLine",
+            "value": "      ^ That's a U+2029 PARAGRAPH SEPARATOR UTF-16 char (between 'before' and 'after')",
+            "start": 18,
+            "end": 106,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 0
+              },
+              "end": {
+                "line": 3,
+                "column": 88
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": "      ^ That's a U+2029 PARAGRAPH SEPARATOR UTF-16 char (between 'before' and 'after')",
+      "start": 18,
+      "end": 106,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 88
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10435 
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to #8866, this PR fixes when the tokenizer reading a string, it does not update the `lineStart` after U+2028/2029 is read. Note that the `lineStart` is correctly updated when reading a template token
https://github.com/babel/babel/blob/b91720c1ccbfc066cbc6af7e3db6114acefac17a/packages/babel-parser/src/tokenizer/index.js#L1229

So I consider it as a bug fix to unify the different behaviour here.