### PR TITLE
Exclude `import()` tests from pubilsh build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ prepublish-build: clean-lib clean-runtime-helpers
 prepublish:
 	$(MAKE) bootstrap-only
 	$(MAKE) prepublish-build
-	$(MAKE) test
+	IS_PUBLISH=true $(MAKE) test
 
 new-version:
 	git pull --rebase

--- a/packages/babel-core/test/config-chain.js
+++ b/packages/babel-core/test/config-chain.js
@@ -1044,6 +1044,10 @@ describe("buildConfigChain", function() {
         );
         const filename = tmp("src.js");
 
+        // We can't transpile import() while publishing, and it isn't supported
+        // by jest.
+        if (process.env.IS_PUBLISH && name === "babel.config.mjs") return;
+
         await config(name);
 
         expect(await loadOptionsAsync({ filename, cwd })).toEqual({
@@ -1066,6 +1070,15 @@ describe("buildConfigChain", function() {
         const { cwd, tmp, config } = await getTemp(
           `babel-test-dup-config-${name1}-${name2}`,
         );
+
+        // We can't transpile import() while publishing, and it isn't supported
+        // by jest.
+        if (
+          process.env.IS_PUBLISH &&
+          (name1 === "babel.config.mjs" || name2 === "babel.config.mjs")
+        ) {
+          return;
+        }
 
         await Promise.all([config(name1), config(name2)]);
 
@@ -1124,6 +1137,10 @@ describe("buildConfigChain", function() {
         );
         const filename = tmp("src.js");
 
+        // We can't transpile import() while publishing, and it isn't supported
+        // by jest.
+        if (process.env.IS_PUBLISH && name === ".babelrc.mjs") return;
+
         await config(name);
 
         expect(await loadOptionsAsync({ filename, cwd })).toEqual({
@@ -1157,6 +1174,15 @@ describe("buildConfigChain", function() {
           `babel-test-dup-config-${name1}-${name2}`,
         );
 
+        // We can't transpile import() while publishing, and it isn't supported
+        // by jest.
+        if (
+          process.env.IS_PUBLISH &&
+          (name1 === ".babelrc.mjs" || name2 === ".babelrc.mjs")
+        ) {
+          return;
+        }
+
         await Promise.all([config(name1), config(name2)]);
 
         await expect(
@@ -1186,6 +1212,10 @@ describe("buildConfigChain", function() {
         ${"package.json"}  | ${"pkg-error"}          | ${/Error while parsing JSON - /}
       `("should show helpful errors for $config", async ({ dir, error }) => {
         const filename = fixture("config-files", dir, "src.js");
+
+        // We can't transpile import() while publishing, and it isn't supported
+        // by jest.
+        if (process.env.IS_PUBLISH && dir === "babelrc-mjs-error") return;
 
         await expect(
           loadOptionsAsync({ filename, cwd: path.dirname(filename) }),


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Broken publish script
| Tests Added + Pass?      | :cry: 
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Commit message:
> I really don't like this commit, but `import()` is currently breaking our publish script.
> When "normal" tests we are transpiling `import()` so that it works with Jest. We can't do it while publishing because we need to publish the untranspiled import() so that it can load real `.mjs` files.
> 
> Follow up to #10903

Note that we are still running those tests in every other commit; I'm just disabling them when publishing.