### PR TITLE
fix: supply '.' subpath for backward compatibility with node.js 13.0-13.1

### DIFF
--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -6,7 +6,9 @@
   "description": "Engine compat data used in @babel/preset-env",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-compilation-targets",
   "main": "lib/index.js",
-  "exports": false,
+  "exports": {
+    ".": "./lib/index.js"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://stackoverflow.com/questions/59706130/error-package-exports-for-path-to-project-folder-node-modules-babel-helper-c
| Patch: Bug Fix?          | Yes
| Tests Added + Pass?      | Manually tested
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The following snippet will throw on Node.js <= 13.2
```js
require("@babel/helper-compilation-targets")
```
```
Error: Package exports for '<path_to_project_folder>/node_modules/@babel/helper-compilation-targets' do not define a '.' subpath
```
This issue is blocking the `preset-env` users on Node.js 13.0 - 13.1

The issue is from upstream, which was fixed in https://github.com/nodejs/node/pull/29978/files#diff-76195ce57689942222a27f0dbda6d3b7R495 and later shipped in Node.js 13.2.

Since Node 13 is still current, we offer a `.` subpath for backward compatibility to Node.js 13.0 - 13.1. Technically if users are running at node.js 12 with `--experimental-modules` on, they will also see this error, but practically it is a rare situation.

I suggest we simply drop node 13.0 - 13.1 support on Babel v8 so we can continue to use `exports: false`, it is not a big deal because node 13 is not a LTS candidate and will go EOL at June.