### PR TITLE
fix: for-of transform should skip for-await-of

### DIFF
--- a/packages/babel-plugin-transform-for-of/src/index.js
+++ b/packages/babel-plugin-transform-for-of/src/index.js
@@ -19,7 +19,10 @@ export default declare((api, options) => {
       visitor: {
         ForOfStatement(path) {
           const { scope } = path;
-          const { left, right, body } = path.node;
+          const { left, right, body, await: isAwait } = path.node;
+          if (isAwait) {
+            return;
+          }
           const i = scope.generateUidIdentifier("i");
           let array = scope.maybeGenerateMemoised(right, true);
 

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-await-of/input.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-await-of/input.js
@@ -1,0 +1,1 @@
+async () => { for await (let foo of []); };

--- a/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-await-of/output.js
+++ b/packages/babel-plugin-transform-for-of/test/fixtures/for-of-as-array/for-await-of/output.js
@@ -1,0 +1,3 @@
+async () => {
+  for await (let foo of []);
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes second link of https://twitter.com/devsnek/status/1217908827829354496
| Patch: Bug Fix?          | Yes
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Skip `for-await-of` in for-of transform.