### PR TITLE
chore: update caniuse-usage Chrome 49 related fixtures

### DIFF
--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -3,7 +3,7 @@
 Using targets:
 {
   "android": "77",
-  "chrome": "77",
+  "chrome": "49",
   "edge": "17",
   "firefox": "68",
   "ios": "12.2",
@@ -17,7 +17,7 @@ Using modules transform: auto
 Using plugins:
   transform-template-literals { "ios":"12.2", "safari":"5.1" }
   transform-literals { "safari":"5.1" }
-  transform-function-name { "edge":"17", "safari":"5.1" }
+  transform-function-name { "chrome":"49", "edge":"17", "safari":"5.1" }
   transform-arrow-functions { "safari":"5.1" }
   transform-block-scoped-functions { "safari":"5.1" }
   transform-classes { "safari":"5.1" }
@@ -25,26 +25,26 @@ Using plugins:
   transform-shorthand-properties { "safari":"5.1" }
   transform-duplicate-keys { "safari":"5.1" }
   transform-computed-properties { "safari":"5.1" }
-  transform-for-of { "safari":"5.1" }
+  transform-for-of { "chrome":"49", "safari":"5.1" }
   transform-sticky-regex { "safari":"5.1" }
-  transform-dotall-regex { "edge":"17", "firefox":"68", "safari":"5.1" }
-  transform-unicode-regex { "safari":"5.1" }
+  transform-dotall-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
+  transform-unicode-regex { "chrome":"49", "safari":"5.1" }
   transform-spread { "safari":"5.1" }
   transform-parameters { "edge":"17", "safari":"5.1" }
-  transform-destructuring { "safari":"5.1" }
+  transform-destructuring { "chrome":"49", "safari":"5.1" }
   transform-block-scoping { "safari":"5.1" }
   transform-typeof-symbol { "safari":"5.1" }
   transform-new-target { "safari":"5.1" }
-  transform-regenerator { "safari":"5.1" }
-  transform-exponentiation-operator { "safari":"5.1" }
-  transform-async-to-generator { "safari":"5.1" }
-  proposal-async-generator-functions { "edge":"17", "safari":"5.1" }
-  proposal-object-rest-spread { "edge":"17", "safari":"5.1" }
-  proposal-unicode-property-regex { "edge":"17", "firefox":"68", "safari":"5.1" }
-  proposal-json-strings { "edge":"17", "safari":"5.1" }
-  proposal-optional-catch-binding { "edge":"17", "safari":"5.1" }
-  transform-named-capturing-groups-regex { "edge":"17", "firefox":"68", "safari":"5.1" }
-  transform-modules-commonjs { "android":"77", "chrome":"77", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
-  proposal-dynamic-import { "android":"77", "chrome":"77", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  transform-regenerator { "chrome":"49", "safari":"5.1" }
+  transform-exponentiation-operator { "chrome":"49", "safari":"5.1" }
+  transform-async-to-generator { "chrome":"49", "safari":"5.1" }
+  proposal-async-generator-functions { "chrome":"49", "edge":"17", "safari":"5.1" }
+  proposal-object-rest-spread { "chrome":"49", "edge":"17", "safari":"5.1" }
+  proposal-unicode-property-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
+  proposal-json-strings { "chrome":"49", "edge":"17", "safari":"5.1" }
+  proposal-optional-catch-binding { "chrome":"49", "edge":"17", "safari":"5.1" }
+  transform-named-capturing-groups-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
+  transform-modules-commonjs { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  proposal-dynamic-import { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -3,7 +3,7 @@
 Using targets:
 {
   "android": "77",
-  "chrome": "77",
+  "chrome": "49",
   "edge": "17",
   "firefox": "68",
   "ie": "11",
@@ -18,7 +18,7 @@ Using modules transform: auto
 Using plugins:
   transform-template-literals { "ie":"11", "ios":"12.2", "safari":"5.1" }
   transform-literals { "ie":"11", "safari":"5.1" }
-  transform-function-name { "edge":"17", "ie":"11", "safari":"5.1" }
+  transform-function-name { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
   transform-arrow-functions { "ie":"11", "safari":"5.1" }
   transform-block-scoped-functions { "safari":"5.1" }
   transform-classes { "ie":"11", "safari":"5.1" }
@@ -26,26 +26,26 @@ Using plugins:
   transform-shorthand-properties { "ie":"11", "safari":"5.1" }
   transform-duplicate-keys { "ie":"11", "safari":"5.1" }
   transform-computed-properties { "ie":"11", "safari":"5.1" }
-  transform-for-of { "ie":"11", "safari":"5.1" }
+  transform-for-of { "chrome":"49", "ie":"11", "safari":"5.1" }
   transform-sticky-regex { "ie":"11", "safari":"5.1" }
-  transform-dotall-regex { "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
-  transform-unicode-regex { "ie":"11", "safari":"5.1" }
+  transform-dotall-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
+  transform-unicode-regex { "chrome":"49", "ie":"11", "safari":"5.1" }
   transform-spread { "ie":"11", "safari":"5.1" }
   transform-parameters { "edge":"17", "ie":"11", "safari":"5.1" }
-  transform-destructuring { "ie":"11", "safari":"5.1" }
+  transform-destructuring { "chrome":"49", "ie":"11", "safari":"5.1" }
   transform-block-scoping { "ie":"11", "safari":"5.1" }
   transform-typeof-symbol { "ie":"11", "safari":"5.1" }
   transform-new-target { "ie":"11", "safari":"5.1" }
-  transform-regenerator { "ie":"11", "safari":"5.1" }
-  transform-exponentiation-operator { "ie":"11", "safari":"5.1" }
-  transform-async-to-generator { "ie":"11", "safari":"5.1" }
-  proposal-async-generator-functions { "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-object-rest-spread { "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-unicode-property-regex { "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
-  proposal-json-strings { "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-optional-catch-binding { "edge":"17", "ie":"11", "safari":"5.1" }
-  transform-named-capturing-groups-regex { "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
-  transform-modules-commonjs { "android":"77", "chrome":"77", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
-  proposal-dynamic-import { "android":"77", "chrome":"77", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  transform-regenerator { "chrome":"49", "ie":"11", "safari":"5.1" }
+  transform-exponentiation-operator { "chrome":"49", "ie":"11", "safari":"5.1" }
+  transform-async-to-generator { "chrome":"49", "ie":"11", "safari":"5.1" }
+  proposal-async-generator-functions { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  proposal-object-rest-spread { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  proposal-unicode-property-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
+  proposal-json-strings { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  proposal-optional-catch-binding { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  transform-named-capturing-groups-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
+  transform-modules-commonjs { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  proposal-dynamic-import { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
 
 Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix Recent CI Error
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
According to the [usage table](https://caniuse.com/usage-table), Chrome 49 goes up a little bit from 0.5% to 0.52%, which is thus included in the browserslists defaults again.

I will expect I have to revert this change later some time when it comes back to 0.5% and maybe back and forth.

Feed the search engine: caniuse-usage chrome-49