### PR TITLE
Override toString in case this function is printed

### DIFF
--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -218,15 +218,18 @@ function wrapWithStateOrWrapper(oldVisitor, state, wrapper: ?Function) {
       let newFn = fn;
 
       if (state) {
-        newFn = function(path) {
+        newFn = function (path) {
           return fn.call(state, path, state);
         };
-        // Override toString in case this function is printed, we want to print the wrapped function, same as we do in `wrapCheck`
-        newFn.toString = () => fn.toString();
       }
 
       if (wrapper) {
         newFn = wrapper(state.key, key, newFn);
+      }
+
+      // Override toString in case this function is printed, we want to print the wrapped function, same as we do in `wrapCheck` 
+      if (newFn !== fn) {
+        newFn.toString = () => fn.toString();
       }
 
       return newFn;

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -221,6 +221,8 @@ function wrapWithStateOrWrapper(oldVisitor, state, wrapper: ?Function) {
         newFn = function(path) {
           return fn.call(state, path, state);
         };
+        // Override toString in case this function is printed, we want to print the wrapped function, same as we do in `wrapCheck`
+        newFn.toString = () => fn.toString();
       }
 
       if (wrapper) {

--- a/packages/babel-traverse/src/visitors.js
+++ b/packages/babel-traverse/src/visitors.js
@@ -218,7 +218,7 @@ function wrapWithStateOrWrapper(oldVisitor, state, wrapper: ?Function) {
       let newFn = fn;
 
       if (state) {
-        newFn = function (path) {
+        newFn = function(path) {
           return fn.call(state, path, state);
         };
       }
@@ -227,7 +227,7 @@ function wrapWithStateOrWrapper(oldVisitor, state, wrapper: ?Function) {
         newFn = wrapper(state.key, key, newFn);
       }
 
-      // Override toString in case this function is printed, we want to print the wrapped function, same as we do in `wrapCheck` 
+      // Override toString in case this function is printed, we want to print the wrapped function, same as we do in `wrapCheck`
       if (newFn !== fn) {
         newFn.toString = () => fn.toString();
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I hit an error, but the error message pointed me to this code instead of my code.  This change will put my function in the error message instead of this function.  The same is done in `wrapCheck()` in the same file.  Related to https://stackoverflow.com/questions/59543968/unexpected-return-value-from-visitor-method