### PR TITLE
chore: use @babel/eslint-config-internal

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -19,6 +19,7 @@ codemods/*/test/fixtures
 codemods/*/test/tmp
 packages/babel-preset-env/data/[^(plugin-features|shipped-proposals).js]
 packages/babel-preset-env/test/debug-fixtures
+packages/babel-preset-env/build
 packages/babel-preset-env-standalone/babel-preset-env.js
 packages/babel-preset-env-standalone/babel-preset-env.min.js
 packages/babel-standalone/babel.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,10 @@
+const path = require("path");
+
 module.exports = {
   root: true,
   plugins: ["prettier", "@babel/development", "import"],
-  extends: "babel",
+  // replace it by `@babel/internal` when `@babel/eslint-config-internal` is published
+  extends: path.resolve(__dirname, "eslint/babel-eslint-config-internal"),
   rules: {
     "prettier/prettier": "error",
     // TODO: remove after babel-eslint-config-internal is fully integrated into this repository.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "derequire": "^2.0.2",
     "enhanced-resolve": "^3.0.0",
     "eslint": "^6.0.1",
-    "eslint-config-babel": "^9.0.0",
     "eslint-import-resolver-node": "^0.3.2",
     "eslint-plugin-flowtype": "^3.8.2",
     "eslint-plugin-import": "^2.17.2",

--- a/packages/babel-parser/src/plugins/estree.js
+++ b/packages/babel-parser/src/plugins/estree.js
@@ -1,7 +1,5 @@
 // @flow
 
-/* global BigInt */
-
 import { types as tt, TokenType } from "../tokenizer/types";
 import type Parser from "../parser";
 import type { ExpressionErrors } from "../parser/util";

--- a/packages/babel-parser/test/helpers/runFixtureTests.js
+++ b/packages/babel-parser/test/helpers/runFixtureTests.js
@@ -1,5 +1,3 @@
-/* global BigInt */
-
 import { multiple as getFixtures } from "@babel/helper-fixtures";
 import { codeFrameColumns } from "@babel/code-frame";
 import fs from "fs";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,11 +4167,6 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-babel@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-babel/-/eslint-config-babel-9.0.0.tgz#bcfb9e9a1892aff29b8773cb9d2c76639de83c07"
-  integrity sha512-J7l2KdDKi2y9QifMqXdSIkghrVXr6fcpxegj+803C+4xBfpp0h2LcY9X5N+ivJMBoX6G2PJ/TBTM1Kro0MELBA==
-
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR updates the ESLint config to use `@babel/eslint-config-internal`.
Since it is not published yet, it can not be added to the `devDependencies`. We workaround this by providing its relative path.