### PR TITLE
Fix: TopLevelAwait should respect await identifiers defined in sub scope.

### DIFF
--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -5,7 +5,7 @@ import type { File, JSXOpeningElement } from "../types";
 import type { PluginList } from "../plugin-utils";
 import { getOptions } from "../options";
 import StatementParser from "./statement";
-import { SCOPE_PROGRAM } from "../util/scopeflags";
+import { SCOPE_ASYNC, SCOPE_PROGRAM } from "../util/scopeflags";
 import ScopeHandler from "../util/scope";
 
 export type PluginsMap = Map<string, { [string]: any }>;
@@ -35,7 +35,11 @@ export default class Parser extends StatementParser {
   }
 
   parse(): File {
-    this.scope.enter(SCOPE_PROGRAM);
+    let scopeFlags = SCOPE_PROGRAM;
+    if (this.hasPlugin("topLevelAwait") && this.inModule) {
+      scopeFlags |= SCOPE_ASYNC;
+    }
+    this.scope.enter(scopeFlags);
     const file = this.startNode();
     const program = this.startNode();
     this.nextToken();

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/input.js
@@ -1,0 +1,3 @@
+export class C {
+  p = await 0;
+}

--- a/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/top-level-await/inside-class-property/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "topLevelAwait",
+    "classProperties"
+  ],
+  "sourceType": "module",
+  "throws": "Unexpected token, expected \";\" (2:12)"
+}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/input.ts
@@ -1,0 +1,3 @@
+namespace N {
+    const x = await 42;
+}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/top-level-await/options.json
@@ -1,0 +1,8 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "typescript",
+    "topLevelAwait"
+  ],
+  "throws": "Unexpected token, expected \";\" (2:20)"
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel incorrectly parse AwaitExpression when `topLevelAwait` is enabled
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR includes commits in #10946 because one of the test case relies on that PR. Only commits descending from b60de33 should be reviewed.

This PR assigns `SCOPE_ASYNC` to the program scope if topLevelAwait is enabled and sourceType is module. By doing so we can reused the `inAsync` check in `isAwaitAllowed`, this can avoid parsing await expression when await is an identifier which is not defined in the top level.

The added test cases are parsed successfully before this PR, which should throw. 