### PR TITLE
Make @babel/transform-runtime's absoluteRuntime/relative test meaningful

### DIFF
--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/output.js
@@ -1,4 +1,4 @@
-var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/node_modules/@babel/runtime/helpers/classCallCheck");
+var _classCallCheck = require("<CWD>/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/helpers/classCallCheck");
 
 let Foo = function Foo() {
   "use strict";

--- a/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/absoluteRuntime/relative/subfolder/node_modules/@babel/runtime/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@babel/runtime",
+  "private": true
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The previous test would have passed even if `"./subfolder"` was considered as `true`, because it resolved to the same top-level `@babel/runtime`.
