### PR TITLE
Clean babel-eslint-*/**/lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,10 +268,8 @@ bootstrap: bootstrap-only
 	$(MAKE) build
 
 clean-lib:
-	# TODO: Don't delete eslint/*/lib when they use src
 	$(foreach source, $(SOURCES), \
-		$(if $(filter-out $(source), eslint), \
-			$(call clean-source-lib, $(source))))
+		$(call clean-source-lib, $(source)))
 
 clean-runtime-helpers:
 	rm -f packages/babel-runtime/helpers/**/*.js
@@ -307,8 +305,7 @@ define clean-source-test
 endef
 
 define clean-source-all
-	# TODO: Don't delete eslint/*/lib when they use src
-	$(if $(filter-out $1, eslint), $(call clean-source-lib, $1))
+	$(call clean-source-lib, $1)
 	rm -rf $(1)/*/node_modules
 	rm -rf $(1)/*/package-lock.json
 

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "repository": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-config-internal",
-  "main": "lib/index.js",
+  "main": "index.js",
   "peerDependencies": {
     "babel-eslint": "^10.0.0 || ^11.0.0-0",
     "eslint-plugin-flowtype": "^3.0.0"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | :+1:
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I was having trouble running `make lint` locally because I had an old `babel-eslint-config-internal/lib` that was being used. Since the main file in question isn't in `src`, it wasn't getting recompiled and I was therefore using the old compiled output.

I don't _think_ we need to avoid cleaning the ESLint packages now that they're all using `src` if they're compiled` and are not in `src` if not.