### PR TITLE
fix: `isPluginRequired` returns the opposite result in v7.8.0

### DIFF
--- a/packages/babel-preset-env/src/index.js
+++ b/packages/babel-preset-env/src/index.js
@@ -32,7 +32,7 @@ import type { BuiltInsOption, ModuleOption } from "./types";
 
 // TODO: Remove in Babel 8
 export function isPluginRequired(targets: Targets, support: Targets) {
-  return !isRequired("fake-name", targets, {
+  return isRequired("fake-name", targets, {
     compatData: { "fake-name": support },
   });
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

As far as I can tell, the new `isRequired` function in this PR https://github.com/babel/babel/pull/10899/files does the same job as the legacy `isPluginRequired`, so the `!` here seems incorrect.

It breaks Vue CLI's tests at the moment (though it seems few people have noticed).