### PR TITLE
chore: replace yarn-upgrade by bump-babel-dependencies in vuejs e2e tests

### DIFF
--- a/scripts/integration-tests/e2e-create-react-app.sh
+++ b/scripts/integration-tests/e2e-create-react-app.sh
@@ -23,9 +23,9 @@ cd tmp/create-react-app || exit
 
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
 yarn install
-# "yarn upgrade --scope @babel --latest" doesn't seem to work.
-# a means "all", while \n is the enter needed to confirm the selection.
-printf "a\n" | yarn upgrade-interactive --scope @babel --latest
+node "$PWD"/../../utils/bump-babel-dependencies.js
+yarn lerna exec -- node "$PWD"/../../utils/bump-babel-dependencies.js
+yarn install
 
 # Test
 CI=true yarn test

--- a/scripts/integration-tests/e2e-vue-cli.sh
+++ b/scripts/integration-tests/e2e-vue-cli.sh
@@ -22,13 +22,10 @@ cd tmp/vue-cli || exit
 #==============================================================================#
 
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
-# Workaround https://github.com/yarnpkg/yarn/issues/7797
-yarn policies set-version 1.18.0
 yarn install
-yarn lerna bootstrap
-# "yarn upgrade --scope @babel --latest" doesn't seem to work.
-# a means "all", while \n is the enter needed to confirm the selection.
-printf "a\n" | yarn upgrade-interactive --scope @babel --latest
+node "$PWD"/../../utils/bump-babel-dependencies.js
+yarn lerna exec -- node "$PWD"/../../utils/bump-babel-dependencies.js
+yarn install
 
 # Test
 CI=true yarn test -p babel,babel-preset-app

--- a/scripts/integration-tests/e2e-vue-cli.sh
+++ b/scripts/integration-tests/e2e-vue-cli.sh
@@ -22,9 +22,10 @@ cd tmp/vue-cli || exit
 #==============================================================================#
 
 startLocalRegistry "$PWD"/../../verdaccio-config.yml
-yarn install
 # Workaround https://github.com/yarnpkg/yarn/issues/7797
-yarn add --dev -W @babel/core
+yarn policies set-version 1.18.0
+yarn install
+yarn lerna bootstrap
 # "yarn upgrade --scope @babel --latest" doesn't seem to work.
 # a means "all", while \n is the enter needed to confirm the selection.
 printf "a\n" | yarn upgrade-interactive --scope @babel --latest

--- a/scripts/integration-tests/utils/bump-babel-dependencies.js
+++ b/scripts/integration-tests/utils/bump-babel-dependencies.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+const cwd = process.cwd();
+const packageJSONPath = path.resolve(cwd, "./package.json");
+const content = JSON.parse(fs.readFileSync(packageJSONPath));
+
+let bumped = false;
+function bumpBabelDependency(dependencies) {
+  for (const dep of Object.keys(dependencies)) {
+    if (dep.startsWith("@babel/")) {
+      dependencies[dep] = "latest";
+      bumped = true;
+    }
+  }
+}
+
+if ("peerDependencies" in content) {
+  bumpBabelDependency(content.peerDependencies);
+}
+if ("devDependencies" in content) {
+  bumpBabelDependency(content.devDependencies);
+}
+if ("dependencies" in content) {
+  bumpBabelDependency(content.dependencies);
+}
+
+if (bumped) {
+  fs.writeFileSync(packageJSONPath, JSON.stringify(content, undefined, 2));
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix failing vue-cli e2e tests
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
