### PR TITLE
Add TypeScript declarations to scope tracker

### DIFF
--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -188,6 +188,64 @@ describe("scope", () => {
       ).toBe("ImportSpecifier");
     });
 
+    it("typescript declare function", function() {
+      expect(
+        getPath("declare function test(): void", {
+          plugins: ["typescript"],
+        }).scope.getBinding("test").path.type,
+      ).toBe("TSDeclareFunction");
+    });
+
+    it("typescript enum", function() {
+      expect(
+        getPath("enum Foo {a, b}", {
+          plugins: ["typescript"],
+        }).scope.getBinding("Foo").path.type,
+      ).toBe("TSEnumDeclaration");
+    });
+
+    it("typescript import equals", function() {
+      expect(
+        getPath("import foo = require('foo')", {
+          plugins: ["typescript"],
+          sourceType: "module",
+        }).scope.getBinding("foo").path.type,
+      ).toBe("TSImportEqualsDeclaration");
+    });
+
+    it("typescript interface declarations", function() {
+      expect(
+        getPath("interface Foo { a: string }", {
+          plugins: ["typescript"],
+        }).scope.getBinding("Foo").path.type,
+      ).toBe("TSInterfaceDeclaration");
+    });
+
+    it("typescript module declarations", function() {
+      expect(
+        getPath("module foo {}", {
+          plugins: ["typescript"],
+        }).scope.getBinding("foo").path.type,
+      ).toBe("TSModuleDeclaration");
+    });
+
+    it("typescript namespace exports", function() {
+      expect(
+        getPath("export as namespace Foo", {
+          plugins: ["typescript"],
+          sourceType: "module",
+        }).scope.getBinding("Foo").path.type,
+      ).toBe("TSNamespaceExportDeclaration");
+    });
+
+    it("typescript type aliases", function() {
+      expect(
+        getPath("type Foo = string", {
+          plugins: ["typescript"],
+        }).scope.getBinding("Foo").path.type,
+      ).toBe("TSTypeAliasDeclaration");
+    });
+
     it("variable constantness", function() {
       expect(getPath("var a = 1;").scope.getBinding("a").constant).toBe(true);
       expect(getPath("var a = 1; a = 2;").scope.getBinding("a").constant).toBe(

--- a/packages/babel-types/src/definitions/typescript.js
+++ b/packages/babel-types/src/definitions/typescript.js
@@ -420,7 +420,7 @@ defineType("TSImportType", {
 });
 
 defineType("TSImportEqualsDeclaration", {
-  aliases: ["Statement"],
+  aliases: ["Statement", "Declaration"],
   visitor: ["id", "moduleReference"],
   fields: {
     isExport: validate(bool),
@@ -456,7 +456,7 @@ defineType("TSExportAssignment", {
 });
 
 defineType("TSNamespaceExportDeclaration", {
-  aliases: ["Statement"],
+  aliases: ["Statement", "Declaration"],
   visitor: ["id"],
   fields: {
     id: validateType("Identifier"),

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.js
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.js
@@ -81,6 +81,14 @@ getBindingIdentifiers.keys = {
   TypeAlias: ["id"],
   OpaqueType: ["id"],
 
+  TSDeclareFunction: ["id"],
+  TSEnumDeclaration: ["id"],
+  TSImportEqualsDeclaration: ["id"],
+  TSInterfaceDeclaration: ["id"],
+  TSModuleDeclaration: ["id"],
+  TSNamespaceExportDeclaration: ["id"],
+  TSTypeAliasDeclaration: ["id"],
+
   CatchClause: ["param"],
   LabeledStatement: ["label"],
   UnaryExpression: ["argument"],


### PR DESCRIPTION
TypeScript declarations were missing from Babel's scope tracking due to missing config in `getBindingIdentifiers`. This adds the missing identifiers and adds tests to ensure TypeScript declarations are accessible via the scope.