### PR TITLE
Avoid compiling the _typeof helper with itself

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -12,6 +12,8 @@ const helper = (minVersion: string) => tpl => ({
 
 helpers.typeof = helper("7.0.0-beta.0")`
   export default function _typeof(obj) {
+    "@babel/helpers - typeof";
+
     if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
       _typeof = function (obj) { return typeof obj; };
     } else {

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/regression/6154/output.js
@@ -1,4 +1,4 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/legacy-regression/7030/output.js
@@ -1,4 +1,4 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T7537/output.js
@@ -1,4 +1,4 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -9,7 +9,7 @@ var _args = _interopRequireDefault(require("utils/url/args"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -19,6 +19,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",
-    "@babel/helper-plugin-test-runner": "^7.8.3"
+    "@babel/helper-plugin-test-runner": "^7.8.3",
+    "@babel/runtime": "^7.8.3",
+    "@babel/runtime-corejs2": "^7.8.3",
+    "@babel/runtime-corejs3": "^7.8.3",
+    "resolve": "^1.15.0"
   }
 }

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.js
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.js
@@ -36,8 +36,23 @@ export default declare(api => {
           }
         }
 
+        let isUnderHelper = path.findParent(path => {
+          if (path.isFunction()) {
+            return (
+              path.get("body.directives.0")?.node.value.value ===
+              "@babel/helpers - typeof"
+            );
+          }
+        });
+
+        if (isUnderHelper) return;
+
         const helper = this.addHelper("typeof");
-        const isUnderHelper = path.findParent(path => {
+
+        // TODO: This is needed for backward compatibility with
+        // @babel/helpers <= 7.8.3.
+        // Remove in Babel 8
+        isUnderHelper = path.findParent(path => {
           return (
             (path.isVariableDeclarator() && path.node.id === helper) ||
             (path.isFunctionDeclaration() &&

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/builtin-global/output.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/builtin-global/output.mjs
@@ -1,3 +1,3 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 (typeof Reflect === "undefined" ? "undefined" : _typeof(Reflect)) === "object";

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/default-export/output.mjs
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/default-export/output.mjs
@@ -1,4 +1,4 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 export default function () {
   _typeof({}) === "object";

--- a/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/shadow/output.js
+++ b/packages/babel-plugin-transform-typeof-symbol/test/fixtures/symbols/shadow/output.js
@@ -1,4 +1,4 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 var _Symbol = foo();
 

--- a/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
+++ b/packages/babel-plugin-transform-typeof-symbol/test/helper.spec.js
@@ -1,0 +1,52 @@
+import * as babel from "@babel/core";
+import resolvePath from "resolve";
+import fs from "fs";
+
+import transformTypeofSymbol from "..";
+
+const resolve = path =>
+  new Promise((resolve, reject) =>
+    resolvePath(path, (err, path) => (err ? reject(err) : resolve(path))),
+  );
+const readFile = path =>
+  new Promise((resolve, reject) =>
+    fs.readFile(path, "utf8", (err, contents) => {
+      if (err) reject(err);
+      else resolve(contents);
+    }),
+  );
+
+describe("@babel/plugin-transform-typeof-symbol", () => {
+  test.each`
+    runtime                     | type
+    ${"@babel/runtime"}         | ${"esm"}
+    ${"@babel/runtime"}         | ${"cjs"}
+    ${"@babel/runtime-corejs2"} | ${"esm"}
+    ${"@babel/runtime-corejs2"} | ${"cjs"}
+    ${"@babel/runtime-corejs3"} | ${"esm"}
+    ${"@babel/runtime-corejs3"} | ${"cjs"}
+  `(
+    "shouldn't transpile the $type $runtime helper",
+    async ({ type, runtime }) => {
+      const path = await resolve(
+        `${runtime}/helpers${type === "esm" ? "/esm/" : "/"}typeof`,
+      );
+      const src = await readFile(path);
+
+      const ast = babel.parseSync(src, {
+        configFile: false,
+        sourceType: type === "esm" ? "module" : "script",
+      });
+
+      const withPlugin = babel.transformFromAstSync(ast, src, {
+        configFile: false,
+        plugins: [transformTypeofSymbol],
+      });
+      const withoutPlugin = babel.transformFromAstSync(ast, src, {
+        configFile: false,
+      });
+
+      expect(withPlugin.code).toBe(withoutPlugin.code);
+    },
+  );
+});

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/auto-esm-unsupported-import-unsupported/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/auto-esm-unsupported-import-unsupported/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/modules-amd/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/modules-amd/output.js
@@ -1,5 +1,5 @@
 define(["require"], function (_require) {
-  function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+  function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
   function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 

--- a/packages/babel-preset-env/test/fixtures/dynamic-import/modules-cjs/output.js
+++ b/packages/babel-preset-env/test/fixtures/dynamic-import/modules-cjs/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-10662/output.js
@@ -13,7 +13,7 @@
 })(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
 
-  function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+  function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
   var globalThis = {};
 

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-7527/output.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/packages/babel-preset-env/test/fixtures/preset-options/loose-with-typeof-symbol-includes/output.js
+++ b/packages/babel-preset-env/test/fixtures/preset-options/loose-with-typeof-symbol-includes/output.js
@@ -1,5 +1,5 @@
 "use strict";
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 _typeof(Symbol());


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11047, fixes #10996, fixes #8571, fixes #9127, fixes #11036, ref #2954, ref #3737
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We already had some logic to prevent the `typeof-symbol` plugin from transpiling its own helper. It worked by generating the helper name and checking if the current path is inside a function or a variable declaration with that name.

However, it had a few problems:
1. It doesn't work with `@babel/runtime`, because the generated name is a unique identifier so it's guaranteed _not_ to be equal to the `_typeof` helper name.
1. Sometimes, multiple names are generated (`_typeof2` and `_typeof3`), causing circular dependencies. This is probably caused by running twice the plugin, but we can avoid failing in that case.

I initially hard-coded the helper name in the `isUnderHelper` logic to make it work with `@babel/runtime`, but:
1. It doesn't fix (2)
1. If `@babel/runtime` is bundled in an app/library by `rollup`, the function name might change
1. It doesn't work with minifiers.

I then decided to introduce a `"@babel/helpers - typeof"` directive, which has a few advantage:
1. We don't need to generate the helper code _before_ checking if we are inside the helper, which would always lead to duplicated code when transpiling `@babel/runtime/helpers/typeof`
1. It fixes (2) and works with Rollup.

The directive still doesn't work with Terser and UglifyJS because they strip them by default. We could either suggest to whoever finds this bug to set the `directives: false` option in their minifier settings, or we could ask UglifyJS and Terser's maintainers if they could keep this specific directive in the minified output.

This PR makes it safe to transpile `@babel/runtime`, which should provide a solution for #9903