### PR TITLE
fix: Class Field Initializer should not allow await expression as immediate child

### DIFF
--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -56,7 +56,18 @@ export default class ScopeHandler<IScope: Scope = Scope> {
     return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0;
   }
   get inAsync() {
-    return (this.currentVarScope().flags & SCOPE_ASYNC) > 0;
+    for (let i = this.scopeStack.length - 1; ; i--) {
+      const scope = this.scopeStack[i];
+      const isVarScope = scope.flags & SCOPE_VAR;
+      const isClassScope = scope.flags & SCOPE_CLASS;
+      if (isClassScope && !isVarScope) {
+        // If it meets a class scope before a var scope, it means it is a class property initializer
+        // which does not have an [Await] parameter in its grammar
+        return false;
+      } else if (isVarScope) {
+        return (scope.flags & SCOPE_ASYNC) > 0;
+      }
+    }
   }
   get allowSuper() {
     return (this.currentThisScope().flags & SCOPE_SUPER) > 0;

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -55,6 +55,8 @@ export default class ScopeHandler<IScope: Scope = Scope> {
   get inGenerator() {
     return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0;
   }
+  // the following loop always exit because SCOPE_PROGRAM is SCOPE_VAR
+  // $FlowIgnore
   get inAsync() {
     for (let i = this.scopeStack.length - 1; ; i--) {
       const scope = this.scopeStack[i];

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-class-methods/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-class-methods/input.js
@@ -1,0 +1,3 @@
+() => class {
+  async m() { await 42 }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-class-methods/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-class-methods/output.json
@@ -1,0 +1,210 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 40,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 40,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 40,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 40,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "ClassExpression",
+            "start": 6,
+            "end": 40,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            },
+            "id": null,
+            "superClass": null,
+            "body": {
+              "type": "ClassBody",
+              "start": 12,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 12
+                },
+                "end": {
+                  "line": 3,
+                  "column": 1
+                }
+              },
+              "body": [
+                {
+                  "type": "ClassMethod",
+                  "start": 16,
+                  "end": 38,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 24
+                    }
+                  },
+                  "static": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 22,
+                    "end": 23,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 9
+                      },
+                      "identifierName": "m"
+                    },
+                    "name": "m"
+                  },
+                  "computed": false,
+                  "kind": "method",
+                  "id": null,
+                  "generator": false,
+                  "async": true,
+                  "params": [],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 26,
+                    "end": 38,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 24
+                      }
+                    },
+                    "body": [
+                      {
+                        "type": "ExpressionStatement",
+                        "start": 28,
+                        "end": 36,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 22
+                          }
+                        },
+                        "expression": {
+                          "type": "AwaitExpression",
+                          "start": 28,
+                          "end": 36,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 14
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 22
+                            }
+                          },
+                          "argument": {
+                            "type": "NumericLiteral",
+                            "start": 34,
+                            "end": 36,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 20
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 22
+                              }
+                            },
+                            "extra": {
+                              "rawValue": 42,
+                              "raw": "42"
+                            },
+                            "value": 42
+                          }
+                        }
+                      }
+                    ],
+                    "directives": []
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-computed-class-property/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-computed-class-property/input.js
@@ -1,0 +1,3 @@
+async () => class {
+  [await 42]() { }
+}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-computed-class-property/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-inside-computed-class-property/output.json
@@ -1,0 +1,177 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 40,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 40,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 40,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 40,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "ClassExpression",
+            "start": 12,
+            "end": 40,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            },
+            "id": null,
+            "superClass": null,
+            "body": {
+              "type": "ClassBody",
+              "start": 18,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 18
+                },
+                "end": {
+                  "line": 3,
+                  "column": 1
+                }
+              },
+              "body": [
+                {
+                  "type": "ClassMethod",
+                  "start": 22,
+                  "end": 38,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 18
+                    }
+                  },
+                  "static": false,
+                  "computed": true,
+                  "key": {
+                    "type": "AwaitExpression",
+                    "start": 23,
+                    "end": 31,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 11
+                      }
+                    },
+                    "argument": {
+                      "type": "NumericLiteral",
+                      "start": 29,
+                      "end": 31,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 11
+                        }
+                      },
+                      "extra": {
+                        "rawValue": 42,
+                        "raw": "42"
+                      },
+                      "value": 42
+                    }
+                  },
+                  "kind": "method",
+                  "id": null,
+                  "generator": false,
+                  "async": false,
+                  "params": [],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 35,
+                    "end": 38,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 18
+                      }
+                    },
+                    "body": [],
+                    "directives": []
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-async-in-private-property/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-async-in-private-property/input.js
@@ -1,0 +1,3 @@
+class C {
+  #p = async () => await 42;
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-async-in-private-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-async-in-private-property/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classPrivateProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-async-in-private-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-async-in-private-property/output.json
@@ -1,0 +1,187 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 40,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 40,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 40,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "C"
+          },
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 40,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassPrivateProperty",
+              "start": 12,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 28
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start": 12,
+                "end": 14,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 4
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 13,
+                  "end": 14,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 4
+                    },
+                    "identifierName": "p"
+                  },
+                  "name": "p"
+                }
+              },
+              "value": {
+                "type": "ArrowFunctionExpression",
+                "start": 17,
+                "end": 37,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 27
+                  }
+                },
+                "id": null,
+                "generator": false,
+                "async": true,
+                "params": [],
+                "body": {
+                  "type": "AwaitExpression",
+                  "start": 29,
+                  "end": 37,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 27
+                    }
+                  },
+                  "argument": {
+                    "type": "NumericLiteral",
+                    "start": 35,
+                    "end": 37,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      }
+                    },
+                    "extra": {
+                      "rawValue": 42,
+                      "raw": "42"
+                    },
+                    "value": 42
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-private-property-in-async/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-private-property-in-async/input.js
@@ -1,0 +1,6 @@
+async () => {
+  class C {
+    // here await is an identifier reference
+    #p = await + 42;
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-private-property-in-async/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-private-property-in-async/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classPrivateProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-private-property-in-async/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-private-properties/await-in-private-property-in-async/output.json
@@ -1,0 +1,274 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 97,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 97,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 97,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 97,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 12,
+            "end": 97,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 6,
+                "column": 1
+              }
+            },
+            "body": [
+              {
+                "type": "ClassDeclaration",
+                "start": 16,
+                "end": 95,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 22,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "identifierName": "C"
+                  },
+                  "name": "C"
+                },
+                "superClass": null,
+                "body": {
+                  "type": "ClassBody",
+                  "start": 24,
+                  "end": 95,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 3
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ClassPrivateProperty",
+                      "start": 75,
+                      "end": 91,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 20
+                        }
+                      },
+                      "static": false,
+                      "key": {
+                        "type": "PrivateName",
+                        "start": 75,
+                        "end": 77,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 6
+                          }
+                        },
+                        "id": {
+                          "type": "Identifier",
+                          "start": 76,
+                          "end": 77,
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 5
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 6
+                            },
+                            "identifierName": "p"
+                          },
+                          "name": "p"
+                        }
+                      },
+                      "value": {
+                        "type": "BinaryExpression",
+                        "start": 80,
+                        "end": 90,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 19
+                          }
+                        },
+                        "left": {
+                          "type": "Identifier",
+                          "start": 80,
+                          "end": 85,
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 14
+                            },
+                            "identifierName": "await"
+                          },
+                          "name": "await"
+                        },
+                        "operator": "+",
+                        "right": {
+                          "type": "NumericLiteral",
+                          "start": 88,
+                          "end": 90,
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 17
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 19
+                            }
+                          },
+                          "extra": {
+                            "rawValue": 42,
+                            "raw": "42"
+                          },
+                          "value": 42
+                        }
+                      },
+                      "leadingComments": [
+                        {
+                          "type": "CommentLine",
+                          "value": " here await is an identifier reference",
+                          "start": 30,
+                          "end": 70,
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 44
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " here await is an identifier reference",
+      "start": 30,
+      "end": 70,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 44
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-async-in-class-property/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-async-in-class-property/input.js
@@ -1,0 +1,3 @@
+class C {
+  p = async () => await + 42;
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-async-in-class-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-async-in-class-property/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-async-in-class-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-async-in-class-property/output.json
@@ -1,0 +1,190 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "C"
+          },
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 41,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 29
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 12,
+                "end": 13,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "identifierName": "p"
+                },
+                "name": "p"
+              },
+              "computed": false,
+              "value": {
+                "type": "ArrowFunctionExpression",
+                "start": 16,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 28
+                  }
+                },
+                "id": null,
+                "generator": false,
+                "async": true,
+                "params": [],
+                "body": {
+                  "type": "AwaitExpression",
+                  "start": 28,
+                  "end": 38,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 28
+                    }
+                  },
+                  "argument": {
+                    "type": "UnaryExpression",
+                    "start": 34,
+                    "end": 38,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 24
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 28
+                      }
+                    },
+                    "operator": "+",
+                    "prefix": true,
+                    "argument": {
+                      "type": "NumericLiteral",
+                      "start": 36,
+                      "end": 38,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 26
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 28
+                        }
+                      },
+                      "extra": {
+                        "rawValue": 42,
+                        "raw": "42"
+                      },
+                      "value": 42
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-class-property-in-async/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-class-property-in-async/input.js
@@ -1,0 +1,6 @@
+async () => {
+  class C {
+    // here await is an identifier reference
+    p = await + 42;
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-class-property-in-async/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-class-property-in-async/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-class-property-in-async/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/await-in-class-property-in-async/output.json
@@ -1,0 +1,260 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 96,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 96,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 96,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 96,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 12,
+            "end": 96,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 6,
+                "column": 1
+              }
+            },
+            "body": [
+              {
+                "type": "ClassDeclaration",
+                "start": 16,
+                "end": 94,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 22,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 9
+                    },
+                    "identifierName": "C"
+                  },
+                  "name": "C"
+                },
+                "superClass": null,
+                "body": {
+                  "type": "ClassBody",
+                  "start": 24,
+                  "end": 94,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 3
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ClassProperty",
+                      "start": 75,
+                      "end": 90,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 19
+                        }
+                      },
+                      "static": false,
+                      "key": {
+                        "type": "Identifier",
+                        "start": 75,
+                        "end": 76,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 5
+                          },
+                          "identifierName": "p"
+                        },
+                        "name": "p"
+                      },
+                      "computed": false,
+                      "value": {
+                        "type": "BinaryExpression",
+                        "start": 79,
+                        "end": 89,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 18
+                          }
+                        },
+                        "left": {
+                          "type": "Identifier",
+                          "start": 79,
+                          "end": 84,
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 13
+                            },
+                            "identifierName": "await"
+                          },
+                          "name": "await"
+                        },
+                        "operator": "+",
+                        "right": {
+                          "type": "NumericLiteral",
+                          "start": 87,
+                          "end": 89,
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 16
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 18
+                            }
+                          },
+                          "extra": {
+                            "rawValue": 42,
+                            "raw": "42"
+                          },
+                          "value": 42
+                        }
+                      },
+                      "leadingComments": [
+                        {
+                          "type": "CommentLine",
+                          "value": " here await is an identifier reference",
+                          "start": 30,
+                          "end": 70,
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 44
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " here await is an identifier reference",
+      "start": 30,
+      "end": 70,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 44
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #6687
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

This PR fixes the `isAwaitAllowed` logic by excluding `await` identifier reference immediately nested in a class property initializer.

Per https://tc39.es/proposal-class-fields/#sec-new-syntax
```
FieldDefinition[Yield, Await]:
   ClassElementName[?Yield, ?Await] Initializer[In, ~Yield, ~Await]opt
```
the spec dictates that the `Initializer` can _not_ contain `IdentifierReference_Yield` or `IdentifierReference_Await`, which means `await` should be considered as identifier reference here, unless its `[Await]` parameter is enabled by other language structures.

The original snippet in #6687 
```js
async function a() {
  class Foo {
    bar = await baz();
  }
}
```
will still throw because `await` is an identifier instead of await expression, but not because the constructor is _not_ an async function. Think of the following example, which should still throw even the static property does not need a constructor to initialize.
```js
async function a() {
  class Foo {
    static bar = await baz();
  }
}
```

Note that we have a similar issue regarding to the generators:
Parsing the following code should throw because `yield` is an identifier, which turns out to be a reserved word since it resides in a class declaration where all parts are in strict code mode.
```js
function* f() {
  return class { p = yield + 42 }
}
```
I will address this in a separate PR.