### PR TITLE
Refactor await/yield production parameter tracking

### DIFF
--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -5,6 +5,7 @@ import type State from "../tokenizer/state";
 import type { PluginsMap } from "./index";
 import type ScopeHandler from "../util/scope";
 import type ClassScopeHandler from "../util/class-scope";
+import type ProductionParameterHandler from "../util/production-parameter";
 
 export default class BaseParser {
   // Properties set by constructor in index.js
@@ -12,6 +13,7 @@ export default class BaseParser {
   inModule: boolean;
   scope: ScopeHandler<*>;
   classScope: ClassScopeHandler;
+  param: ProductionParameterHandler;
   plugins: PluginsMap;
   filename: ?string;
   sawUnambiguousESM: boolean = false;

--- a/packages/babel-parser/src/parser/base.js
+++ b/packages/babel-parser/src/parser/base.js
@@ -13,7 +13,7 @@ export default class BaseParser {
   inModule: boolean;
   scope: ScopeHandler<*>;
   classScope: ClassScopeHandler;
-  param: ProductionParameterHandler;
+  prodParam: ProductionParameterHandler;
   plugins: PluginsMap;
   filename: ?string;
   sawUnambiguousESM: boolean = false;

--- a/packages/babel-parser/src/parser/expression.js
+++ b/packages/babel-parser/src/parser/expression.js
@@ -43,6 +43,7 @@ import {
 import { ExpressionErrors } from "./util";
 import {
   PARAM_AWAIT,
+  PARAM_RETURN,
   PARAM,
   functionFlags,
 } from "../util/production-parameter";
@@ -1986,7 +1987,11 @@ export default class ExpressionParser extends LValParser {
         allowExpression,
         !oldStrict && useStrict,
       );
+      // FunctionBody[Yield, Await]:
+      //   StatementList[?Yield, ?Await, +Return] opt
+      this.prodParam.enter(this.prodParam.currentFlags() | PARAM_RETURN);
       node.body = this.parseBlock(true, false);
+      this.prodParam.exit();
       this.state.labels = oldLabels;
     }
 

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -5,9 +5,13 @@ import type { File, JSXOpeningElement } from "../types";
 import type { PluginList } from "../plugin-utils";
 import { getOptions } from "../options";
 import StatementParser from "./statement";
-import { SCOPE_ASYNC, SCOPE_PROGRAM } from "../util/scopeflags";
+import { SCOPE_PROGRAM } from "../util/scopeflags";
 import ScopeHandler from "../util/scope";
 import ClassScopeHandler from "../util/class-scope";
+import ProductionParameterHandler, {
+  PARAM_AWAIT,
+  PARAM_,
+} from "../util/production-parameter";
 
 export type PluginsMap = Map<string, { [string]: any }>;
 
@@ -26,6 +30,7 @@ export default class Parser extends StatementParser {
     this.options = options;
     this.inModule = this.options.sourceType === "module";
     this.scope = new ScopeHandler(this.raise.bind(this), this.inModule);
+    this.param = new ProductionParameterHandler();
     this.classScope = new ClassScopeHandler(this.raise.bind(this));
     this.plugins = pluginsMap(this.options.plugins);
     this.filename = options.sourceFilename;
@@ -37,11 +42,12 @@ export default class Parser extends StatementParser {
   }
 
   parse(): File {
-    let scopeFlags = SCOPE_PROGRAM;
+    let paramFlags = PARAM_;
     if (this.hasPlugin("topLevelAwait") && this.inModule) {
-      scopeFlags |= SCOPE_ASYNC;
+      paramFlags |= PARAM_AWAIT;
     }
-    this.scope.enter(scopeFlags);
+    this.scope.enter(SCOPE_PROGRAM);
+    this.param.enter(paramFlags);
     const file = this.startNode();
     const program = this.startNode();
     this.nextToken();

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -10,7 +10,7 @@ import ScopeHandler from "../util/scope";
 import ClassScopeHandler from "../util/class-scope";
 import ProductionParameterHandler, {
   PARAM_AWAIT,
-  PARAM_,
+  PARAM,
 } from "../util/production-parameter";
 
 export type PluginsMap = Map<string, { [string]: any }>;
@@ -30,7 +30,7 @@ export default class Parser extends StatementParser {
     this.options = options;
     this.inModule = this.options.sourceType === "module";
     this.scope = new ScopeHandler(this.raise.bind(this), this.inModule);
-    this.param = new ProductionParameterHandler();
+    this.prodParam = new ProductionParameterHandler();
     this.classScope = new ClassScopeHandler(this.raise.bind(this));
     this.plugins = pluginsMap(this.options.plugins);
     this.filename = options.sourceFilename;
@@ -42,12 +42,12 @@ export default class Parser extends StatementParser {
   }
 
   parse(): File {
-    let paramFlags = PARAM_;
+    let paramFlags = PARAM;
     if (this.hasPlugin("topLevelAwait") && this.inModule) {
       paramFlags |= PARAM_AWAIT;
     }
     this.scope.enter(SCOPE_PROGRAM);
-    this.param.enter(paramFlags);
+    this.prodParam.enter(paramFlags);
     const file = this.startNode();
     const program = this.startNode();
     this.nextToken();

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -15,8 +15,8 @@ import {
   BIND_LEXICAL,
   BIND_VAR,
   BIND_FUNCTION,
-  functionFlags,
   SCOPE_CLASS,
+  SCOPE_FUNCTION,
   SCOPE_OTHER,
   SCOPE_SIMPLE_CATCH,
   SCOPE_SUPER,
@@ -28,6 +28,7 @@ import {
   type BindingTypes,
 } from "../util/scopeflags";
 import { ExpressionErrors } from "./util";
+import { PARAM_, functionFlags } from "../util/production-parameter";
 
 const loopLabel = { kind: "loop" },
   switchLabel = { kind: "switch" };
@@ -1059,7 +1060,8 @@ export default class StatementParser extends ExpressionParser {
     this.state.maybeInArrowParameters = false;
     this.state.yieldPos = -1;
     this.state.awaitPos = -1;
-    this.scope.enter(functionFlags(node.async, node.generator));
+    this.scope.enter(SCOPE_FUNCTION);
+    this.param.enter(functionFlags(isAsync, node.generator));
 
     if (!isStatement) {
       node.id = this.parseFunctionId();
@@ -1078,6 +1080,7 @@ export default class StatementParser extends ExpressionParser {
       );
     });
 
+    this.param.exit();
     this.scope.exit();
 
     if (isStatement && !isHangingStatement) {
@@ -1599,9 +1602,12 @@ export default class StatementParser extends ExpressionParser {
     node: N.ClassPrivateProperty,
   ): N.ClassPrivateProperty {
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
+    // [In] production parameter is tracked in parseMaybeAssign
+    this.param.enter(PARAM_);
 
     node.value = this.eat(tt.eq) ? this.parseMaybeAssign() : null;
     this.semicolon();
+    this.param.exit();
 
     this.scope.exit();
 
@@ -1614,6 +1620,8 @@ export default class StatementParser extends ExpressionParser {
     }
 
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
+    // [In] production parameter is tracked in parseMaybeAssign
+    this.param.enter(PARAM_);
 
     if (this.match(tt.eq)) {
       this.expectPlugin("classProperties");
@@ -1624,6 +1632,7 @@ export default class StatementParser extends ExpressionParser {
     }
     this.semicolon();
 
+    this.param.exit();
     this.scope.exit();
 
     return this.finishNode(node, "ClassProperty");

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -28,7 +28,7 @@ import {
   type BindingTypes,
 } from "../util/scopeflags";
 import { ExpressionErrors } from "./util";
-import { PARAM_, functionFlags } from "../util/production-parameter";
+import { PARAM, functionFlags } from "../util/production-parameter";
 
 const loopLabel = { kind: "loop" },
   switchLabel = { kind: "switch" };
@@ -1061,7 +1061,7 @@ export default class StatementParser extends ExpressionParser {
     this.state.yieldPos = -1;
     this.state.awaitPos = -1;
     this.scope.enter(SCOPE_FUNCTION);
-    this.param.enter(functionFlags(isAsync, node.generator));
+    this.prodParam.enter(functionFlags(isAsync, node.generator));
 
     if (!isStatement) {
       node.id = this.parseFunctionId();
@@ -1080,7 +1080,7 @@ export default class StatementParser extends ExpressionParser {
       );
     });
 
-    this.param.exit();
+    this.prodParam.exit();
     this.scope.exit();
 
     if (isStatement && !isHangingStatement) {
@@ -1603,11 +1603,11 @@ export default class StatementParser extends ExpressionParser {
   ): N.ClassPrivateProperty {
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
     // [In] production parameter is tracked in parseMaybeAssign
-    this.param.enter(PARAM_);
+    this.prodParam.enter(PARAM);
 
     node.value = this.eat(tt.eq) ? this.parseMaybeAssign() : null;
     this.semicolon();
-    this.param.exit();
+    this.prodParam.exit();
 
     this.scope.exit();
 
@@ -1621,7 +1621,7 @@ export default class StatementParser extends ExpressionParser {
 
     this.scope.enter(SCOPE_CLASS | SCOPE_SUPER);
     // [In] production parameter is tracked in parseMaybeAssign
-    this.param.enter(PARAM_);
+    this.prodParam.enter(PARAM);
 
     if (this.match(tt.eq)) {
       this.expectPlugin("classProperties");
@@ -1632,7 +1632,7 @@ export default class StatementParser extends ExpressionParser {
     }
     this.semicolon();
 
-    this.param.exit();
+    this.prodParam.exit();
     this.scope.exit();
 
     return this.finishNode(node, "ClassProperty");

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -575,7 +575,7 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseReturnStatement(node: N.ReturnStatement): N.ReturnStatement {
-    if (!this.scope.inFunction && !this.options.allowReturnOutsideFunction) {
+    if (!this.prodParam.hasReturn && !this.options.allowReturnOutsideFunction) {
       this.raise(this.state.start, "'return' outside of function");
     }
 

--- a/packages/babel-parser/src/plugins/flow.js
+++ b/packages/babel-parser/src/plugins/flow.js
@@ -12,13 +12,13 @@ import { types as tc } from "../tokenizer/context";
 import * as charCodes from "charcodes";
 import { isIteratorStart } from "../util/identifier";
 import {
-  functionFlags,
   type BindingTypes,
   BIND_NONE,
   BIND_LEXICAL,
   BIND_VAR,
   BIND_FUNCTION,
   SCOPE_ARROW,
+  SCOPE_FUNCTION,
   SCOPE_OTHER,
 } from "../util/scopeflags";
 import type { ExpressionErrors } from "../parser/util";
@@ -1891,7 +1891,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         node.extra?.trailingComma,
       );
       // Enter scope, as checkParams defines bindings
-      this.scope.enter(functionFlags(false, false) | SCOPE_ARROW);
+      this.scope.enter(SCOPE_FUNCTION | SCOPE_ARROW);
       // Use super's method to force the parameters to be checked
       super.checkParams(node, false, true);
       this.scope.exit();

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -26,6 +26,7 @@ import {
 import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";
 import type { ExpressionErrors } from "../../parser/util";
+import { PARAM_ } from "../../util/production-parameter";
 
 type TsModifier =
   | "readonly"
@@ -1265,7 +1266,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         node.body = inner;
       } else {
         this.scope.enter(SCOPE_TS_MODULE);
+        this.param.enter(PARAM_);
         node.body = this.tsParseModuleBlock();
+        this.param.exit();
         this.scope.exit();
       }
       return this.finishNode(node, "TSModuleDeclaration");
@@ -1284,7 +1287,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
       if (this.match(tt.braceL)) {
         this.scope.enter(SCOPE_TS_MODULE);
+        this.param.enter(PARAM_);
         node.body = this.tsParseModuleBlock();
+        this.param.exit();
         this.scope.exit();
       } else {
         this.semicolon();
@@ -1439,11 +1444,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // Would like to use tsParseAmbientExternalModuleDeclaration here, but already ran past "global".
           if (this.match(tt.braceL)) {
             this.scope.enter(SCOPE_TS_MODULE);
+            this.param.enter(PARAM_);
             const mod: N.TsModuleDeclaration = node;
             mod.global = true;
             mod.id = expr;
             mod.body = this.tsParseModuleBlock();
             this.scope.exit();
+            this.param.exit();
             return this.finishNode(mod, "TSModuleDeclaration");
           }
           break;

--- a/packages/babel-parser/src/plugins/typescript/index.js
+++ b/packages/babel-parser/src/plugins/typescript/index.js
@@ -26,7 +26,7 @@ import {
 import TypeScriptScopeHandler from "./scope";
 import * as charCodes from "charcodes";
 import type { ExpressionErrors } from "../../parser/util";
-import { PARAM_ } from "../../util/production-parameter";
+import { PARAM } from "../../util/production-parameter";
 
 type TsModifier =
   | "readonly"
@@ -1266,9 +1266,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         node.body = inner;
       } else {
         this.scope.enter(SCOPE_TS_MODULE);
-        this.param.enter(PARAM_);
+        this.prodParam.enter(PARAM);
         node.body = this.tsParseModuleBlock();
-        this.param.exit();
+        this.prodParam.exit();
         this.scope.exit();
       }
       return this.finishNode(node, "TSModuleDeclaration");
@@ -1287,9 +1287,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
       if (this.match(tt.braceL)) {
         this.scope.enter(SCOPE_TS_MODULE);
-        this.param.enter(PARAM_);
+        this.prodParam.enter(PARAM);
         node.body = this.tsParseModuleBlock();
-        this.param.exit();
+        this.prodParam.exit();
         this.scope.exit();
       } else {
         this.semicolon();
@@ -1444,13 +1444,13 @@ export default (superClass: Class<Parser>): Class<Parser> =>
           // Would like to use tsParseAmbientExternalModuleDeclaration here, but already ran past "global".
           if (this.match(tt.braceL)) {
             this.scope.enter(SCOPE_TS_MODULE);
-            this.param.enter(PARAM_);
+            this.prodParam.enter(PARAM);
             const mod: N.TsModuleDeclaration = node;
             mod.global = true;
             mod.id = expr;
             mod.body = this.tsParseModuleBlock();
             this.scope.exit();
-            this.param.exit();
+            this.prodParam.exit();
             return this.finishNode(mod, "TSModuleDeclaration");
           }
           break;

--- a/packages/babel-parser/src/tokenizer/context.js
+++ b/packages/babel-parser/src/tokenizer/context.js
@@ -60,7 +60,7 @@ tt.name.updateContext = function(prevType) {
   if (prevType !== tt.dot) {
     if (
       (this.state.value === "of" && !this.state.exprAllowed) ||
-      (this.state.value === "yield" && this.param.hasYield)
+      (this.state.value === "yield" && this.prodParam.hasYield)
     ) {
       allowed = true;
     }

--- a/packages/babel-parser/src/tokenizer/context.js
+++ b/packages/babel-parser/src/tokenizer/context.js
@@ -60,7 +60,7 @@ tt.name.updateContext = function(prevType) {
   if (prevType !== tt.dot) {
     if (
       (this.state.value === "of" && !this.state.exprAllowed) ||
-      (this.state.value === "yield" && this.scope.inGenerator)
+      (this.state.value === "yield" && this.param.hasYield)
     ) {
       allowed = true;
     }

--- a/packages/babel-parser/src/util/production-parameter.js
+++ b/packages/babel-parser/src/util/production-parameter.js
@@ -1,3 +1,4 @@
+// @flow
 export const PARAM_ = 0b000, // Initial Parameter flags
   PARAM_YIELD = 0b001, // track [Await] production parameter
   PARAM_AWAIT = 0b010; // track [Yield] production parameter
@@ -24,9 +25,11 @@ export const PARAM_ = 0b000, // Initial Parameter flags
 // 6. parse function body
 // 7. exit current stack
 
+export type ParamKind = typeof PARAM_ | typeof PARAM_AWAIT | typeof PARAM_YIELD;
+
 export default class ProductionParameterHandler {
-  stacks: Array = [];
-  enter(flags) {
+  stacks: Array<ParamKind> = [];
+  enter(flags: ParamKind) {
     this.stacks.push(flags);
   }
 
@@ -34,19 +37,22 @@ export default class ProductionParameterHandler {
     this.stacks.pop();
   }
 
-  currentFlags() {
+  currentFlags(): ParamKind {
     return this.stacks[this.stacks.length - 1];
   }
 
-  get hasAwait() {
+  get hasAwait(): boolean {
     return (this.currentFlags() & PARAM_AWAIT) > 0;
   }
 
-  get hasYield() {
+  get hasYield(): boolean {
     return (this.currentFlags() & PARAM_YIELD) > 0;
   }
 }
 
-export function functionFlags(isAsync: boolean, isGenerator: boolean) {
+export function functionFlags(
+  isAsync: boolean,
+  isGenerator: boolean,
+): ParamKind {
   return (isAsync ? PARAM_AWAIT : 0) | (isGenerator ? PARAM_YIELD : 0);
 }

--- a/packages/babel-parser/src/util/production-parameter.js
+++ b/packages/babel-parser/src/util/production-parameter.js
@@ -1,12 +1,13 @@
 // @flow
-export const PARAM = 0b00, // Initial Parameter flags
-  PARAM_YIELD = 0b01, // track [Await] production parameter
-  PARAM_AWAIT = 0b10; // track [Yield] production parameter
+export const PARAM = 0b000, // Initial Parameter flags
+  PARAM_YIELD = 0b001, // track [Yield] production parameter
+  PARAM_AWAIT = 0b010, // track [Await] production parameter
+  PARAM_RETURN = 0b100; // track [Return] production parameter
 
 // ProductionParameterHandler is a stack fashioned production parameter tracker
 // https://tc39.es/ecma262/#sec-grammar-notation
-// It only tracks [Await] and [Yield] parameter. The [In] parameter is tracked
-// in `noIn` argument of `parseExpression`.
+// The tracked parameters are defined above. Note that the [In] parameter is
+// tracked in `noIn` argument of `parseExpression`.
 //
 // Whenever [+Await]/[+Yield] appears in the right-hand sides of a production,
 // we must enter a new tracking stack. For example when parsing
@@ -47,6 +48,10 @@ export default class ProductionParameterHandler {
 
   get hasYield(): boolean {
     return (this.currentFlags() & PARAM_YIELD) > 0;
+  }
+
+  get hasReturn(): boolean {
+    return (this.currentFlags() & PARAM_RETURN) > 0;
   }
 }
 

--- a/packages/babel-parser/src/util/production-parameter.js
+++ b/packages/babel-parser/src/util/production-parameter.js
@@ -1,7 +1,7 @@
 // @flow
-export const PARAM_ = 0b000, // Initial Parameter flags
-  PARAM_YIELD = 0b001, // track [Await] production parameter
-  PARAM_AWAIT = 0b010; // track [Yield] production parameter
+export const PARAM = 0b00, // Initial Parameter flags
+  PARAM_YIELD = 0b01, // track [Await] production parameter
+  PARAM_AWAIT = 0b10; // track [Yield] production parameter
 
 // ProductionParameterHandler is a stack fashioned production parameter tracker
 // https://tc39.es/ecma262/#sec-grammar-notation
@@ -25,7 +25,7 @@ export const PARAM_ = 0b000, // Initial Parameter flags
 // 6. parse function body
 // 7. exit current stack
 
-export type ParamKind = typeof PARAM_ | typeof PARAM_AWAIT | typeof PARAM_YIELD;
+export type ParamKind = typeof PARAM | typeof PARAM_AWAIT | typeof PARAM_YIELD;
 
 export default class ProductionParameterHandler {
   stacks: Array<ParamKind> = [];

--- a/packages/babel-parser/src/util/production-parameter.js
+++ b/packages/babel-parser/src/util/production-parameter.js
@@ -1,0 +1,52 @@
+export const PARAM_ = 0b000, // Initial Parameter flags
+  PARAM_YIELD = 0b001, // track [Await] production parameter
+  PARAM_AWAIT = 0b010; // track [Yield] production parameter
+
+// ProductionParameterHandler is a stack fashioned production parameter tracker
+// https://tc39.es/ecma262/#sec-grammar-notation
+// It only tracks [Await] and [Yield] parameter. The [In] parameter is tracked
+// in `noIn` argument of `parseExpression`.
+//
+// Whenever [+Await]/[+Yield] appears in the right-hand sides of a production,
+// we must enter a new tracking stack. For example when parsing
+//
+// AsyncFunctionDeclaration [Yield, Await]:
+//   async [no LineTerminator here] function BindingIdentifier[?Yield, ?Await]
+//     ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+//
+// we must follow such process:
+//
+// 1. parse async keyword
+// 2. parse function keyword
+// 3. parse bindingIdentifier <= inherit current parameters: [?Await]
+// 4. enter new stack with (PARAM_AWAIT)
+// 5. parse formal parameters <= must have [Await] parameter [+Await]
+// 6. parse function body
+// 7. exit current stack
+
+export default class ProductionParameterHandler {
+  stacks: Array = [];
+  enter(flags) {
+    this.stacks.push(flags);
+  }
+
+  exit() {
+    this.stacks.pop();
+  }
+
+  currentFlags() {
+    return this.stacks[this.stacks.length - 1];
+  }
+
+  get hasAwait() {
+    return (this.currentFlags() & PARAM_AWAIT) > 0;
+  }
+
+  get hasYield() {
+    return (this.currentFlags() & PARAM_YIELD) > 0;
+  }
+}
+
+export function functionFlags(isAsync: boolean, isGenerator: boolean) {
+  return (isAsync ? PARAM_AWAIT : 0) | (isGenerator ? PARAM_YIELD : 0);
+}

--- a/packages/babel-parser/src/util/scope.js
+++ b/packages/babel-parser/src/util/scope.js
@@ -1,10 +1,8 @@
 // @flow
 import {
   SCOPE_ARROW,
-  SCOPE_ASYNC,
   SCOPE_DIRECT_SUPER,
   SCOPE_FUNCTION,
-  SCOPE_GENERATOR,
   SCOPE_SIMPLE_CATCH,
   SCOPE_SUPER,
   SCOPE_PROGRAM,
@@ -52,25 +50,6 @@ export default class ScopeHandler<IScope: Scope = Scope> {
 
   get inFunction() {
     return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
-  }
-  get inGenerator() {
-    return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0;
-  }
-  // the following loop always exit because SCOPE_PROGRAM is SCOPE_VAR
-  // $FlowIgnore
-  get inAsync() {
-    for (let i = this.scopeStack.length - 1; ; i--) {
-      const scope = this.scopeStack[i];
-      const isVarScope = scope.flags & SCOPE_VAR;
-      const isClassScope = scope.flags & SCOPE_CLASS;
-      if (isClassScope && !isVarScope) {
-        // If it meets a class scope before a var scope, it means it is a class property initializer
-        // which does not have an [Await] parameter in its grammar
-        return false;
-      } else if (isVarScope) {
-        return (scope.flags & SCOPE_ASYNC) > 0;
-      }
-    }
   }
   get allowSuper() {
     return (this.currentThisScope().flags & SCOPE_SUPER) > 0;

--- a/packages/babel-parser/src/util/scopeflags.js
+++ b/packages/babel-parser/src/util/scopeflags.js
@@ -5,8 +5,6 @@
 export const SCOPE_OTHER        = 0b0000000000,
              SCOPE_PROGRAM      = 0b0000000001,
              SCOPE_FUNCTION     = 0b0000000010,
-             SCOPE_ASYNC        = 0b0000000100,
-             SCOPE_GENERATOR    = 0b0000001000,
              SCOPE_ARROW        = 0b0000010000,
              SCOPE_SIMPLE_CATCH = 0b0000100000,
              SCOPE_SUPER        = 0b0001000000,
@@ -20,21 +18,11 @@ export type ScopeFlags =
   | typeof SCOPE_PROGRAM
   | typeof SCOPE_FUNCTION
   | typeof SCOPE_VAR
-  | typeof SCOPE_ASYNC
-  | typeof SCOPE_GENERATOR
   | typeof SCOPE_ARROW
   | typeof SCOPE_SIMPLE_CATCH
   | typeof SCOPE_SUPER
   | typeof SCOPE_DIRECT_SUPER
   | typeof SCOPE_CLASS;
-
-export function functionFlags(isAsync: boolean, isGenerator: boolean) {
-  return (
-    SCOPE_FUNCTION |
-    (isAsync ? SCOPE_ASYNC : 0) |
-    (isGenerator ? SCOPE_GENERATOR : 0)
-  );
-}
 
 // These flags are meant to be _only_ used inside the Scope class (or subclasses).
 // prettier-ignore

--- a/packages/babel-parser/src/util/scopeflags.js
+++ b/packages/babel-parser/src/util/scopeflags.js
@@ -2,15 +2,15 @@
 
 // Each scope gets a bitset that may contain these flags
 // prettier-ignore
-export const SCOPE_OTHER        = 0b0000000000,
-             SCOPE_PROGRAM      = 0b0000000001,
-             SCOPE_FUNCTION     = 0b0000000010,
-             SCOPE_ARROW        = 0b0000010000,
-             SCOPE_SIMPLE_CATCH = 0b0000100000,
-             SCOPE_SUPER        = 0b0001000000,
-             SCOPE_DIRECT_SUPER = 0b0010000000,
-             SCOPE_CLASS        = 0b0100000000,
-             SCOPE_TS_MODULE    = 0b1000000000,
+export const SCOPE_OTHER        = 0b00000000,
+             SCOPE_PROGRAM      = 0b00000001,
+             SCOPE_FUNCTION     = 0b00000010,
+             SCOPE_ARROW        = 0b00000100,
+             SCOPE_SIMPLE_CATCH = 0b00001000,
+             SCOPE_SUPER        = 0b00010000,
+             SCOPE_DIRECT_SUPER = 0b00100000,
+             SCOPE_CLASS        = 0b01000000,
+             SCOPE_TS_MODULE    = 0b10000000,
              SCOPE_VAR = SCOPE_PROGRAM | SCOPE_FUNCTION | SCOPE_TS_MODULE;
 
 export type ScopeFlags =

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-class-property-in-generator/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-class-property-in-generator/input.js
@@ -1,0 +1,6 @@
+function* foo() {
+  class C {
+    // here yield is an identifier reference
+    p = yield + 42;
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-class-property-in-generator/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-class-property-in-generator/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-class-property-in-generator/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-class-property-in-generator/output.json
@@ -1,0 +1,264 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 100,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 1
+    }
+  },
+  "errors": [
+    "SyntaxError: Unexpected reserved word 'yield' (4:8)"
+  ],
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 100,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 100,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 10,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            },
+            "identifierName": "foo"
+          },
+          "name": "foo"
+        },
+        "generator": true,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 16,
+          "end": 100,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassDeclaration",
+              "start": 20,
+              "end": 98,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 3
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 26,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "identifierName": "C"
+                },
+                "name": "C"
+              },
+              "superClass": null,
+              "body": {
+                "type": "ClassBody",
+                "start": 28,
+                "end": 98,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ClassProperty",
+                    "start": 79,
+                    "end": 94,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 19
+                      }
+                    },
+                    "static": false,
+                    "key": {
+                      "type": "Identifier",
+                      "start": 79,
+                      "end": 80,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 5
+                        },
+                        "identifierName": "p"
+                      },
+                      "name": "p"
+                    },
+                    "computed": false,
+                    "value": {
+                      "type": "BinaryExpression",
+                      "start": 83,
+                      "end": 93,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 18
+                        }
+                      },
+                      "left": {
+                        "type": "Identifier",
+                        "start": 83,
+                        "end": 88,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 13
+                          },
+                          "identifierName": "yield"
+                        },
+                        "name": "yield"
+                      },
+                      "operator": "+",
+                      "right": {
+                        "type": "NumericLiteral",
+                        "start": 91,
+                        "end": 93,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 18
+                          }
+                        },
+                        "extra": {
+                          "rawValue": 42,
+                          "raw": "42"
+                        },
+                        "value": 42
+                      }
+                    },
+                    "leadingComments": [
+                      {
+                        "type": "CommentLine",
+                        "value": " here yield is an identifier reference",
+                        "start": 34,
+                        "end": 74,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 44
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " here yield is an identifier reference",
+      "start": 34,
+      "end": 74,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 44
+        }
+      }
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-generator-in-class-property/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-generator-in-class-property/input.js
@@ -1,0 +1,3 @@
+class C {
+  p = function* () { yield + 42 };
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-generator-in-class-property/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-generator-in-class-property/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-generator-in-class-property/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/class-properties/yield-in-generator-in-class-property/output.json
@@ -1,0 +1,224 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 46,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 46,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 46,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 7,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "identifierName": "C"
+          },
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 8,
+          "end": 46,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 12,
+              "end": 44,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 34
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 12,
+                "end": 13,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "identifierName": "p"
+                },
+                "name": "p"
+              },
+              "computed": false,
+              "value": {
+                "type": "FunctionExpression",
+                "start": 16,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 33
+                  }
+                },
+                "id": null,
+                "generator": true,
+                "async": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 29,
+                  "end": 43,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 33
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "start": 31,
+                      "end": 41,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 21
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 31
+                        }
+                      },
+                      "expression": {
+                        "type": "YieldExpression",
+                        "start": 31,
+                        "end": 41,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 21
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 31
+                          }
+                        },
+                        "delegate": false,
+                        "argument": {
+                          "type": "UnaryExpression",
+                          "start": 37,
+                          "end": 41,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 27
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 31
+                            }
+                          },
+                          "operator": "+",
+                          "prefix": true,
+                          "argument": {
+                            "type": "NumericLiteral",
+                            "start": 39,
+                            "end": 41,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 29
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 31
+                              }
+                            },
+                            "extra": {
+                              "rawValue": 42,
+                              "raw": "42"
+                            },
+                            "value": 42
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "directives": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Class Field Initializers should not allow YieldExpression
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR includes commits from #10947, I will rebase once that PR is merged.

The current parser scoping is meant to track declarations and bindings, it serves well for the purpose of declaration scope. It is also mixed with `[Await]` and `[Yield]` production parameter tracks, historically it was okay because when `[Await]`/`[Yield]` are changed, it must be when a function declaration/expression is parsed, where a declaration scope is also created. 
However, class fields initializers is an exception where a declaration scope is _not_ created but production parameter is changed. Fixing this issue in parser scoping is cumbersome and error-prone: https://github.com/babel/babel/pull/10946/files#diff-a9acee4ca26b68744fe0a1cb5aa03e34R60, therefore I extract the `SCOPE_ASYNC` and `SCOPE_GENERATOR` tracking into a dedicate stack fashioned handler, the code is now more intuitive.

I should point out the idea comes out from an offline discussion with @nicolo-ribaudo and I am really appreciated.

Note that after this PR is merged, ultimately `isAwaitAllowed`
https://github.com/babel/babel/blob/9f832c271647b71a21baf5ba61fd75cb5db6f754/packages/babel-parser/src/parser/expression.js#L2186-L2191
should be simplified to
```js
return (this.param.hasAwait || this.options.allowAwaitOutsideFunction)
```
which is a faithful implementation of the spec text

> BindingIdentifier: await 
> It is a Syntax Error if this production has an [Await] parameter

But we still have trouble on tracking arrow / async arrow expressions. We are try to recover such error in `awaitPos` when parsing arrow expressions. Unless we are parsing the ambiguous `ArrayExpression/ParenthesizedExpression` (like what v8 does in https://docs.google.com/document/d/1FAvEp9EUK-G8kHfDIEo_385Hs2SUBCYbJ5H-NnLvq8M/edit ) and record these errors to be fulfilled or rejected later when it becomes unambiguous, we still relies on the `scope.inFunction` guard.