### PR TITLE
polish: throw human-friendly error when item-option pair is incorrectly unwrapped

### DIFF
--- a/packages/babel-core/src/config/config-descriptors.js
+++ b/packages/babel-core/src/config/config-descriptors.js
@@ -15,7 +15,6 @@ import type {
   PluginList,
   PluginItem,
 } from "./validation/options";
-import { assertNoUnwrappedItemOptionPairs } from "./validation/options";
 
 // Represents a config object and functions to lazily load the descriptors
 // for the plugins and presets so we don't load the plugins/presets unless
@@ -230,7 +229,6 @@ function createDescriptors(
   alias: string,
   ownPass?: boolean,
 ): Array<UnloadedDescriptor> {
-  assertNoUnwrappedItemOptionPairs(items, type);
   const descriptors = items.map((item, index) =>
     createDescriptor(item, dirname, {
       type,

--- a/packages/babel-core/src/config/config-descriptors.js
+++ b/packages/babel-core/src/config/config-descriptors.js
@@ -15,6 +15,7 @@ import type {
   PluginList,
   PluginItem,
 } from "./validation/options";
+import { assertNoUnwrappedItemOptionPairs } from "./validation/options";
 
 // Represents a config object and functions to lazily load the descriptors
 // for the plugins and presets so we don't load the plugins/presets unless
@@ -229,6 +230,7 @@ function createDescriptors(
   alias: string,
   ownPass?: boolean,
 ): Array<UnloadedDescriptor> {
+  assertNoUnwrappedItemOptionPairs(items, type);
   const descriptors = items.map((item, index) =>
     createDescriptor(item, dirname, {
       type,

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -27,6 +27,7 @@ import {
   type Validator,
   type OptionPath,
 } from "./option-assertions";
+import { validatePluginObject } from "./plugins";
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
@@ -296,6 +297,10 @@ function getSource(loc: NestingPath): OptionsSource {
 }
 
 export function validate(type: OptionsSource, opts: {}): ValidatedOptions {
+  //todo: consider merge validatePluginObject with validateNested
+  if (type === "plugin") {
+    return validatePluginObject(opts);
+  }
   return validateNested(
     {
       type: "root",

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -442,7 +442,7 @@ function assertOverridesList(loc: OptionPath, value: mixed): OverridesList {
 }
 
 export function assertNoUnwrappedItemOptionPairs(
-  items: [PluginItem, PluginItem],
+  items: PluginList,
   type: "plugin" | "preset",
 ): void {
   if (

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -376,6 +376,7 @@ function throwUnknownError(loc: OptionPath) {
         loc,
       )}. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.`,
     );
+    // $FlowIgnore
     unknownOptErr.code = "BABEL_UNKNOWN_OPTION";
 
     throw unknownOptErr;

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -27,6 +27,7 @@ import {
   type Validator,
   type OptionPath,
 } from "./option-assertions";
+import { validatePluginObject } from "./plugins";
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
@@ -451,7 +452,9 @@ export function assertNoUnwrappedItemOptionPairs(
     !Array.isArray(items[1])
   ) {
     try {
-      validate(type, items[1]);
+      type === "preset"
+        ? validate(type, items[1])
+        : validatePluginObject(items[1]);
     } catch (e) {
       throw new Error(
         `.${type}[1] is not a valid ${type}. Maybe you meant to use\n` +

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -439,3 +439,24 @@ function assertOverridesList(loc: OptionPath, value: mixed): OverridesList {
   }
   return (arr: any);
 }
+
+export function assertNoUnwrappedItemOptionPairs(
+  items: [PluginItem, PluginItem],
+  type: "plugin" | "preset",
+): void {
+  if (
+    items.length === 2 &&
+    typeof items[0] === "string" &&
+    typeof items[1] === "object"
+  ) {
+    try {
+      validate(items[1]);
+    } catch (e) {
+      throw new Error(
+        `.${type}[1] is not a valid ${type}. Maybe you meant to use\n` +
+          `"${type}": [\n  ["${items[0]}", ${JSON.stringify(items[1])}]\n]\n` +
+          `To be a valid ${type}, its name and options should be wrapped in a pair of brackets`,
+      );
+    }
+  }
+}

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -447,10 +447,11 @@ export function assertNoUnwrappedItemOptionPairs(
   if (
     items.length === 2 &&
     typeof items[0] === "string" &&
-    typeof items[1] === "object"
+    typeof items[1] === "object" &&
+    !Array.isArray(items[1])
   ) {
     try {
-      validate(items[1]);
+      validate(type, items[1]);
     } catch (e) {
       throw new Error(
         `.${type}[1] is not a valid ${type}. Maybe you meant to use\n` +

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -27,7 +27,6 @@ import {
   type Validator,
   type OptionPath,
 } from "./option-assertions";
-import { validatePluginObject } from "./plugins";
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: (assertString: Validator<$PropertyType<ValidatedOptions, "cwd">>),
@@ -297,10 +296,6 @@ function getSource(loc: NestingPath): OptionsSource {
 }
 
 export function validate(type: OptionsSource, opts: {}): ValidatedOptions {
-  //todo: consider merge validatePluginObject with validateNested
-  if (type === "plugin") {
-    return validatePluginObject(opts);
-  }
   return validateNested(
     {
       type: "root",

--- a/packages/babel-core/src/config/validation/options.js
+++ b/packages/babel-core/src/config/validation/options.js
@@ -366,12 +366,12 @@ function throwUnknownError(loc: OptionPath) {
   if (removed[key]) {
     const { message, version = 5 } = removed[key];
 
-    throw new ReferenceError(
+    throw new Error(
       `Using removed Babel ${version} option: ${msg(loc)} - ${message}`,
     );
   } else {
     // eslint-disable-next-line max-len
-    const unknownOptErr = new ReferenceError(
+    const unknownOptErr = new Error(
       `Unknown option: ${msg(
         loc,
       )}. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.`,

--- a/packages/babel-core/src/config/validation/plugins.js
+++ b/packages/babel-core/src/config/validation/plugins.js
@@ -97,7 +97,13 @@ export function validatePluginObject(obj: {}): PluginObject {
     };
 
     if (validator) validator(optLoc, obj[key]);
-    else throw new Error(`.${key} is not a valid Plugin property`);
+    else {
+      const invalidPluginPropertyError = new Error(
+        `.${key} is not a valid Plugin property`,
+      );
+      invalidPluginPropertyError.code = "BABEL_UNKNOWN_PLUGIN_PROPERTY";
+      throw invalidPluginPropertyError;
+    }
   });
 
   return (obj: any);

--- a/packages/babel-core/src/config/validation/plugins.js
+++ b/packages/babel-core/src/config/validation/plugins.js
@@ -101,6 +101,7 @@ export function validatePluginObject(obj: {}): PluginObject {
       const invalidPluginPropertyError = new Error(
         `.${key} is not a valid Plugin property`,
       );
+      // $FlowIgnore
       invalidPluginPropertyError.code = "BABEL_UNKNOWN_PLUGIN_PROPERTY";
       throw invalidPluginPropertyError;
     }

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -1,17 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
-".plugin[1] is not a valid plugin. Maybe you meant to use
+"[BABEL] unknown: .plugin[1] is not a valid plugin. Maybe you meant to use
 \\"plugin\\": [
-  [\\"@babel/transform-react-jsx\\", {\\"useSpread\\":true}]
+  [\\"./fixtures/option-manager/babel-plugin-foo\\", {
+  \\"useSpread\\": true
+}]
 ]
 To be a valid plugin, its name and options should be wrapped in a pair of brackets"
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
-".preset[1] is not a valid preset. Maybe you meant to use
+"[BABEL] unknown: .preset[1] is not a valid preset. Maybe you meant to use
 \\"preset\\": [
-  [\\"@babel/env\\", {\\"useBuiltIns\\":\\"entry\\"}]
+  [\\"./fixtures/option-manager/babel-preset-bar\\", {
+  \\"useBuiltIns\\": \\"entry\\"
+}]
 ]
 To be a valid preset, its name and options should be wrapped in a pair of brackets"
 `;

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
+".plugin[1] is not a valid plugin. Maybe you meant to use
+\\"plugin\\": [
+  [\\"@babel/transform-react-jsx\\", {\\"useSpread\\":true}]
+]
+To be a valid plugin, its name and options should be wrapped in a pair of brackets"
+`;
+
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
 ".preset[1] is not a valid preset. Maybe you meant to use
 \\"preset\\": [

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`option-manager config plugin/preset flattening and overriding should throw when an option is following a preset 1`] = `
+"[BABEL] unknown: Unknown option: .useSpread. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
+- Maybe you meant to use
+\\"preset\\": [
+  [\\"./fixtures/option-manager/babel-preset-bar\\", {
+  \\"useSpread\\": true
+}]
+]
+To be a valid preset, its name and options should be wrapped in a pair of brackets"
+`;
+
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
 "[BABEL] unknown: .useSpread is not a valid Plugin property
 - Maybe you meant to use

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a plugin 1`] = `
-"[BABEL] unknown: .plugin[1] is not a valid plugin. Maybe you meant to use
+"[BABEL] unknown: .useSpread is not a valid Plugin property
+- Maybe you meant to use
 \\"plugin\\": [
   [\\"./fixtures/option-manager/babel-plugin-foo\\", {
   \\"useSpread\\": true
@@ -11,7 +12,8 @@ To be a valid plugin, its name and options should be wrapped in a pair of bracke
 `;
 
 exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
-"[BABEL] unknown: .preset[1] is not a valid preset. Maybe you meant to use
+"[BABEL] unknown: Unknown option: .useBuiltIns. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
+- Maybe you meant to use
 \\"preset\\": [
   [\\"./fixtures/option-manager/babel-preset-bar\\", {
   \\"useBuiltIns\\": \\"entry\\"

--- a/packages/babel-core/test/__snapshots__/option-manager.js.snap
+++ b/packages/babel-core/test/__snapshots__/option-manager.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`option-manager config plugin/preset flattening and overriding should throw when an option is provided as a preset 1`] = `
+".preset[1] is not a valid preset. Maybe you meant to use
+\\"preset\\": [
+  [\\"@babel/env\\", {\\"useBuiltIns\\":\\"entry\\"}]
+]
+To be a valid preset, its name and options should be wrapped in a pair of brackets"
+`;

--- a/packages/babel-core/test/fixtures/option-manager/babel-plugin-foo/index.js
+++ b/packages/babel-core/test/fixtures/option-manager/babel-plugin-foo/index.js
@@ -1,0 +1,1 @@
+module.exports = () => ({});

--- a/packages/babel-core/test/fixtures/option-manager/babel-preset-bar/index.js
+++ b/packages/babel-core/test/fixtures/option-manager/babel-preset-bar/index.js
@@ -1,0 +1,1 @@
+module.exports = () => ({});

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -35,6 +35,14 @@ describe("option-manager", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
+    it("should throw when an option is provided as a plugin", () => {
+      expect(() => {
+        loadOptions({
+          plugins: ["@babel/transform-react-jsx", { useSpread: true }],
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
     it("should throw if a plugin is repeated, with information about the repeated plugin", () => {
       const { calls, plugin } = makePlugin("my-plugin");
 

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -30,7 +30,10 @@ describe("option-manager", () => {
     it("should throw when an option is provided as a preset", () => {
       expect(() => {
         loadOptions({
-          presets: ["@babel/env", { useBuiltIns: "entry" }],
+          presets: [
+            "./fixtures/option-manager/babel-preset-bar",
+            { useBuiltIns: "entry" },
+          ],
         });
       }).toThrowErrorMatchingSnapshot();
     });
@@ -38,7 +41,10 @@ describe("option-manager", () => {
     it("should throw when an option is provided as a plugin", () => {
       expect(() => {
         loadOptions({
-          plugins: ["@babel/transform-react-jsx", { useSpread: true }],
+          plugins: [
+            "./fixtures/option-manager/babel-plugin-foo",
+            { useSpread: true },
+          ],
         });
       }).toThrowErrorMatchingSnapshot();
     });

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -27,6 +27,14 @@ describe("option-manager", () => {
       return { plugin, calls };
     }
 
+    it("should throw when an option is provided as a preset", () => {
+      expect(() => {
+        loadOptions({
+          presets: ["@babel/env", { useBuiltIns: "entry" }],
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
     it("should throw if a plugin is repeated, with information about the repeated plugin", () => {
       const { calls, plugin } = makePlugin("my-plugin");
 

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -43,6 +43,18 @@ describe("option-manager", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
+    it("should not throw when a preset string followed by valid preset object", () => {
+      const { plugin } = makePlugin("my-plugin");
+      expect(
+        loadOptions({
+          presets: [
+            "@babel/env",
+            { plugins: [[plugin, undefined, "my-plugin"]] },
+          ],
+        }),
+      ).toBeTruthy();
+    });
+
     it("should throw if a plugin is repeated, with information about the repeated plugin", () => {
       const { calls, plugin } = makePlugin("my-plugin");
 

--- a/packages/babel-core/test/option-manager.js
+++ b/packages/babel-core/test/option-manager.js
@@ -49,6 +49,18 @@ describe("option-manager", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
+    it("should throw when an option is following a preset", () => {
+      expect(() => {
+        loadOptions({
+          presets: [
+            "./fixtures/option-manager/babel-plugin-foo",
+            "./fixtures/option-manager/babel-preset-bar",
+            { useSpread: true },
+          ],
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
     it("should not throw when a preset string followed by valid preset object", () => {
       const { plugin } = makePlugin("my-plugin");
       expect(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I want to focus on the scenario I want to help instead of giving too much technical details of this PR. Anyway the approach is straightforward.

When you begin to use `babel`, the config may be as simple as
```json
{
  "presets": ["@babel/env"]
}
```
It works out of box. It is great.

After you have learned more about babel, you may begin to add options to preset-env, let's say you try
```json
{
  "presets": ["@babel/env", { "useBuiltIns": true }]
}
```
It looks quite intuitive, right? But unfortunately it will throw
```
[BABEL] unknown: Unknown option: .useBuiltIns. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
```

The error message is _technically_ correct. But this message is tremendously confusing even if you are a babel veteran because `.useBuiltIns` _is_ an option for preset-env, and especially after you have double check you didn't wrote it as `useBuiltins`. But why babel throws unknown options for `.useBuiltIns`? Well when I was learning to configure babel, it takes me quite a while before I realize that I should add a `[]` to wrap the preset name and its options
```json
presets: [["@babel/env", { "useBuiltIns": true }]]
```

In this PR we detect this error pattern and give a human friendly error message.