### PR TITLE
fix: generated builder parameter should respect builder keys

### DIFF
--- a/packages/babel-types/scripts/generators/flow.js
+++ b/packages/babel-types/scripts/generators/flow.js
@@ -54,6 +54,7 @@ for (const type in t.NODE_FIELDS) {
 
   const struct = ['type: "' + type + '";'];
   const args = [];
+  const builderNames = t.BUILDER_KEYS[type];
 
   Object.keys(t.NODE_FIELDS[type])
     .sort((fieldA, fieldB) => {
@@ -80,8 +81,9 @@ for (const type in t.NODE_FIELDS) {
       if (typeAnnotation) {
         suffix += ": " + typeAnnotation;
       }
-
-      args.push(t.toBindingIdentifierName(fieldName) + suffix);
+      if (builderNames.includes(fieldName)) {
+        args.push(t.toBindingIdentifierName(fieldName) + suffix);
+      }
 
       if (t.isValidIdentifier(fieldName)) {
         struct.push(fieldName + suffix + ";");

--- a/packages/babel-types/scripts/generators/typescript.js
+++ b/packages/babel-types/scripts/generators/typescript.js
@@ -56,6 +56,7 @@ const lines = [];
 for (const type in t.NODE_FIELDS) {
   const fields = t.NODE_FIELDS[type];
   const fieldNames = sortFieldNames(Object.keys(t.NODE_FIELDS[type]), type);
+  const builderNames = t.BUILDER_KEYS[type];
 
   const struct = ['type: "' + type + '";'];
   const args = [];
@@ -75,18 +76,20 @@ for (const type in t.NODE_FIELDS) {
       typeAnnotation += " | null";
     }
 
-    if (areAllRemainingFieldsNullable(fieldName, fieldNames, fields)) {
-      args.push(
-        `${t.toBindingIdentifierName(fieldName)}${
-          isNullable(field) ? "?:" : ":"
-        } ${typeAnnotation}`
-      );
-    } else {
-      args.push(
-        `${t.toBindingIdentifierName(fieldName)}: ${typeAnnotation}${
-          isNullable(field) ? " | undefined" : ""
-        }`
-      );
+    if (builderNames.includes(fieldName)) {
+      if (areAllRemainingFieldsNullable(fieldName, builderNames, fields)) {
+        args.push(
+          `${t.toBindingIdentifierName(fieldName)}${
+            isNullable(field) ? "?:" : ":"
+          } ${typeAnnotation}`
+        );
+      } else {
+        args.push(
+          `${t.toBindingIdentifierName(fieldName)}: ${typeAnnotation}${
+            isNullable(field) ? " | undefined" : ""
+          }`
+        );
+      }
     }
 
     const alphaNumeric = /^\w+$/;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #10998 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No, see explainers below
| Tests Added + Pass?      | Manual tested
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR fixes a regression introduced in #10917. 

In https://github.com/babel/babel/pull/10917/files#diff-dd23409d66e27b24936f7ae4e316073eR265, the `optional` meta-field is added only if the `default` meta-field presents. This change makes sense but unexpectedly it breaks 
https://github.com/babel/babel/blob/d0a8982c124ac495b6008f9e5958ec8ad9b5a3f8/packages/babel-types/scripts/generators/typescript.js#L336

which relies on `optional` to detect if it is a nullable key, so the non-builder fields are marked as non-optional and included in the definition. For example, here is what `Program` definition 

https://github.com/babel/babel/blob/d0a8982c124ac495b6008f9e5958ec8ad9b5a3f8/packages/babel-types/src/definitions/core.js#L642

generates in different versions.

v7.7.4
```ts
export function program(
  body: Array<Statement>,
  directives?: Array<Directive>,
  sourceType?: "script" | "module",
  interpreter?: InterpreterDirective | null,
  sourceFile?: string | null
): Program;
```

v7.8.0
```ts
export function program(
  body: Array<Statement>,
  directives: Array<Directive> | undefined,
  sourceType: "script" | "module" | undefined,
  interpreter: InterpreterDirective | null | undefined,
  sourceFile: string
): Program;
```
The `sourceFile` is not nullable so all the parameters before `sourceFile` becomes non optional parameters. This is a breaking change for types consumers.

The problem here is that we should not include `sourceFile` at all because it is not defined in `builders` and we are really lucky that nobody ever complains that the fifth argument `sourceFile?` does not work _at_ _all_.

This PR filter the args against `BUILDER_KEYS` so the generated types become
```ts
export function program(
  body: Array<Statement>,
  directives?: Array<Directive>,
  sourceType?: "script" | "module",
  interpreter?: InterpreterDirective | null
): Program;
```
where the `sourceFile` is removed from builder arguments definition, technically it is a breaking change but practically it should not break anyone because the builder will check the arguments length at runtime.

In the long term we should add the generated `index.js.flow` and `index.d.ts` to the codebase so we can track such changes.