### PR TITLE
Re-generate preset-env fixtures

### DIFF
--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -1,13 +1,12 @@
 {
-  "proposal-async-generator-functions": {
-    "chrome": "63",
-    "firefox": "57",
-    "safari": "12",
-    "node": "10",
-    "ios": "12",
-    "samsung": "8.2",
-    "opera": "50",
-    "electron": "3.1"
+  "proposal-nullish-coalescing-operator": {
+    "chrome": "80",
+    "firefox": "72",
+    "opera": "67"
+  },
+  "proposal-optional-chaining": {
+    "chrome": "80",
+    "opera": "67"
   },
   "proposal-json-strings": {
     "chrome": "66",
@@ -19,10 +18,25 @@
     "opera": "53",
     "electron": "3.1"
   },
-  "proposal-nullish-coalescing-operator": {
-    "chrome": "80",
-    "firefox": "72",
-    "opera": "67"
+  "proposal-optional-catch-binding": {
+    "chrome": "66",
+    "firefox": "58",
+    "safari": "11.1",
+    "node": "10",
+    "ios": "11.3",
+    "samsung": "9.2",
+    "opera": "53",
+    "electron": "3.1"
+  },
+  "proposal-async-generator-functions": {
+    "chrome": "63",
+    "firefox": "57",
+    "safari": "12",
+    "node": "10",
+    "ios": "12",
+    "samsung": "8.2",
+    "opera": "50",
+    "electron": "3.1"
   },
   "proposal-object-rest-spread": {
     "chrome": "60",
@@ -34,19 +48,14 @@
     "opera": "47",
     "electron": "2.1"
   },
-  "proposal-optional-catch-binding": {
-    "chrome": "66",
-    "firefox": "58",
+  "transform-dotall-regex": {
+    "chrome": "62",
     "safari": "11.1",
-    "node": "10",
+    "node": "8.10",
     "ios": "11.3",
-    "samsung": "9.2",
-    "opera": "53",
+    "samsung": "8.2",
+    "opera": "49",
     "electron": "3.1"
-  },
-  "proposal-optional-chaining": {
-    "chrome": "80",
-    "opera": "67"
   },
   "proposal-unicode-property-regex": {
     "chrome": "64",
@@ -57,16 +66,14 @@
     "opera": "51",
     "electron": "3.1"
   },
-  "transform-arrow-functions": {
-    "chrome": "47",
-    "edge": "13",
-    "firefox": "45",
-    "safari": "10",
-    "node": "6",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "34",
-    "electron": "0.36"
+  "transform-named-capturing-groups-regex": {
+    "chrome": "64",
+    "safari": "11.1",
+    "node": "10",
+    "ios": "11.3",
+    "samsung": "9.2",
+    "opera": "51",
+    "electron": "3.1"
   },
   "transform-async-to-generator": {
     "chrome": "55",
@@ -78,6 +85,60 @@
     "samsung": "6.2",
     "opera": "42",
     "electron": "1.6"
+  },
+  "transform-exponentiation-operator": {
+    "chrome": "52",
+    "edge": "14",
+    "firefox": "52",
+    "safari": "10.1",
+    "node": "7",
+    "ios": "10.3",
+    "samsung": "6.2",
+    "opera": "39",
+    "electron": "1.3"
+  },
+  "transform-template-literals": {
+    "chrome": "41",
+    "edge": "13",
+    "firefox": "34",
+    "safari": "13",
+    "node": "4",
+    "ios": "13",
+    "samsung": "3.4",
+    "opera": "28",
+    "electron": "0.24"
+  },
+  "transform-literals": {
+    "chrome": "44",
+    "edge": "12",
+    "firefox": "53",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "samsung": "4",
+    "opera": "31",
+    "electron": "0.31"
+  },
+  "transform-function-name": {
+    "chrome": "51",
+    "firefox": "53",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "38",
+    "electron": "1.2"
+  },
+  "transform-arrow-functions": {
+    "chrome": "47",
+    "edge": "13",
+    "firefox": "45",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "34",
+    "electron": "0.36"
   },
   "transform-block-scoped-functions": {
     "chrome": "41",
@@ -91,140 +152,10 @@
     "opera": "28",
     "electron": "0.24"
   },
-  "transform-block-scoping": {
-    "chrome": "49",
-    "edge": "14",
-    "firefox": "51",
-    "safari": "11",
-    "node": "6",
-    "ios": "11",
-    "samsung": "5",
-    "opera": "36",
-    "electron": "1"
-  },
   "transform-classes": {
     "chrome": "46",
     "edge": "13",
     "firefox": "45",
-    "safari": "10",
-    "node": "5",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "33",
-    "electron": "0.36"
-  },
-  "transform-computed-properties": {
-    "chrome": "44",
-    "edge": "12",
-    "firefox": "34",
-    "safari": "7.1",
-    "node": "4",
-    "ios": "8",
-    "samsung": "4",
-    "opera": "31",
-    "electron": "0.31"
-  },
-  "transform-destructuring": {
-    "chrome": "51",
-    "edge": "15",
-    "firefox": "53",
-    "safari": "10",
-    "node": "6.5",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "38",
-    "electron": "1.2"
-  },
-  "transform-dotall-regex": {
-    "chrome": "62",
-    "safari": "11.1",
-    "node": "8.10",
-    "ios": "11.3",
-    "samsung": "8.2",
-    "opera": "49",
-    "electron": "3.1"
-  },
-  "transform-duplicate-keys": {
-    "chrome": "42",
-    "edge": "12",
-    "firefox": "34",
-    "safari": "9",
-    "node": "4",
-    "ios": "9",
-    "samsung": "3.4",
-    "opera": "29",
-    "electron": "0.27"
-  },
-  "transform-exponentiation-operator": {
-    "chrome": "52",
-    "edge": "14",
-    "firefox": "52",
-    "safari": "10.1",
-    "node": "7",
-    "ios": "10.3",
-    "samsung": "6.2",
-    "opera": "39",
-    "electron": "1.3"
-  },
-  "transform-for-of": {
-    "chrome": "51",
-    "edge": "15",
-    "firefox": "53",
-    "safari": "10",
-    "node": "6.5",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "38",
-    "electron": "1.2"
-  },
-  "transform-function-name": {
-    "chrome": "51",
-    "firefox": "53",
-    "safari": "10",
-    "node": "6.5",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "38",
-    "electron": "1.2"
-  },
-  "transform-literals": {
-    "chrome": "44",
-    "edge": "12",
-    "firefox": "53",
-    "safari": "9",
-    "node": "4",
-    "ios": "9",
-    "samsung": "4",
-    "opera": "31",
-    "electron": "0.31"
-  },
-  "transform-member-expression-literals": {
-    "chrome": "7",
-    "opera": "12",
-    "edge": "12",
-    "firefox": "2",
-    "safari": "5.1",
-    "node": "0.10",
-    "ie": "9",
-    "android": "4",
-    "ios": "6",
-    "phantom": "2",
-    "samsung": "2.1",
-    "electron": "5"
-  },
-  "transform-named-capturing-groups-regex": {
-    "chrome": "64",
-    "safari": "11.1",
-    "node": "10",
-    "ios": "11.3",
-    "samsung": "9.2",
-    "opera": "51",
-    "electron": "3.1"
-  },
-  "transform-new-target": {
-    "chrome": "46",
-    "edge": "14",
-    "firefox": "41",
     "safari": "10",
     "node": "5",
     "ios": "10",
@@ -243,6 +174,83 @@
     "opera": "33",
     "electron": "0.36"
   },
+  "transform-shorthand-properties": {
+    "chrome": "43",
+    "edge": "12",
+    "firefox": "33",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "samsung": "4",
+    "opera": "30",
+    "electron": "0.29"
+  },
+  "transform-duplicate-keys": {
+    "chrome": "42",
+    "edge": "12",
+    "firefox": "34",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "samsung": "3.4",
+    "opera": "29",
+    "electron": "0.27"
+  },
+  "transform-computed-properties": {
+    "chrome": "44",
+    "edge": "12",
+    "firefox": "34",
+    "safari": "7.1",
+    "node": "4",
+    "ios": "8",
+    "samsung": "4",
+    "opera": "31",
+    "electron": "0.31"
+  },
+  "transform-for-of": {
+    "chrome": "51",
+    "edge": "15",
+    "firefox": "53",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "38",
+    "electron": "1.2"
+  },
+  "transform-sticky-regex": {
+    "chrome": "49",
+    "edge": "13",
+    "firefox": "3",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "36",
+    "electron": "1"
+  },
+  "transform-unicode-regex": {
+    "chrome": "50",
+    "edge": "13",
+    "firefox": "46",
+    "safari": "12",
+    "node": "6",
+    "ios": "12",
+    "samsung": "5",
+    "opera": "37",
+    "electron": "1.1"
+  },
+  "transform-spread": {
+    "chrome": "46",
+    "edge": "13",
+    "firefox": "36",
+    "safari": "10",
+    "node": "5",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "33",
+    "electron": "0.36"
+  },
   "transform-parameters": {
     "chrome": "49",
     "edge": "18",
@@ -253,6 +261,75 @@
     "samsung": "5",
     "opera": "36",
     "electron": "1"
+  },
+  "transform-destructuring": {
+    "chrome": "51",
+    "edge": "15",
+    "firefox": "53",
+    "safari": "10",
+    "node": "6.5",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "38",
+    "electron": "1.2"
+  },
+  "transform-block-scoping": {
+    "chrome": "49",
+    "edge": "14",
+    "firefox": "51",
+    "safari": "11",
+    "node": "6",
+    "ios": "11",
+    "samsung": "5",
+    "opera": "36",
+    "electron": "1"
+  },
+  "transform-typeof-symbol": {
+    "chrome": "38",
+    "edge": "12",
+    "firefox": "36",
+    "safari": "9",
+    "node": "0.12",
+    "ios": "9",
+    "samsung": "3",
+    "opera": "25",
+    "electron": "0.2"
+  },
+  "transform-new-target": {
+    "chrome": "46",
+    "edge": "14",
+    "firefox": "41",
+    "safari": "10",
+    "node": "5",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "33",
+    "electron": "0.36"
+  },
+  "transform-regenerator": {
+    "chrome": "50",
+    "edge": "13",
+    "firefox": "53",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "samsung": "5",
+    "opera": "37",
+    "electron": "1.1"
+  },
+  "transform-member-expression-literals": {
+    "chrome": "7",
+    "opera": "12",
+    "edge": "12",
+    "firefox": "2",
+    "safari": "5.1",
+    "node": "0.10",
+    "ie": "9",
+    "android": "4",
+    "ios": "6",
+    "phantom": "2",
+    "samsung": "2.1",
+    "electron": "5"
   },
   "transform-property-literals": {
     "chrome": "7",
@@ -268,17 +345,6 @@
     "samsung": "2.1",
     "electron": "5"
   },
-  "transform-regenerator": {
-    "chrome": "50",
-    "edge": "13",
-    "firefox": "53",
-    "safari": "10",
-    "node": "6",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "37",
-    "electron": "1.1"
-  },
   "transform-reserved-words": {
     "chrome": "13",
     "opera": "10.50",
@@ -292,71 +358,5 @@
     "phantom": "2",
     "samsung": "2.1",
     "electron": "0.2"
-  },
-  "transform-shorthand-properties": {
-    "chrome": "43",
-    "edge": "12",
-    "firefox": "33",
-    "safari": "9",
-    "node": "4",
-    "ios": "9",
-    "samsung": "4",
-    "opera": "30",
-    "electron": "0.29"
-  },
-  "transform-spread": {
-    "chrome": "46",
-    "edge": "13",
-    "firefox": "36",
-    "safari": "10",
-    "node": "5",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "33",
-    "electron": "0.36"
-  },
-  "transform-sticky-regex": {
-    "chrome": "49",
-    "edge": "13",
-    "firefox": "3",
-    "safari": "10",
-    "node": "6",
-    "ios": "10",
-    "samsung": "5",
-    "opera": "36",
-    "electron": "1"
-  },
-  "transform-template-literals": {
-    "chrome": "41",
-    "edge": "13",
-    "firefox": "34",
-    "safari": "13",
-    "node": "4",
-    "ios": "13",
-    "samsung": "3.4",
-    "opera": "28",
-    "electron": "0.24"
-  },
-  "transform-typeof-symbol": {
-    "chrome": "38",
-    "edge": "12",
-    "firefox": "36",
-    "safari": "9",
-    "node": "0.12",
-    "ios": "9",
-    "samsung": "3",
-    "opera": "25",
-    "electron": "0.2"
-  },
-  "transform-unicode-regex": {
-    "chrome": "50",
-    "edge": "13",
-    "firefox": "46",
-    "safari": "12",
-    "node": "6",
-    "ios": "12",
-    "samsung": "5",
-    "opera": "37",
-    "electron": "1.1"
   }
 }

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -1,3 +1,6 @@
+// WARNING: Plugin ordering is important. Don't reorder this file
+// without checking that it doesn't break anything.
+
 const es5 = {
   "transform-member-expression-literals":
     "Object/array literal extensions / Reserved words as property names",
@@ -97,10 +100,6 @@ const es2018 = {
   "proposal-async-generator-functions": "Asynchronous Iterators",
   "proposal-object-rest-spread": "object rest/spread properties",
 
-  // We want to apply this prior to unicode regex so that "." and "u"
-  // are properly handled.
-  //
-  // Ref: https://github.com/babel/babel/pull/7065#issuecomment-395959112
   "transform-dotall-regex": "s (dotAll) flag for regular expressions",
   "proposal-unicode-property-regex": "RegExp Unicode Property Escapes",
   "transform-named-capturing-groups-regex": "RegExp named capture groups",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -1,98 +1,50 @@
-/* eslint sort-keys: "error" */
+const es5 = {
+  "transform-member-expression-literals":
+    "Object/array literal extensions / Reserved words as property names",
+  "transform-property-literals":
+    "Object/array literal extensions / Reserved words as property names",
+  "transform-reserved-words": "Miscellaneous / Unreserved words",
+};
 
-module.exports = {
-  "proposal-async-generator-functions": "Asynchronous Iterators",
-  "proposal-json-strings": "JSON superset",
-  "proposal-nullish-coalescing-operator": "nullish coalescing operator (??)",
-  "proposal-object-rest-spread": "object rest/spread properties",
-  "proposal-optional-catch-binding": "optional catch binding",
-  "proposal-optional-chaining": "optional chaining operator (?.)",
-  "proposal-unicode-property-regex": "RegExp Unicode Property Escapes",
-
-  "transform-arrow-functions": {
-    features: ["arrow functions"],
-  },
-
-  "transform-async-to-generator": {
-    features: ["async functions"],
-  },
-
-  "transform-block-scoped-functions": {
-    features: ["block-level function declaration"],
-  },
-  "transform-block-scoping": {
-    features: ["const", "let"],
-  },
-  "transform-classes": {
-    features: ["class", "super"],
-  },
-  "transform-computed-properties": {
-    features: ["object literal extensions / computed properties"],
-  },
-  "transform-destructuring": {
-    features: ["destructuring, assignment", "destructuring, declarations"],
-  },
-
-  // We want to apply this prior to unicode regex so that "." and "u"
-  // are properly handled.
-  //
-  // Ref: https://github.com/babel/babel/pull/7065#issuecomment-395959112
-  "transform-dotall-regex": "s (dotAll) flag for regular expressions",
-
-  "transform-duplicate-keys": {
-    features: ["miscellaneous / duplicate property names in strict mode"],
-  },
-  "transform-exponentiation-operator": {
-    features: ["exponentiation (**) operator"],
-  },
-  "transform-for-of": {
-    features: ["for..of loops"],
-  },
-  "transform-function-name": {
-    features: ['function "name" property'],
+const es2015 = {
+  "transform-template-literals": {
+    features: ["template literals"],
   },
   "transform-literals": {
     features: ["Unicode code point escapes"],
   },
-  "transform-member-expression-literals":
-    "Object/array literal extensions / Reserved words as property names",
-  "transform-named-capturing-groups-regex": "RegExp named capture groups",
-  "transform-new-target": {
-    features: ["new.target"],
+  "transform-function-name": {
+    features: ['function "name" property'],
+  },
+  "transform-arrow-functions": {
+    features: ["arrow functions"],
+  },
+  "transform-block-scoped-functions": {
+    features: ["block-level function declaration"],
+  },
+  "transform-classes": {
+    features: ["class", "super"],
   },
   "transform-object-super": {
     features: ["super"],
   },
-  "transform-parameters": {
-    features: [
-      "default function parameters",
-      "rest parameters",
-      "destructuring, parameters / defaults, arrow function",
-    ],
-  },
-  "transform-property-literals":
-    "Object/array literal extensions / Reserved words as property names",
-  "transform-regenerator": {
-    features: ["generators"],
-  },
-  "transform-reserved-words": "Miscellaneous / Unreserved words",
   "transform-shorthand-properties": {
     features: ["object literal extensions / shorthand properties"],
   },
-  "transform-spread": {
-    features: "spread syntax for iterable objects",
+  "transform-duplicate-keys": {
+    features: ["miscellaneous / duplicate property names in strict mode"],
+  },
+  "transform-computed-properties": {
+    features: ["object literal extensions / computed properties"],
+  },
+  "transform-for-of": {
+    features: ["for..of loops"],
   },
   "transform-sticky-regex": {
     features: [
       'RegExp "y" and "u" flags / "y" flag, lastIndex',
       'RegExp "y" and "u" flags / "y" flag',
     ],
-  },
-  "transform-template-literals": {
-    features: ["template literals"],
-  },
-  "transform-typeof-symbol": {
-    features: ["Symbol / typeof support"],
   },
   "transform-unicode-regex": {
     features: [
@@ -102,4 +54,76 @@ module.exports = {
       'RegExp "y" and "u" flags / "u" flag',
     ],
   },
+  "transform-spread": {
+    features: ["spread syntax for iterable objects"],
+  },
+  "transform-parameters": {
+    features: [
+      "default function parameters",
+      "rest parameters",
+      "destructuring, parameters / defaults, arrow function",
+    ],
+  },
+  "transform-destructuring": {
+    features: ["destructuring, assignment", "destructuring, declarations"],
+  },
+  "transform-block-scoping": {
+    features: ["const", "let"],
+  },
+  "transform-typeof-symbol": {
+    features: ["Symbol / typeof support"],
+  },
+  "transform-new-target": {
+    features: ["new.target"],
+  },
+  "transform-regenerator": {
+    features: ["generators"],
+  },
 };
+
+const es2016 = {
+  "transform-exponentiation-operator": {
+    features: ["exponentiation (**) operator"],
+  },
+};
+
+const es2017 = {
+  "transform-async-to-generator": {
+    features: ["async functions"],
+  },
+};
+
+const es2018 = {
+  "proposal-async-generator-functions": "Asynchronous Iterators",
+  "proposal-object-rest-spread": "object rest/spread properties",
+
+  // We want to apply this prior to unicode regex so that "." and "u"
+  // are properly handled.
+  //
+  // Ref: https://github.com/babel/babel/pull/7065#issuecomment-395959112
+  "transform-dotall-regex": "s (dotAll) flag for regular expressions",
+  "proposal-unicode-property-regex": "RegExp Unicode Property Escapes",
+  "transform-named-capturing-groups-regex": "RegExp named capture groups",
+};
+
+const es2019 = {
+  "proposal-json-strings": "JSON superset",
+  "proposal-optional-catch-binding": "optional catch binding",
+};
+
+const es2020 = {
+  "proposal-nullish-coalescing-operator": "nullish coalescing operator (??)",
+  "proposal-optional-chaining": "optional chaining operator (?.)",
+};
+
+// Run plugins for modern features first
+module.exports = Object.assign(
+  {},
+  es2020,
+  es2019,
+  es2018,
+  es2017,
+  es2016,
+  es2015,
+  es5
+);

--- a/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
@@ -13,21 +13,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-optional-chaining { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-json-strings { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-optional-catch-binding { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-async-generator-functions { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
+  transform-dotall-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-unicode-property-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  transform-named-capturing-groups-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
   transform-template-literals { "ios":"10.3", "safari":"10.1" }
   transform-function-name { "edge":"16" }
-  transform-dotall-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
   transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
   transform-parameters { "edge":"16" }
   transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  proposal-async-generator-functions { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  proposal-unicode-property-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-json-strings { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-optional-catch-binding { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-optional-chaining { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  transform-named-capturing-groups-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-nullish-coalescing-operator { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
   syntax-dynamic-import { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
 
 Using polyfills with `usage` option:

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -13,21 +13,21 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-optional-chaining { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-json-strings { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-optional-catch-binding { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-async-generator-functions { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
+  transform-dotall-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  proposal-unicode-property-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  transform-named-capturing-groups-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
+  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
   transform-template-literals { "ios":"10.3", "safari":"10.1" }
   transform-function-name { "edge":"16" }
-  transform-dotall-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
   transform-unicode-regex { "ios":"10.3", "safari":"10.1" }
   transform-parameters { "edge":"16" }
   transform-block-scoping { "ios":"10.3", "safari":"10.1" }
-  transform-async-to-generator { "ios":"10.3", "safari":"10.1" }
-  proposal-async-generator-functions { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-object-rest-spread { "edge":"16", "ios":"10.3", "safari":"10.1" }
-  proposal-unicode-property-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-json-strings { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-optional-catch-binding { "chrome":"61", "edge":"16", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-optional-chaining { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  transform-named-capturing-groups-regex { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
-  proposal-nullish-coalescing-operator { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
   syntax-dynamic-import { "chrome":"61", "edge":"16", "firefox":"60", "ios":"10.3", "opera":"48", "safari":"10.1" }
 
 Using polyfills with `usage` option:

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
@@ -8,6 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "android":"3" }
+  proposal-optional-chaining { "android":"3" }
+  proposal-json-strings { "android":"3" }
+  proposal-optional-catch-binding { "android":"3" }
+  proposal-async-generator-functions { "android":"3" }
+  proposal-object-rest-spread { "android":"3" }
+  transform-dotall-regex { "android":"3" }
+  proposal-unicode-property-regex { "android":"3" }
+  transform-named-capturing-groups-regex { "android":"3" }
+  transform-async-to-generator { "android":"3" }
+  transform-exponentiation-operator { "android":"3" }
   transform-template-literals { "android":"3" }
   transform-literals { "android":"3" }
   transform-function-name { "android":"3" }
@@ -20,7 +31,6 @@ Using plugins:
   transform-computed-properties { "android":"3" }
   transform-for-of { "android":"3" }
   transform-sticky-regex { "android":"3" }
-  transform-dotall-regex { "android":"3" }
   transform-unicode-regex { "android":"3" }
   transform-spread { "android":"3" }
   transform-parameters { "android":"3" }
@@ -29,19 +39,9 @@ Using plugins:
   transform-typeof-symbol { "android":"3" }
   transform-new-target { "android":"3" }
   transform-regenerator { "android":"3" }
-  transform-exponentiation-operator { "android":"3" }
-  transform-async-to-generator { "android":"3" }
-  proposal-async-generator-functions { "android":"3" }
-  proposal-object-rest-spread { "android":"3" }
-  proposal-unicode-property-regex { "android":"3" }
-  proposal-json-strings { "android":"3" }
-  proposal-optional-catch-binding { "android":"3" }
-  proposal-optional-chaining { "android":"3" }
-  transform-named-capturing-groups-regex { "android":"3" }
   transform-member-expression-literals { "android":"3" }
   transform-property-literals { "android":"3" }
   transform-reserved-words { "android":"3" }
-  proposal-nullish-coalescing-operator { "android":"3" }
   transform-modules-commonjs { "android":"3" }
   proposal-dynamic-import { "android":"3" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -15,6 +15,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  proposal-optional-chaining { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  proposal-json-strings { "chrome":"49", "edge":"17", "safari":"5.1" }
+  proposal-optional-catch-binding { "chrome":"49", "edge":"17", "safari":"5.1" }
+  proposal-async-generator-functions { "chrome":"49", "edge":"17", "safari":"5.1" }
+  proposal-object-rest-spread { "chrome":"49", "edge":"17", "safari":"5.1" }
+  transform-dotall-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
+  proposal-unicode-property-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
+  transform-named-capturing-groups-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
+  transform-async-to-generator { "chrome":"49", "safari":"5.1" }
+  transform-exponentiation-operator { "chrome":"49", "safari":"5.1" }
   transform-template-literals { "ios":"12.2", "safari":"5.1" }
   transform-literals { "safari":"5.1" }
   transform-function-name { "chrome":"49", "edge":"17", "safari":"5.1" }
@@ -27,7 +38,6 @@ Using plugins:
   transform-computed-properties { "safari":"5.1" }
   transform-for-of { "chrome":"49", "safari":"5.1" }
   transform-sticky-regex { "safari":"5.1" }
-  transform-dotall-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
   transform-unicode-regex { "chrome":"49", "safari":"5.1" }
   transform-spread { "safari":"5.1" }
   transform-parameters { "edge":"17", "safari":"5.1" }
@@ -36,16 +46,6 @@ Using plugins:
   transform-typeof-symbol { "safari":"5.1" }
   transform-new-target { "safari":"5.1" }
   transform-regenerator { "chrome":"49", "safari":"5.1" }
-  transform-exponentiation-operator { "chrome":"49", "safari":"5.1" }
-  transform-async-to-generator { "chrome":"49", "safari":"5.1" }
-  proposal-async-generator-functions { "chrome":"49", "edge":"17", "safari":"5.1" }
-  proposal-object-rest-spread { "chrome":"49", "edge":"17", "safari":"5.1" }
-  proposal-unicode-property-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
-  proposal-json-strings { "chrome":"49", "edge":"17", "safari":"5.1" }
-  proposal-optional-catch-binding { "chrome":"49", "edge":"17", "safari":"5.1" }
-  proposal-optional-chaining { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
-  transform-named-capturing-groups-regex { "chrome":"49", "edge":"17", "firefox":"68", "safari":"5.1" }
-  proposal-nullish-coalescing-operator { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
   transform-modules-commonjs { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
   proposal-dynamic-import { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -16,6 +16,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  proposal-optional-chaining { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
+  proposal-json-strings { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  proposal-optional-catch-binding { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  proposal-async-generator-functions { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  proposal-object-rest-spread { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
+  transform-dotall-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
+  proposal-unicode-property-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
+  transform-named-capturing-groups-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
+  transform-async-to-generator { "chrome":"49", "ie":"11", "safari":"5.1" }
+  transform-exponentiation-operator { "chrome":"49", "ie":"11", "safari":"5.1" }
   transform-template-literals { "ie":"11", "ios":"12.2", "safari":"5.1" }
   transform-literals { "ie":"11", "safari":"5.1" }
   transform-function-name { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
@@ -28,7 +39,6 @@ Using plugins:
   transform-computed-properties { "ie":"11", "safari":"5.1" }
   transform-for-of { "chrome":"49", "ie":"11", "safari":"5.1" }
   transform-sticky-regex { "ie":"11", "safari":"5.1" }
-  transform-dotall-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
   transform-unicode-regex { "chrome":"49", "ie":"11", "safari":"5.1" }
   transform-spread { "ie":"11", "safari":"5.1" }
   transform-parameters { "edge":"17", "ie":"11", "safari":"5.1" }
@@ -37,16 +47,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11", "safari":"5.1" }
   transform-new-target { "ie":"11", "safari":"5.1" }
   transform-regenerator { "chrome":"49", "ie":"11", "safari":"5.1" }
-  transform-exponentiation-operator { "chrome":"49", "ie":"11", "safari":"5.1" }
-  transform-async-to-generator { "chrome":"49", "ie":"11", "safari":"5.1" }
-  proposal-async-generator-functions { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-object-rest-spread { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-unicode-property-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
-  proposal-json-strings { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-optional-catch-binding { "chrome":"49", "edge":"17", "ie":"11", "safari":"5.1" }
-  proposal-optional-chaining { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
-  transform-named-capturing-groups-regex { "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "safari":"5.1" }
-  proposal-nullish-coalescing-operator { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
   transform-modules-commonjs { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
   proposal-dynamic-import { "android":"77", "chrome":"49", "edge":"17", "firefox":"68", "ie":"11", "ios":"12.2", "opera":"63", "safari":"5.1", "samsung":"9.2" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -15,18 +15,18 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-template-literals { "safari":"12.1" }
-  transform-function-name { "edge":"17" }
-  transform-dotall-regex { "edge":"17", "firefox":"70" }
-  transform-parameters { "edge":"17" }
-  proposal-async-generator-functions { "edge":"17" }
-  proposal-object-rest-spread { "edge":"17" }
-  proposal-unicode-property-regex { "edge":"17", "firefox":"70" }
+  proposal-nullish-coalescing-operator { "android":"77", "chrome":"77", "edge":"17", "firefox":"70", "ios":"13", "opera":"63", "safari":"12.1", "samsung":"9.2" }
+  proposal-optional-chaining { "android":"77", "chrome":"77", "edge":"17", "firefox":"70", "ios":"13", "opera":"63", "safari":"12.1", "samsung":"9.2" }
   proposal-json-strings { "edge":"17" }
   proposal-optional-catch-binding { "edge":"17" }
-  proposal-optional-chaining { "android":"77", "chrome":"77", "edge":"17", "firefox":"70", "ios":"13", "opera":"63", "safari":"12.1", "samsung":"9.2" }
+  proposal-async-generator-functions { "edge":"17" }
+  proposal-object-rest-spread { "edge":"17" }
+  transform-dotall-regex { "edge":"17", "firefox":"70" }
+  proposal-unicode-property-regex { "edge":"17", "firefox":"70" }
   transform-named-capturing-groups-regex { "edge":"17", "firefox":"70" }
-  proposal-nullish-coalescing-operator { "android":"77", "chrome":"77", "edge":"17", "firefox":"70", "ios":"13", "opera":"63", "safari":"12.1", "samsung":"9.2" }
+  transform-template-literals { "safari":"12.1" }
+  transform-function-name { "edge":"17" }
+  transform-parameters { "edge":"17" }
   transform-modules-commonjs { "android":"77", "chrome":"77", "edge":"17", "firefox":"70", "ios":"13", "opera":"63", "safari":"12.1", "samsung":"9.2" }
   proposal-dynamic-import { "android":"77", "chrome":"77", "edge":"17", "firefox":"70", "ios":"13", "opera":"63", "safari":"12.1", "samsung":"9.2" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
@@ -8,6 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -20,7 +31,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -29,19 +39,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
@@ -8,6 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "android":"4" }
+  proposal-optional-chaining { "android":"4" }
+  proposal-json-strings { "android":"4" }
+  proposal-optional-catch-binding { "android":"4" }
+  proposal-async-generator-functions { "android":"4" }
+  proposal-object-rest-spread { "android":"4" }
+  transform-dotall-regex { "android":"4" }
+  proposal-unicode-property-regex { "android":"4" }
+  transform-named-capturing-groups-regex { "android":"4" }
+  transform-async-to-generator { "android":"4" }
+  transform-exponentiation-operator { "android":"4" }
   transform-template-literals { "android":"4" }
   transform-literals { "android":"4" }
   transform-function-name { "android":"4" }
@@ -20,7 +31,6 @@ Using plugins:
   transform-computed-properties { "android":"4" }
   transform-for-of { "android":"4" }
   transform-sticky-regex { "android":"4" }
-  transform-dotall-regex { "android":"4" }
   transform-unicode-regex { "android":"4" }
   transform-spread { "android":"4" }
   transform-parameters { "android":"4" }
@@ -29,17 +39,7 @@ Using plugins:
   transform-typeof-symbol { "android":"4" }
   transform-new-target { "android":"4" }
   transform-regenerator { "android":"4" }
-  transform-exponentiation-operator { "android":"4" }
-  transform-async-to-generator { "android":"4" }
-  proposal-async-generator-functions { "android":"4" }
-  proposal-object-rest-spread { "android":"4" }
-  proposal-unicode-property-regex { "android":"4" }
-  proposal-json-strings { "android":"4" }
-  proposal-optional-catch-binding { "android":"4" }
-  proposal-optional-chaining { "android":"4" }
-  transform-named-capturing-groups-regex { "android":"4" }
   transform-reserved-words { "android":"4" }
-  proposal-nullish-coalescing-operator { "android":"4" }
   transform-modules-commonjs { "android":"4" }
   proposal-dynamic-import { "android":"4" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
@@ -15,27 +15,27 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "electron":"0.36" }
+  proposal-optional-chaining { "electron":"0.36" }
+  proposal-json-strings { "electron":"0.36" }
+  proposal-optional-catch-binding { "electron":"0.36" }
+  proposal-async-generator-functions { "electron":"0.36" }
+  proposal-object-rest-spread { "electron":"0.36" }
+  transform-dotall-regex { "electron":"0.36" }
+  proposal-unicode-property-regex { "electron":"0.36" }
+  transform-named-capturing-groups-regex { "electron":"0.36" }
+  transform-async-to-generator { "electron":"0.36" }
+  transform-exponentiation-operator { "electron":"0.36" }
   transform-function-name { "electron":"0.36" }
   transform-for-of { "electron":"0.36" }
   transform-sticky-regex { "electron":"0.36" }
-  transform-dotall-regex { "electron":"0.36" }
   transform-unicode-regex { "electron":"0.36" }
   transform-parameters { "electron":"0.36" }
   transform-destructuring { "electron":"0.36" }
   transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
-  transform-exponentiation-operator { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
-  proposal-async-generator-functions { "electron":"0.36" }
-  proposal-object-rest-spread { "electron":"0.36" }
-  proposal-unicode-property-regex { "electron":"0.36" }
-  proposal-json-strings { "electron":"0.36" }
-  proposal-optional-catch-binding { "electron":"0.36" }
-  proposal-optional-chaining { "electron":"0.36" }
-  transform-named-capturing-groups-regex { "electron":"0.36" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "electron":"0.36" }
   transform-modules-commonjs { "electron":"0.36" }
   proposal-dynamic-import { "electron":"0.36" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
@@ -8,6 +8,17 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"55" }
+  proposal-optional-chaining { "chrome":"55" }
+  proposal-json-strings { "chrome":"55" }
+  proposal-optional-catch-binding { "chrome":"55" }
+  proposal-async-generator-functions { "chrome":"55" }
+  proposal-object-rest-spread { "chrome":"55" }
+  transform-dotall-regex { "chrome":"55" }
+  proposal-unicode-property-regex { "chrome":"55" }
+  transform-named-capturing-groups-regex { "chrome":"55" }
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -20,7 +31,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex { "chrome":"55" }
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -29,19 +39,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator { "chrome":"55" }
   syntax-dynamic-import { "chrome":"55" }
 
 Using polyfills with `entry` option:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  transform-destructuring { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
+  proposal-nullish-coalescing-operator { "node":"6" }
+  proposal-optional-chaining { "node":"6" }
   proposal-json-strings { "node":"6" }
   proposal-optional-catch-binding { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
+  proposal-async-generator-functions { "node":"6" }
+  proposal-object-rest-spread { "node":"6" }
+  transform-dotall-regex { "node":"6" }
+  proposal-unicode-property-regex { "node":"6" }
   transform-named-capturing-groups-regex { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
+  transform-async-to-generator { "node":"6" }
+  transform-exponentiation-operator { "node":"6" }
+  transform-function-name { "node":"6" }
+  transform-for-of { "node":"6" }
+  transform-destructuring { "node":"6" }
   transform-modules-commonjs { "node":"6" }
   proposal-dynamic-import { "node":"6" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
@@ -13,6 +13,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
   transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
   transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
@@ -25,7 +36,6 @@ Using plugins:
   transform-computed-properties { "ie":"10", "safari":"7" }
   transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
   transform-spread { "ie":"10", "ios":"9", "safari":"7" }
   transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
@@ -34,16 +44,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10", "safari":"7" }
   transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
@@ -19,6 +19,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
@@ -31,7 +42,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-unicode-regex { "electron":"0.36", "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "electron":"0.36", "ie":"10" }
@@ -40,18 +50,8 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
-  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
+  transform-exponentiation-operator { "ie":"10", "node":"6" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10", "node":"6" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10", "node":"6" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
@@ -8,6 +8,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "android":"4" }
+  proposal-optional-chaining { "android":"4" }
+  proposal-json-strings { "android":"4" }
+  proposal-optional-catch-binding { "android":"4" }
+  proposal-async-generator-functions { "android":"4" }
+  proposal-object-rest-spread { "android":"4" }
+  transform-dotall-regex { "android":"4" }
+  proposal-unicode-property-regex { "android":"4" }
+  transform-named-capturing-groups-regex { "android":"4" }
+  transform-async-to-generator { "android":"4" }
+  transform-exponentiation-operator { "android":"4" }
   transform-template-literals { "android":"4" }
   transform-literals { "android":"4" }
   transform-function-name { "android":"4" }
@@ -20,7 +31,6 @@ Using plugins:
   transform-computed-properties { "android":"4" }
   transform-for-of { "android":"4" }
   transform-sticky-regex { "android":"4" }
-  transform-dotall-regex { "android":"4" }
   transform-unicode-regex { "android":"4" }
   transform-spread { "android":"4" }
   transform-parameters { "android":"4" }
@@ -29,17 +39,7 @@ Using plugins:
   transform-typeof-symbol { "android":"4" }
   transform-new-target { "android":"4" }
   transform-regenerator { "android":"4" }
-  transform-exponentiation-operator { "android":"4" }
-  transform-async-to-generator { "android":"4" }
-  proposal-async-generator-functions { "android":"4" }
-  proposal-object-rest-spread { "android":"4" }
-  proposal-unicode-property-regex { "android":"4" }
-  proposal-json-strings { "android":"4" }
-  proposal-optional-catch-binding { "android":"4" }
-  proposal-optional-chaining { "android":"4" }
-  transform-named-capturing-groups-regex { "android":"4" }
   transform-reserved-words { "android":"4" }
-  proposal-nullish-coalescing-operator { "android":"4" }
   transform-modules-commonjs { "android":"4" }
   proposal-dynamic-import { "android":"4" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -15,27 +15,27 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "electron":"0.36" }
+  proposal-optional-chaining { "electron":"0.36" }
+  proposal-json-strings { "electron":"0.36" }
+  proposal-optional-catch-binding { "electron":"0.36" }
+  proposal-async-generator-functions { "electron":"0.36" }
+  proposal-object-rest-spread { "electron":"0.36" }
+  transform-dotall-regex { "electron":"0.36" }
+  proposal-unicode-property-regex { "electron":"0.36" }
+  transform-named-capturing-groups-regex { "electron":"0.36" }
+  transform-async-to-generator { "electron":"0.36" }
+  transform-exponentiation-operator { "electron":"0.36" }
   transform-function-name { "electron":"0.36" }
   transform-for-of { "electron":"0.36" }
   transform-sticky-regex { "electron":"0.36" }
-  transform-dotall-regex { "electron":"0.36" }
   transform-unicode-regex { "electron":"0.36" }
   transform-parameters { "electron":"0.36" }
   transform-destructuring { "electron":"0.36" }
   transform-block-scoping { "electron":"0.36" }
   transform-regenerator { "electron":"0.36" }
-  transform-exponentiation-operator { "electron":"0.36" }
-  transform-async-to-generator { "electron":"0.36" }
-  proposal-async-generator-functions { "electron":"0.36" }
-  proposal-object-rest-spread { "electron":"0.36" }
-  proposal-unicode-property-regex { "electron":"0.36" }
-  proposal-json-strings { "electron":"0.36" }
-  proposal-optional-catch-binding { "electron":"0.36" }
-  proposal-optional-chaining { "electron":"0.36" }
-  transform-named-capturing-groups-regex { "electron":"0.36" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "electron":"0.36" }
   transform-modules-commonjs { "electron":"0.36" }
   proposal-dynamic-import { "electron":"0.36" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
@@ -8,6 +8,17 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"55" }
+  proposal-optional-chaining { "chrome":"55" }
+  proposal-json-strings { "chrome":"55" }
+  proposal-optional-catch-binding { "chrome":"55" }
+  proposal-async-generator-functions { "chrome":"55" }
+  proposal-object-rest-spread { "chrome":"55" }
+  transform-dotall-regex { "chrome":"55" }
+  proposal-unicode-property-regex { "chrome":"55" }
+  transform-named-capturing-groups-regex { "chrome":"55" }
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -20,7 +31,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex { "chrome":"55" }
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -29,19 +39,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator { "chrome":"55" }
   syntax-dynamic-import { "chrome":"55" }
 
 Using polyfills with `entry` option:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  transform-destructuring { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
+  proposal-nullish-coalescing-operator { "node":"6" }
+  proposal-optional-chaining { "node":"6" }
   proposal-json-strings { "node":"6" }
   proposal-optional-catch-binding { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
+  proposal-async-generator-functions { "node":"6" }
+  proposal-object-rest-spread { "node":"6" }
+  transform-dotall-regex { "node":"6" }
+  proposal-unicode-property-regex { "node":"6" }
   transform-named-capturing-groups-regex { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
+  transform-async-to-generator { "node":"6" }
+  transform-exponentiation-operator { "node":"6" }
+  transform-function-name { "node":"6" }
+  transform-for-of { "node":"6" }
+  transform-destructuring { "node":"6" }
   transform-modules-commonjs { "node":"6" }
   proposal-dynamic-import { "node":"6" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
@@ -13,6 +13,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
+  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-template-literals { "ie":"10", "ios":"9", "safari":"7" }
   transform-literals { "firefox":"49", "ie":"10", "safari":"7" }
   transform-function-name { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
@@ -25,7 +36,6 @@ Using plugins:
   transform-computed-properties { "ie":"10", "safari":"7" }
   transform-for-of { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-sticky-regex { "ie":"10", "ios":"9", "safari":"7" }
-  transform-dotall-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-unicode-regex { "ie":"10", "ios":"9", "safari":"7" }
   transform-spread { "ie":"10", "ios":"9", "safari":"7" }
   transform-parameters { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
@@ -34,16 +44,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10", "safari":"7" }
   transform-new-target { "edge":"13", "ie":"10", "ios":"9", "safari":"7" }
   transform-regenerator { "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-exponentiation-operator { "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-async-to-generator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-async-generator-functions { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-object-rest-spread { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-unicode-property-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-json-strings { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-catch-binding { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-optional-chaining { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  transform-named-capturing-groups-regex { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   transform-modules-commonjs { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
   proposal-dynamic-import { "chrome":"54", "edge":"13", "firefox":"49", "ie":"10", "ios":"9", "safari":"7" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
@@ -8,14 +8,14 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "samsung":"8.2" }
+  proposal-optional-chaining { "samsung":"8.2" }
+  proposal-json-strings { "samsung":"8.2" }
+  proposal-optional-catch-binding { "samsung":"8.2" }
   syntax-async-generators { "samsung":"8.2" }
   syntax-object-rest-spread { "samsung":"8.2" }
   proposal-unicode-property-regex { "samsung":"8.2" }
-  proposal-json-strings { "samsung":"8.2" }
-  proposal-optional-catch-binding { "samsung":"8.2" }
-  proposal-optional-chaining { "samsung":"8.2" }
   transform-named-capturing-groups-regex { "samsung":"8.2" }
-  proposal-nullish-coalescing-operator { "samsung":"8.2" }
   transform-modules-commonjs { "samsung":"8.2" }
   proposal-dynamic-import { "samsung":"8.2" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
@@ -19,6 +19,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
+  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "electron":"0.36", "ie":"10", "node":"6.1" }
@@ -31,7 +42,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-sticky-regex { "electron":"0.36", "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-unicode-regex { "electron":"0.36", "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "electron":"0.36", "ie":"10" }
@@ -40,18 +50,8 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "electron":"0.36", "ie":"10" }
-  transform-exponentiation-operator { "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-async-to-generator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-async-generator-functions { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-object-rest-spread { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-unicode-property-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-json-strings { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-catch-binding { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  proposal-optional-chaining { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
-  transform-named-capturing-groups-regex { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-member-expression-literals { "electron":"0.36" }
   transform-property-literals { "electron":"0.36" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   transform-modules-commonjs { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
   proposal-dynamic-import { "chrome":"54", "electron":"0.36", "ie":"10", "node":"6.1" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
+  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6.10" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6.10" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6.10" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6.10" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6.10" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6.10" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
+  transform-exponentiation-operator { "ie":"10", "node":"6" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10", "node":"6" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10", "node":"6" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-function-name { "node":"6" }
-  transform-for-of { "node":"6" }
-  transform-dotall-regex { "node":"6" }
-  transform-destructuring { "node":"6" }
-  transform-exponentiation-operator { "node":"6" }
-  transform-async-to-generator { "node":"6" }
-  proposal-async-generator-functions { "node":"6" }
-  proposal-object-rest-spread { "node":"6" }
-  proposal-unicode-property-regex { "node":"6" }
+  proposal-nullish-coalescing-operator { "node":"6" }
+  proposal-optional-chaining { "node":"6" }
   proposal-json-strings { "node":"6" }
   proposal-optional-catch-binding { "node":"6" }
-  proposal-optional-chaining { "node":"6" }
+  proposal-async-generator-functions { "node":"6" }
+  proposal-object-rest-spread { "node":"6" }
+  transform-dotall-regex { "node":"6" }
+  proposal-unicode-property-regex { "node":"6" }
   transform-named-capturing-groups-regex { "node":"6" }
-  proposal-nullish-coalescing-operator { "node":"6" }
+  transform-async-to-generator { "node":"6" }
+  transform-exponentiation-operator { "node":"6" }
+  transform-function-name { "node":"6" }
+  transform-for-of { "node":"6" }
+  transform-destructuring { "node":"6" }
   transform-modules-commonjs { "node":"6" }
   proposal-dynamic-import { "node":"6" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
@@ -6,6 +6,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator {}
+  proposal-optional-chaining {}
+  proposal-json-strings {}
+  proposal-optional-catch-binding {}
+  proposal-async-generator-functions {}
+  proposal-object-rest-spread {}
+  transform-dotall-regex {}
+  proposal-unicode-property-regex {}
+  transform-named-capturing-groups-regex {}
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -18,7 +29,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex {}
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -27,19 +37,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions {}
-  proposal-object-rest-spread {}
-  proposal-unicode-property-regex {}
-  proposal-json-strings {}
-  proposal-optional-catch-binding {}
-  proposal-optional-chaining {}
-  transform-named-capturing-groups-regex {}
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator {}
   transform-modules-commonjs {}
   proposal-dynamic-import {}
 

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
@@ -11,6 +11,17 @@ Using targets:
 Using modules transform: false
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"55" }
+  proposal-optional-chaining { "chrome":"55" }
+  proposal-json-strings { "chrome":"55" }
+  proposal-optional-catch-binding { "chrome":"55" }
+  proposal-async-generator-functions { "chrome":"55" }
+  proposal-object-rest-spread { "chrome":"55" }
+  transform-dotall-regex { "chrome":"55" }
+  proposal-unicode-property-regex { "chrome":"55" }
+  transform-named-capturing-groups-regex { "chrome":"55" }
+  transform-async-to-generator {}
+  transform-exponentiation-operator {}
   transform-template-literals {}
   transform-literals {}
   transform-function-name {}
@@ -23,7 +34,6 @@ Using plugins:
   transform-computed-properties {}
   transform-for-of {}
   transform-sticky-regex {}
-  transform-dotall-regex { "chrome":"55" }
   transform-unicode-regex {}
   transform-spread {}
   transform-parameters {}
@@ -32,19 +42,9 @@ Using plugins:
   transform-typeof-symbol {}
   transform-new-target {}
   transform-regenerator {}
-  transform-exponentiation-operator {}
-  transform-async-to-generator {}
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
-  proposal-json-strings { "chrome":"55" }
-  proposal-optional-catch-binding { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
-  transform-named-capturing-groups-regex { "chrome":"55" }
   transform-member-expression-literals {}
   transform-property-literals {}
   transform-reserved-words {}
-  proposal-nullish-coalescing-operator { "chrome":"55" }
   syntax-dynamic-import { "chrome":"55" }
 
 Using polyfills with `entry` option:

--- a/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
+  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
+  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
+  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
+  transform-exponentiation-operator { "ie":"10", "node":"6" }
   transform-template-literals { "ie":"10" }
   transform-literals { "ie":"10" }
   transform-function-name { "ie":"10", "node":"6" }
@@ -22,7 +33,6 @@ Using plugins:
   transform-computed-properties { "ie":"10" }
   transform-for-of { "ie":"10", "node":"6" }
   transform-sticky-regex { "ie":"10" }
-  transform-dotall-regex { "chrome":"54", "ie":"10", "node":"6" }
   transform-unicode-regex { "ie":"10" }
   transform-spread { "ie":"10" }
   transform-parameters { "ie":"10" }
@@ -31,16 +41,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"10" }
   transform-new-target { "ie":"10" }
   transform-regenerator { "ie":"10" }
-  transform-exponentiation-operator { "ie":"10", "node":"6" }
-  transform-async-to-generator { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-async-generator-functions { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-object-rest-spread { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-unicode-property-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-json-strings { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-catch-binding { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-optional-chaining { "chrome":"54", "ie":"10", "node":"6" }
-  transform-named-capturing-groups-regex { "chrome":"54", "ie":"10", "node":"6" }
-  proposal-nullish-coalescing-operator { "chrome":"54", "ie":"10", "node":"6" }
   transform-modules-commonjs { "chrome":"54", "ie":"10", "node":"6" }
   proposal-dynamic-import { "chrome":"54", "ie":"10", "node":"6" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
@@ -16,19 +16,19 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "firefox":"52", "node":"7.4" }
+  proposal-optional-chaining { "firefox":"52", "node":"7.4" }
+  proposal-json-strings { "firefox":"52", "node":"7.4" }
+  proposal-optional-catch-binding { "firefox":"52", "node":"7.4" }
+  proposal-async-generator-functions { "firefox":"52", "node":"7.4" }
+  proposal-object-rest-spread { "firefox":"52", "node":"7.4" }
+  transform-dotall-regex { "firefox":"52", "node":"7.4" }
+  proposal-unicode-property-regex { "firefox":"52", "node":"7.4" }
+  transform-named-capturing-groups-regex { "firefox":"52", "node":"7.4" }
   transform-literals { "firefox":"52" }
   transform-function-name { "firefox":"52" }
   transform-for-of { "firefox":"52" }
-  transform-dotall-regex { "firefox":"52", "node":"7.4" }
   transform-destructuring { "firefox":"52" }
-  proposal-async-generator-functions { "firefox":"52", "node":"7.4" }
-  proposal-object-rest-spread { "firefox":"52", "node":"7.4" }
-  proposal-unicode-property-regex { "firefox":"52", "node":"7.4" }
-  proposal-json-strings { "firefox":"52", "node":"7.4" }
-  proposal-optional-catch-binding { "firefox":"52", "node":"7.4" }
-  proposal-optional-chaining { "firefox":"52", "node":"7.4" }
-  transform-named-capturing-groups-regex { "firefox":"52", "node":"7.4" }
-  proposal-nullish-coalescing-operator { "firefox":"52", "node":"7.4" }
   transform-modules-commonjs { "firefox":"52", "node":"7.4" }
   proposal-dynamic-import { "firefox":"52", "node":"7.4" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
@@ -8,15 +8,15 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-dotall-regex { "chrome":"55" }
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
+  proposal-nullish-coalescing-operator { "chrome":"55" }
+  proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }
   proposal-optional-catch-binding { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
+  proposal-async-generator-functions { "chrome":"55" }
+  proposal-object-rest-spread { "chrome":"55" }
+  transform-dotall-regex { "chrome":"55" }
+  proposal-unicode-property-regex { "chrome":"55" }
   transform-named-capturing-groups-regex { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
   transform-modules-commonjs { "chrome":"55" }
   proposal-dynamic-import { "chrome":"55" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
@@ -8,12 +8,12 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  syntax-async-generators { "chrome":"71" }
-  syntax-object-rest-spread { "chrome":"71" }
+  proposal-nullish-coalescing-operator { "chrome":"71" }
+  proposal-optional-chaining { "chrome":"71" }
   syntax-json-strings { "chrome":"71" }
   syntax-optional-catch-binding { "chrome":"71" }
-  proposal-optional-chaining { "chrome":"71" }
-  proposal-nullish-coalescing-operator { "chrome":"71" }
+  syntax-async-generators { "chrome":"71" }
+  syntax-object-rest-spread { "chrome":"71" }
   transform-modules-commonjs { "chrome":"71" }
   proposal-dynamic-import { "chrome":"71" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
@@ -8,15 +8,15 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-dotall-regex { "chrome":"55" }
-  proposal-async-generator-functions { "chrome":"55" }
-  proposal-object-rest-spread { "chrome":"55" }
-  proposal-unicode-property-regex { "chrome":"55" }
+  proposal-nullish-coalescing-operator { "chrome":"55" }
+  proposal-optional-chaining { "chrome":"55" }
   proposal-json-strings { "chrome":"55" }
   proposal-optional-catch-binding { "chrome":"55" }
-  proposal-optional-chaining { "chrome":"55" }
+  proposal-async-generator-functions { "chrome":"55" }
+  proposal-object-rest-spread { "chrome":"55" }
+  transform-dotall-regex { "chrome":"55" }
+  proposal-unicode-property-regex { "chrome":"55" }
   transform-named-capturing-groups-regex { "chrome":"55" }
-  proposal-nullish-coalescing-operator { "chrome":"55" }
   transform-modules-commonjs { "chrome":"55" }
   proposal-dynamic-import { "chrome":"55" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
@@ -10,6 +10,17 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
+  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
+  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
   transform-template-literals { "ie":"11" }
   transform-literals { "firefox":"50", "ie":"11" }
   transform-function-name { "firefox":"50", "ie":"11" }
@@ -21,7 +32,6 @@ Using plugins:
   transform-computed-properties { "ie":"11" }
   transform-for-of { "firefox":"50", "ie":"11" }
   transform-sticky-regex { "ie":"11" }
-  transform-dotall-regex { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-unicode-regex { "ie":"11" }
   transform-spread { "ie":"11" }
   transform-parameters { "firefox":"50", "ie":"11" }
@@ -30,16 +40,6 @@ Using plugins:
   transform-typeof-symbol { "ie":"11" }
   transform-new-target { "ie":"11" }
   transform-regenerator { "firefox":"50", "ie":"11" }
-  transform-exponentiation-operator { "firefox":"50", "ie":"11" }
-  transform-async-to-generator { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-async-generator-functions { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-object-rest-spread { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-unicode-property-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-json-strings { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-catch-binding { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-optional-chaining { "chrome":"52", "firefox":"50", "ie":"11" }
-  transform-named-capturing-groups-regex { "chrome":"52", "firefox":"50", "ie":"11" }
-  proposal-nullish-coalescing-operator { "chrome":"52", "firefox":"50", "ie":"11" }
   transform-modules-commonjs { "chrome":"52", "firefox":"50", "ie":"11" }
   proposal-dynamic-import { "chrome":"52", "firefox":"50", "ie":"11" }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
@@ -8,20 +8,20 @@ Using targets:
 Using modules transform: auto
 
 Using plugins:
-  transform-template-literals { "safari":"10" }
-  transform-dotall-regex { "safari":"10" }
-  transform-unicode-regex { "safari":"10" }
-  transform-block-scoping { "safari":"10" }
-  transform-exponentiation-operator { "safari":"10" }
-  transform-async-to-generator { "safari":"10" }
-  proposal-async-generator-functions { "safari":"10" }
-  proposal-object-rest-spread { "safari":"10" }
-  proposal-unicode-property-regex { "safari":"10" }
+  proposal-nullish-coalescing-operator { "safari":"10" }
+  proposal-optional-chaining { "safari":"10" }
   proposal-json-strings { "safari":"10" }
   proposal-optional-catch-binding { "safari":"10" }
-  proposal-optional-chaining { "safari":"10" }
+  proposal-async-generator-functions { "safari":"10" }
+  proposal-object-rest-spread { "safari":"10" }
+  transform-dotall-regex { "safari":"10" }
+  proposal-unicode-property-regex { "safari":"10" }
   transform-named-capturing-groups-regex { "safari":"10" }
-  proposal-nullish-coalescing-operator { "safari":"10" }
+  transform-async-to-generator { "safari":"10" }
+  transform-exponentiation-operator { "safari":"10" }
+  transform-template-literals { "safari":"10" }
+  transform-unicode-regex { "safari":"10" }
+  transform-block-scoping { "safari":"10" }
   transform-modules-commonjs { "safari":"10" }
   proposal-dynamic-import { "safari":"10" }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR should only re-order the logged plugins. I don't know why GitHub shows more created lines than deleted, but locally the match:
```
➜ git diff --numstat HEAD^..HEAD

10	10	packages/babel-preset-env/test/fixtures/corejs2/usage-browserslist-config-ignore/stdout.txt
10	10	packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/browserslists-android-3/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
7	7	packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/corejs-without-usebuiltins/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-android/stdout.txt
15	15	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-electron/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-force-all-transforms/stdout.txt
9	9	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-no-import/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-proposals/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-shippedProposals/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-specific-targets/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-decimals/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs2-versions-strings/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs2/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-all/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-android/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-babel-polyfill/stdout.txt
15	15	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-chrome-71/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es-proposals/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-es/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-force-all-transforms/stdout.txt
9	9	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-no-import/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-proposals/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only-chrome-71/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-runtime-only/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-entries/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-specific-targets/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-chrome-71/stdout.txt
3	3	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable-samsung-8.2/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stable/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-stage/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-decimals/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.0/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings-minor-3.1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-versions-strings/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web-chrome-71/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-corejs3-web/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-corejs3/stdout.txt
9	9	packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-no-import/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-shippedProposals/stdout.txt
25	25	packages/babel-preset-env/test/fixtures/debug/entry-no-corejs-uglify/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/entry-no-corejs/stdout.txt
8	8	packages/babel-preset-env/test/fixtures/debug/plugins-only/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-2/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-1/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-chrome-71-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-none-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-2/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-1/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-proposals-chrome-71-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-shippedProposals-2/stdout.txt
4	4	packages/babel-preset-env/test/fixtures/debug/usage-corejs2-with-import/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-2/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-1/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-chrome-71-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-none-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-2/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-1/stdout.txt
2	2	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-proposals-chrome-71-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-shippedProposals-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.0-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-versions-strings-minor-3.1-2/stdout.txt
4	4	packages/babel-preset-env/test/fixtures/debug/usage-corejs3-with-import/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-2/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-1/stdout.txt
24	24	packages/babel-preset-env/test/fixtures/debug/usage-no-corejs-none-2/stdout.txt
9	9	packages/babel-preset-env/test/fixtures/preset-options/safari-10_3-block-scoped/stdout.txt
15	10	packages/babel-preset-env/test/fixtures/sanity/block-scoping-for-of/output.js
```