### PR TITLE
Only download compat-table if it's not already downloaded

### DIFF
--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -2,6 +2,12 @@
 set -e
 
 COMPAT_TABLE_COMMIT=4e9369a699b0e15ba5c21586ce3bdd34299db9c1
+GIT_HEAD=build/compat-table/.git/HEAD
+
+if [ -f "$GIT_HEAD" -a "$(cat $GIT_HEAD)" == $COMPAT_TABLE_COMMIT ]; then
+  exit 0
+fi
+
 rm -rf build/compat-table
 mkdir -p build
 git clone --branch=gh-pages --single-branch --shallow-since=2019-11-14 https://github.com/kangax/compat-table.git build/compat-table

--- a/packages/babel-compat-data/scripts/download-compat-table.sh
+++ b/packages/babel-compat-data/scripts/download-compat-table.sh
@@ -4,8 +4,14 @@ set -e
 COMPAT_TABLE_COMMIT=4e9369a699b0e15ba5c21586ce3bdd34299db9c1
 GIT_HEAD=build/compat-table/.git/HEAD
 
-if [ -f "$GIT_HEAD" -a "$(cat $GIT_HEAD)" == $COMPAT_TABLE_COMMIT ]; then
-  exit 0
+if [ -d "build/compat-table" ]; then
+  cd build/compat-table
+  commit="$(git rev-parse HEAD)"
+  cd ../..
+
+  if [ $commit == $COMPAT_TABLE_COMMIT ]; then
+    exit 0
+  fi
 fi
 
 rm -rf build/compat-table


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm currently working on a PR where I need to run `make build-compat-data` many times, and it's a bit annoying that it re-clones the repo every time :stuck_out_tongue: 