### PR TITLE
chore: skip coverage GitHub actions when [skip ci] is specified

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
         node-version: [13.x]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The `[skip ci]` does not skip coverage GitHub action, see https://github.com/babel/babel/commit/b138b5a62ec2be5c403bf2668126c897515afc22
| Tests Added + Pass?      | This PR are self-tested.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Sort-of hacky, learned on https://github.com/veggiemonk/skip-commit#just-use-yaml-recommended

Todo
- [ ] Apparently it does not work on the pull_request event, I will test on the `test_actions` repo before landing here.