### PR TITLE
Do not publish build directory of compat-data (#11078) [skip ci]

### DIFF
--- a/packages/babel-compat-data/.npmignore
+++ b/packages/babel-compat-data/.npmignore
@@ -1,3 +1,4 @@
+build
 scripts
 src
 test


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | y
| Major: Breaking Change?  | n
| Minor: New Feature?      | n
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | n
| License                  | MIT

The build directory should not be published.

Also we do not have a src or test directory in this package.
