### PR TITLE
fix: check await when parsing AsyncArrowBindingIdentifier

### DIFF
--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -955,8 +955,18 @@ export default class ExpressionParser extends LValParser {
           this.match(tt.name) &&
           !this.canInsertSemicolon()
         ) {
+          const oldMaybeInArrowParameters = this.state.maybeInArrowParameters;
+          const oldYieldPos = this.state.yieldPos;
+          const oldAwaitPos = this.state.awaitPos;
+          this.state.maybeInArrowParameters = true;
+          this.state.yieldPos = -1;
+          this.state.awaitPos = -1;
           const params = [this.parseIdentifier()];
           this.expect(tt.arrow);
+          this.checkYieldAwaitInDefaultParams();
+          this.state.maybeInArrowParameters = oldMaybeInArrowParameters;
+          this.state.yieldPos = oldYieldPos;
+          this.state.awaitPos = oldAwaitPos;
           // let foo = async bar => {};
           this.parseArrowExpression(node, params, true);
           return node;

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/input.js
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/input.js
@@ -1,0 +1,1 @@
+async await => {}

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/output.json
@@ -1,0 +1,107 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 17,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 17
+    }
+  },
+  "errors": [
+    "SyntaxError: Await cannot be used as name inside an async function (1:6)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 17,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 17
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 17,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        "expression": {
+          "type": "ArrowFunctionExpression",
+          "start": 0,
+          "end": 17,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 17
+            }
+          },
+          "id": null,
+          "generator": false,
+          "async": true,
+          "params": [
+            {
+              "type": "Identifier",
+              "start": 6,
+              "end": 11,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11
+                },
+                "identifierName": "await"
+              },
+              "name": "await"
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 15,
+            "end": 17,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When parsing AsyncArrowBindingIdentifier, we should check if it is `await`.
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When parsing
```
async [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] =>
  AsyncConciseBody[?In],
```
the `await` check is missing so babel does not throw on `async await => {}`, this PR adds the context manipulation step also used in `parseParenAndDistinguishExpression`.