### PR TITLE
Enable `no-process-exit`

### DIFF
--- a/eslint/babel-eslint-config-internal/index.js
+++ b/eslint/babel-eslint-config-internal/index.js
@@ -34,7 +34,7 @@ module.exports = {
     "no-inner-declarations": "off",
     "no-labels": "off",
     "no-loop-func": "off",
-    "no-process-exit": "off",
+    "no-process-exit": "error",
     "no-return-assign": "off",
     "no-shadow": "off",
     "no-underscore-dangle": "off",

--- a/packages/babel-compat-data/scripts/build-data.js
+++ b/packages/babel-compat-data/scripts/build-data.js
@@ -290,7 +290,7 @@ const generateData = (environments, features) => {
   });
 };
 
-["plugin", "corejs2-built-in"].forEach(target => {
+for (const target of ["plugin", "corejs2-built-in"]) {
   const newData = generateData(
     environments,
     require(`./data/${target}-features`)
@@ -305,11 +305,10 @@ const generateData = (environments, features) => {
         "The newly generated plugin/built-in data does not match the current " +
           "files. Re-run `npm run build-data`."
       );
-      process.exit(1);
+      process.exitCode = 1;
+      break;
     }
-
-    process.exit(0);
+  } else {
+    fs.writeFileSync(dataPath, `${JSON.stringify(newData, null, 2)}\n`);
   }
-
-  fs.writeFileSync(dataPath, `${JSON.stringify(newData, null, 2)}\n`);
-});
+}

--- a/packages/babel-node/src/babel-node.js
+++ b/packages/babel-node/src/babel-node.js
@@ -92,7 +92,7 @@ getV8Flags(function(err, v8Flags) {
         if (signal) {
           process.kill(process.pid, signal);
         } else {
-          process.exit(code);
+          process.exitCode = code;
         }
       });
     });

--- a/packages/babel-parser/bin/babel-parser.js
+++ b/packages/babel-parser/bin/babel-parser.js
@@ -7,10 +7,9 @@ var fs = require("fs");
 var filename = process.argv[2];
 if (!filename) {
   console.error("no filename specified");
-  process.exit(0);
+} else {
+  var file = fs.readFileSync(filename, "utf8");
+  var ast = parser.parse(file);
+
+  console.log(JSON.stringify(ast, null, "  "));
 }
-
-var file = fs.readFileSync(filename, "utf8");
-var ast = parser.parse(file);
-
-console.log(JSON.stringify(ast, null, "  "));

--- a/packages/babel-preset-env/scripts/smoke-test.js
+++ b/packages/babel-preset-env/scripts/smoke-test.js
@@ -108,4 +108,4 @@ console.log("Cleaning up");
 fs.removeSync(tempFolderPath);
 fs.removeSync(packPath);
 
-process.exit(errorOccurred ? 1 : 0);
+process.exitCode = errorOccurred ? 1 : 0;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR includes commits from #11026.

Enabled `no-process-exit` rule and fixed linting errors. Rationale: https://nodejs.org/api/process.html#process_process_exit_code

In most case the synchronous `process.exit()` is unnecessary, and it causes asynchronous IO operations terminated even when they are not fulfilled, e.g. writes to `stdout` or `stderr`.

In our codebase, `process.exit()` is often used as top level return: It is straightforward to fix: wrap the statements into an `else` branch so we are not scheduling new tasks for the event loop.